### PR TITLE
Update environment.yml for python 3.10

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 - default
 - mantid/label/nightly
 dependencies:
-- python=3.8
+- python=3.10
 - pip
 - pydantic>=1.10,<2
 - mantidworkbench


### PR DESCRIPTION
Mantid nightly now requires python 3.10.  This could be why new changes to mantid are not reaching SNAPRed.