### PR TITLE
Get rid of second setuptools install

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,10 +21,9 @@ dependencies:
 - setuptools
 - sphinx
 - sphinx_rtd_theme=1.2.*
+- types-pyyaml
 - python-build
 - boa
 - pycifrw
 - pip:
   - check-wheel-contents
-  - types-pyyaml
-  - setuptools==47.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - python=3.10
 - pip
 - pydantic>=1.10,<2
-- mantidworkbench
+- mantidworkbench>=6.7
 - qtpy
 - pre-commit
 - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["setuptools >= 42", "wheel", "toml", "versioningit"]
+requires = ["setuptools", "wheel", "toml", "versioningit"]
 build-backend = "setuptools.build_meta"
 
 [tool.versioningit.vcs]

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ package_dir=
    =src
 include_package_data = True
 packages = find:
-python_requires >= 3.8
+python_requires >= 3.10
 install_requires =
     pydantic >=1.10,<2
     mantidworkbench


### PR DESCRIPTION
**Description of work**

By not installing setuptools a second time, distutils doesn't exist and the install error doesn't appear.

**To test:**

See that CI is happy.

There is no EWM item
