### PR TITLE
Fixed that case and pathing within LocalDataService.

### DIFF
--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -86,7 +86,7 @@ class LocalDataService:
         except KeyError as e:
             raise KeyError(f"{e}: while reading instrument configuration '{self.instrumentConfigPath}'") from e
         if self.dataPath:
-            instrumentConfig.calibrationDirectory = self.dataPath / "shared/Calibration/"
+            instrumentConfig.calibrationDirectory = Path(Config["instrument.calibration.home"])
             if self.verifyPaths and not instrumentConfig.calibrationDirectory.exists():
                 raise _createFileNotFoundError("[calibration directory]", instrumentConfig.calibrationDirectory)
 

--- a/src/snapred/ui/presenter/InitializeCalibrationPresenter.py
+++ b/src/snapred/ui/presenter/InitializeCalibrationPresenter.py
@@ -87,8 +87,8 @@ class CalibrationCheck(QObject):
         elif response.code == 500 and "Could not find all required logs in file" in response.message:
             self._labelView(str(response.message))
             return
-
-        elif response.code == 500:
+        
+        elif response.code == 500 or (response.code == 200 and response.data is False):
             reply = QMessageBox.question(
                 self.view,
                 "Initialize State",

--- a/src/snapred/ui/presenter/InitializeCalibrationPresenter.py
+++ b/src/snapred/ui/presenter/InitializeCalibrationPresenter.py
@@ -87,7 +87,7 @@ class CalibrationCheck(QObject):
         elif response.code == 500 and "Could not find all required logs in file" in response.message:
             self._labelView(str(response.message))
             return
-        
+
         elif response.code == 500 or (response.code == 200 and response.data is False):
             reply = QMessageBox.question(
                 self.view,


### PR DESCRIPTION
**Description of work**
Fixed an exception that was found by Malcolm and a pathing error found by Michael. The `hasState()` method within `CalibrationService` returned the correct boolean value but there was not exception handling to encompass this particular type of return error. Should be fixed.
**To test:**
Please launch SNAPRed UI and follow the `Check Calibration` workflow within the `Test Panel`.
<!--
There should be sufficient instructions for someone unfamiliar with the application to test
- unless a specific reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Link to EWM item
