### PR TITLE
Create simple algorithm to load data for other algoritrhms

### DIFF
--- a/src/snapred/backend/recipe/algorithm/RaidPantry.py
+++ b/src/snapred/backend/recipe/algorithm/RaidPantry.py
@@ -1,0 +1,69 @@
+import json
+from typing import Dict, List, Tuple
+
+import numpy as np
+from mantid.api import (
+    AlgorithmFactory,
+    PythonAlgorithm,
+)
+from mantid.kernel import (
+    Direction,
+    FileAction,
+    FileProperty,
+    StringListValidator,
+)
+
+from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
+
+name = "RaidPantry"
+
+
+class RaidPantry(PythonAlgorithm):
+    """
+    For general-purpose loading scattering data into a workspace.
+    """
+
+    def PyInit(self):
+        # declare properties
+        self.declareProperty(
+            FileProperty(
+                "Filename",
+                defaultValue="",
+                action=FileAction.OptionalLoad,
+                extensions=["xml", "h5", "nxs", "hd5"],
+            ),
+            direction=Direction.Input,
+        )
+        self.declareProperty(
+            "Workspace",
+            defaultValue="",
+            direction=Direction.Output,
+        )
+        self.declareProperty(
+            "LoaderType",
+            "",
+            StringListValidator(["LoadNexus", "LoadEventNexus", "LoadNexuxProcessed"]),
+            Direction.Input,
+        )
+        self.mantidSnapper = MantidSnapper(self, name)
+
+    def PyExec(self) -> None:
+        filename = self.getProperty("Filename").value
+        outWS = self.getProperty("Workspace").value
+        loaderType = self.getProperty("LoaderType").value
+        if not self.mantidSnapper.mtd.doesExist(outWS):
+            if loaderType == "":
+                self.mantidSnapper.Load(
+                    Filename=filename,
+                    OutputWorkspace=outWS,
+                )
+            else:
+                getattr(self.mantidSnapper, loaderType)(
+                    Filename=filename,
+                    OutputWorkspace=outWS,
+                )
+        self.mantidSnapper.executeQueue()
+
+
+# Register algorithm with Mantid
+AlgorithmFactory.subscribe(RaidPantry)


### PR DESCRIPTION
**Description of work**

Algorithms frequently need to use actual neutron scattering data.

It is undesirable for them to handle their own loading.  It would be better to pass this off somewhere.  Algorithms and recipes should not be calling services to do this.  At the recipe level, an algorithm is needed which will load scattering data, before the workspace is passed to an algorithm.

This is a first step.

**To test:**

The following algorithms call some form of "Load" function with nexus data:
- `AlignAndFocusReductionAlgorithm`
- `CalculateOffsetDIFC`
- `CalibrationReductionAlgorithm`
- `GroupByGroupCalibration`
- `ReductionAlgorithm`
- `VanadiumFocussedReductionAlgorithm`

In each, replace the Load function with a call to `RaidPantry`, passing if you wish the name of the Load function used in the `LoaderType` argument.  Then re-run unit tests and verify everything worked.

**Link to EWM item**
None, I did this for fun, following discussion in hackathon.