### PR TITLE
change ServiceFactory to expect delimited path

### DIFF
--- a/src/snapred/backend/api/InterfaceController.py
+++ b/src/snapred/backend/api/InterfaceController.py
@@ -21,7 +21,7 @@ class InterfaceController:
         # execute the recipe
         # return the result
         try:
-            result = self.serviceFactory.getService(request.mode).orchestrateRecipe(request)
+            result = self.serviceFactory.getService(request.path).orchestrateRecipe(request)
 
             response = SNAPResponse(responseCode=200, responseMessage=None, responseData=result)
         except Exception as e:  # noqa BLE001

--- a/src/snapred/backend/dao/SNAPRequest.py
+++ b/src/snapred/backend/dao/SNAPRequest.py
@@ -1,13 +1,14 @@
 from typing import List
 
 from pydantic import BaseModel
+
 from snapred.backend.dao.RunConfig import RunConfig
 
 
 class SNAPRequest(BaseModel):
     """"""
 
-    mode: str
+    path: str
     runs: List[RunConfig]
 
     # if we need specific getter and setter methods, we can use the @property decorator

--- a/src/snapred/backend/service/CalibrationReductionService.py
+++ b/src/snapred/backend/service/CalibrationReductionService.py
@@ -5,6 +5,7 @@ from snapred.meta.Singleton import Singleton
 
 @Singleton
 class CalibrationReductionService:
+    name = "calibration"
     dataFactoryService = DataFactoryService()
 
     # register the service in ServiceFactory please!

--- a/src/snapred/backend/service/ConfigLookupService.py
+++ b/src/snapred/backend/service/ConfigLookupService.py
@@ -10,6 +10,7 @@ from snapred.meta.Singleton import Singleton
 
 @Singleton
 class ConfigLookupService:
+    name = "config"
     dataFactoryService = DataFactoryService()
 
     # register the service in ServiceFactory

--- a/src/snapred/backend/service/ExtractionService.py
+++ b/src/snapred/backend/service/ExtractionService.py
@@ -8,6 +8,7 @@ from snapred.meta.Singleton import Singleton
 
 @Singleton
 class ExtractionService:
+    name = "extraction"
     dataFactoryService = DataFactoryService()
 
     # register the service in ServiceFactory please!

--- a/src/snapred/backend/service/ReductionService.py
+++ b/src/snapred/backend/service/ReductionService.py
@@ -8,6 +8,7 @@ from snapred.meta.Singleton import Singleton
 
 @Singleton
 class ReductionService:
+    name = "reduction"
     dataFactoryService = DataFactoryService()
 
     # register the service in ServiceFactory please!

--- a/src/snapred/backend/service/StateIdLookupService.py
+++ b/src/snapred/backend/service/StateIdLookupService.py
@@ -7,6 +7,7 @@ from snapred.meta.Singleton import Singleton
 
 @Singleton
 class StateIdLookupService:
+    name = "stateId"
     dataFactoryService = DataFactoryService()
 
     # register the service in ServiceFactory please!

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -1,5 +1,9 @@
 # environment: dev
 
+orchestration:
+  path:
+    delimiter: /
+
 instrument:
   name: SNAP
   home: /SNS/SNAP/

--- a/src/snapred/ui/model/LogTableModel.py
+++ b/src/snapred/ui/model/LogTableModel.py
@@ -4,7 +4,7 @@ from snapred.backend.dao.SNAPRequest import SNAPRequest
 # should probably use the DAO layer to some degree
 class LogTableModel(object):
     def __init__(self):
-        self.someVariable = SNAPRequest(mode="test", runs=[])
+        self.someVariable = SNAPRequest(path="test", runs=[])
 
     def getRecipeConfig(self):
         return self.someVariable

--- a/src/snapred/ui/presenter/LogTablePresenter.py
+++ b/src/snapred/ui/presenter/LogTablePresenter.py
@@ -1,6 +1,7 @@
 from time import sleep
 
 from PyQt5.QtWidgets import QMessageBox
+
 from snapred.backend.api.InterfaceController import InterfaceController
 from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.dao.SNAPRequest import SNAPRequest
@@ -58,7 +59,7 @@ class LogTablePresenter(object):
     def handle_button_clicked(self):
         self.view.button.setEnabled(False)
 
-        request = SNAPRequest(mode="Reduction", runs=[RunConfig(runNumber="48741")])
+        request = SNAPRequest(path="/reduction", runs=[RunConfig(runNumber="48741")])
 
         # setup workers with work targets and args
         self.worker = self.worker_pool.createWorker(target=self.interfaceController.executeRequest, args=(request))

--- a/src/snapred/ui/presenter/TestPanelPresenter.py
+++ b/src/snapred/ui/presenter/TestPanelPresenter.py
@@ -1,8 +1,8 @@
-from PyQt5.QtWidgets import QMessageBox
 from snapred.backend.api.InterfaceController import InterfaceController
-from snapred.backend.dao.SNAPRequest import SNAPRequest
 from snapred.backend.dao.RunConfig import RunConfig
+from snapred.backend.dao.SNAPRequest import SNAPRequest
 from snapred.ui.threading.worker_pool import WorkerPool
+
 
 class TestPanelPresenter(object):
     interfaceController = InterfaceController()
@@ -21,7 +21,7 @@ class TestPanelPresenter(object):
         self.view.show()
 
     def handleCalibrationReductinButtonClicked(self):
-        reductionRequest = SNAPRequest(mode="Calibration Reduction", runs=[RunConfig(runNumber="57514")])
+        reductionRequest = SNAPRequest(path="calibration", runs=[RunConfig(runNumber="57514")])
         self.handleButtonClicked(reductionRequest, self.view.calibrationReductinButton)
 
     def handleButtonClicked(self, reductionRequest, button):

--- a/tests/unit/backend/api/test_InterfaceController.py
+++ b/tests/unit/backend/api/test_InterfaceController.py
@@ -47,7 +47,7 @@ def test_executeRequest_successful():
     """Test executeRequest with a successful service"""
     interfaceController = mockedSuccessfulInterfaceController()
     reductionRequest = mock.Mock()
-    reductionRequest.mode = "Test Service"
+    reductionRequest.path = "Test Service"
     response = interfaceController.executeRequest(reductionRequest)
     assert response.responseCode == 200
     assert response.responseMessage is None
@@ -58,7 +58,7 @@ def test_executeRequest_unsuccessful():
     """Test executeRequest with an unsuccessful service"""
     interfaceController = mockedSuccessfulInterfaceController()
     reductionRequest = mock.Mock()
-    reductionRequest.mode = "Non-existent Test Service"
+    reductionRequest.path = "Non-existent Test Service"
     # mock orchestrateRecipe to raise an exception
     response = interfaceController.executeRequest(reductionRequest)
     assert response.responseCode == 500


### PR DESCRIPTION
This will allow us to specify specific actions in each service, so that its not restricted to just executing a recipe.

Ex. The calibration service would like to save its calibration it just created upon the user approving it, the ui would then specify
`calibration/recipe` to execute the initial recipe
`calibration/save` to save the current result to the calibration index.