### PR TITLE
Add test for starting GUI in CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -45,7 +45,7 @@ jobs:
       uses: codecov/codecov-action@v3
     - name: Gui tests
       run: |
-        which snapred
+        python -m pip install -e . # install the application in editable mode
         xvfb-run --server-args="-screen 0 1280x1024x16" --auto-servernum snapred --headcheck
 
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -45,11 +45,8 @@ jobs:
       uses: codecov/codecov-action@v3
     - name: Gui tests
       run: |
-        # copy a set of instrument parameters into the test area
-        mkdir -p SNAP/shared/Calibration/
-        cp tests/resources/inputs/SNAPInstPrm.json SNAP/shared/Calibration/SNAPInstPrm.json
         python -m pip install -e . # install the application in editable mode
-        env=tests/resources/test.yml xvfb-run --server-args="-screen 0 1280x1024x16" --auto-servernum snapred --headcheck
+        env=tests/resources/headcheck.yml xvfb-run --server-args="-screen 0 1280x1024x16" --auto-servernum snapred --headcheck
 
   conda-build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -45,8 +45,9 @@ jobs:
       uses: codecov/codecov-action@v3
     - name: Gui tests
       run: |
+        # copy a set of instrument parameters into the test area
         mkdir -p SNAP/shared/Calibration/
-        touch SNAP/shared/Calibration/SNAPInstPrm.json
+        cp tests/resources/inputs/SNAPInstPrm.json SNAP/shared/Calibration/SNAPInstPrm.json
         python -m pip install -e . # install the application in editable mode
         env=tests/resources/test.yml xvfb-run --server-args="-screen 0 1280x1024x16" --auto-servernum snapred --headcheck
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -46,8 +46,7 @@ jobs:
     - name: Gui tests
       run: |
         python -m pip install -e . # install the application in editable mode
-        xvfb-run --server-args="-screen 0 1280x1024x16" --auto-servernum env=tests/resources/test.yml snapred --headcheck
-
+        env=tests/resources/test.yml xvfb-run --server-args="-screen 0 1280x1024x16" --auto-servernum snapred --headcheck
 
   conda-build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Gui tests
       run: |
         which snapred
-        xvfb-run --server-args="-screen 0 1280x1024x16 --auto-servernum snapred --headcheck
+        xvfb-run --server-args="-screen 0 1280x1024x16" --auto-servernum snapred --headcheck
 
 
   conda-build:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -35,13 +35,18 @@ jobs:
       run: |
         sudo apt update
         sudo apt-get install xvfb
+    - name: Start xvfb daemon
+      run: |
         /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
     - name: Test with pytest
       run: |
-        xvfb-run --server-args="-screen 0 1280x1024x16 --auto-servernum snapred --headcheck
         python -m pytest --cov=src --cov-report=xml --cov-report=term
     - name: Upload coverage reports
       uses: codecov/codecov-action@v3
+    - name: Gui tests
+      run: |
+        which snapred
+        xvfb-run --server-args="-screen 0 1280x1024x16 --auto-servernum snapred --headcheck
 
 
   conda-build:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -31,9 +31,14 @@ jobs:
       if: steps.cache-load.outputs.cache-hit != 'true'
       run: |
         mamba env update --file environment.yml  --prune
+    - name: Apt install deps
+      run: |
+        sudo apt update
+        sudo apt-get install xvfb
+        /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
     - name: Test with pytest
       run: |
-        mamba install pytest
+        xvfb-run --server-args="-screen 0 1280x1024x16 --auto-servernum snapred --headcheck
         python -m pytest --cov=src --cov-report=xml --cov-report=term
     - name: Upload coverage reports
       uses: codecov/codecov-action@v3

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -45,6 +45,8 @@ jobs:
       uses: codecov/codecov-action@v3
     - name: Gui tests
       run: |
+        mkdir -p SNAP/shared/Calibration/
+        touch SNAP/shared/Calibration/SNAPInstPrm.json
         python -m pip install -e . # install the application in editable mode
         env=tests/resources/test.yml xvfb-run --server-args="-screen 0 1280x1024x16" --auto-servernum snapred --headcheck
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Gui tests
       run: |
         python -m pip install -e . # install the application in editable mode
-        xvfb-run --server-args="-screen 0 1280x1024x16" --auto-servernum snapred --headcheck
+        xvfb-run --server-args="-screen 0 1280x1024x16" --auto-servernum env=tests/resources/test.yml snapred --headcheck
 
 
   conda-build:

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -8,3 +8,28 @@ Installation
 
 
 Under Construction!
+
+Application settings
+--------------------
+
+Settings for the application are shipped with the package in the `application.yml <https://github.com/neutrons/SNAPRed/blob/next/src/snapred/resources/application.yml>`_ file.
+There is also a `test application.yml <https://github.com/neutrons/SNAPRed/blob/next/tests/resources/application.yml>`_ file used in tests.
+Most of what is included in the settings is a parameterization of options for the instrument.
+It may be desireable to override some of the settings which can be done via environment injection.
+For example
+
+.. code-block:: yaml
+   :caption: Example environment ``myenv.yml``
+
+   environment: myenv
+
+   instrument:
+     home: ~/snapred-testing/
+
+Can be used to override the ``instrument.home`` directory to ``~/snapred-testing/``.
+At this time, only the ``instrument.home`` and ``samples.home`` directories will expand ``~/`` to a directory.
+This file can be supplied via command line injection
+
+.. code-block:: sh
+
+   env=myenv.yml snapred

--- a/src/snapred/__main__.py
+++ b/src/snapred/__main__.py
@@ -1,12 +1,12 @@
 import sys
 
+from snapred import __version__ as snapred_version
 from snapred.meta.Config import Resource
 
 
-def main(args=None):  # noqa: ARG001
-    # ex.resize(700, 700)
-    asciiPath = "ascii.txt"
-    with Resource.open(asciiPath, "r") as asciiArt:
+def _print_text_splash():
+    TXT_FILENAME = "ascii.txt"
+    with Resource.open(TXT_FILENAME, "r") as asciiArt:
         artString = asciiArt.read().split("\n")
         ornlLogo = artString[:33]
         snapRedText = artString[33:]
@@ -14,6 +14,19 @@ def main(args=None):  # noqa: ARG001
             print("\033[38:2:8:{}:{}:{}m{}\033[00m".format(0, 60 + value * 4, value * 2, line))
         for value, line in enumerate(snapRedText):
             print("\033[38:2:0:136:{}:{}m {}\033[00m".format(value * 4 + 51, value * 4 + 46, line))
+
+
+def main(args=None):
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="snapred", description="Data reduction software for SNAP", epilog="https://snapred.readthedocs.io/"
+    )
+    parser.add_argument("-v", "--version", action="version", version=snapred_version)
+    parser.parse_args(args)
+
+    # show the ascii splash screen
+    _print_text_splash()
 
     # start the gui
     from snapred.ui.main import start

--- a/src/snapred/__main__.py
+++ b/src/snapred/__main__.py
@@ -1,6 +1,7 @@
 import sys
 
 from snapred import __version__ as snapred_version
+from snapred.backend.shims import amend_mantid_config
 from snapred.meta.Config import Resource
 
 
@@ -16,6 +17,16 @@ def _print_text_splash():
             print("\033[38:2:0:136:{}:{}m {}\033[00m".format(value * 4 + 51, value * 4 + 46, line))
 
 
+def _bool_to_mtd_str(arg: bool) -> str:
+    """mantid.kernel.ConfigService does not understand bool, but does understand
+    the strings "0" and "1". This method converts things
+    """
+    if arg:
+        return "1"
+    else:
+        return "0"
+
+
 def main(args=None):
     import argparse
 
@@ -23,15 +34,34 @@ def main(args=None):
         prog="snapred", description="Data reduction software for SNAP", epilog="https://snapred.readthedocs.io/"
     )
     parser.add_argument("-v", "--version", action="version", version=snapred_version)
-    parser.parse_args(args)
+    parser.add_argument("--checkfornewmantid", action="store_true", help="check for new mantid version on startup")
+    parser.add_argument(
+        "--updateinstruments", action="store_true", help="update user's cache of mantid instrument definitions"
+    )
+    parser.add_argument(
+        "--reportusage", action="store_true", help="post telemetry data to mantid usage reporting service"
+    )
+    options = parser.parse_args(args)
+
+    # fix up some of the options for mantid
+    options.checkfornewmantid = _bool_to_mtd_str(options.checkfornewmantid)
+    options.updateinstruments = _bool_to_mtd_str(options.updateinstruments)
+    options.reportusage = _bool_to_mtd_str(options.reportusage)
 
     # show the ascii splash screen
     _print_text_splash()
 
     # start the gui
-    from snapred.ui.main import start
+    with amend_mantid_config(
+        new_config={
+            "CheckMantidVersion.OnStartup": options.checkfornewmantid,
+            "UpdateInstrumentDefinitions.OnStartup": options.updateinstruments,
+            "usagereports.enabled": options.reportusage,
+        }
+    ):
+        from snapred.ui.main import start
 
-    return start()
+        return start(options)
 
 
 if __name__ == "__main__":

--- a/src/snapred/__main__.py
+++ b/src/snapred/__main__.py
@@ -15,9 +15,10 @@ def main(args=None):  # noqa: ARG001
         for value, line in enumerate(snapRedText):
             print("\033[38:2:0:136:{}:{}m {}\033[00m".format(value * 4 + 51, value * 4 + 46, line))
 
+    # start the gui
     from snapred.ui.main import start
 
-    start()
+    return start()
 
 
 if __name__ == "__main__":

--- a/src/snapred/__main__.py
+++ b/src/snapred/__main__.py
@@ -41,6 +41,11 @@ def main(args=None):
     parser.add_argument(
         "--reportusage", action="store_true", help="post telemetry data to mantid usage reporting service"
     )
+    parser.add_argument(
+        "--headcheck",
+        action="store_true",
+        help="start the gui then shut it down after 5 seconds. This is used for testing",
+    )
     options = parser.parse_args(args)
 
     # fix up some of the options for mantid

--- a/src/snapred/__main__.py
+++ b/src/snapred/__main__.py
@@ -21,10 +21,7 @@ def _bool_to_mtd_str(arg: bool) -> str:
     """mantid.kernel.ConfigService does not understand bool, but does understand
     the strings "0" and "1". This method converts things
     """
-    if arg:
-        return "1"
-    else:
-        return "0"
+    return "1" if arg else "0"
 
 
 def main(args=None):

--- a/src/snapred/__main__.py
+++ b/src/snapred/__main__.py
@@ -1,128 +1,23 @@
 import sys
 
-from mantidqt.widgets.algorithmprogress import AlgorithmProgressWidget
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import (
-    QApplication,
-    QHBoxLayout,
-    QMainWindow,
-    QMessageBox,
-    QPushButton,
-    QSplitter,
-    QStatusBar,
-    QVBoxLayout,
-    QWidget,
-)
-from workbench.plugins.workspacewidget import WorkspaceWidget
-
-from snapred.backend.log.logger import snapredLogger
 from snapred.meta.Config import Resource
-from snapred.ui.widget.LogTable import LogTable
-from snapred.ui.widget.TestPanel import TestPanel
-from snapred.ui.widget.ToolBar import ToolBar
-
-logger = snapredLogger.getLogger(__name__)
-
-
-class SNAPRedGUI(QMainWindow):
-    def __init__(self, parent=None):
-        super(SNAPRedGUI, self).__init__(parent)
-        self.setAttribute(Qt.WA_TranslucentBackground, True)
-        self.setAttribute(Qt.WA_DontCreateNativeAncestors, True)
-        logTable = LogTable("load dummy", self)
-        splitter = QSplitter(Qt.Vertical)
-        splitter.addWidget(logTable.widget)
-
-        # add button to open new window
-        button = QPushButton("Open Test Panel")
-        button.clicked.connect(self.openNewWindow)
-        splitter.addWidget(button)
-
-        # myiv = get_instrumentview(ws)
-        # myiv.show_view()
-
-        # import pdb; pdb.set_trace()
-        workspaceWidgetWrapper = QWidget()
-        workspaceWidgetWrapperLayout = QHBoxLayout()
-        workspaceWidget = WorkspaceWidget(self)
-        workspaceWidgetWrapper.setObjectName("workspaceTreeWidget")
-        workspaceWidgetWrapperLayout.addWidget(workspaceWidget, alignment=Qt.AlignCenter)
-        workspaceWidgetWrapper.setLayout(workspaceWidgetWrapperLayout)
-        splitter.addWidget(workspaceWidgetWrapper)
-        splitter.addWidget(AlgorithmProgressWidget())
-
-        centralWidget = QWidget()
-        centralWidget.setObjectName("centralwidget")
-        centralLayout = QVBoxLayout()
-        centralWidget.setLayout(centralLayout)
-
-        self.setCentralWidget(centralWidget)
-        self.setWindowTitle("SNAPRed")
-        self.setWindowFlags(self.windowFlags() | Qt.FramelessWindowHint)
-
-        self.titleBar = ToolBar(centralWidget)
-        centralLayout.addWidget(self.titleBar.widget)
-        centralLayout.addWidget(splitter)
-
-        self.setContentsMargins(0, self.titleBar.widget.height(), 0, 0)
-
-        self.resize(320, self.titleBar.widget.height() + 480)
-        self.setMinimumSize(320, self.titleBar.widget.height() + 480)
-
-        self.statusBar = QStatusBar()
-        self.setStatusBar(self.statusBar)
-
-    def openNewWindow(self):
-        self.newWindow = TestPanel(self)
-        self.newWindow.widget.setWindowTitle("Test Panel")
-        self.newWindow.widget.show()
-
-    def closeEvent(self, event):
-        event.accept()
-
-    def changeEvent(self, event):
-        if event.type() == event.WindowStateChange:
-            self.titleBar.presenter.windowStateChanged(self.windowState())
-
-    def resizeEvent(self, event):
-        self.titleBar.presenter.resizeEvent(event)
-
-
-def qapp():
-    if QApplication.instance():
-        _app = QApplication.instance()
-    else:
-        _app = QApplication(sys.argv)
-    return _app
 
 
 def main(args=None):  # noqa: ARG001
-    app = qapp()
-    with Resource.open("style.qss", "r") as styleSheet:
-        app.setStyleSheet(styleSheet.read())
-    try:
-        ex = SNAPRedGUI()
+    # ex.resize(700, 700)
+    asciiPath = "ascii.txt"
+    with Resource.open(asciiPath, "r") as asciiArt:
+        artString = asciiArt.read().split("\n")
+        ornlLogo = artString[:33]
+        snapRedText = artString[33:]
+        for value, line in enumerate(ornlLogo):
+            print("\033[38:2:8:{}:{}:{}m{}\033[00m".format(0, 60 + value * 4, value * 2, line))
+        for value, line in enumerate(snapRedText):
+            print("\033[38:2:0:136:{}:{}m {}\033[00m".format(value * 4 + 51, value * 4 + 46, line))
 
-        # ex.resize(700, 700)
-        asciiPath = "ascii.txt"
-        with Resource.open(asciiPath, "r") as asciiArt:
-            artString = asciiArt.read().split("\n")
-            ornlLogo = artString[:33]
-            snapRedText = artString[33:]
-            for value, line in enumerate(ornlLogo):
-                print("\033[38:2:8:{}:{}:{}m{}\033[00m".format(0, 60 + value * 4, value * 2, line))
-            for value, line in enumerate(snapRedText):
-                print("\033[38:2:0:136:{}:{}m {}\033[00m".format(value * 4 + 51, value * 4 + 46, line))
+    from snapred.ui.main import start
 
-        logger.info("Welcome User! Happy Reducing!")
-        ex.show()
-        ret = app.exec_()
-        return sys.exit(ret)
-
-    except Exception as uncaughtError:  # noqa: BLE001
-        ex = QWidget()
-        logger.exception("Uncaught Error bubbled up to main!")
-        QMessageBox.critical(ex, "Uncaught Error!", str(uncaughtError))
+    start()
 
 
 if __name__ == "__main__":

--- a/src/snapred/backend/shims.py
+++ b/src/snapred/backend/shims.py
@@ -1,0 +1,53 @@
+from contextlib import contextmanager
+from copy import deepcopy
+
+from mantid.kernel import ConfigService
+
+
+@contextmanager
+def amend_mantid_config(new_config=None, data_dir=None):
+    r"""
+    Context manager to safely modify Mantid Configuration Service while
+    the function is executed.
+
+    This is taken from drtsans
+
+    Parameters
+    ----------
+    new_config: dict
+        (key, value) pairs to substitute in the configuration service
+    data_dir: str, list
+        Append one (when passing a string) or more (when passing a list)
+        directories to the list of data search directories.
+    """
+    modified_keys = list()
+    backup = dict()
+    config = ConfigService.Instance()
+    if new_config is not None:
+        SEARCH_ARCHIVE = "datasearch.searcharchive"
+        if SEARCH_ARCHIVE not in new_config:
+            new_config[SEARCH_ARCHIVE] = "hfir, sns"
+        DEFAULT_FACILITY = "default.facility"
+        if DEFAULT_FACILITY not in new_config:
+            new_config[DEFAULT_FACILITY] = "SNS"
+        for key, val in new_config.items():
+            backup[key] = config[key]
+            config[key] = val  # config does not have an 'update' method
+            modified_keys.append(key)
+    if data_dir is not None:
+        data_dirs = (
+            [
+                data_dir,
+            ]
+            if isinstance(data_dir, str)
+            else data_dir
+        )
+        key = "datasearch.directories"
+        backup[key] = deepcopy(config[key])
+        # prepend our custom data directories to the list of data search directories
+        config.setDataSearchDirs(data_dirs + list(config.getDataSearchDirs()))
+    try:
+        yield
+    finally:
+        for key in modified_keys:
+            config[key] = backup[key]

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -6,7 +6,6 @@ from PyQt5.QtWidgets import (
     QApplication,
     QHBoxLayout,
     QMainWindow,
-    QMessageBox,
     QPushButton,
     QSplitter,
     QStatusBar,
@@ -20,8 +19,6 @@ from snapred.meta.Config import Resource
 from snapred.ui.widget.LogTable import LogTable
 from snapred.ui.widget.TestPanel import TestPanel
 from snapred.ui.widget.ToolBar import ToolBar
-
-logger = snapredLogger.getLogger(__name__)
 
 
 class SNAPRedGUI(QMainWindow):
@@ -97,18 +94,19 @@ def qapp():
 
 
 def start(option=None):  # noqa: ARG001
+    logger = snapredLogger.getLogger(__name__)
+
     app = qapp()
     with Resource.open("style.qss", "r") as styleSheet:
         app.setStyleSheet(styleSheet.read())
+
+    logger.info("Welcome User! Happy Reducing!")
     try:
         ex = SNAPRedGUI()
-
-        logger.info("Welcome User! Happy Reducing!")
         ex.show()
-        ret = app.exec_()
-        return sys.exit(ret)
 
-    except Exception as uncaughtError:  # noqa: BLE001
-        ex = QWidget()
+        return app.exec_()
+
+    except Exception:
         logger.exception("Uncaught Error bubbled up to main!")
-        QMessageBox.critical(ex, "Uncaught Error!", str(uncaughtError))
+        return -1

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -1,7 +1,7 @@
 import sys
 
 from mantidqt.widgets.algorithmprogress import AlgorithmProgressWidget
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QTimer
 from PyQt5.QtWidgets import (
     QApplication,
     QHBoxLayout,
@@ -93,7 +93,7 @@ def qapp():
     return _app
 
 
-def start(option=None):  # noqa: ARG001
+def start(options=None):
     logger = snapredLogger.getLogger(__name__)
 
     app = qapp()
@@ -105,7 +105,11 @@ def start(option=None):  # noqa: ARG001
         ex = SNAPRedGUI()
         ex.show()
 
-        return app.exec_()
+        if options.headcheck:
+            SECONDS = 3  # arbitrarily chosen
+            logger.warn(f"Closing in {SECONDS} seconds")
+            QTimer.singleShot(SECONDS * 1000, lambda: app.exit(0))
+        return app.exec()
 
     except Exception:
         logger.exception("Uncaught Error bubbled up to main!")

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -1,0 +1,114 @@
+import sys
+
+from mantidqt.widgets.algorithmprogress import AlgorithmProgressWidget
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QApplication,
+    QHBoxLayout,
+    QMainWindow,
+    QMessageBox,
+    QPushButton,
+    QSplitter,
+    QStatusBar,
+    QVBoxLayout,
+    QWidget,
+)
+from workbench.plugins.workspacewidget import WorkspaceWidget
+
+from snapred.backend.log.logger import snapredLogger
+from snapred.meta.Config import Resource
+from snapred.ui.widget.LogTable import LogTable
+from snapred.ui.widget.TestPanel import TestPanel
+from snapred.ui.widget.ToolBar import ToolBar
+
+logger = snapredLogger.getLogger(__name__)
+
+
+class SNAPRedGUI(QMainWindow):
+    def __init__(self, parent=None):
+        super(SNAPRedGUI, self).__init__(parent)
+        self.setAttribute(Qt.WA_TranslucentBackground, True)
+        self.setAttribute(Qt.WA_DontCreateNativeAncestors, True)
+        logTable = LogTable("load dummy", self)
+        splitter = QSplitter(Qt.Vertical)
+        splitter.addWidget(logTable.widget)
+
+        # add button to open new window
+        button = QPushButton("Open Test Panel")
+        button.clicked.connect(self.openNewWindow)
+        splitter.addWidget(button)
+
+        # myiv = get_instrumentview(ws)
+        # myiv.show_view()
+
+        # import pdb; pdb.set_trace()
+        workspaceWidgetWrapper = QWidget()
+        workspaceWidgetWrapperLayout = QHBoxLayout()
+        workspaceWidget = WorkspaceWidget(self)
+        workspaceWidgetWrapper.setObjectName("workspaceTreeWidget")
+        workspaceWidgetWrapperLayout.addWidget(workspaceWidget, alignment=Qt.AlignCenter)
+        workspaceWidgetWrapper.setLayout(workspaceWidgetWrapperLayout)
+        splitter.addWidget(workspaceWidgetWrapper)
+        splitter.addWidget(AlgorithmProgressWidget())
+
+        centralWidget = QWidget()
+        centralWidget.setObjectName("centralwidget")
+        centralLayout = QVBoxLayout()
+        centralWidget.setLayout(centralLayout)
+
+        self.setCentralWidget(centralWidget)
+        self.setWindowTitle("SNAPRed")
+        self.setWindowFlags(self.windowFlags() | Qt.FramelessWindowHint)
+
+        self.titleBar = ToolBar(centralWidget)
+        centralLayout.addWidget(self.titleBar.widget)
+        centralLayout.addWidget(splitter)
+
+        self.setContentsMargins(0, self.titleBar.widget.height(), 0, 0)
+
+        self.resize(320, self.titleBar.widget.height() + 480)
+        self.setMinimumSize(320, self.titleBar.widget.height() + 480)
+
+        self.statusBar = QStatusBar()
+        self.setStatusBar(self.statusBar)
+
+    def openNewWindow(self):
+        self.newWindow = TestPanel(self)
+        self.newWindow.widget.setWindowTitle("Test Panel")
+        self.newWindow.widget.show()
+
+    def closeEvent(self, event):
+        event.accept()
+
+    def changeEvent(self, event):
+        if event.type() == event.WindowStateChange:
+            self.titleBar.presenter.windowStateChanged(self.windowState())
+
+    def resizeEvent(self, event):
+        self.titleBar.presenter.resizeEvent(event)
+
+
+def qapp():
+    if QApplication.instance():
+        _app = QApplication.instance()
+    else:
+        _app = QApplication(sys.argv)
+    return _app
+
+
+def start(option=None):  # noqa: ARG001
+    app = qapp()
+    with Resource.open("style.qss", "r") as styleSheet:
+        app.setStyleSheet(styleSheet.read())
+    try:
+        ex = SNAPRedGUI()
+
+        logger.info("Welcome User! Happy Reducing!")
+        ex.show()
+        ret = app.exec_()
+        return sys.exit(ret)
+
+    except Exception as uncaughtError:  # noqa: BLE001
+        ex = QWidget()
+        logger.exception("Uncaught Error bubbled up to main!")
+        QMessageBox.critical(ex, "Uncaught Error!", str(uncaughtError))

--- a/tests/resources/headcheck.yml
+++ b/tests/resources/headcheck.yml
@@ -1,0 +1,7 @@
+instrument:
+  home: ""
+  config: tests/resources/inputs/SNAPInstPrm.json
+
+localdataservice:
+  config:
+    verifypaths: false

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -34,15 +34,15 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         return reductionParameters
 
     def test_readInstrumentConfig():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readInstrumentParameters = _readInstrumentParameters
-        actual = localDataService.readInstrumentConfig()
+        actual = localDataService.readInstrumentConfig(False)
         assert actual is not None
         assert actual.version == "1.4"
         assert actual.name == "SNAP"
 
     def test_readInstrumentParameters():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService.instrumentConfigPath = Resource.getPath("inputs/SNAPInstPrm.json")
         actual = localDataService._readInstrumentParameters()
         assert actual is not None
@@ -58,7 +58,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         return instrumentConfig
 
     def test_readStateConfig():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readReductionParameters = _readReductionParameters
         localDataService._readDiffractionCalibrant = mock.Mock()
         localDataService._readDiffractionCalibrant.return_value = (
@@ -77,7 +77,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.stateId == "123"
 
     def test_readDiffractionCalibrant():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readReductionParameters = _readReductionParameters
         reductionParameters = _readReductionParameters("test")
         localDataService.instrumentConfig = getMockInstrumentConfig()
@@ -86,7 +86,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.filename == reductionParameters["calFileName"]
 
     def test_readNormalizationCalibrant():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readReductionParameters = _readReductionParameters
         reductionParameters = _readReductionParameters("test")
         localDataService.instrumentConfig = getMockInstrumentConfig()
@@ -95,7 +95,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.mask == reductionParameters["VMsk"]
 
     def test_readFocusGroups():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readReductionParameters = _readReductionParameters
         _readReductionParameters("test")
         localDataService.instrumentConfig = getMockInstrumentConfig()
@@ -104,7 +104,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert len(actual) == 3
 
     def test_readRunConfig():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readRunConfig = mock.Mock()
         localDataService._readRunConfig.return_value = reductionIngredients.runConfig
         actual = localDataService.readRunConfig(mock.Mock())
@@ -112,7 +112,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.runNumber == "57514"
 
     def test__readRunConfig():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._findIPTS = mock.Mock()
         localDataService._findIPTS.return_value = "IPTS-123"
         localDataService._readReductionParameters = _readReductionParameters
@@ -122,12 +122,12 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.runNumber == "57514"
 
     def test__findIPTS():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService.instrumentConfig = getMockInstrumentConfig()
         assert localDataService._findIPTS("57514") is not None
 
     def test_readPVFile():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readReductionParameters = _readReductionParameters
         localDataService.instrumentConfig = getMockInstrumentConfig()
         localDataService._constructPVFilePath = mock.Mock()
@@ -136,7 +136,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual is not None
 
     def test__generateStateId():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readReductionParameters = _readReductionParameters
         localDataService._readPVFile = mock.Mock()
         fileMock = mock.Mock()
@@ -146,7 +146,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual == "9618b936a4419a6e"
 
     def test__findMatchingFileList():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readReductionParameters = _readReductionParameters
         localDataService.instrumentConfig = getMockInstrumentConfig()
         actual = localDataService._findMatchingFileList(Resource.getPath("inputs/SNAPInstPrm.json"), False)
@@ -154,7 +154,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert len(actual) == 1
 
     def test_readCalibrationIndexMissing():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -164,7 +164,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert len(localDataService.readCalibrationIndex("123")) == 0
 
     def test_writeCalibrationIndexEntry():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -188,7 +188,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualEntries[0].runNumber == "57514"
 
     def test_readCalibrationIndexExisting():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -210,7 +210,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
             return ReductionIngredients.parse_raw(f.read())
 
     def test_readWriteCalibrationRecord():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -225,7 +225,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualRecord.parameters.runConfig.runNumber == "57514"
 
     def test_readWriteCalibrationRecordV2():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -240,7 +240,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualRecord.parameters.runConfig.runNumber == "57514"
 
     def test_getCalibrationRecordPath():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
         localDataService._constructCalibrationPath = mock.Mock()
@@ -249,12 +249,12 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualPath == Resource.getPath("outputs/57514") + "/v_1/CalibrationRecord.json"
 
     def test_extractFileVersion():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         actualVersion = localDataService._extractFileVersion("Powder/1234/v_4/CalibrationRecord.json")
         assert actualVersion == 4
 
     def test__getFileOfVersion():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._findMatchingFileList = mock.Mock()
         localDataService._findMatchingFileList.return_value = [
             "/v_1/CalibrationRecord.json",
@@ -264,7 +264,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualFile == "/v_3/CalibrationRecord.json"
 
     def test__getLatestFile():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._findMatchingFileList = mock.Mock()
         localDataService._findMatchingFileList.return_value = [
             "Powder/1234/v_1/CalibrationRecord.json",
@@ -282,7 +282,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         with mock.patch.dict("sys.modules", {"mantid.api": mantid.api}):
             from snapred.backend.data.LocalDataService import LocalDataService as LocalDataService2
 
-            localDataService = LocalDataService2()
+            localDataService = LocalDataService2(False)
             localDataService._generateStateId = mock.Mock()
             localDataService._generateStateId.return_value = ("123", "456")
             localDataService._constructCalibrationPath = mock.Mock()
@@ -293,25 +293,25 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
             assert mantid.api.AlgorithmManager.create.called
 
     def test__isApplicableEntry_equals():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         entry = mock.Mock()
         entry.appliesTo = "123"
         assert localDataService._isApplicableEntry(entry, "123")
 
     def test__isApplicableEntry_greaterThan():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         entry = mock.Mock()
         entry.appliesTo = ">123"
         assert localDataService._isApplicableEntry(entry, "456")
 
     def test__isApplicableEntry_lessThan():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         entry = mock.Mock()
         entry.appliesTo = "<123"
         assert localDataService._isApplicableEntry(entry, "99")
 
     def test__getVersionFromCalibrationIndex():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService.readCalibrationIndex = mock.Mock()
         localDataService.readCalibrationIndex.return_value = [mock.Mock()]
         localDataService.readCalibrationIndex.return_value[0] = CalibrationIndexEntry(
@@ -321,7 +321,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualVersion == "1"
 
     def test__getCurrentCalibrationRecord():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._getVersionFromCalibrationIndex = mock.Mock()
         localDataService._getVersionFromCalibrationIndex.return_value = "1"
         localDataService.readCalibrationRecord = mock.Mock()
@@ -331,7 +331,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualRecord == mockRecord
 
     def test_getCalibrationStatePath():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
         localDataService._constructCalibrationPath = mock.Mock()
@@ -340,7 +340,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualPath == Resource.getPath("outputs/57514") + "/v_1/CalibrationParameters.json"
 
     def test_readCalibrationState():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
         localDataService.getCalibrationStatePath = mock.Mock()
@@ -355,7 +355,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualState == Calibration.parse_file(Resource.getPath("inputs/calibration/CalibrationParameters.json"))
 
     def test_writeCalibrationState():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
         localDataService._constructCalibrationPath = mock.Mock()
@@ -369,7 +369,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         shutil.rmtree(Resource.getPath("outputs/123"))
 
     def test_initializeState():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readPVFile = mock.Mock()
         pvFileMock = mock.Mock()
         pvFileMock.get.side_effect = [[1], [2], [1.1], [1.2], [1], [1], [2]]

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -4,6 +4,7 @@ import shutil
 import unittest.mock as mock
 from typing import List
 
+import pytest
 from pydantic import parse_raw_as
 from snapred.meta.Config import Resource
 
@@ -381,3 +382,8 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         actual = localDataService.initializeState("123", "test")
         actual.creationDate = testCalibrationData.creationDate
         assert actual == testCalibrationData
+
+    def test_badPaths():
+        """This verifies that a broken configuration (from production) can't find all of the files"""
+        with pytest.raises(FileNotFoundError):
+            LocalDataService()

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -385,5 +385,10 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
 
     def test_badPaths():
         """This verifies that a broken configuration (from production) can't find all of the files"""
+        # get a handle on the service
+        service = LocalDataService()
+        service.verifyPaths = True  # override test setting
         with pytest.raises(FileNotFoundError):
-            LocalDataService()
+            service.readInstrumentConfig()
+
+        service.verifyPaths = False  # put the setting back

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -34,15 +34,15 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         return reductionParameters
 
     def test_readInstrumentConfig():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readInstrumentParameters = _readInstrumentParameters
-        actual = localDataService.readInstrumentConfig(False)
+        actual = localDataService.readInstrumentConfig()
         assert actual is not None
         assert actual.version == "1.4"
         assert actual.name == "SNAP"
 
     def test_readInstrumentParameters():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService.instrumentConfigPath = Resource.getPath("inputs/SNAPInstPrm.json")
         actual = localDataService._readInstrumentParameters()
         assert actual is not None
@@ -58,7 +58,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         return instrumentConfig
 
     def test_readStateConfig():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
         localDataService._readDiffractionCalibrant = mock.Mock()
         localDataService._readDiffractionCalibrant.return_value = (
@@ -77,7 +77,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.stateId == "123"
 
     def test_readDiffractionCalibrant():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
         reductionParameters = _readReductionParameters("test")
         localDataService.instrumentConfig = getMockInstrumentConfig()
@@ -86,7 +86,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.filename == reductionParameters["calFileName"]
 
     def test_readNormalizationCalibrant():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
         reductionParameters = _readReductionParameters("test")
         localDataService.instrumentConfig = getMockInstrumentConfig()
@@ -95,7 +95,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.mask == reductionParameters["VMsk"]
 
     def test_readFocusGroups():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
         _readReductionParameters("test")
         localDataService.instrumentConfig = getMockInstrumentConfig()
@@ -104,7 +104,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert len(actual) == 3
 
     def test_readRunConfig():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readRunConfig = mock.Mock()
         localDataService._readRunConfig.return_value = reductionIngredients.runConfig
         actual = localDataService.readRunConfig(mock.Mock())
@@ -112,7 +112,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.runNumber == "57514"
 
     def test__readRunConfig():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._findIPTS = mock.Mock()
         localDataService._findIPTS.return_value = "IPTS-123"
         localDataService._readReductionParameters = _readReductionParameters
@@ -122,12 +122,12 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.runNumber == "57514"
 
     def test__findIPTS():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService.instrumentConfig = getMockInstrumentConfig()
         assert localDataService._findIPTS("57514") is not None
 
     def test_readPVFile():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
         localDataService.instrumentConfig = getMockInstrumentConfig()
         localDataService._constructPVFilePath = mock.Mock()
@@ -136,7 +136,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual is not None
 
     def test__generateStateId():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
         localDataService._readPVFile = mock.Mock()
         fileMock = mock.Mock()
@@ -146,7 +146,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual == "9618b936a4419a6e"
 
     def test__findMatchingFileList():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
         localDataService.instrumentConfig = getMockInstrumentConfig()
         actual = localDataService._findMatchingFileList(Resource.getPath("inputs/SNAPInstPrm.json"), False)
@@ -154,7 +154,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert len(actual) == 1
 
     def test_readCalibrationIndexMissing():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -164,7 +164,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert len(localDataService.readCalibrationIndex("123")) == 0
 
     def test_writeCalibrationIndexEntry():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -188,7 +188,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualEntries[0].runNumber == "57514"
 
     def test_readCalibrationIndexExisting():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -210,7 +210,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
             return ReductionIngredients.parse_raw(f.read())
 
     def test_readWriteCalibrationRecord():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -225,7 +225,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualRecord.parameters.runConfig.runNumber == "57514"
 
     def test_readWriteCalibrationRecordV2():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -240,7 +240,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualRecord.parameters.runConfig.runNumber == "57514"
 
     def test_getCalibrationRecordPath():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
         localDataService._constructCalibrationPath = mock.Mock()
@@ -249,12 +249,12 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualPath == Resource.getPath("outputs/57514") + "/v_1/CalibrationRecord.json"
 
     def test_extractFileVersion():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         actualVersion = localDataService._extractFileVersion("Powder/1234/v_4/CalibrationRecord.json")
         assert actualVersion == 4
 
     def test__getFileOfVersion():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._findMatchingFileList = mock.Mock()
         localDataService._findMatchingFileList.return_value = [
             "/v_1/CalibrationRecord.json",
@@ -264,7 +264,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualFile == "/v_3/CalibrationRecord.json"
 
     def test__getLatestFile():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._findMatchingFileList = mock.Mock()
         localDataService._findMatchingFileList.return_value = [
             "Powder/1234/v_1/CalibrationRecord.json",
@@ -282,7 +282,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         with mock.patch.dict("sys.modules", {"mantid.api": mantid.api}):
             from snapred.backend.data.LocalDataService import LocalDataService as LocalDataService2
 
-            localDataService = LocalDataService2(False)
+            localDataService = LocalDataService2()
             localDataService._generateStateId = mock.Mock()
             localDataService._generateStateId.return_value = ("123", "456")
             localDataService._constructCalibrationPath = mock.Mock()
@@ -293,25 +293,25 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
             assert mantid.api.AlgorithmManager.create.called
 
     def test__isApplicableEntry_equals():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         entry = mock.Mock()
         entry.appliesTo = "123"
         assert localDataService._isApplicableEntry(entry, "123")
 
     def test__isApplicableEntry_greaterThan():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         entry = mock.Mock()
         entry.appliesTo = ">123"
         assert localDataService._isApplicableEntry(entry, "456")
 
     def test__isApplicableEntry_lessThan():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         entry = mock.Mock()
         entry.appliesTo = "<123"
         assert localDataService._isApplicableEntry(entry, "99")
 
     def test__getVersionFromCalibrationIndex():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService.readCalibrationIndex = mock.Mock()
         localDataService.readCalibrationIndex.return_value = [mock.Mock()]
         localDataService.readCalibrationIndex.return_value[0] = CalibrationIndexEntry(
@@ -321,7 +321,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualVersion == "1"
 
     def test__getCurrentCalibrationRecord():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._getVersionFromCalibrationIndex = mock.Mock()
         localDataService._getVersionFromCalibrationIndex.return_value = "1"
         localDataService.readCalibrationRecord = mock.Mock()
@@ -331,7 +331,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualRecord == mockRecord
 
     def test_getCalibrationStatePath():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
         localDataService._constructCalibrationPath = mock.Mock()
@@ -340,7 +340,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualPath == Resource.getPath("outputs/57514") + "/v_1/CalibrationParameters.json"
 
     def test_readCalibrationState():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
         localDataService.getCalibrationStatePath = mock.Mock()
@@ -355,7 +355,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualState == Calibration.parse_file(Resource.getPath("inputs/calibration/CalibrationParameters.json"))
 
     def test_writeCalibrationState():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
         localDataService._constructCalibrationPath = mock.Mock()
@@ -369,7 +369,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         shutil.rmtree(Resource.getPath("outputs/123"))
 
     def test_initializeState():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readPVFile = mock.Mock()
         pvFileMock = mock.Mock()
         pvFileMock.get.side_effect = [[1], [2], [1.1], [1.2], [1], [1], [2]]

--- a/tests/unit/backend/test_main.py
+++ b/tests/unit/backend/test_main.py
@@ -1,0 +1,8 @@
+import pytest
+from snapred.__main__ import main
+
+
+@pytest.mark.parametrize("option", ["-h", "--help", "-v", "--version"])
+def test_simple(option):
+    with pytest.raises(SystemExit):
+        main([option])

--- a/tests/unit/backend/test_shim.py
+++ b/tests/unit/backend/test_shim.py
@@ -1,0 +1,10 @@
+from mantid.kernel import ConfigService
+from snapred.backend.shims import amend_mantid_config
+
+
+def test_amend_config():
+    config = ConfigService.Instance()
+    old_instrument = config["instrumentName"]
+    with amend_mantid_config({"instrumentName": "42"}):
+        assert config["instrumentName"] == "42"
+    assert config["instrumentName"] == old_instrument


### PR DESCRIPTION
A couple of very big items
* Add `argparse` with various options including `--headcheck` which is intended for use in CI
* Default disable mantid's network capabilities (can be turned on with command line options)
* Clarify error messages associated with misconfigured system settings and missing files
* Remove the registration of `ExtractionService` so the GUI can be started

~~Do not merge before #64~~