### PR TITLE
Fix peaks list purge overlapping peaks algo

### DIFF
--- a/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
@@ -31,6 +31,10 @@ class PurgeOverlappingPeaksAlgorithm(PythonAlgorithm):
         self.mantidSnapper.executeQueue()
         predictedPeaks_json = json.loads(result.get())
 
+        allPeaks = [peak for group in predictedPeaks_json for peak in group]
+
+        uniquePeaks = list(set(allPeaks))
+
         # build lists of non-overlapping peaks for each focus group. Combine them into the total list.
         outputPeaks = []
         for focusGroupPeaks_json in predictedPeaks_json:

--- a/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
@@ -38,10 +38,10 @@ class PurgeOverlappingPeaksAlgorithm(PythonAlgorithm):
             groupPeakList = GroupPeakList.parse_obj(focusGroupPeaks_json)
 
             # ensure peaks are unique
-            unique_peaks = {peak.position.value: peak for peak in groupPeakList.peaks}.values()
+            uniquePeaks = {peak.position.value: peak for peak in groupPeakList.peaks}.values()
 
             # do the overlap rejection logic on unique peaks
-            peakList = list(unique_peaks)
+            peakList = list(uniquePeaks)
             nPks = len(peakList)
             keep = [True for _ in range(nPks)]
             outputPeakList = []

--- a/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
@@ -43,7 +43,7 @@ class PurgeOverlappingPeaksAlgorithm(PythonAlgorithm):
             # do the overlap rejection logic on unique peaks
             peakList = list(uniquePeaks)
             nPks = len(peakList)
-            keep = [True for _ in range(nPks)]
+            keep = [True for i in range(nPks)]
             outputPeakList = []
             for i in range(nPks - 1):
                 if keep[i]:
@@ -58,7 +58,7 @@ class PurgeOverlappingPeaksAlgorithm(PythonAlgorithm):
             if nPks > 0 and keep[-1]:
                 outputPeakList.append(peakList[-1])
 
-            self.log().notice(f"{nPks} peaks in and {len(outputPeakList)} peaks out")
+            self.log().notice(f" {nPks} peaks in and {len(outputPeakList)} peaks out")
             outputGroupPeakList = GroupPeakList(
                 groupID=groupPeakList.groupID,
                 peaks=outputPeakList,


### PR DESCRIPTION
**Description of work**
As per [Story 2435](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=2435) `PurgeOverlappingPeaksAlgorithm` was updated to create a unique list of peaks as first step. This was achieved by modifying the code and adding an additional line:
```python
uniquePeaks = {peak.position.value: peak for peak in groupPeakList.peaks}.values()
```
**To test:**
Please run `Pytest` and then an additional test would be to replicate the script that this issue was originally found in (I forget the script) within the workbench on analysis and then run that script to inspect if the output is correct.
<!--
There should be sufficient instructions for someone unfamiliar with the application to test
- unless a specific reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Link to EWM [item](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=2435)
