### PR TITLE
Enable mypy in pre-commit pre-push stage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,8 +27,8 @@ repos:
     - id: black
       args: ['--line-length=120']
       exclude: "tests/cis_tests/.*"
-# disable for now
-#- repo: https://github.com/pre-commit/mirrors-mypy
-#  rev: v1.1.1
-#  hooks:
-#  - id: mypy
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.4.1
+  hooks:
+    - id: mypy
+      stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,4 @@ repos:
   hooks:
     - id: mypy
       stages: [pre-push]
+      additional_dependencies: [ pydantic<2 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,11 @@ select = ["A", "ARG", "BLE", "E", "F", "I", "PT"]
 ignore = ["F403", "F405", "F401", # wild imports and  unknown names
 ]
 
+[tool.mypy]
+plugins = [
+  "pydantic.mypy"
+]
+
 [[tool.mypy.overrides]]
 module = [
     "yaml",

--- a/src/snapred/backend/dao/InstrumentConfig.py
+++ b/src/snapred/backend/dao/InstrumentConfig.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from pydantic import BaseModel
 
 
@@ -11,7 +13,7 @@ class InstrumentConfig(BaseModel):
     nexusFilePrefix: str
     calibrationFileExtension: str
     calibrationFilePrefix: str
-    calibrationDirectory: str
+    calibrationDirectory: Path
     pixelGroupingDirectory: str
     sharedDirectory: str
     nexusDirectory: str

--- a/src/snapred/backend/dao/InstrumentConfig.py
+++ b/src/snapred/backend/dao/InstrumentConfig.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from pydantic import BaseModel
 
 
@@ -13,7 +11,7 @@ class InstrumentConfig(BaseModel):
     nexusFilePrefix: str
     calibrationFileExtension: str
     calibrationFilePrefix: str
-    calibrationDirectory: Path
+    calibrationDirectory: str
     pixelGroupingDirectory: str
     sharedDirectory: str
     nexusDirectory: str

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -90,6 +90,7 @@ class LocalDataService:
             instrumentConfig.calibrationDirectory = Path(Config["instrument.calibration.home"])
             if self.verifyPaths and not instrumentConfig.calibrationDirectory.exists():
                 raise _createFileNotFoundError("[calibration directory]", instrumentConfig.calibrationDirectory)
+            instrumentConfig.calibrationDirectory = str(calibrationDirectory)
 
         return instrumentConfig
 
@@ -116,7 +117,7 @@ class LocalDataService:
             isLiteMode=True,  # TODO: Support non lite mode
             rawVanadiumCorrectionFileName=reductionParameters["rawVCorrFileName"],
             vanadiumFilePath=str(
-                self.instrumentConfig.calibrationDirectory
+                Path(self.instrumentConfig.calibrationDirectory)
                 / "Powder"
                 / reductionParameters["stateId"]
                 / reductionParameters["rawVCorrFileName"]
@@ -139,7 +140,7 @@ class LocalDataService:
             runNumber=reductionParameters["CRun"][0],
             name=reductionParameters.get("CalibrantName"),
             diffCalPath=str(
-                self.instrumentConfig.calibrationDirectory
+                Path(self.instrumentConfig.calibrationDirectory)
                 / "Powder"
                 / reductionParameters["stateId"]
                 / reductionParameters["calFileName"]
@@ -183,7 +184,7 @@ class LocalDataService:
                     dMax=reductionParameters["focGroupDMax"][i],
                     dMin=reductionParameters["focGroupDMin"][i],
                     definition=str(
-                        self.instrumentConfig.calibrationDirectory
+                        Path(self.instrumentConfig.calibrationDirectory)
                         / "Powder"
                         / self.instrumentConfig.pixelGroupingDirectory
                         / reductionParameters["focGroupDefinition"][i]
@@ -299,8 +300,8 @@ class LocalDataService:
         return fileList
 
     def _constructCalibrationStatePath(self, stateId):
-        # TODO: Propogate pathlib through codebase
-        return f"{self.instrumentConfig.calibrationDirectory / 'Powder' / stateId}/"
+        filepath = Path(self.instrumentConfig.calibrationDirectory) / "Powder" / str(stateId)
+        return str(filepath)
 
     def _readReductionParameters(self, runId: str) -> Dict[Any, Any]:
         # lookup IPTS number


### PR DESCRIPTION
*DO NOT MERGE INTO NEXT UNTIL ISSUES ARE FIXED*

This turns mypy on for pre-push stage so pre-commit.ci will not timeout during its runs, but the developer can still see what is happening with the code.

To try this out
```sh
pre-commit run mypy --hook-stage=pre-push  --all
```

At the time of the last push, this results in
```sh
Found 35 errors in 15 files (checked 187 source files)
```

References
----------
* [Using mypy with an existing codebase](https://mypy.readthedocs.io/en/stable/existing_code.html)
* [pydantic with mypy](https://docs.pydantic.dev/latest/integrations/mypy/)