### PR TITLE
Update calculation of pixel grouping dependent parameters

### DIFF
--- a/src/snapred/backend/dao/PixelGroupingIngredients.py
+++ b/src/snapred/backend/dao/PixelGroupingIngredients.py
@@ -1,11 +1,11 @@
 from pydantic import BaseModel
 
-from snapred.backend.dao.calibration.Calibration import Calibration
+from snapred.backend.dao.state.InstrumentState import InstrumentState
 
 
 class PixelGroupingIngredients(BaseModel):
     """Class to hold the ingredients necessary for pixel grouping parameter calculation."""
 
-    calibrationState: Calibration
+    instrumentState: InstrumentState
     instrumentDefinitionFile: str
     groupingFile: str

--- a/src/snapred/backend/recipe/PixelGroupingParametersCalculationRecipe.py
+++ b/src/snapred/backend/recipe/PixelGroupingParametersCalculationRecipe.py
@@ -24,16 +24,16 @@ class PixelGroupingParametersCalculationRecipe:
 
         algo = AlgorithmManager.create(self.PixelGroupingParametersCalculationAlgorithmName)
 
-        algo.setProperty("InputState", ingredients.calibrationState.json())
+        algo.setProperty("InstrumentState", ingredients.instrumentState.json())
         algo.setProperty("InstrumentDefinitionFile", ingredients.instrumentDefinitionFile)
         algo.setProperty("GroupingFile", ingredients.groupingFile)
 
         try:
             data["result"] = algo.execute()
             # parse the algorithm output and create a list of calculated PixelGroupingParameters
-            pixelGroupingParams_strs = json.loads(algo.getProperty("OutputParameters").value)
+            pixelGroupingParams_json = json.loads(algo.getProperty("OutputParameters").value)
             pixelGroupingParams = []
-            for item in pixelGroupingParams_strs:
+            for item in pixelGroupingParams_json:
                 pixelGroupingParams.append(PixelGroupingParameters.parse_raw(item))
             data["parameters"] = pixelGroupingParams
         except RuntimeError as e:

--- a/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
@@ -157,8 +157,14 @@ class PixelGroupingParametersCalculationAlgorithm(PythonAlgorithm):
                 "Loading instrument...", Workspace=ws_name, FileName=idf, RewriteSpectraMap=False
             )
         else:  # full instrument
+            # self.mantidSnapper.LoadInstrument(
+            #     "Loading instrument...", Workspace=ws_name, InstrumentName="SNAP", RewriteSpectraMap="False"
+            # )
             self.mantidSnapper.LoadInstrument(
-                "Loading instrument...", Workspace=ws_name, InstrumentName="SNAP", RewriteSpectraMap="False"
+                "Loading instrument...",
+                Workspace=ws_name,
+                FileName="/opt/anaconda/envs/mantid-dev/instrument/SNAP_Definition.xml",
+                RewriteSpectraMap=False,
             )
         self.mantidSnapper.executeQueue()
 

--- a/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
@@ -1,7 +1,9 @@
 import json
 import math
 import pathlib
+from statistics import mean
 
+import numpy as np
 from mantid.api import (
     AlgorithmFactory,
     PythonAlgorithm,
@@ -9,8 +11,8 @@ from mantid.api import (
 )
 from mantid.kernel import Direction
 
-from snapred.backend.dao.calibration.Calibration import Calibration
 from snapred.backend.dao.Limit import Limit
+from snapred.backend.dao.state.InstrumentState import InstrumentState
 from snapred.backend.dao.state.PixelGroupingParameters import PixelGroupingParameters
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 
@@ -20,7 +22,7 @@ name = "PixelGroupingParametersCalculationAlgorithm"
 class PixelGroupingParametersCalculationAlgorithm(PythonAlgorithm):
     def PyInit(self):
         # declare properties
-        self.declareProperty("InputState", defaultValue="", direction=Direction.Input)
+        self.declareProperty("InstrumentState", defaultValue="", direction=Direction.Input)
 
         self.declareProperty("InstrumentDefinitionFile", defaultValue="", direction=Direction.Input)
 
@@ -52,8 +54,7 @@ class PixelGroupingParametersCalculationAlgorithm(PythonAlgorithm):
         self.mantidSnapper.executeQueue()
 
         # define/calculate some auxiliary state-derived parameters
-        calibrationState = Calibration.parse_raw(self.getProperty("InputState").value)
-        instrumentState = calibrationState.instrumentState
+        instrumentState = InstrumentState.parse_raw(self.getProperty("InstrumentState").value)
         tofMin = instrumentState.particleBounds.tof.minimum
         tofMax = instrumentState.particleBounds.tof.maximum
         deltaTOverT = instrumentState.instrumentConfig.delTOverT
@@ -74,23 +75,44 @@ class PixelGroupingParametersCalculationAlgorithm(PythonAlgorithm):
         )
         self.mantidSnapper.executeQueue()
 
-        # calculate and store all pixel grouping parameters as strings
-        allGroupingParams_str = []
-        grouped_ws = mtd[grouped_ws_name]
+        # calculate parameters for all pixel groupings and store them in json format
+        allGroupingParams_json = []
+        grouping_ws = self.mantidSnapper.mtd[grouping_ws_name]
+        grouped_ws = self.mantidSnapper.mtd[grouped_ws_name]
         resws = mtd["pgpca_resolution_ws"]
-        specInfo = grouped_ws.spectrumInfo()
+
+        grouping_detInfo = grouping_ws.detectorInfo()
         for groupIndex in range(grouped_ws.getNumberHistograms()):
-            twoTheta = specInfo.twoTheta(groupIndex)
-            dMin = 3.9561e-3 * (1 / (2 * math.sin(twoTheta / 2))) * tofMin / L
-            dMax = 3.9561e-3 * (1 / (2 * math.sin(twoTheta / 2))) * tofMax / L
+            detIDsInGroup = grouping_ws.getDetectorIDsOfGroup(groupIndex + 1)
+
+            groupMin2Theta = 2 * np.pi
+            groupMax2Theta = 0.0
+            groupAverage2Theta = 0.0
+            count = 0
+            for detID in detIDsInGroup:
+                if grouping_detInfo.isMonitor(int(detID)) or grouping_detInfo.isMasked(int(detID)):
+                    continue
+                count += 1
+                twoThetaTemp = grouping_detInfo.twoTheta(int(detID))
+                groupMin2Theta = min(groupMin2Theta, twoThetaTemp)
+                groupMax2Theta = max(groupMax2Theta, twoThetaTemp)
+                groupAverage2Theta += twoThetaTemp
+            if count > 0:
+                groupAverage2Theta /= count
+            del twoThetaTemp
+
+            dMin = 3.9561e-3 * (1 / (2 * math.sin(groupMax2Theta / 2))) * tofMin / L
+            dMax = 3.9561e-3 * (1 / (2 * math.sin(groupMin2Theta / 2))) * tofMax / L
             delta_d_over_d = resws.readY(groupIndex)[0]
 
-            groupingParams_str = PixelGroupingParameters(
-                twoTheta=twoTheta, dResolution=Limit(minimum=dMin, maximum=dMax), dRelativeResolution=delta_d_over_d
+            groupingParams_json = PixelGroupingParameters(
+                twoTheta=groupAverage2Theta,
+                dResolution=Limit(minimum=dMin, maximum=dMax),
+                dRelativeResolution=delta_d_over_d,
             ).json()
-            allGroupingParams_str.append(groupingParams_str)
+            allGroupingParams_json.append(groupingParams_json)
 
-        outputParams = json.dumps(allGroupingParams_str)
+        outputParams = json.dumps(allGroupingParams_json)
         self.setProperty("OutputParameters", outputParams)
 
     # create a grouping workspace from a grouping file
@@ -115,8 +137,8 @@ class PixelGroupingParametersCalculationAlgorithm(PythonAlgorithm):
         idf = self.getProperty("InstrumentDefinitionFile").value
 
         # get detector state from the input state
-        calibrationState = Calibration.parse_raw(self.getProperty("InputState").value)
-        detectorState = calibrationState.instrumentState.detectorState
+        instrumentState = InstrumentState.parse_raw(self.getProperty("InstrumentState").value)
+        detectorState = instrumentState.detectorState
 
         # add sample logs with detector "arc" and "lin" parameters to the workspace
         for param_name in ["arc", "lin"]:
@@ -130,9 +152,14 @@ class PixelGroupingParametersCalculationAlgorithm(PythonAlgorithm):
                 )
         self.mantidSnapper.executeQueue()
 
-        self.mantidSnapper.LoadInstrument(
-            "Loading instrument...", Workspace=ws_name, FileName=idf, RewriteSpectraMap="False"
-        )
+        if idf != "":  # lite instrument
+            self.mantidSnapper.LoadInstrument(
+                "Loading instrument...", Workspace=ws_name, FileName=idf, RewriteSpectraMap=False
+            )
+        else:  # full instrument
+            self.mantidSnapper.LoadInstrument(
+                "Loading instrument...", Workspace=ws_name, InstrumentName="SNAP", RewriteSpectraMap="False"
+            )
         self.mantidSnapper.executeQueue()
 
 

--- a/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
@@ -133,9 +133,6 @@ class PixelGroupingParametersCalculationAlgorithm(PythonAlgorithm):
     def LoadSNAPInstrument(self, ws_name):
         self.log().notice("Load SNAP instrument based on the Instrument Definition File")
 
-        # load the idf into workspace
-        idf = self.getProperty("InstrumentDefinitionFile").value
-
         # get detector state from the input state
         instrumentState = InstrumentState.parse_raw(self.getProperty("InstrumentState").value)
         detectorState = instrumentState.detectorState
@@ -150,22 +147,13 @@ class PixelGroupingParametersCalculationAlgorithm(PythonAlgorithm):
                     LogText=str(getattr(detectorState, param_name)[index]),
                     LogType="Number Series",
                 )
-        self.mantidSnapper.executeQueue()
 
-        if idf != "":  # lite instrument
-            self.mantidSnapper.LoadInstrument(
-                "Loading instrument...", Workspace=ws_name, FileName=idf, RewriteSpectraMap=False
-            )
-        else:  # full instrument
-            # self.mantidSnapper.LoadInstrument(
-            #     "Loading instrument...", Workspace=ws_name, InstrumentName="SNAP", RewriteSpectraMap="False"
-            # )
-            self.mantidSnapper.LoadInstrument(
-                "Loading instrument...",
-                Workspace=ws_name,
-                FileName="/opt/anaconda/envs/mantid-dev/instrument/SNAP_Definition.xml",
-                RewriteSpectraMap=False,
-            )
+        # load the idf into workspace
+        idf = self.getProperty("InstrumentDefinitionFile").value
+        self.mantidSnapper.LoadInstrument(
+            "Loading instrument...", Workspace=ws_name, FileName=idf, RewriteSpectraMap=False
+        )
+
         self.mantidSnapper.executeQueue()
 
 

--- a/tests/unit/backend/recipe/algorithm/test_PixelGroupingParametersCalculationAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_PixelGroupingParametersCalculationAlgorithm.py
@@ -50,14 +50,19 @@ with mock.patch.dict(
             Calibration, "/SNS/SNAP/shared/Calibration_Prototype/Powder/04bd2c53f6bf6754/CalibrationParameters.json"
         ).instrumentState.json()
 
+    def getInstrumentDefinitionFilePath(isLite=True):
+        if isLite:
+            return "/SNS/SNAP/shared/Calibration/Powder/SNAPLite.xml"
+        else:
+            return "/opt/anaconda/envs/mantid-dev/instrument/SNAP_Definition.xml"
+
     @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
     def test_column():
-        instrumentDefinitionFile = ""
         groupingFile = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_Column.xml"
         referenceParametersFile = "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Column_parameters_newCalc.json"
 
         run_test(
-            instrumentDefinitionFile=instrumentDefinitionFile,
+            instrumentDefinitionFile=getInstrumentDefinitionFilePath(isLite=False),
             instrumentState=getInstrumentState(),
             groupingFile=groupingFile,
             referenceParametersFile=referenceParametersFile,
@@ -65,14 +70,13 @@ with mock.patch.dict(
 
     @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
     def test_column_lite():
-        instrumentDefinitionFile = "/SNS/SNAP/shared/Calibration/Powder/SNAPLite.xml"
         groupingFile = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_Column.lite.nxs"
         referenceParametersFile = (
             "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Column_parameters_newCalc.lite.json"
         )
 
         run_test(
-            instrumentDefinitionFile=instrumentDefinitionFile,
+            instrumentDefinitionFile=getInstrumentDefinitionFilePath(),
             instrumentState=getInstrumentState(),
             groupingFile=groupingFile,
             referenceParametersFile=referenceParametersFile,
@@ -80,12 +84,11 @@ with mock.patch.dict(
 
     @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
     def test_bank():
-        instrumentDefinitionFile = ""
         groupingFile = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_Bank.xml"
         referenceParametersFile = "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Bank_parameters_newCalc.json"
 
         run_test(
-            instrumentDefinitionFile=instrumentDefinitionFile,
+            instrumentDefinitionFile=getInstrumentDefinitionFilePath(isLite=False),
             instrumentState=getInstrumentState(),
             groupingFile=groupingFile,
             referenceParametersFile=referenceParametersFile,
@@ -93,14 +96,13 @@ with mock.patch.dict(
 
     @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
     def test_bank_lite():
-        instrumentDefinitionFile = "/SNS/SNAP/shared/Calibration/Powder/SNAPLite.xml"
         groupingFile = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_Bank.lite.nxs"
         referenceParametersFile = (
             "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Bank_parameters_newCalc.lite.json"
         )
 
         run_test(
-            instrumentDefinitionFile=instrumentDefinitionFile,
+            instrumentDefinitionFile=getInstrumentDefinitionFilePath(),
             instrumentState=getInstrumentState(),
             groupingFile=groupingFile,
             referenceParametersFile=referenceParametersFile,
@@ -108,12 +110,11 @@ with mock.patch.dict(
 
     @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
     def test_all():
-        instrumentDefinitionFile = ""
         groupingFile = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_All.xml"
         referenceParametersFile = "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/All_parameters_newCalc.json"
 
         run_test(
-            instrumentDefinitionFile=instrumentDefinitionFile,
+            instrumentDefinitionFile=getInstrumentDefinitionFilePath(isLite=False),
             instrumentState=getInstrumentState(),
             groupingFile=groupingFile,
             referenceParametersFile=referenceParametersFile,
@@ -121,14 +122,13 @@ with mock.patch.dict(
 
     @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
     def test_all_lite():
-        instrumentDefinitionFile = "/SNS/SNAP/shared/Calibration/Powder/SNAPLite.xml"
         groupingFile = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_All.lite.nxs"
         referenceParametersFile = (
             "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/All_parameters_newCalc.lite.json"
         )
 
         run_test(
-            instrumentDefinitionFile=instrumentDefinitionFile,
+            instrumentDefinitionFile=getInstrumentDefinitionFilePath(),
             instrumentState=getInstrumentState(),
             groupingFile=groupingFile,
             referenceParametersFile=referenceParametersFile,
@@ -136,14 +136,13 @@ with mock.patch.dict(
 
     @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
     def test_wrong_idf():
-        instrumentDefinitionFile = "junk"
         groupingFile = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_Column.lite.nxs"
         referenceParametersFile = (
             "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Column_parameters_newCalc.lite.json"
         )
         with pytest.raises(RuntimeError) as excinfo:
             run_test(
-                instrumentDefinitionFile=instrumentDefinitionFile,
+                instrumentDefinitionFile="junk",
                 instrumentState=getInstrumentState(),
                 groupingFile=groupingFile,
                 referenceParametersFile=referenceParametersFile,
@@ -152,7 +151,6 @@ with mock.patch.dict(
 
     @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
     def test_wrong_grouping_file():
-        instrumentDefinitionFile = "/SNS/SNAP/shared/Calibration/Powder/SNAPLite.xml"
         groupingFile = "junk"
         referenceParametersFile = (
             "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Column_parameters_newCalc.lite.json"
@@ -160,7 +158,7 @@ with mock.patch.dict(
 
         with pytest.raises(RuntimeError) as excinfo:
             run_test(
-                instrumentDefinitionFile=instrumentDefinitionFile,
+                instrumentDefinitionFile=getInstrumentDefinitionFilePath(),
                 instrumentState=getInstrumentState(),
                 groupingFile=groupingFile,
                 referenceParametersFile=referenceParametersFile,
@@ -169,7 +167,6 @@ with mock.patch.dict(
 
     @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
     def test_wrong_instrument_state():
-        instrumentDefinitionFile = "/SNS/SNAP/shared/Calibration/Powder/SNAPLite.xml"
         groupingFile = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_Column.lite.nxs"
         referenceParametersFile = (
             "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Column_parameters_newCalc.lite.json"
@@ -177,7 +174,7 @@ with mock.patch.dict(
 
         with pytest.raises(RuntimeError) as excinfo:
             run_test(
-                instrumentDefinitionFile=instrumentDefinitionFile,
+                instrumentDefinitionFile=getInstrumentDefinitionFilePath(),
                 instrumentState="junk",
                 groupingFile=groupingFile,
                 referenceParametersFile=referenceParametersFile,

--- a/tests/unit/backend/recipe/algorithm/test_PixelGroupingParametersCalculationAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_PixelGroupingParametersCalculationAlgorithm.py
@@ -45,107 +45,108 @@ with mock.patch.dict(
         yield
         teardown()
 
-    def getCalibrationState():
+    def getInstrumentState():
         return parse_file_as(
-            Calibration, "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/CalibrationParameters.json"
-        ).json()
+            Calibration, "/SNS/SNAP/shared/Calibration_Prototype/Powder/04bd2c53f6bf6754/CalibrationParameters.json"
+        ).instrumentState.json()
 
     @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
     def test_column():
-        instrumentDefinitionFile = "/opt/anaconda/envs/mantid-dev/instrument/SNAP_Definition_2011-09-07.xml"
+        instrumentDefinitionFile = ""
         groupingFile = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_Column.xml"
-        referenceParametersFile = "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Column_parameters.json"
+        referenceParametersFile = "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Column_parameters_newCalc.json"
 
         run_test(
             instrumentDefinitionFile=instrumentDefinitionFile,
-            calibrationState=getCalibrationState(),
+            instrumentState=getInstrumentState(),
             groupingFile=groupingFile,
             referenceParametersFile=referenceParametersFile,
-            reverseGroupingIndex=False,
         )
 
     @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
     def test_column_lite():
         instrumentDefinitionFile = "/SNS/SNAP/shared/Calibration/Powder/SNAPLite.xml"
         groupingFile = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_Column.lite.nxs"
-        referenceParametersFile = "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Column_lite_parameters.json"
+        referenceParametersFile = (
+            "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Column_parameters_newCalc.lite.json"
+        )
 
         run_test(
             instrumentDefinitionFile=instrumentDefinitionFile,
-            calibrationState=getCalibrationState(),
+            instrumentState=getInstrumentState(),
             groupingFile=groupingFile,
             referenceParametersFile=referenceParametersFile,
-            reverseGroupingIndex=True,
         )
 
     @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
     def test_bank():
-        instrumentDefinitionFile = "/opt/anaconda/envs/mantid-dev/instrument/SNAP_Definition_2011-09-07.xml"
+        instrumentDefinitionFile = ""
         groupingFile = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_Bank.xml"
-        referenceParametersFile = "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Bank_parameters.json"
+        referenceParametersFile = "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Bank_parameters_newCalc.json"
 
         run_test(
             instrumentDefinitionFile=instrumentDefinitionFile,
-            calibrationState=getCalibrationState(),
+            instrumentState=getInstrumentState(),
             groupingFile=groupingFile,
             referenceParametersFile=referenceParametersFile,
-            reverseGroupingIndex=False,
         )
 
     @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
     def test_bank_lite():
         instrumentDefinitionFile = "/SNS/SNAP/shared/Calibration/Powder/SNAPLite.xml"
         groupingFile = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_Bank.lite.nxs"
-        referenceParametersFile = "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Bank_lite_parameters.json"
+        referenceParametersFile = (
+            "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Bank_parameters_newCalc.lite.json"
+        )
 
         run_test(
             instrumentDefinitionFile=instrumentDefinitionFile,
-            calibrationState=getCalibrationState(),
+            instrumentState=getInstrumentState(),
             groupingFile=groupingFile,
             referenceParametersFile=referenceParametersFile,
-            reverseGroupingIndex=True,
         )
 
     @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
     def test_all():
-        instrumentDefinitionFile = "/opt/anaconda/envs/mantid-dev/instrument/SNAP_Definition_2011-09-07.xml"
+        instrumentDefinitionFile = ""
         groupingFile = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_All.xml"
-        referenceParametersFile = "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/All_parameters.json"
+        referenceParametersFile = "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/All_parameters_newCalc.json"
 
         run_test(
             instrumentDefinitionFile=instrumentDefinitionFile,
-            calibrationState=getCalibrationState(),
+            instrumentState=getInstrumentState(),
             groupingFile=groupingFile,
             referenceParametersFile=referenceParametersFile,
-            reverseGroupingIndex=False,
         )
 
     @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
     def test_all_lite():
         instrumentDefinitionFile = "/SNS/SNAP/shared/Calibration/Powder/SNAPLite.xml"
         groupingFile = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_All.lite.nxs"
-        referenceParametersFile = "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/All_lite_parameters.json"
+        referenceParametersFile = (
+            "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/All_parameters_newCalc.lite.json"
+        )
 
         run_test(
             instrumentDefinitionFile=instrumentDefinitionFile,
-            calibrationState=getCalibrationState(),
+            instrumentState=getInstrumentState(),
             groupingFile=groupingFile,
             referenceParametersFile=referenceParametersFile,
-            reverseGroupingIndex=True,
         )
 
     @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
     def test_wrong_idf():
         instrumentDefinitionFile = "junk"
         groupingFile = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_Column.lite.nxs"
-        referenceParametersFile = "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Column_lite_parameters.json"
+        referenceParametersFile = (
+            "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Column_parameters_newCalc.lite.json"
+        )
         with pytest.raises(RuntimeError) as excinfo:
             run_test(
                 instrumentDefinitionFile=instrumentDefinitionFile,
-                calibrationState=getCalibrationState(),
+                instrumentState=getInstrumentState(),
                 groupingFile=groupingFile,
                 referenceParametersFile=referenceParametersFile,
-                reverseGroupingIndex=True,
             )
         assert "FileDescriptor" in str(excinfo.value)
 
@@ -153,55 +154,51 @@ with mock.patch.dict(
     def test_wrong_grouping_file():
         instrumentDefinitionFile = "/SNS/SNAP/shared/Calibration/Powder/SNAPLite.xml"
         groupingFile = "junk"
-        referenceParametersFile = "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Column_lite_parameters.json"
+        referenceParametersFile = (
+            "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Column_parameters_newCalc.lite.json"
+        )
 
         with pytest.raises(RuntimeError) as excinfo:
             run_test(
                 instrumentDefinitionFile=instrumentDefinitionFile,
-                calibrationState=getCalibrationState(),
+                instrumentState=getInstrumentState(),
                 groupingFile=groupingFile,
                 referenceParametersFile=referenceParametersFile,
-                reverseGroupingIndex=True,
             )
         assert "Filename" in str(excinfo.value)
 
     @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
-    def test_wrong_calibration_state():
+    def test_wrong_instrument_state():
         instrumentDefinitionFile = "/SNS/SNAP/shared/Calibration/Powder/SNAPLite.xml"
         groupingFile = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_Column.lite.nxs"
-        referenceParametersFile = "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Column_lite_parameters.json"
+        referenceParametersFile = (
+            "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/Column_parameters_newCalc.lite.json"
+        )
 
         with pytest.raises(RuntimeError) as excinfo:
             run_test(
                 instrumentDefinitionFile=instrumentDefinitionFile,
-                calibrationState="junk",
+                instrumentState="junk",
                 groupingFile=groupingFile,
                 referenceParametersFile=referenceParametersFile,
-                reverseGroupingIndex=True,
             )
-        assert "Calibration" in str(excinfo.value)
+        assert "InstrumentState" in str(excinfo.value)
 
-    def run_test(
-        instrumentDefinitionFile,
-        calibrationState,
-        groupingFile,
-        referenceParametersFile,
-        reverseGroupingIndex,
-    ):
+    def run_test(instrumentDefinitionFile, instrumentState, groupingFile, referenceParametersFile):
         """Test execution of PixelGroupingParametersCalculationAlgorithm"""
         pixelGroupingAlgo = PixelGroupingParametersCalculationAlgorithm()
         pixelGroupingAlgo.initialize()
 
-        pixelGroupingAlgo.setProperty("InputState", calibrationState)
+        pixelGroupingAlgo.setProperty("InstrumentState", instrumentState)
         pixelGroupingAlgo.setProperty("InstrumentDefinitionFile", instrumentDefinitionFile)
         pixelGroupingAlgo.setProperty("GroupingFile", groupingFile)
 
         assert pixelGroupingAlgo.execute()
 
         # parse the algorithm output and create a list of PixelGroupingParameters
-        pixelGroupingParams_str = json.loads(pixelGroupingAlgo.getProperty("OutputParameters").value)
+        pixelGroupingParams_json = json.loads(pixelGroupingAlgo.getProperty("OutputParameters").value)
         pixelGroupingParams_calc = []
-        for item in pixelGroupingParams_str:
+        for item in pixelGroupingParams_json:
             pixelGroupingParams_calc.append(PixelGroupingParameters.parse_raw(item))
 
         # parse the reference file. Note, in the reference file each kind of parameter is grouped into its own list
@@ -215,25 +212,22 @@ with mock.patch.dict(
         assert len(pixelGroupingParams_ref["dMax"]) == number_of_groupings_calc
         assert len(pixelGroupingParams_ref["delDOverD"]) == number_of_groupings_calc
 
-        # reverseGroupingIndex takes care of the different order of pixel groupings between "full" anf "lite"
-        # instruments. This has to do with how Mantid treats different kinds of grouping files used by
-        # PixelGroupingParametersCalculationAlgorithm
-        index = 0 if reverseGroupingIndex else number_of_groupings_calc - 1
+        index = 0
         for param in pixelGroupingParams_ref["twoTheta"]:
-            assert abs(float(param) - pixelGroupingParams_calc[index].twoTheta) < 1.0e-5
-            index += 1 if reverseGroupingIndex else -1
+            assert abs(float(param) - pixelGroupingParams_calc[index].twoTheta) == 0
+            index += 1
 
-        index = 0 if reverseGroupingIndex else number_of_groupings_calc - 1
+        index = 0
         for param in pixelGroupingParams_ref["dMin"]:
-            assert abs(float(param) - pixelGroupingParams_calc[index].dResolution.minimum) < 1.0e-4
-            index += 1 if reverseGroupingIndex else -1
+            assert abs(float(param) - pixelGroupingParams_calc[index].dResolution.minimum) == 0
+            index += 1
 
-        index = 0 if reverseGroupingIndex else number_of_groupings_calc - 1
+        index = 0
         for param in pixelGroupingParams_ref["dMax"]:
-            assert abs(float(param) - pixelGroupingParams_calc[index].dResolution.maximum) < 1.0e-4
-            index += 1 if reverseGroupingIndex else -1
+            assert abs(float(param) - pixelGroupingParams_calc[index].dResolution.maximum) == 0
+            index += 1
 
-        index = 0 if reverseGroupingIndex else number_of_groupings_calc - 1
+        index = 0
         for param in pixelGroupingParams_ref["delDOverD"]:
             assert abs(float(param) - pixelGroupingParams_calc[index].dRelativeResolution) < 1.0e-3
-            index += 1 if reverseGroupingIndex else -1
+            index += 1


### PR DESCRIPTION
- Update the math used for calculation of pixel grouping-dependent parameters: [Story 1929](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=1929)
- Reduce the algorithm input level from `CalibrationState` to `InstrumentState`, b/c passing the whole calibration state is unnecessary
- In the testing script, use a helper method for getting the IDF path. For the full instrument, use `SNAP_Definition.xml` instead of `SNAP_Definition_2011-09-07.xml`. The latter file isn't valid as of 2018 and apparently causes a reverse group ordering problem
- Remove the code bits that reverse group ordering when testing calculation results against reference data.  
- Change `json` string variable suffixes from `_str(s)` to `_json`.