### PR TITLE
Make MantidSnapper handle a case with output property not set ahead of time.

### DIFF
--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -137,9 +137,9 @@ class MantidSnapper:
                 if name == "LoadDiffCal":
                     if prop in ["GroupingWorkspace", "MaskWorkspace", "CalWorkspace"]:
                         continue
-                returnVal = algorithm.getProperty(prop).value
+                returnVal = getattr(algorithm.getProperty(prop), "value", None)
                 if not returnVal:
-                    returnVal = algorithm.getProperty(prop).valueAsStr
+                    returnVal = getattr(algorithm.getProperty(prop), "valueAsStr", None)
                 val.update(returnVal)
         except RuntimeError as e:
             raise AlgorithmException(name, str(e))


### PR DESCRIPTION
This fix suggested by @walshmm fixes an issue with `MantidSnapper` executing `LoadDetectorsGroupingFile` where apparently the `OutputWorkspace` property is not set by `Mantid` ahead of time.  More specifically, this PR fixes several broken pixel grouping tests executed on the analysis cluster. 