### PR TITLE
For EWM 2121.

### DIFF
--- a/src/snapred/backend/recipe/algorithm/IngestCrystallographicInfoAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/IngestCrystallographicInfoAlgorithm.py
@@ -36,10 +36,9 @@ class IngestCrystallographicInfoAlgorithm(PythonAlgorithm):
         # Generate reflections
         generator = ReflectionGenerator(xtal)
 
-        # Create list of unique reflections between 0.7 and 3.0 Angstrom
-        # TODO: fix dMin, dMax to specific values
-        dMin = 0.5
-        dMax = 5.0
+        # Create list of unique reflections between 0.1 and 100.0 Angstrom
+        dMin = 0.1
+        dMax = 100.0
         hkls = generator.getUniqueHKLsUsingFilter(dMin, dMax, ReflectionConditionFilter.StructureFactor)
 
         # Calculate d and F^2

--- a/tests/unit/backend/recipe/test_IngestionRecipe.py
+++ b/tests/unit/backend/recipe/test_IngestionRecipe.py
@@ -28,7 +28,7 @@ with mock.patch.dict(
             assert xtal.hkl[5] == (4, 0, 0)
             assert xtal.dSpacing[0] == 3.13592994862768
             assert xtal.dSpacing[4] == 1.0453099828758932
-            assert data["fSquaredThreshold"] == 541.8942599465485
+            assert data["fSquaredThreshold"] == 0.002484449522957245
 
     def test_failed_path():
         """Test failure of crystal ingestion recipe with a bad path name"""


### PR DESCRIPTION
This changes the values for `dMin` & `dMax` from 0.5 and 5.0 to 0.1 and 100.0 respectively. This change is to increase the sensitivity to include a large range of peaks which was an issue found in the testing of `SmoothDataExcludingPeaks` (EWM 757).