### PR TITLE
change to actions so that pre-commit actuall runs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -19,8 +19,13 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: 3.x
-    - uses: pre-commit-ci/lite-action@v1.0.1
-      if: always()
+    - id: file_changes
+      uses: trilom/file-changes-action@v1.2.3
+      with:
+        output: ' '
+    - uses: pre-commit/action@v2.0.0
+      with:
+        extra_args: --files ${{ steps.file_changes.outputs.files}}
 
 
   tests:


### PR DESCRIPTION
The old [pre-commit method using the lite action](https://pre-commit.ci/lite.html) was not working.

I implemented this solution, [found here](https://github.com/pre-commit/action/issues/7#issuecomment-669149713).  

Testing with a PR, this fixes the issue.