### PR TITLE
Pin version of pydantic to be what is actually supported

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -26,8 +26,9 @@ build:
 
 requirements:
   host:
-    - versioningit
     - python
+    - versioningit
+    - pydantic=1.10
 
   build:
     - setuptools

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -32,13 +32,13 @@ requirements:
   build:
     - setuptools
     - versioningit
-    - pydantic
+    - {{ pin_compatible("pydantic", min_pin="1.10", max_pin="2") }}
     - mantidworkbench
     - qtpy
     - pytest
 
   run:
-    - pydantic
+    - {{ pin_compatible("pydantic", min_pin="1.10", max_pin="2") }}
     - mantidworkbench
 
 about:

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
 - python=3.8
 - pip
-- pydantic
+- pydantic>=1.10,<2
 - mantidworkbench
 - qtpy
 - pre-commit

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ include_package_data = True
 packages = find:
 python_requires >= 3.8
 install_requires =
-    pydantic
+    pydantic >=1.10,<2
     mantidworkbench
     qtpy
 tests_require =


### PR DESCRIPTION
We are using features of pydantic >=1.10,<2. Set that in the builds and in the packaging.