### PR TITLE
expose PeakIntensityThreshold to PurgeOverlappingPeaks

### DIFF
--- a/src/snapred/backend/recipe/algorithm/DetectorPeakPredictor.py
+++ b/src/snapred/backend/recipe/algorithm/DetectorPeakPredictor.py
@@ -81,7 +81,7 @@ class DetectorPeakPredictor(PythonAlgorithm):
                 singleFocusGroupPeaks.append(
                     DetectorPeak(position=LimitedValue(value=d, minimum=d - widthLeft, maximum=d + widthRight))
                 )
-            maxFwhm = 2.35 * max(dList) * delDoD
+            maxFwhm = 2.35 * max(dList, default=0.0) * delDoD
 
             singleFocusGroupPeakList = GroupPeakList(peaks=singleFocusGroupPeaks, groupID=groupID, maxfwhm=maxFwhm)
             self.log().notice(f"Focus group {groupID} : {len(dList)} peaks out")

--- a/src/snapred/backend/recipe/algorithm/DiffractionSpectrumWeightCalculator.py
+++ b/src/snapred/backend/recipe/algorithm/DiffractionSpectrumWeightCalculator.py
@@ -36,7 +36,7 @@ class DiffractionSpectrumWeightCalculator(PythonAlgorithm):
                 "Predicting peaks...",
                 InstrumentState=self.getProperty("InstrumentState").value,
                 CrystalInfo=self.getProperty("CrystalInfo").value,
-                PeakIntensityThreshold="0",
+                PeakIntensityThreshold=0.0,
             )
             self.mantidSnapper.executeQueue()
             predictedPeaks_json = json.loads(result.get())

--- a/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
@@ -17,6 +17,12 @@ class PurgeOverlappingPeaksAlgorithm(PythonAlgorithm):
         self.declareProperty("InstrumentState", defaultValue="", direction=Direction.Input)
         self.declareProperty("CrystalInfo", defaultValue="", direction=Direction.Input)
         self.declareProperty("OutputPeakMap", defaultValue="", direction=Direction.Output)
+        self.declareProperty(
+            "PeakIntensityThreshold",
+            defaultValue=0.05,
+            direction=Direction.Input,
+            doc="Fraction of max for threshold peak intensity",
+        )
 
         self.setRethrows(True)
         self.mantidSnapper = MantidSnapper(self, name)
@@ -27,6 +33,7 @@ class PurgeOverlappingPeaksAlgorithm(PythonAlgorithm):
             "Predicting peaks...",
             InstrumentState=self.getProperty("InstrumentState").value,
             CrystalInfo=self.getProperty("CrystalInfo").value,
+            PeakIntensityThreshold=self.getProperty("PeakIntensityThreshold").value,
         )
         self.mantidSnapper.executeQueue()
         predictedPeaks_json = json.loads(result.get())

--- a/tests/unit/backend/recipe/algorithm/test_PurgeOverlappingPeaksAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_PurgeOverlappingPeaksAlgorithm.py
@@ -26,6 +26,7 @@ with mock.patch.dict(
         purgeAlgo.initialize()
         purgeAlgo.setProperty("InstrumentState", instrumentState.json())
         purgeAlgo.setProperty("CrystalInfo", crystalInfo.json())
+        purgeAlgo.setProperty("PeakIntensityThreshold", 0.045)
         assert purgeAlgo.getProperty("InstrumentState").value == instrumentState.json()
         assert CrystallographicInfo.parse_raw(purgeAlgo.getProperty("CrystalInfo").value) == crystalInfo
 
@@ -40,6 +41,7 @@ with mock.patch.dict(
         purgeAlgo.initialize()
         purgeAlgo.setProperty("InstrumentState", instrumentState.json())
         purgeAlgo.setProperty("CrystalInfo", crystalInfo.json())
+        purgeAlgo.setProperty("PeakIntensityThreshold", 0.05)
         purgeAlgo.execute()
 
         actual_pos_json = json.loads(purgeAlgo.getProperty("OutputPeakMap").value)
@@ -47,3 +49,10 @@ with mock.patch.dict(
         expected_pos_json = json.loads(Resource.read("/outputs/predict_peaks/peaks.json"))
 
         assert expected_pos_json == actual_pos_json
+
+        # test the threshold -- set to over-1 value and verify no peaks are found
+        purgeAlgo.setProperty("PeakIntensityThreshold", 1.2)
+        purgeAlgo.execute()
+        no_pos_json = json.loads(purgeAlgo.getProperty("OutputPeakMap").value)
+        for x in no_pos_json:
+            assert len(x["peaks"]) == 0


### PR DESCRIPTION
### Description of work

A threshold factor is given for cutting off small peaks predicted from a CIF file.  This is handled inside the `DetectorPeakPredictor` algorithm, which uses the factor to exclude small peaks from a list.

However, the ability to set this factor was not exposed through `PurgeOverlappingPeaks`, which instead relied on the default.  This work exposes the factor through the `"PeakThresholdIntensity"` property in `PurgeOverlappingPeaks` so that it may be adjusted.

There is an additional unit test that this property can be set.

The only other algorithm calling `DetectorPeakPredictor` is `DiffractionSpectrumWeightCalculator`, which seems to rather intentionally be setting this fraction to `0` to include every single peak.

### To test

Try the following:
``` python
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
import json

from snapred.backend.recipe.algorithm.PurgeOverlappingPeaksAlgorithm import PurgeOverlappingPeaksAlgorithm
from snapred.backend.service.CalibrationService import CalibrationService
from snapred.backend.data.DataFactoryService import DataFactoryService
from snapred.backend.service.CrystallographicInfoService import CrystallographicInfoService
from snapred.backend.log.logger import snapredLogger
from snapred.meta.redantic import list_to_raw_pretty

snapredLogger._level = 20

#User inputs ###########################
runNumber = '58882'
cifPath = '/SNS/SNAP/shared/Calibration/CalibrantSamples/Silicon_NIST_640d.cif'
#######################################
dataFactoryService=DataFactoryService()
calibrationService = CalibrationService()

pixelGroupingParameters = calibrationService.retrievePixelGroupingParams(runNumber)

calibration = dataFactoryService.getCalibrationState(runNumber)
instrumentState = calibration.instrumentState
crystalInfoDict = CrystallographicInfoService().ingest(cifPath)
instrumentState.pixelGroupingInstrumentParameters = pixelGroupingParameters[0]

# construct a list of all intensity (A) values
xtal = crystalInfoDict['crystalInfo']
A = [F2 * M * d**4 for F2,M,d in zip(xtal.fSquared, xtal.dSpacing, xtal.multiplicities)]
maxA = max(A)

# run to get every single peak
detectorAlgo = PurgeOverlappingPeaksAlgorithm()
detectorAlgo.initialize()
detectorAlgo.setProperty("InstrumentState", instrumentState.json())
detectorAlgo.setProperty("CrystalInfo", crystalInfoDict['crystalInfo'].json())
detectorAlgo.setProperty("PeakIntensityThreshold", 0.0) # <<--- ADJUST THIS HERE
detectorAlgo.execute()
groupPeaks = json.loads(detectorAlgo.getProperty("OutputPeakMap").value)

# construct a dictionary of intensity at each peak center
allPeaks = []
for x in groupPeaks:
    allPeaks.extend(x['peaks'])
allPeakVals = [x['position']['value'] for x in allPeaks]

print(allPeakVals)
```

Adjust the value of the PeakIntensityThreshold, and verify that by changing this, the number of peaks also changes, in an expected way.  Compare output to the SNAPTools version.


<!--
There should be sufficient instructions for someone unfamiliar with the application to test
- unless a specific reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

### Link to EWM item

[EWM 2603](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2603)
