### PR TITLE
pin check-wheel-contents so it doesnt install pydantic 2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,4 +26,4 @@ dependencies:
 - boa
 - pycifrw
 - pip:
-  - check-wheel-contents
+  - check-wheel-contents=0.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -26,4 +26,4 @@ dependencies:
 - boa
 - pycifrw
 - pip:
-  - check-wheel-contents=0.4.0
+  - check-wheel-contents==0.4.0


### PR DESCRIPTION
**Description of work**
for some reason check-wheel-contents overwrites our pydantic 1 requirement.  Need to pin it.


**To test:**

check that the readthedocs build passes!
