### PR TITLE
Make transparent background optional so gui can be loaded with mantid

### DIFF
--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -22,9 +22,11 @@ from snapred.ui.widget.ToolBar import ToolBar
 
 
 class SNAPRedGUI(QMainWindow):
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, window_flags=None, translucentBackground=False):
         super(SNAPRedGUI, self).__init__(parent)
-        self.setAttribute(Qt.WA_TranslucentBackground, True)
+        if window_flags:
+            self.setWindowFlags(window_flags)
+        self.setAttribute(Qt.WA_TranslucentBackground, translucentBackground)
         self.setAttribute(Qt.WA_DontCreateNativeAncestors, True)
         logTable = LogTable("load dummy", self)
         splitter = QSplitter(Qt.Vertical)
@@ -102,7 +104,7 @@ def start(options=None):
 
     logger.info("Welcome User! Happy Reducing!")
     try:
-        ex = SNAPRedGUI()
+        ex = SNAPRedGUI(translucentBackground=True)
         ex.show()
 
         if options.headcheck:


### PR DESCRIPTION
When creating https://github.com/mantidproject/mantid/pull/35885 it was discovered that snapred (w/o the style-sheet) is translucent. This makes it optional (default is opaque) so it doesn't look so crazy when launched from mantid, and is still correct when launched stand-alone.

This is part of [EWM1577](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=1577).