### PR TITLE
Defect 2431, fixed a bunch of items for running calibration reduction ux

### DIFF
--- a/src/snapred/backend/api/InterfaceController.py
+++ b/src/snapred/backend/api/InterfaceController.py
@@ -29,6 +29,7 @@ class InterfaceController:
             # handle exceptions, inform client if recoverable
             self.logger.exception("Failed to call service")
             response = SNAPResponse(code=500, message=str(e))
+            return response
 
         self.logger.debug(response.json())
         return response

--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -69,3 +69,9 @@ class DataFactoryService:
 
     def checkCalibrationStateExists(self, runId: str):
         return self.lookupService.checkCalibrationFileExists(runId)
+
+    def getSamplePaths(self):
+        return self.lookupService.readSamplePaths()
+
+    def getGroupingFiles(self):
+        return self.lookupService.readGroupingFiles()

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -671,3 +671,22 @@ class LocalDataService:
             return True
         else:
             return False
+
+    def readSamplePaths(self):
+        sampleFolder = Config["instrument.calibration.sample.home"]
+        # collect list of all json in folder
+        samples = self._findMatchingFileList(f"{sampleFolder}/*.json", throws=False)
+        if len(samples) < 1:
+            raise RuntimeError(f"No samples found in {sampleFolder}")
+        return samples
+
+    def readGroupingFiles(self):
+        groupingFolder = Config["instrument.calibration.powder.grouping.home"]
+        extensions = Config["instrument.calibration.powder.grouping.extensions"]
+        # collect list of all files in folder that are applicable extensions
+        groupingFiles = []
+        for extension in extensions:
+            groupingFiles += self._findMatchingFileList(f"{groupingFolder}/*.{extension}", throws=False)
+        if len(groupingFiles) < 1:
+            raise RuntimeError(f"No grouping files found in {groupingFolder} for extensions {extensions}")
+        return groupingFiles

--- a/src/snapred/backend/service/ConfigLookupService.py
+++ b/src/snapred/backend/service/ConfigLookupService.py
@@ -18,11 +18,20 @@ class ConfigLookupService(Service):
         super().__init__()
         self.dataFactoryService = DataFactoryService()
         self.registerPath("", self.getConfigs)
+        self.registerPath("samplePaths", self.getSamplePaths)
+        self.registerPath("groupingFiles", self.getGroupingFiles)
+
         return
 
     @staticmethod
     def name():
         return "config"
+
+    def getSamplePaths(self):
+        return self.dataFactoryService.getSamplePaths()
+
+    def getGroupingFiles(self):
+        return self.dataFactoryService.getGroupingFiles()
 
     @FromString
     def getConfigs(self, runs: List[RunConfig]):

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -7,6 +7,18 @@ orchestration:
 instrument:
   name: SNAP
   home: /SNS/SNAP/
+  calibration:
+    home: ${instrument.home}shared/Calibration
+    sample:
+      home: ${instrument.calibration.home}/CalibrantSamples
+    powder:
+      home: ${instrument.calibration.home}/Powder
+      grouping:
+        home: ${instrument.calibration.powder.home}/PixelGroupingDefinitions
+        extensions:
+          - xml
+          - nxs
+          - hdf
   config: shared/Calibration/SNAPInstPrm.json
   lite:
     definition:

--- a/src/snapred/resources/dev.yml
+++ b/src/snapred/resources/dev.yml
@@ -1,2 +1,2 @@
 instrument:
-  home: /SNS/users/wqp/SNAP/
+  home: /home/wqp/SNS/SNAP/

--- a/src/snapred/resources/style.qss
+++ b/src/snapred/resources/style.qss
@@ -5,6 +5,11 @@ QWidget {
     color: #0B0014;
 }
 
+QWidget:disabled {
+    background-color: #f6dbde;
+    color: #ddc5c7;
+}
+
 QMainWindow {
     background: transparent;
 }

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -72,9 +72,21 @@ class SNAPRedGUI(QMainWindow):
         self.setStatusBar(self.statusBar)
 
     def openNewWindow(self):
-        self.newWindow = TestPanel(self)
-        self.newWindow.widget.setWindowTitle("Test Panel")
-        self.newWindow.widget.show()
+        try:
+            self.newWindow = TestPanel(self)
+            self.newWindow.widget.setWindowTitle("Test Panel")
+            self.newWindow.widget.show()
+        except Exception as e:  # noqa: BLE001
+            # show error message as popup
+            print(e)
+            from PyQt5.QtWidgets import QMessageBox
+
+            errorPopup = QMessageBox()
+            errorPopup.setIcon(QMessageBox.Critical)
+            errorPopup.setText("Sorry!\nError In TestPanel!\nPlease try again avoiding whatever you just did.")
+            errorPopup.setDetailedText(str(e))
+            errorPopup.setFixedSize(500, 200)
+            errorPopup.exec()
 
     def closeEvent(self, event):
         event.accept()

--- a/src/snapred/ui/presenter/WorkflowNodePresenter.py
+++ b/src/snapred/ui/presenter/WorkflowNodePresenter.py
@@ -1,4 +1,18 @@
+from time import sleep
+
 from snapred.ui.threading.worker_pool import WorkerPool
+
+
+class _Spinner:
+    i = 0
+    symbols = ["|", "/", "-", "\\"]
+
+    def getAndIterate(self):
+        symbol = self.symbols[self.i % 4]
+        self.i += 1
+        if self.i > 3:
+            self.i = 0
+        return symbol
 
 
 class WorkflowPresenter(object):
@@ -36,7 +50,25 @@ class WorkflowPresenter(object):
         self.worker.finished.connect(lambda: self.view.continueButton.setEnabled(True))
         self.worker.finished.connect(lambda: self.view.quitButton.setEnabled(True))
 
+        self.infworker = self.worker_pool.createInfiniteWorker(target=self._buttonSpinner, args=(_Spinner()))
+
+        # update according to results
+        self.infworker.result.connect(self._updateButton)
+
+        # Final resets
+        self.worker.finished.connect(self.infworker.stop)
+        self.infworker.finished.connect(lambda: self.infworker.stop())
+        self.infworker.finished.connect(lambda: self._updateButton("Continue \U00002705"))
+
+        self.worker_pool.submitWorker(self.infworker)
         self.worker_pool.submitWorker(self.worker)
 
     def handleQuitButtonClicked(self):
         self.view.close()
+
+    def _updateButton(self, text):
+        self.view.button.setText(text)
+
+    def _buttonSpinner(self, spinner):
+        sleep(0.25)
+        return "Loading " + spinner.getAndIterate()

--- a/src/snapred/ui/threading/worker_pool.py
+++ b/src/snapred/ui/threading/worker_pool.py
@@ -22,8 +22,10 @@ class Worker(QObject):
     def run(self):
         """Long-running task."""
         try:
-            self.result.emit(self.target(self.args))
-            self.success.emit(True)
+            results = self.target(self.args)
+            # results.code = 200 # set to 200 for testing
+            self.result.emit(results)
+            self.success.emit(results.code - 200 < 100)
         except Exception as e:  # noqa: BLE001
             # print stacktrace
             import traceback

--- a/src/snapred/ui/view/BackendRequestView.py
+++ b/src/snapred/ui/view/BackendRequestView.py
@@ -13,21 +13,12 @@ class BackendRequestView(QWidget):
 
     def __init__(self, jsonForm, selection, parent=None):
         super(BackendRequestView, self).__init__(parent)
+        self.selection = selection
         self.layout = QGridLayout()
         self.setLayout(self.layout)
         self.jsonForm = jsonForm
         self.layout.addWidget(jsonForm.widget, 2, 0, 1, 2)
-
-        self.beginFlowButton = QPushButton("Begin Operation")
-        self.layout.addWidget(self.beginFlowButton, 3, 0, 1, 2)
-
-        def commenceFlow():
-            if selection.startswith("fitMultiplePeaks") or selection.startswith("vanadium"):
-                return
-            request = SNAPRequest(path=selection, payload=json.dumps(jsonForm.collectData()))
-            self.handleButtonClicked(request, self.beginFlowButton)
-
-        self.beginFlowButton.clicked.connect(commenceFlow)
+        jsonForm.widget.setVisible(False)
 
     def getFieldText(self, key):
         return self.jsonForm.getField(key).text()
@@ -45,20 +36,3 @@ class BackendRequestView(QWidget):
         layout.addWidget(label)
         layout.addWidget(field)
         return widget
-
-    def handleButtonClicked(self, reductionRequest, button):
-        button.setEnabled(False)
-
-        def executeRequest(reductionRequest):
-            response = self.interfaceController.executeRequest(reductionRequest)
-            if response.code != 200:
-                ex = QWidget()
-                QMessageBox.critical(ex, "Error! :^(", str(response.message))
-
-        # setup workers with work targets and args
-        self.worker = self.worker_pool.createWorker(target=executeRequest, args=(reductionRequest))
-
-        # Final resets
-        self.worker.finished.connect(lambda: button.setEnabled(True))
-
-        self.worker_pool.submitWorker(self.worker)

--- a/src/snapred/ui/view/CalibrationAssessmentView.py
+++ b/src/snapred/ui/view/CalibrationAssessmentView.py
@@ -1,0 +1,48 @@
+from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtWidgets import QComboBox, QGridLayout, QLabel, QLineEdit, QWidget
+
+from snapred.ui.widget.JsonFormList import JsonFormList
+from snapred.ui.widget.LabeledField import LabeledField
+
+
+class CalibrationAssessmentView(QWidget):
+    signalRunNumberUpdate = pyqtSignal(str)
+    signalSampleUpdate = pyqtSignal(int)
+
+    def __init__(self, name, jsonSchemaMap, samples=[], parent=None):
+        super().__init__(parent)
+        self._jsonFormList = JsonFormList(name, jsonSchemaMap, parent=parent)
+
+        self.layout = QGridLayout()
+        self.setLayout(self.layout)
+
+        self.interactionText = QLabel("Calibration Complete! Would you like to assess the calibration now?")
+
+        self.fieldRunNumber = LabeledField("Run Number :", self._jsonFormList.getField("run.runNumber"), self)
+        self.fieldRunNumber.setEnabled(False)
+        self.signalRunNumberUpdate.connect(self._updateRunNumber)
+
+        self.sampleDropdown = QComboBox()
+        self.sampleDropdown.setEnabled(False)
+        self.sampleDropdown.addItem("Select Sample")
+        self.sampleDropdown.addItems(samples)
+        self.sampleDropdown.model().item(0).setEnabled(False)
+        self.signalSampleUpdate.connect(self._updateSample)
+
+        self.layout.addWidget(self.interactionText)
+        self.layout.addWidget(self.fieldRunNumber)
+        self.layout.addWidget(LabeledField("Sample :", self.sampleDropdown, self))
+
+    # This signal boilerplate mumbo jumbo is necessary because worker threads cant update the gui directly
+    # So we have to send a signal to the main thread to update the gui, else we get an unhelpful segfault
+    def _updateRunNumber(self, runNumber):
+        self.fieldRunNumber.setText(runNumber)
+
+    def updateRunNumber(self, runNumber):
+        self.signalRunNumberUpdate.emit(runNumber)
+
+    def _updateSample(self, sampleIndex):
+        self.sampleDropdown.setCurrentIndex(sampleIndex)
+
+    def updateSample(self, sampleIndex):
+        self.signalSampleUpdate.emit(sampleIndex)

--- a/src/snapred/ui/view/CalibrationReductionRequestView.py
+++ b/src/snapred/ui/view/CalibrationReductionRequestView.py
@@ -5,19 +5,24 @@ from snapred.ui.widget.Toggle import Toggle
 
 
 class CalibrationReductionRequestView(BackendRequestView):
-    def __init__(self, jsonForm, parent=None):
+    def __init__(self, jsonForm, samples=[], groups=[], parent=None):
         selection = "calibration/reduction"
         super(CalibrationReductionRequestView, self).__init__(jsonForm, selection, parent=parent)
-        runNumberField = self._labeledField("Run Number", jsonForm.getField("runNumber"))
-        litemodeToggle = self._labeledField("Lite Mode", Toggle(parent=self))
-        self.layout.addWidget(runNumberField, 0, 0)
-        self.layout.addWidget(litemodeToggle, 0, 1)
+        self.runNumberField = self._labeledField("Run Number", jsonForm.getField("runNumber"))
+        self.litemodeToggle = self._labeledField("Lite Mode", Toggle(parent=self, state=True))
+        self.litemodeToggle.setEnabled(False)
+        self.layout.addWidget(self.runNumberField, 0, 0)
+        self.layout.addWidget(self.litemodeToggle, 0, 1)
 
-        sampleDropdown = QComboBox()
-        sampleDropdown.addItem("Select Sample")
+        self.sampleDropdown = QComboBox()
+        self.sampleDropdown.addItem("Select Sample")
+        self.sampleDropdown.addItems(samples)
+        self.sampleDropdown.model().item(0).setEnabled(False)
         # todo: get samples from backend
-        groupingFileDropdown = QComboBox()
-        groupingFileDropdown.addItem("Select Grouping File")
+        self.groupingFileDropdown = QComboBox()
+        self.groupingFileDropdown.addItem("Select Grouping File")
+        self.groupingFileDropdown.addItems(groups)
+        self.groupingFileDropdown.model().item(0).setEnabled(False)
         # todo get grouping files from backend
-        self.layout.addWidget(sampleDropdown, 1, 0)
-        self.layout.addWidget(groupingFileDropdown, 1, 1)
+        self.layout.addWidget(self.sampleDropdown, 1, 0)
+        self.layout.addWidget(self.groupingFileDropdown, 1, 1)

--- a/src/snapred/ui/view/JsonFormListView.py
+++ b/src/snapred/ui/view/JsonFormListView.py
@@ -19,11 +19,10 @@ class JsonFormListView(QWidget):
         field = self.getField(fieldPath)
         if field is not None:
             return field.text()
-        return None
 
     def getField(self, fieldPath):
         for jsonForm in self._jsonForms:
             field = jsonForm.getField(fieldPath)
             if field is not None:
                 return field
-        return None
+        RuntimeError("Field not found in json form list: " + fieldPath)

--- a/src/snapred/ui/view/JsonFormView.py
+++ b/src/snapred/ui/view/JsonFormView.py
@@ -55,7 +55,7 @@ class FormBuilder:
             data = {}
             iterable = None
             if prop.get("items") is None:
-                breakpoint()
+                RuntimeError("Invalid JSON Schema")
             if isinstance(prop["items"], list):
                 iterable = [("type", p["type"]) for p in prop["items"]]
             if isinstance(prop["items"], dict):

--- a/src/snapred/ui/view/LogTableView.py
+++ b/src/snapred/ui/view/LogTableView.py
@@ -8,20 +8,6 @@ class LogTableView(QtWidgets.QWidget):
         super(LogTableView, self).__init__(parent)
         self.grid = QtWidgets.QGridLayout(self)
         self.message = name
-        self.buttonAction = self._empty
-        self.button = QtWidgets.QPushButton(name, self)
-        self.button.clicked.connect(self.execButtonAction)
-        self.grid.addWidget(self.button)
-
-    def addRecipeConfig(self, reductionConfigs):
-        self.grid.addWidget(QtWidgets.QLabel(str(reductionConfigs)), self.position, 0)
-        self.position += 1
-
-    def execButtonAction(self):
-        self.buttonAction()
 
     def _empty(self):
         pass
-
-    def on_button_clicked(self, slot):
-        self.buttonAction = slot

--- a/src/snapred/ui/view/ReductionView.py
+++ b/src/snapred/ui/view/ReductionView.py
@@ -1,0 +1,31 @@
+from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtWidgets import QGridLayout, QLabel, QLineEdit, QWidget
+
+from snapred.ui.widget.JsonFormList import JsonFormList
+from snapred.ui.widget.LabeledField import LabeledField
+
+
+class ReductionView(QWidget):
+    signalRunNumberUpdate = pyqtSignal(str)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.layout = QGridLayout()
+        self.setLayout(self.layout)
+
+        self.interactionText = QLabel("Which Run would you like to reduce today?")
+
+        self.fieldRunNumber = LabeledField("Run Number :", QLineEdit(), self)
+        self.signalRunNumberUpdate.connect(self._updateRunNumber)
+
+        self.layout.addWidget(self.interactionText)
+        self.layout.addWidget(self.fieldRunNumber)
+
+    # This signal boilerplate mumbo jumbo is necessary because worker threads cant update the gui directly
+    # So we have to send a signal to the main thread to update the gui, else we get an unhelpful segfault
+    def _updateRunNumber(self, runNumber):
+        self.fieldRunNumber.setText(runNumber)
+
+    def updateRunNumber(self, runNumber):
+        self.signalRunNumberUpdate.emit(runNumber)

--- a/src/snapred/ui/view/SaveCalibrationView.py
+++ b/src/snapred/ui/view/SaveCalibrationView.py
@@ -1,0 +1,61 @@
+from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtWidgets import QGridLayout, QLabel, QWidget
+
+from snapred.ui.widget.JsonFormList import JsonFormList
+from snapred.ui.widget.LabeledField import LabeledField
+
+
+class SaveCalibrationView(QWidget):
+    signalRunNumberUpdate = pyqtSignal(str)
+
+    def __init__(self, name, jsonSchemaMap, parent=None):
+        super().__init__(parent)
+        self._jsonFormList = JsonFormList(name, jsonSchemaMap, parent=parent)
+
+        self.layout = QGridLayout()
+        self.setLayout(self.layout)
+
+        self.interactionText = QLabel("Assessment Complete! Would you like to save the calibration now?")
+
+        self.fieldRunNumber = LabeledField(
+            "Run Number :", self._jsonFormList.getField("calibrationIndexEntry.runNumber"), self
+        )
+        self.fieldRunNumber.setEnabled(False)
+        self.signalRunNumberUpdate.connect(self._updateRunNumber)
+
+        self.fieldVersion = LabeledField(
+            "Version :", self._jsonFormList.getField("calibrationIndexEntry.version"), self
+        )
+        # add tooltip to leave blank for new version
+        self.fieldVersion.setToolTip("Leave blank for new version!")
+
+        self.fieldAppliesTo = LabeledField(
+            "Applies To :", self._jsonFormList.getField("calibrationIndexEntry.appliesTo"), self
+        )
+        self.fieldAppliesTo.setToolTip(
+            "Determines which runs this calibration applies to. 'runNumber', '>runNumber', or \
+                '<runNumber', default is '>runNumber'."
+        )
+
+        self.fieldComments = LabeledField(
+            "Comments :", self._jsonFormList.getField("calibrationIndexEntry.comments"), self
+        )
+        self.fieldComments.setToolTip("Comments about the calibration, documentation of important information.")
+
+        self.fieldAuthor = LabeledField("Author :", self._jsonFormList.getField("calibrationIndexEntry.author"), self)
+        self.fieldAuthor.setToolTip("Author of the calibration.")
+
+        self.layout.addWidget(self.interactionText)
+        self.layout.addWidget(self.fieldRunNumber)
+        self.layout.addWidget(self.fieldVersion)
+        self.layout.addWidget(self.fieldAppliesTo)
+        self.layout.addWidget(self.fieldComments)
+        self.layout.addWidget(self.fieldAuthor)
+
+    # This signal boilerplate mumbo jumbo is necessary because worker threads cant update the gui directly
+    # So we have to send a signal to the main thread to update the gui, else we get an unhelpful segfault
+    def _updateRunNumber(self, runNumber):
+        self.fieldRunNumber.setText(runNumber)
+
+    def updateRunNumber(self, runNumber):
+        self.signalRunNumberUpdate.emit(runNumber)

--- a/src/snapred/ui/view/TestPanelView.py
+++ b/src/snapred/ui/view/TestPanelView.py
@@ -1,4 +1,4 @@
-from qtpy.QtWidgets import QGridLayout, QMainWindow, QWidget
+from qtpy.QtWidgets import QGridLayout, QMainWindow, QTabWidget, QWidget
 
 
 class TestPanelView(QMainWindow):
@@ -13,4 +13,7 @@ class TestPanelView(QMainWindow):
         self.grid.columnStretch(1)
         self.grid.rowStretch(1)
         self.centralWidget.setLayout(self.grid)
+        self.tabWidget = QTabWidget()
+        self.tabWidget.setTabPosition(QTabWidget.West)
+        self.grid.addWidget(self.tabWidget)
         self.adjustSize()

--- a/src/snapred/ui/widget/LabeledField.py
+++ b/src/snapred/ui/widget/LabeledField.py
@@ -1,0 +1,38 @@
+from PyQt5.QtWidgets import QHBoxLayout, QLabel, QLineEdit, QWidget
+
+
+class LabeledField(QWidget):
+    def __init__(self, label, field=None, parent=None):
+        super(LabeledField, self).__init__(parent)
+        self.setStyleSheet("background-color: #F5E9E2;")
+        layout = QHBoxLayout()
+        self.setLayout(layout)
+
+        self._label = QLabel(label)
+        if field is not None:
+            self._field = field
+        else:
+            self._field = QLineEdit(parent=self)
+
+        layout.addWidget(self._label)
+        layout.addWidget(self._field)
+        # adjust layout size such that label has no whitespace
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        self._label.adjustSize()
+        self._field.adjustSize()
+        self.adjustSize()
+
+    @property
+    def label(self):
+        return self._label
+
+    @property
+    def field(self):
+        return self._field
+
+    def text(self):
+        return self._field.text()
+
+    def setText(self, text):
+        self._field.setText(text)

--- a/src/snapred/ui/widget/Toggle.py
+++ b/src/snapred/ui/widget/Toggle.py
@@ -4,9 +4,9 @@ from qtpy.QtWidgets import QWidget
 
 
 class Toggle(QWidget):
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, state=False):
         super().__init__(parent=parent)
-        self._state = False
+        self._state = state
         self._ellipsePosition = 0.0
         self.toggleAnimation = QPropertyAnimation(self, b"ellipsePosition")
         # fixed height width ratio
@@ -14,6 +14,7 @@ class Toggle(QWidget):
         self.setFixedWidth(60)
         # self.update = self._doNothing
         self.toggleAnimation.finished.connect(self.update)
+        self.animateClick()
 
     @Property(float)
     def ellipsePosition(self):

--- a/src/snapred/ui/widget/Workflow.py
+++ b/src/snapred/ui/widget/Workflow.py
@@ -4,9 +4,9 @@ from snapred.ui.view.WorkflowView import WorkflowView
 
 
 class Workflow:
-    def __init__(self, model: WorkflowNodeModel, parent=None):
+    def __init__(self, model: WorkflowNodeModel, cancelLambda=None, parent=None):
         # default loading subview
-        self._presenter = WorkflowPresenter(model, parent)
+        self._presenter = WorkflowPresenter(model, cancelLambda=cancelLambda, parent=parent)
 
     @property
     def presenter(self):
@@ -15,6 +15,10 @@ class Workflow:
     @property
     def widget(self):
         return self._presenter.widget
+
+    @property
+    def nextWidget(self):
+        return self._presenter.nextView
 
     def show(self):
         self._presenter.show()

--- a/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
+++ b/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
@@ -6,9 +6,14 @@ from snapred.backend.api.InterfaceController import InterfaceController
 from snapred.backend.dao import RunConfig, SNAPRequest
 from snapred.backend.dao.calibration import CalibrationIndexEntry, CalibrationRecord
 from snapred.backend.dao.request import CalibrationAssessmentRequest, CalibrationExportRequest
+from snapred.backend.log.logger import snapredLogger
+from snapred.ui.view.CalibrationAssessmentView import CalibrationAssessmentView
 from snapred.ui.view.CalibrationReductionRequestView import CalibrationReductionRequestView
+from snapred.ui.view.SaveCalibrationView import SaveCalibrationView
 from snapred.ui.widget.JsonFormList import JsonFormList
 from snapred.ui.workflow.WorkflowBuilder import WorkflowBuilder
+
+logger = snapredLogger.getLogger(__name__)
 
 
 class DiffractionCalibrationCreationWorkflow:
@@ -28,22 +33,37 @@ class DiffractionCalibrationCreationWorkflow:
         request = SNAPRequest(path="api/parameters", payload="calibration/save")
         self.saveSchema = self.interfaceController.executeRequest(request).data
         self.saveSchema = {key: json.loads(value) for key, value in self.saveSchema.items()}
+        cancelLambda = None
+        if parent is not None and hasattr(parent, "close"):
+            cancelLambda = parent.close
+
+        request = SNAPRequest(path="config/samplePaths")
+        self.samplePaths = self.interfaceController.executeRequest(request).data
+
+        request = SNAPRequest(path="config/groupingFiles")
+        self.groupingFiles = self.interfaceController.executeRequest(request).data
+
+        self._calibrationReductionView = CalibrationReductionRequestView(
+            jsonForm, samples=self.samplePaths, groups=self.groupingFiles, parent=parent
+        )
+        self._calibrationAssessmentView = CalibrationAssessmentView(
+            "Assessing Calibration", self.assessmentSchema, samples=self.samplePaths, parent=parent
+        )
+        self._saveCalibrationView = SaveCalibrationView("Saving Calibration", self.saveSchema, parent)
 
         self.workflow = (
-            WorkflowBuilder(parent)
+            WorkflowBuilder(cancelLambda=cancelLambda, parent=parent)
             .addNode(
                 self._triggerCalibrationReduction,
-                CalibrationReductionRequestView(jsonForm, parent=parent),
+                self._calibrationReductionView,
                 "Calibrating",
             )
             .addNode(
                 self._assessCalibration,
-                JsonFormList("Assessing Calibration", self.assessmentSchema, parent).widget,
+                self._calibrationAssessmentView,
                 "Assessing",
             )
-            .addNode(
-                self._saveCalibration, JsonFormList("Saving Calibration", self.saveSchema, parent).widget, "Saving"
-            )
+            .addNode(self._saveCalibration, self._saveCalibrationView, "Saving")
             .build()
         )
 
@@ -53,24 +73,30 @@ class DiffractionCalibrationCreationWorkflow:
 
         # TODO: prepopulate next run number
         self.runNumber = view.getFieldText("runNumber")
-        # This code cause a segmentation fault when the ui element is viewed, why??
-        # nextRunNumberField = workflowPresenter.widget.nextTabView.getField("run.runNumber")
-        # nextRunNumberField.setText(self.runNumber)
+        sampleIndex = view.sampleDropdown.currentIndex()
+
+        self._calibrationAssessmentView.updateSample(sampleIndex)
+        self._calibrationAssessmentView.updateRunNumber(self.runNumber)
+        self._saveCalibrationView.updateRunNumber(self.runNumber)
 
         payload = RunConfig(runNumber=self.runNumber)
         request = SNAPRequest(path="calibration/reduction", payload=payload.json())
         response = self.interfaceController.executeRequest(request)
         self.responses.append(response)
+        return response
 
     def _assessCalibration(self, workflowPresenter):
         # TODO Load Previous ->
         view = workflowPresenter.widget.tabView
         # pull fields from view for calibration assessment
-        runNumber = view.getFieldText("run.runNumber")
-        payload = CalibrationAssessmentRequest(run=RunConfig(runNumber=runNumber), cifPath=view.getFieldText("cifPath"))
+        runNumber = view.fieldRunNumber.text()
+        payload = CalibrationAssessmentRequest(
+            run=RunConfig(runNumber=runNumber), cifPath=view.sampleDropdown.currentText()
+        )
         request = SNAPRequest(path="calibration/assessment", payload=payload.json())
         response = self.interfaceController.executeRequest(request)
         self.responses.append(response)
+        return response
 
     def _saveCalibration(self, workflowPresenter):
         view = workflowPresenter.widget.tabView
@@ -87,6 +113,7 @@ class DiffractionCalibrationCreationWorkflow:
         request = SNAPRequest(path="calibration/save", payload=payload.json())
         response = self.interfaceController.executeRequest(request)
         self.responses.append(response)
+        return response
 
     @property
     def widget(self):

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -1,0 +1,54 @@
+from snapred.backend.api.InterfaceController import InterfaceController
+from snapred.backend.dao import RunConfig, SNAPRequest
+from snapred.backend.log.logger import snapredLogger
+from snapred.ui.view.ReductionView import ReductionView
+from snapred.ui.workflow.WorkflowBuilder import WorkflowBuilder
+
+logger = snapredLogger.getLogger(__name__)
+
+
+class ReductionWorkflow:
+    def __init__(self, parent=None):
+        # create a tree of flows for the user to successfully execute diffraction calibration
+        # Calibrate     ->
+        # Assess        ->
+        # Save?         ->
+        self.requests = []
+        self.responses = []
+        self.interfaceController = InterfaceController()
+        cancelLambda = None
+        if parent is not None and hasattr(parent, "close"):
+            cancelLambda = parent.close
+
+        self._reductionView = ReductionView(parent=parent)
+
+        self.workflow = (
+            WorkflowBuilder(cancelLambda=cancelLambda, parent=parent)
+            .addNode(
+                self._triggerReduction,
+                self._reductionView,
+                "Reduction",
+            )
+            .build()
+        )
+
+    def _triggerReduction(self, workflowPresenter):
+        view = workflowPresenter.widget.tabView
+        # pull fields from view for calibration reduction
+
+        self.runNumber = view.fieldRunNumber.text()
+
+        payload = RunConfig(runNumber=self.runNumber)
+        request = SNAPRequest(path="reduction", payload=payload.json())
+        response = self.interfaceController.executeRequest(request)
+        self.responses.append(response)
+        return response
+
+    @property
+    def widget(self):
+        return self.workflow.presenter.widget
+
+    def show(self):
+        # wrap workflow.presenter.widget in a QMainWindow
+        # show the QMainWindow
+        pass

--- a/src/snapred/ui/workflow/WorkflowBuilder.py
+++ b/src/snapred/ui/workflow/WorkflowBuilder.py
@@ -3,8 +3,9 @@ from snapred.ui.widget.Workflow import Workflow
 
 
 class WorkflowBuilder:
-    def __init__(self, parent=None):
+    def __init__(self, cancelLambda=None, parent=None):
         self.parent = parent
+        self._cancelLambda = cancelLambda
         self._workflow = None
 
     def addNode(self, continueAction, subview, name="Unnamed"):
@@ -20,4 +21,4 @@ class WorkflowBuilder:
         return self
 
     def build(self):
-        return Workflow(self._workflow, self.parent)
+        return Workflow(self._workflow, self._cancelLambda, self.parent)

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -7,6 +7,18 @@ orchestration:
 instrument:
   name: SNAP
   home: /SNS/SNAP/
+  calibration:
+    home: ${instrument.home}shared/Calibration
+    sample:
+      home: ${instrument.calibration.home}/CalibrantSamples
+    powder:
+      home: ${instrument.calibration.home}/Powder
+      grouping:
+        home: ${instrument.calibration.powder.home}/PixelGroupingDefinitions
+        extensions:
+          - xml
+          - nxs
+          - hdf
   config: shared/Calibration/SNAPInstPrm.json
   lite:
     definition:

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -69,3 +69,19 @@ with mock.patch.dict(
         actual = dataExportService.getCalibrationState(mock.Mock())
 
         assert actual == "expected"
+
+    def test_getSamplePaths():
+        dataExportService = DataFactoryService()
+        dataExportService.lookupService.readSamplePaths = mock.Mock()
+        dataExportService.lookupService.readSamplePaths.return_value = "expected"
+        actual = dataExportService.getSamplePaths()
+
+        assert actual == "expected"
+
+    def test_getGroupingFile():
+        dataExportService = DataFactoryService()
+        dataExportService.lookupService.readGroupingFiles = mock.Mock()
+        dataExportService.lookupService.readGroupingFiles.return_value = "expected"
+        actual = dataExportService.getGroupingFiles()
+
+        assert actual == "expected"

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -394,3 +394,48 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
             service.readInstrumentConfig()
 
         service.verifyPaths = False  # put the setting back
+
+    def test_readSamplePaths():
+        localDataService = LocalDataService()
+        localDataService._findMatchingFileList = mock.Mock()
+        localDataService._findMatchingFileList.return_value = [
+            "/sample1.json",
+            "/sample2.json",
+        ]
+        result = localDataService.readSamplePaths()
+        assert len(result) == 2
+        assert result[0] == "/sample1.json"
+        assert result[1] == "/sample2.json"
+
+    def test_readNoSamplePaths():
+        localDataService = LocalDataService()
+        localDataService._findMatchingFileList = mock.Mock()
+        localDataService._findMatchingFileList.return_value = []
+        try:
+            localDataService.readSamplePaths()
+            pytest.fail("Should have thrown an exception")
+        except RuntimeError:
+            assert True
+
+    def test_readGroupingFiles():
+        localDataService = LocalDataService()
+        localDataService._findMatchingFileList = mock.Mock()
+        localDataService._findMatchingFileList.return_value = [
+            "/group1.json",
+            "/group2.json",
+        ]
+        result = localDataService.readGroupingFiles()
+        # 6 because there are 3 file types and the mock returns 2 files per
+        assert len(result) == 6
+        assert result[0] == "/group1.json"
+        assert result[1] == "/group2.json"
+
+    def test_readNoGroupingFiles():
+        localDataService = LocalDataService()
+        localDataService._findMatchingFileList = mock.Mock()
+        localDataService._findMatchingFileList.return_value = []
+        try:
+            localDataService.readGroupingFiles()
+            pytest.fail("Should have thrown an exception")
+        except RuntimeError:
+            assert True


### PR DESCRIPTION
**Description of work**
- ~~Remove "Load Dummy"~~
	- ~~move reduction to its own screen.~~

### Diffraction Calibration UI Flow
- ~~lite toggle, default on, disabled~~
- ~~implement  setsample,  set grouping file~~
	- ~~populate the cif file dropdown (use the defined jsons)~~
- ~~remove "begin operation" button~~
- **pixelgroupingparamters call should be using user input grouping file. (Not Done)**
- ~~hide advanced json form parameters until further developed~~
- ~~make disabled buttons visibly disabled ~~

#### Assessment Step
- ~~Would you like to commence assessment?~~
- ~~pull out runnumber and cif file field~~
- ~~removed the advanced options~~
- ~~error handling~~
		- ~~shouldnt continue or disable continue button if a failure occurred due to user input


**To test:**

open the ui and muck about with the test panel, see what breaks and why.  This is mostly a ux pr so you might want to hotwire worker_pool to always treat returns as code 200

<!--
There should be sufficient instructions for someone unfamiliar with the application to test
- unless a specific reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Link to EWM item

[Defect 2431](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2431)