### PR TITLE
Modify values in test.yml to reduce mock object use

### DIFF
--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -3,6 +3,8 @@ import glob
 import hashlib
 import json
 import os
+from errno import ENOENT as NOT_FOUND
+from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 import h5py
@@ -35,35 +37,58 @@ from snapred.meta.decorators.Singleton import Singleton
 """
 
 
+def _createFileNotFoundError(msg, filename):
+    return FileNotFoundError(NOT_FOUND, os.strerror(NOT_FOUND) + " " + msg, filename)
+
+
 @Singleton
 class LocalDataService:
     reductionParameterCache: Dict[str, Any] = {}
     iptsCache: Dict[str, Any] = {}
     stateIdCache: Dict[str, str] = {}
-    dataPath = Config["instrument.home"]
-    instrumentConfigPath: str = dataPath + Config["instrument.config"]
     instrumentConfig: InstrumentConfig  # Optional[InstrumentConfig]
 
-    def __init__(self) -> None:
-        self.instrumentConfig = self.readInstrumentConfig()
+    def __init__(self, verifyPaths: bool = True) -> None:
+        self.instrumentConfig = self.readInstrumentConfig(verifyPaths)
 
-    def readInstrumentConfig(self) -> InstrumentConfig:
+    def _determineInstrConfigPaths(self, verifyPaths) -> None:
+        """This method locates the instrument configuration path and
+        sets the instance variable ``instrumentConfigPath``."""
+        # verify parent directory exists
+        self.dataPath = Path(Config["instrument.home"])
+        if verifyPaths and not self.dataPath.exists():
+            raise _createFileNotFoundError("Config['instrument.home']", self.dataPath)
+
+        # look for the config file and verify it exists
+        self.instrumentConfigPath = self.dataPath / Config["instrument.config"]
+
+    def readInstrumentConfig(self, verifyPaths: bool = True) -> InstrumentConfig:
+        self._determineInstrConfigPaths(verifyPaths)
+
         instrumentParameterMap = self._readInstrumentParameters()
-        instrumentParameterMap["bandwidth"] = instrumentParameterMap.pop("neutronBandwidth")
-        instrumentParameterMap["maxBandwidth"] = instrumentParameterMap.pop("extendedNeutronBandwidth")
-        instrumentParameterMap["delTOverT"] = instrumentParameterMap.pop("delToT")
-        instrumentParameterMap["delLOverL"] = instrumentParameterMap.pop("delLoL")
-        instrumentConfig = InstrumentConfig(**instrumentParameterMap)
+        try:
+            instrumentParameterMap["bandwidth"] = instrumentParameterMap.pop("neutronBandwidth")
+            instrumentParameterMap["maxBandwidth"] = instrumentParameterMap.pop("extendedNeutronBandwidth")
+            instrumentParameterMap["delTOverT"] = instrumentParameterMap.pop("delToT")
+            instrumentParameterMap["delLOverL"] = instrumentParameterMap.pop("delLoL")
+            instrumentConfig = InstrumentConfig(**instrumentParameterMap)
+        except KeyError as e:
+            raise KeyError(f"{e}: while reading instrument configuration '{self.instrumentConfigPath}'") from e
         if self.dataPath:
-            instrumentConfig.calibrationDirectory = self.dataPath + "shared/Calibration/"
+            instrumentConfig.calibrationDirectory = self.dataPath / "shared/Calibration/"
+            if verifyPaths and not instrumentConfig.calibrationDirectory.exists():
+                raise _createFileNotFoundError("[calibration directory]", instrumentConfig.calibrationDirectory)
 
         return instrumentConfig
 
     def _readInstrumentParameters(self) -> Dict[str, Any]:
         instrumentParameterMap: Dict[str, Any] = {}
-        with open(self.instrumentConfigPath, "r") as json_file:
-            instrumentParameterMap = json.load(json_file)
-        return instrumentParameterMap
+        try:
+            with open(self.instrumentConfigPath, "r") as json_file:
+                instrumentParameterMap = json.load(json_file)
+            return instrumentParameterMap
+        except FileNotFoundError as e:
+            raise _createFileNotFoundError("Instrument configuration file", self.instrumentConfigPath) from e
 
     def readStateConfig(self, runId: str) -> StateConfig:
         reductionParameters = self._readReductionParameters(runId)

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -47,23 +47,25 @@ class LocalDataService:
     iptsCache: Dict[str, Any] = {}
     stateIdCache: Dict[str, str] = {}
     instrumentConfig: InstrumentConfig  # Optional[InstrumentConfig]
+    verifyPaths: bool = True
 
-    def __init__(self, verifyPaths: bool = True) -> None:
-        self.instrumentConfig = self.readInstrumentConfig(verifyPaths)
+    def __init__(self) -> None:
+        self.verifyPaths = Config["localdataservice.config.verifypaths"]
+        self.instrumentConfig = self.readInstrumentConfig()
 
-    def _determineInstrConfigPaths(self, verifyPaths) -> None:
+    def _determineInstrConfigPaths(self) -> None:
         """This method locates the instrument configuration path and
         sets the instance variable ``instrumentConfigPath``."""
         # verify parent directory exists
         self.dataPath = Path(Config["instrument.home"])
-        if verifyPaths and not self.dataPath.exists():
+        if self.verifyPaths and not self.dataPath.exists():
             raise _createFileNotFoundError("Config['instrument.home']", self.dataPath)
 
         # look for the config file and verify it exists
         self.instrumentConfigPath = self.dataPath / Config["instrument.config"]
 
-    def readInstrumentConfig(self, verifyPaths: bool = True) -> InstrumentConfig:
-        self._determineInstrConfigPaths(verifyPaths)
+    def readInstrumentConfig(self) -> InstrumentConfig:
+        self._determineInstrConfigPaths()
 
         instrumentParameterMap = self._readInstrumentParameters()
         try:
@@ -76,7 +78,7 @@ class LocalDataService:
             raise KeyError(f"{e}: while reading instrument configuration '{self.instrumentConfigPath}'") from e
         if self.dataPath:
             instrumentConfig.calibrationDirectory = self.dataPath / "shared/Calibration/"
-            if verifyPaths and not instrumentConfig.calibrationDirectory.exists():
+            if self.verifyPaths and not instrumentConfig.calibrationDirectory.exists():
                 raise _createFileNotFoundError("[calibration directory]", instrumentConfig.calibrationDirectory)
 
         return instrumentConfig

--- a/src/snapred/backend/service/ServiceFactory.py
+++ b/src/snapred/backend/service/ServiceFactory.py
@@ -9,7 +9,6 @@ from snapred.backend.service.CalibrationService import CalibrationService
 # here in order to autoregister them
 from snapred.backend.service.ConfigLookupService import ConfigLookupService
 from snapred.backend.service.CrystallographicInfoService import CrystallographicInfoService
-from snapred.backend.service.ExtractionService import ExtractionService
 from snapred.backend.service.FitMultiplePeakService import FitMultiplePeaksService
 from snapred.backend.service.ReductionService import ReductionService
 from snapred.backend.service.ServiceDirectory import ServiceDirectory
@@ -29,7 +28,6 @@ class ServiceFactory:
         self.serviceDirectory.registerService(ConfigLookupService())
         self.serviceDirectory.registerService(ReductionService())
         self.serviceDirectory.registerService(StateIdLookupService())
-        self.serviceDirectory.registerService(ExtractionService())
         self.serviceDirectory.registerService(CalibrationService())
         self.serviceDirectory.registerService(CrystallographicInfoService())
         self.serviceDirectory.registerService(CalibrantSampleService())

--- a/src/snapred/meta/Config.py
+++ b/src/snapred/meta/Config.py
@@ -12,10 +12,10 @@ from snapred.meta.decorators.Singleton import Singleton
 
 def _find_root_dir():
     ROOT_MODULE = None
-    if os.environ.get("env") != "test":
-        ROOT_MODULE = sys.modules["__main__"].__file__
-    else:
+    if os.environ.get("env") == "test":
         ROOT_MODULE = sys.modules["conftest"].__file__
+    else:
+        ROOT_MODULE = sys.modules["snapred"].__file__
 
     if ROOT_MODULE is None:
         raise Exception("Unable to determine root directory")

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -32,6 +32,10 @@ calibration:
         - 0.02
         - 0.05
 
+localdataservice:
+  config:
+    verifypaths: true
+
 logging:
   level: 10
   SNAP:

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -36,6 +36,10 @@ calibration:
         - 2
       peakTailCoefficient: 2.0
 
+localdataservice:
+  config:
+    verifypaths: true
+
 logging:
   level: 10
   SNAP:

--- a/tests/resources/test.yml
+++ b/tests/resources/test.yml
@@ -2,6 +2,10 @@ instrument:
   home: ""
   config: inputs/SNAPInstPrm.json
 
+localdataservice:
+  config:
+    verifypaths: false
+
 test:
   outputs:
     calibration:

--- a/tests/resources/test.yml
+++ b/tests/resources/test.yml
@@ -1,5 +1,6 @@
 instrument:
-  home: SNAP/
+  home: ""
+  config: inputs/SNAPInstPrm.json
 
 test:
   outputs:

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -32,7 +32,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         reductionParameters["stateId"] = "123"
         return reductionParameters
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_readInstrumentConfig():
         localDataService = LocalDataService()
         localDataService._readInstrumentParameters = _readInstrumentParameters
@@ -41,7 +40,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.version == "1.4"
         assert actual.name == "SNAP"
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_readInstrumentParameters():
         localDataService = LocalDataService()
         localDataService.instrumentConfigPath = Resource.getPath("inputs/SNAPInstPrm.json")
@@ -58,7 +56,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         instrumentConfig.pixelGroupingDirectory = "test"
         return instrumentConfig
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_readStateConfig():
         localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
@@ -78,7 +75,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual is not None
         assert actual.stateId == "123"
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_readDiffractionCalibrant():
         localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
@@ -88,7 +84,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual is not None
         assert actual.filename == reductionParameters["calFileName"]
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_readNormalizationCalibrant():
         localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
@@ -98,7 +93,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual is not None
         assert actual.mask == reductionParameters["VMsk"]
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_readFocusGroups():
         localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
@@ -108,7 +102,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual is not None
         assert len(actual) == 3
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_readRunConfig():
         localDataService = LocalDataService()
         localDataService._readRunConfig = mock.Mock()
@@ -117,7 +110,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual is not None
         assert actual.runNumber == "57514"
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test__readRunConfig():
         localDataService = LocalDataService()
         localDataService._findIPTS = mock.Mock()
@@ -128,13 +120,11 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual is not None
         assert actual.runNumber == "57514"
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test__findIPTS():
         localDataService = LocalDataService()
         localDataService.instrumentConfig = getMockInstrumentConfig()
         assert localDataService._findIPTS("57514") is not None
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_readPVFile():
         localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
@@ -144,7 +134,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         actual = localDataService._readPVFile(mock.Mock())
         assert actual is not None
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test__generateStateId():
         localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
@@ -155,7 +144,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         actual, _ = localDataService._generateStateId(mock.Mock())
         assert actual == "9618b936a4419a6e"
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test__findMatchingFileList():
         localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
@@ -164,7 +152,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual is not None
         assert len(actual) == 1
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_readCalibrationIndexMissing():
         localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
@@ -175,7 +162,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         localDataService._constructCalibrationPath.return_value = Resource.getPath("outputs")
         assert len(localDataService.readCalibrationIndex("123")) == 0
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_writeCalibrationIndexEntry():
         localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
@@ -200,7 +186,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert len(actualEntries) > 0
         assert actualEntries[0].runNumber == "57514"
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_readCalibrationIndexExisting():
         localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
@@ -223,7 +208,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         with Resource.open("/inputs/calibration/input.json", "r") as f:
             return ReductionIngredients.parse_raw(f.read())
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_readWriteCalibrationRecord():
         localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
@@ -239,7 +223,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
 
         assert actualRecord.parameters.runConfig.runNumber == "57514"
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_readWriteCalibrationRecordV2():
         localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
@@ -255,7 +238,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
 
         assert actualRecord.parameters.runConfig.runNumber == "57514"
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_getCalibrationRecordPath():
         localDataService = LocalDataService()
         localDataService._generateStateId = mock.Mock()
@@ -265,13 +247,11 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         actualPath = localDataService.getCalibrationRecordPath("57514", 1)
         assert actualPath == Resource.getPath("outputs/57514") + "/v_1/CalibrationRecord.json"
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_extractFileVersion():
         localDataService = LocalDataService()
         actualVersion = localDataService._extractFileVersion("Powder/1234/v_4/CalibrationRecord.json")
         assert actualVersion == 4
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test__getFileOfVersion():
         localDataService = LocalDataService()
         localDataService._findMatchingFileList = mock.Mock()
@@ -282,7 +262,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         actualFile = localDataService._getFileOfVersion("/v_*/CalibrationRecord", 3)
         assert actualFile == "/v_3/CalibrationRecord.json"
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test__getLatestFile():
         localDataService = LocalDataService()
         localDataService._findMatchingFileList = mock.Mock()
@@ -293,7 +272,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         actualFile = localDataService._getLatestFile("Powder/1234/v_*/CalibrationRecord.json")
         assert actualFile == "Powder/1234/v_2/CalibrationRecord.json"
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_writeCalibrationReductionResult():
         import mantid.api
 
@@ -303,39 +281,34 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         with mock.patch.dict("sys.modules", {"mantid.api": mantid.api}):
             from snapred.backend.data.LocalDataService import LocalDataService as LocalDataService2
 
-            with mock.patch.object(LocalDataService2, "__init__", lambda x: None):  # noqa: PT008, ARG005
-                localDataService = LocalDataService2()
-                localDataService._generateStateId = mock.Mock()
-                localDataService._generateStateId.return_value = ("123", "456")
-                localDataService._constructCalibrationPath = mock.Mock()
-                localDataService._constructCalibrationPath.return_value = Resource.getPath("outputs/")
+            localDataService = LocalDataService2()
+            localDataService._generateStateId = mock.Mock()
+            localDataService._generateStateId.return_value = ("123", "456")
+            localDataService._constructCalibrationPath = mock.Mock()
+            localDataService._constructCalibrationPath.return_value = Resource.getPath("outputs/")
 
-                localDataService.writeCalibrationReductionResult("123", "ws")
+            localDataService.writeCalibrationReductionResult("123", "ws")
 
-                assert mantid.api.AlgorithmManager.create.called
+            assert mantid.api.AlgorithmManager.create.called
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test__isApplicableEntry_equals():
         localDataService = LocalDataService()
         entry = mock.Mock()
         entry.appliesTo = "123"
         assert localDataService._isApplicableEntry(entry, "123")
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test__isApplicableEntry_greaterThan():
         localDataService = LocalDataService()
         entry = mock.Mock()
         entry.appliesTo = ">123"
         assert localDataService._isApplicableEntry(entry, "456")
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test__isApplicableEntry_lessThan():
         localDataService = LocalDataService()
         entry = mock.Mock()
         entry.appliesTo = "<123"
         assert localDataService._isApplicableEntry(entry, "99")
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test__getVersionFromCalibrationIndex():
         localDataService = LocalDataService()
         localDataService.readCalibrationIndex = mock.Mock()
@@ -346,7 +319,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         actualVersion = localDataService._getVersionFromCalibrationIndex("123")
         assert actualVersion == "1"
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test__getCurrentCalibrationRecord():
         localDataService = LocalDataService()
         localDataService._getVersionFromCalibrationIndex = mock.Mock()
@@ -357,7 +329,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         actualRecord = localDataService._getCurrentCalibrationRecord("123")
         assert actualRecord == mockRecord
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_getCalibrationStatePath():
         localDataService = LocalDataService()
         localDataService._generateStateId = mock.Mock()
@@ -367,7 +338,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         actualPath = localDataService.getCalibrationStatePath("57514", 1)
         assert actualPath == Resource.getPath("outputs/57514") + "/v_1/CalibrationParameters.json"
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_readCalibrationState():
         localDataService = LocalDataService()
         localDataService._generateStateId = mock.Mock()
@@ -383,7 +353,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         actualState = localDataService.readCalibrationState("123")
         assert actualState == Calibration.parse_file(Resource.getPath("inputs/calibration/CalibrationParameters.json"))
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_writeCalibrationState():
         localDataService = LocalDataService()
         localDataService._generateStateId = mock.Mock()
@@ -398,7 +367,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert os.path.exists(Resource.getPath("outputs/123/v_1/CalibrationParameters.json"))
         shutil.rmtree(Resource.getPath("outputs/123"))
 
-    @mock.patch.object(LocalDataService, "__init__", lambda x: None)  # noqa: PT008, ARG005
     def test_initializeState():
         localDataService = LocalDataService()
         localDataService._readPVFile = mock.Mock()

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -33,15 +33,15 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         return reductionParameters
 
     def test_readInstrumentConfig():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readInstrumentParameters = _readInstrumentParameters
-        actual = localDataService.readInstrumentConfig()
+        actual = localDataService.readInstrumentConfig(False)
         assert actual is not None
         assert actual.version == "1.4"
         assert actual.name == "SNAP"
 
     def test_readInstrumentParameters():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService.instrumentConfigPath = Resource.getPath("inputs/SNAPInstPrm.json")
         actual = localDataService._readInstrumentParameters()
         assert actual is not None
@@ -57,7 +57,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         return instrumentConfig
 
     def test_readStateConfig():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readReductionParameters = _readReductionParameters
         localDataService._readDiffractionCalibrant = mock.Mock()
         localDataService._readDiffractionCalibrant.return_value = (
@@ -76,7 +76,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.stateId == "123"
 
     def test_readDiffractionCalibrant():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readReductionParameters = _readReductionParameters
         reductionParameters = _readReductionParameters("test")
         localDataService.instrumentConfig = getMockInstrumentConfig()
@@ -85,7 +85,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.filename == reductionParameters["calFileName"]
 
     def test_readNormalizationCalibrant():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readReductionParameters = _readReductionParameters
         reductionParameters = _readReductionParameters("test")
         localDataService.instrumentConfig = getMockInstrumentConfig()
@@ -94,7 +94,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.mask == reductionParameters["VMsk"]
 
     def test_readFocusGroups():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readReductionParameters = _readReductionParameters
         _readReductionParameters("test")
         localDataService.instrumentConfig = getMockInstrumentConfig()
@@ -103,7 +103,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert len(actual) == 3
 
     def test_readRunConfig():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readRunConfig = mock.Mock()
         localDataService._readRunConfig.return_value = reductionIngredients.runConfig
         actual = localDataService.readRunConfig(mock.Mock())
@@ -111,7 +111,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.runNumber == "57514"
 
     def test__readRunConfig():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._findIPTS = mock.Mock()
         localDataService._findIPTS.return_value = "IPTS-123"
         localDataService._readReductionParameters = _readReductionParameters
@@ -121,12 +121,12 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.runNumber == "57514"
 
     def test__findIPTS():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService.instrumentConfig = getMockInstrumentConfig()
         assert localDataService._findIPTS("57514") is not None
 
     def test_readPVFile():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readReductionParameters = _readReductionParameters
         localDataService.instrumentConfig = getMockInstrumentConfig()
         localDataService._constructPVFilePath = mock.Mock()
@@ -135,7 +135,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual is not None
 
     def test__generateStateId():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readReductionParameters = _readReductionParameters
         localDataService._readPVFile = mock.Mock()
         fileMock = mock.Mock()
@@ -145,7 +145,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual == "9618b936a4419a6e"
 
     def test__findMatchingFileList():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readReductionParameters = _readReductionParameters
         localDataService.instrumentConfig = getMockInstrumentConfig()
         actual = localDataService._findMatchingFileList(Resource.getPath("inputs/SNAPInstPrm.json"), False)
@@ -153,7 +153,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert len(actual) == 1
 
     def test_readCalibrationIndexMissing():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -163,7 +163,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert len(localDataService.readCalibrationIndex("123")) == 0
 
     def test_writeCalibrationIndexEntry():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -187,7 +187,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualEntries[0].runNumber == "57514"
 
     def test_readCalibrationIndexExisting():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -209,7 +209,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
             return ReductionIngredients.parse_raw(f.read())
 
     def test_readWriteCalibrationRecord():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -224,7 +224,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualRecord.parameters.runConfig.runNumber == "57514"
 
     def test_readWriteCalibrationRecordV2():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -239,7 +239,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualRecord.parameters.runConfig.runNumber == "57514"
 
     def test_getCalibrationRecordPath():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
         localDataService._constructCalibrationPath = mock.Mock()
@@ -248,12 +248,12 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualPath == Resource.getPath("outputs/57514") + "/v_1/CalibrationRecord.json"
 
     def test_extractFileVersion():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         actualVersion = localDataService._extractFileVersion("Powder/1234/v_4/CalibrationRecord.json")
         assert actualVersion == 4
 
     def test__getFileOfVersion():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._findMatchingFileList = mock.Mock()
         localDataService._findMatchingFileList.return_value = [
             "/v_1/CalibrationRecord.json",
@@ -263,7 +263,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualFile == "/v_3/CalibrationRecord.json"
 
     def test__getLatestFile():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._findMatchingFileList = mock.Mock()
         localDataService._findMatchingFileList.return_value = [
             "Powder/1234/v_1/CalibrationRecord.json",
@@ -281,7 +281,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         with mock.patch.dict("sys.modules", {"mantid.api": mantid.api}):
             from snapred.backend.data.LocalDataService import LocalDataService as LocalDataService2
 
-            localDataService = LocalDataService2()
+            localDataService = LocalDataService2(False)
             localDataService._generateStateId = mock.Mock()
             localDataService._generateStateId.return_value = ("123", "456")
             localDataService._constructCalibrationPath = mock.Mock()
@@ -292,25 +292,25 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
             assert mantid.api.AlgorithmManager.create.called
 
     def test__isApplicableEntry_equals():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         entry = mock.Mock()
         entry.appliesTo = "123"
         assert localDataService._isApplicableEntry(entry, "123")
 
     def test__isApplicableEntry_greaterThan():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         entry = mock.Mock()
         entry.appliesTo = ">123"
         assert localDataService._isApplicableEntry(entry, "456")
 
     def test__isApplicableEntry_lessThan():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         entry = mock.Mock()
         entry.appliesTo = "<123"
         assert localDataService._isApplicableEntry(entry, "99")
 
     def test__getVersionFromCalibrationIndex():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService.readCalibrationIndex = mock.Mock()
         localDataService.readCalibrationIndex.return_value = [mock.Mock()]
         localDataService.readCalibrationIndex.return_value[0] = CalibrationIndexEntry(
@@ -320,7 +320,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualVersion == "1"
 
     def test__getCurrentCalibrationRecord():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._getVersionFromCalibrationIndex = mock.Mock()
         localDataService._getVersionFromCalibrationIndex.return_value = "1"
         localDataService.readCalibrationRecord = mock.Mock()
@@ -330,7 +330,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualRecord == mockRecord
 
     def test_getCalibrationStatePath():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
         localDataService._constructCalibrationPath = mock.Mock()
@@ -339,7 +339,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualPath == Resource.getPath("outputs/57514") + "/v_1/CalibrationParameters.json"
 
     def test_readCalibrationState():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
         localDataService.getCalibrationStatePath = mock.Mock()
@@ -354,7 +354,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualState == Calibration.parse_file(Resource.getPath("inputs/calibration/CalibrationParameters.json"))
 
     def test_writeCalibrationState():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
         localDataService._constructCalibrationPath = mock.Mock()
@@ -368,7 +368,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         shutil.rmtree(Resource.getPath("outputs/123"))
 
     def test_initializeState():
-        localDataService = LocalDataService()
+        localDataService = LocalDataService(False)
         localDataService._readPVFile = mock.Mock()
         pvFileMock = mock.Mock()
         pvFileMock.get.side_effect = [[1], [2], [1.1], [1.2], [1], [1], [2]]

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -33,15 +33,15 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         return reductionParameters
 
     def test_readInstrumentConfig():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readInstrumentParameters = _readInstrumentParameters
-        actual = localDataService.readInstrumentConfig(False)
+        actual = localDataService.readInstrumentConfig()
         assert actual is not None
         assert actual.version == "1.4"
         assert actual.name == "SNAP"
 
     def test_readInstrumentParameters():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService.instrumentConfigPath = Resource.getPath("inputs/SNAPInstPrm.json")
         actual = localDataService._readInstrumentParameters()
         assert actual is not None
@@ -57,7 +57,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         return instrumentConfig
 
     def test_readStateConfig():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
         localDataService._readDiffractionCalibrant = mock.Mock()
         localDataService._readDiffractionCalibrant.return_value = (
@@ -76,7 +76,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.stateId == "123"
 
     def test_readDiffractionCalibrant():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
         reductionParameters = _readReductionParameters("test")
         localDataService.instrumentConfig = getMockInstrumentConfig()
@@ -85,7 +85,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.filename == reductionParameters["calFileName"]
 
     def test_readNormalizationCalibrant():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
         reductionParameters = _readReductionParameters("test")
         localDataService.instrumentConfig = getMockInstrumentConfig()
@@ -94,7 +94,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.mask == reductionParameters["VMsk"]
 
     def test_readFocusGroups():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
         _readReductionParameters("test")
         localDataService.instrumentConfig = getMockInstrumentConfig()
@@ -103,7 +103,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert len(actual) == 3
 
     def test_readRunConfig():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readRunConfig = mock.Mock()
         localDataService._readRunConfig.return_value = reductionIngredients.runConfig
         actual = localDataService.readRunConfig(mock.Mock())
@@ -111,7 +111,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.runNumber == "57514"
 
     def test__readRunConfig():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._findIPTS = mock.Mock()
         localDataService._findIPTS.return_value = "IPTS-123"
         localDataService._readReductionParameters = _readReductionParameters
@@ -121,12 +121,12 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual.runNumber == "57514"
 
     def test__findIPTS():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService.instrumentConfig = getMockInstrumentConfig()
         assert localDataService._findIPTS("57514") is not None
 
     def test_readPVFile():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
         localDataService.instrumentConfig = getMockInstrumentConfig()
         localDataService._constructPVFilePath = mock.Mock()
@@ -135,7 +135,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual is not None
 
     def test__generateStateId():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
         localDataService._readPVFile = mock.Mock()
         fileMock = mock.Mock()
@@ -145,7 +145,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actual == "9618b936a4419a6e"
 
     def test__findMatchingFileList():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readReductionParameters = _readReductionParameters
         localDataService.instrumentConfig = getMockInstrumentConfig()
         actual = localDataService._findMatchingFileList(Resource.getPath("inputs/SNAPInstPrm.json"), False)
@@ -153,7 +153,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert len(actual) == 1
 
     def test_readCalibrationIndexMissing():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -163,7 +163,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert len(localDataService.readCalibrationIndex("123")) == 0
 
     def test_writeCalibrationIndexEntry():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -187,7 +187,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualEntries[0].runNumber == "57514"
 
     def test_readCalibrationIndexExisting():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -209,7 +209,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
             return ReductionIngredients.parse_raw(f.read())
 
     def test_readWriteCalibrationRecord():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -224,7 +224,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualRecord.parameters.runConfig.runNumber == "57514"
 
     def test_readWriteCalibrationRecordV2():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
@@ -239,7 +239,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualRecord.parameters.runConfig.runNumber == "57514"
 
     def test_getCalibrationRecordPath():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
         localDataService._constructCalibrationPath = mock.Mock()
@@ -248,12 +248,12 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualPath == Resource.getPath("outputs/57514") + "/v_1/CalibrationRecord.json"
 
     def test_extractFileVersion():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         actualVersion = localDataService._extractFileVersion("Powder/1234/v_4/CalibrationRecord.json")
         assert actualVersion == 4
 
     def test__getFileOfVersion():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._findMatchingFileList = mock.Mock()
         localDataService._findMatchingFileList.return_value = [
             "/v_1/CalibrationRecord.json",
@@ -263,7 +263,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualFile == "/v_3/CalibrationRecord.json"
 
     def test__getLatestFile():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._findMatchingFileList = mock.Mock()
         localDataService._findMatchingFileList.return_value = [
             "Powder/1234/v_1/CalibrationRecord.json",
@@ -281,7 +281,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         with mock.patch.dict("sys.modules", {"mantid.api": mantid.api}):
             from snapred.backend.data.LocalDataService import LocalDataService as LocalDataService2
 
-            localDataService = LocalDataService2(False)
+            localDataService = LocalDataService2()
             localDataService._generateStateId = mock.Mock()
             localDataService._generateStateId.return_value = ("123", "456")
             localDataService._constructCalibrationPath = mock.Mock()
@@ -292,25 +292,25 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
             assert mantid.api.AlgorithmManager.create.called
 
     def test__isApplicableEntry_equals():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         entry = mock.Mock()
         entry.appliesTo = "123"
         assert localDataService._isApplicableEntry(entry, "123")
 
     def test__isApplicableEntry_greaterThan():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         entry = mock.Mock()
         entry.appliesTo = ">123"
         assert localDataService._isApplicableEntry(entry, "456")
 
     def test__isApplicableEntry_lessThan():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         entry = mock.Mock()
         entry.appliesTo = "<123"
         assert localDataService._isApplicableEntry(entry, "99")
 
     def test__getVersionFromCalibrationIndex():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService.readCalibrationIndex = mock.Mock()
         localDataService.readCalibrationIndex.return_value = [mock.Mock()]
         localDataService.readCalibrationIndex.return_value[0] = CalibrationIndexEntry(
@@ -320,7 +320,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualVersion == "1"
 
     def test__getCurrentCalibrationRecord():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._getVersionFromCalibrationIndex = mock.Mock()
         localDataService._getVersionFromCalibrationIndex.return_value = "1"
         localDataService.readCalibrationRecord = mock.Mock()
@@ -330,7 +330,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualRecord == mockRecord
 
     def test_getCalibrationStatePath():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
         localDataService._constructCalibrationPath = mock.Mock()
@@ -339,7 +339,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualPath == Resource.getPath("outputs/57514") + "/v_1/CalibrationParameters.json"
 
     def test_readCalibrationState():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
         localDataService.getCalibrationStatePath = mock.Mock()
@@ -354,7 +354,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualState == Calibration.parse_file(Resource.getPath("inputs/calibration/CalibrationParameters.json"))
 
     def test_writeCalibrationState():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
         localDataService._constructCalibrationPath = mock.Mock()
@@ -368,7 +368,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         shutil.rmtree(Resource.getPath("outputs/123"))
 
     def test_initializeState():
-        localDataService = LocalDataService(False)
+        localDataService = LocalDataService()
         localDataService._readPVFile = mock.Mock()
         pvFileMock = mock.Mock()
         pvFileMock.get.side_effect = [[1], [2], [1.1], [1.2], [1], [1], [2]]

--- a/tests/unit/meta/test_config.py
+++ b/tests/unit/meta/test_config.py
@@ -12,7 +12,7 @@ def test_find_root_dir():
 
 def test_instrument_home():
     # test verifies that the end of the path is correct
-    correctPathEnding = "/tests/resources/SNAP/"
+    correctPathEnding = "/tests/resources/"
     assert Config["instrument.home"].endswith(correctPathEnding)
 
 


### PR DESCRIPTION
By modifying the settings, there is no need to side-step the LocalDataService in the tests. It is now correctly configured to use information that are in the repository.

The important thing to look at is the change to `test.yml`.