### PR TITLE
SNAPResponse fields

### DIFF
--- a/src/snapred/__main__.py
+++ b/src/snapred/__main__.py
@@ -43,7 +43,7 @@ def main(args=None):
         action="store_true",
         help="start the gui then shut it down after 5 seconds. This is used for testing",
     )
-    options = parser.parse_args(args)
+    options, _ = parser.parse_known_args(args)
 
     # fix up some of the options for mantid
     options.checkfornewmantid = _bool_to_mtd_str(options.checkfornewmantid)

--- a/src/snapred/backend/api/InterfaceController.py
+++ b/src/snapred/backend/api/InterfaceController.py
@@ -24,11 +24,11 @@ class InterfaceController:
             # run the recipe
             result = service.orchestrateRecipe(request)
             # convert the response into object to communicate with
-            response = SNAPResponse(responseCode=200, responseMessage=None, responseData=result)
+            response = SNAPResponse(code=200, message=None, data=result)
         except Exception as e:  # noqa BLE001
             # handle exceptions, inform client if recoverable
             self.logger.exception("Failed to call service")
-            response = SNAPResponse(responseCode=500, responseMessage=str(e))
+            response = SNAPResponse(code=500, message=str(e))
 
         self.logger.debug(response.json())
         return response

--- a/src/snapred/backend/dao/SNAPResponse.py
+++ b/src/snapred/backend/dao/SNAPResponse.py
@@ -1,12 +1,16 @@
+from enum import IntEnum
 from typing import Optional
 
 from pydantic import BaseModel
 
 
-class SNAPResponse(BaseModel):
-    """"""
+class ResponseCode(IntEnum):
+    OK = 200
+    ERROR = 500
 
-    code: int
+
+class SNAPResponse(BaseModel):
+    code: ResponseCode
     message: Optional[str] = None
     data: Optional[dict] = None
 

--- a/src/snapred/backend/dao/SNAPResponse.py
+++ b/src/snapred/backend/dao/SNAPResponse.py
@@ -6,9 +6,9 @@ from pydantic import BaseModel
 class SNAPResponse(BaseModel):
     """"""
 
-    responseCode: int
-    responseMessage: Optional[str] = None
-    responseData: Optional[dict] = None
+    code: int
+    message: Optional[str] = None
+    data: Optional[dict] = None
 
     # if we need specific getter and setter methods, we can use the @property decorator
     # https://docs.python.org/3/library/functions.html#property

--- a/src/snapred/ui/presenter/LogTablePresenter.py
+++ b/src/snapred/ui/presenter/LogTablePresenter.py
@@ -49,7 +49,7 @@ class LogTablePresenter(object):
 
     def update_reduction_config_element(self, response: SNAPResponse):
         # import pdb; pdb.set_trace()
-        if response.responseCode == 200:
+        if response.code == 200:
             from snapred.ui.widget.WorkflowNode import continueWorkflow, finalizeWorkflow, startWorkflow
 
             workflow = startWorkflow(lambda workflow: None, self._labelView("Did it work?"))  # noqa: ARG005
@@ -61,7 +61,7 @@ class LogTablePresenter(object):
         else:
             messageBox = QMessageBox()
             messageBox.setIcon(QMessageBox.Critical)
-            messageBox.setText(response.responseMessage)
+            messageBox.setText(response.message)
             messageBox.setFixedSize(500, 200)
             messageBox.exec()
 

--- a/src/snapred/ui/presenter/TestPanelPresenter.py
+++ b/src/snapred/ui/presenter/TestPanelPresenter.py
@@ -22,7 +22,7 @@ class TestPanelPresenter(object):
 
     def __init__(self, view):
         reductionRequest = SNAPRequest(path="api", payload=None)
-        self.apiDict = self.interfaceController.executeRequest(reductionRequest).responseData
+        self.apiDict = self.interfaceController.executeRequest(reductionRequest).data
 
         self.apiComboBox = self.setupApiComboBox(self.apiDict, view)
 

--- a/src/snapred/ui/view/BackendRequestView.py
+++ b/src/snapred/ui/view/BackendRequestView.py
@@ -45,9 +45,9 @@ class BackendRequestView(QWidget):
 
         def executeRequest(reductionRequest):
             response = self.interfaceController.executeRequest(reductionRequest)
-            if response.responseCode != 200:
+            if response.code != 200:
                 ex = QWidget()
-                QMessageBox.critical(ex, "Error! :^(", str(response.responseMessage))
+                QMessageBox.critical(ex, "Error! :^(", str(response.message))
 
         # setup workers with work targets and args
         self.worker = self.worker_pool.createWorker(target=executeRequest, args=(reductionRequest))

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -23,10 +23,10 @@ def test_excuteRequest_noop():
     response = interfaceController.executeRequest(request=request)
 
     # verify response code
-    assert response.responseCode == 200
+    assert response.code == 200
 
     # verify the expected keys
-    apiDict = response.responseData
+    apiDict = response.data
     keys = list(apiDict.keys())
     keys.sort()
     assert keys == expected_keys

--- a/tests/unit/backend/api/test_InterfaceController.py
+++ b/tests/unit/backend/api/test_InterfaceController.py
@@ -31,9 +31,9 @@ with mock.patch.dict(
         reductionRequest = mock.Mock()
         reductionRequest.path = "Test Service"
         response = interfaceController.executeRequest(reductionRequest)
-        assert response.responseCode == 200
-        assert response.responseMessage is None
-        assert response.responseData["result"] == "Success!"
+        assert response.code == 200
+        assert response.message is None
+        assert response.data["result"] == "Success!"
 
     def test_executeRequest_unsuccessful():
         """Test executeRequest with an unsuccessful service"""
@@ -42,6 +42,6 @@ with mock.patch.dict(
         reductionRequest.path = "Non-existent Test Service"
         # mock orchestrateRecipe to raise an exception
         response = interfaceController.executeRequest(reductionRequest)
-        assert response.responseCode == 500
-        assert response.responseMessage is not None
-        assert response.responseData is None
+        assert response.code == 500
+        assert response.message is not None
+        assert response.data is None

--- a/tests/unit/backend/dao/test_SNAPResponse.py
+++ b/tests/unit/backend/dao/test_SNAPResponse.py
@@ -1,0 +1,17 @@
+import pytest
+from pydantic.error_wrappers import ValidationError
+from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
+
+
+def test_enum():
+    assert ResponseCode.OK == 200
+    assert ResponseCode.ERROR == 500
+
+
+def test_constructors():
+    assert SNAPResponse(code=200).code == ResponseCode.OK
+    assert SNAPResponse(code=500).code == ResponseCode.ERROR
+
+    # cannot be a teapot
+    with pytest.raises(ValidationError):
+        SNAPResponse(code=418)


### PR DESCRIPTION
This renames the fields in SNAPResponse to reduce redundancy and changes the `code` to an `IntEnum`.