### PR TITLE
wash the dishes :plate_with_cutlery: :soap: 

### DIFF
--- a/src/snapred/backend/recipe/algorithm/CalculateOffsetDIFC.py
+++ b/src/snapred/backend/recipe/algorithm/CalculateOffsetDIFC.py
@@ -9,7 +9,6 @@ from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients as
 from snapred.backend.recipe.algorithm.ConvertDiffCalLog import ConvertDiffCalLog
 from snapred.backend.recipe.algorithm.LoadGroupingDefinition import LoadGroupingDefinition
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
-from snapred.backend.recipe.algorithm.WashDishes import WashDishes
 
 name = "CalculateOffsetDIFC"
 

--- a/src/snapred/backend/recipe/algorithm/CalibrationReductionAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/CalibrationReductionAlgorithm.py
@@ -69,8 +69,10 @@ class CalibrationReductionAlgorithm(PythonAlgorithm):
             "Applying DiffCal...", InstrumentWorkspace=raw_data, CalibrationWorkspace=diffCalPrefix + "_cal"
         )
 
-        self.mantidSnapper.DeleteWorkspace("Deleting DiffCal Mask", Workspace=diffCalPrefix + "_mask")
-        self.mantidSnapper.DeleteWorkspace("Deleting DiffCal Calibration", Workspace=diffCalPrefix + "_cal")
+        self.mantidSnapper.WashDishes(
+            "Deleting DiffCal Mask",
+            WorkspaceList=[diffCalPrefix + "_mask", diffCalPrefix + "_cal"],
+        )
 
         data = self.mantidSnapper.ConvertUnits(
             "Converting to Units of dSpacing ...",
@@ -80,7 +82,7 @@ class CalibrationReductionAlgorithm(PythonAlgorithm):
             OutputWorkspace="data",
             ConvertFromPointData=True,
         )
-        self.mantidSnapper.DeleteWorkspace("Deleting Raw Data", Workspace=raw_data)
+        self.mantidSnapper.WashDishes("Deleting Raw Data", Workspace=raw_data)
 
         focused_data = self.mantidSnapper.DiffractionFocussing(
             "Performing Diffraction Focusing ...",
@@ -93,8 +95,10 @@ class CalibrationReductionAlgorithm(PythonAlgorithm):
             "Normalizing Current ...", InputWorkspace=focused_data, OutputWorkspace=focused_data
         )
         self.mantidSnapper.RemoveLogs("Removing Logs...", Workspace=focused_data)
-        self.mantidSnapper.DeleteWorkspace("Deleting Intermediate Data", Workspace=data)
-        self.mantidSnapper.DeleteWorkspace("Deleting Grouping Workspace", Workspace=groupingworkspace)
+        self.mantidSnapper.WashDishes(
+            "Deleting Intermediate Data and Grouping Workspace",
+            WorkspaceList=[data, groupingworkspace],
+        )
 
         # Rename focused_data to runid_calibration_reduction_result
         outputNameFormat = Config["calibration.reduction.output.format"]

--- a/src/snapred/backend/recipe/algorithm/CustomGroupWorkspace.py
+++ b/src/snapred/backend/recipe/algorithm/CustomGroupWorkspace.py
@@ -60,7 +60,10 @@ class CustomGroupWorkspace(PythonAlgorithm):
 
         # cleanup temporary workspace
         if loadEmptyInstrument:
-            self.mantidSnapper.DeleteWorkspace("Deleting empty instrument...", Workspace=donorWorkspace)
+            self.mantidSnapper.WashDishes(
+                "Deleting empty instrument...",
+                Workspace=donorWorkspace,
+            )
             self.mantidSnapper.executeQueue()
 
         # create a workspace group of GroupWorkspaces

--- a/src/snapred/backend/recipe/algorithm/FitMultiplePeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FitMultiplePeaksAlgorithm.py
@@ -100,7 +100,7 @@ class FitMultiplePeaksAlgorithm(PythonAlgorithm):
             for output in outputNames:
                 ws_group.add(output)
 
-        self.mantidSnapper.DeleteWorkspace(
+        self.mantidSnapper.WashDishes(
             "Deleting fitting workspace...",
             Workspace="ws2fit",
         )

--- a/src/snapred/backend/recipe/algorithm/GroupByGroupCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/GroupByGroupCalibration.py
@@ -7,7 +7,6 @@ from mantid.kernel import Direction
 from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients as Ingredients
 from snapred.backend.recipe.algorithm.LoadGroupingDefinition import LoadGroupingDefinition
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
-from snapred.backend.recipe.algorithm.WashDishes import WashDishes
 
 name = "GroupByGroupCalibration"
 

--- a/src/snapred/backend/recipe/algorithm/IngestCrystallographicInfoAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/IngestCrystallographicInfoAlgorithm.py
@@ -64,7 +64,10 @@ class IngestCrystallographicInfoAlgorithm(PythonAlgorithm):
         xtal = CrystallographicInfo(hkl=hkls, dSpacing=dValues, fSquared=fSquared, multiplicities=multiplicities)
         self.setProperty("crystalInfo", xtal.json())
         # ws
-        self.mantidSnapper.DeleteWorkspace("Cleaning up xtal workspace.", Workspace="xtal_data")
+        self.mantidSnapper.WashDishes(
+            "Cleaning up xtal workspace.",
+            Workspace="xtal_data",
+        )
         self.mantidSnapper.executeQueue()
 
 

--- a/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
@@ -65,7 +65,6 @@ class LiteDataCreationAlgo(PythonAlgorithm):
             Filename=Resource.getPath("/inputs/pixel_grouping/SNAPLite_Definition.xml"),
             RewriteSpectraMap=False,
         )
-        # self.mantidSnapper.DeleteWorkspace("Cleaning up input workspace...", Workspace=ws)
         self.mantidSnapper.executeQueue()
 
         self.setProperty("OutputWorkspace", outputWorkspaceName)

--- a/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
@@ -120,8 +120,9 @@ class LoadGroupingDefinition(PythonAlgorithm):
                 OutputWorkspace=output_ws_name,
             )
             if not preserve_donor:
-                self.mantidSnapper.DeleteWorkspace(
-                    "Deleting instrument definition workspace...", Workspace=instrument_donor
+                self.mantidSnapper.WashDishes(
+                    "Deleting instrument definition workspace...",
+                    Workspace=instrument_donor,
                 )
         else:  # must be a NEXUS file
             self.mantidSnapper.LoadNexusProcessed(

--- a/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
@@ -110,7 +110,8 @@ class LoadGroupingDefinition(PythonAlgorithm):
                 # create one from the instrument definition file
                 instrument_donor = self.mantidSnapper.LoadEmptyInstrument(
                     "Loading instrument definition file...",
-                    Filename=self.getProperty("InstrumentFilename").value,
+                    # Filename=self.getProperty("InstrumentFilename").value,
+                    InstrumentName="SNAP",
                     OutputWorkspace="idf",
                 )
             self.mantidSnapper.LoadDetectorsGroupingFile(

--- a/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
@@ -110,8 +110,7 @@ class LoadGroupingDefinition(PythonAlgorithm):
                 # create one from the instrument definition file
                 instrument_donor = self.mantidSnapper.LoadEmptyInstrument(
                     "Loading instrument definition file...",
-                    # Filename=self.getProperty("InstrumentFilename").value,
-                    InstrumentName="SNAP",
+                    Filename=self.getProperty("InstrumentFilename").value,
                     OutputWorkspace="idf",
                 )
             self.mantidSnapper.LoadDetectorsGroupingFile(

--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -6,6 +6,7 @@ from mantid.kernel import Direction
 
 from snapred.backend.error.AlgorithmException import AlgorithmException
 from snapred.backend.log.logger import snapredLogger
+from snapred.backend.recipe.algorithm.WashDishes import WashDishes  # this gets imported a lot
 
 # must import to register with AlgorithmManager
 from snapred.meta.Callback import callback

--- a/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
@@ -133,11 +133,14 @@ class PixelGroupingParametersCalculationAlgorithm(PythonAlgorithm):
 
         outputParams = json.dumps(allGroupingParams_json)
         self.setProperty("OutputParameters", outputParams)
-        self.mantidSnapper.DeleteWorkspace("Cleaning up grouping workspace.", Workspace=self.grouping_ws_name)
-        self.mantidSnapper.DeleteWorkspace("Cleaning up grouped workspace.", Workspace=self.grouped_ws_name)
-        self.mantidSnapper.DeleteWorkspace("Cleaning up resolution workspace.", Workspace=self.resolution_ws_name)
-        self.mantidSnapper.DeleteWorkspace(
-            "Cleaning up partial resolution group workspace.", Workspace=self.partial_resolution_group_ws_name
+        self.mantidSnapper.WashDishes(
+            "Cleaning up grouping, grouped, resolution workspace.",
+            WorkspaceList=[
+                self.grouping_ws_name,
+                self.grouped_ws_name,
+                self.resolution_ws_name,
+                self.partial_resolution_group_ws_name,
+            ],
         )
         self.mantidSnapper.executeQueue()
 

--- a/src/snapred/backend/recipe/algorithm/ReductionAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/ReductionAlgorithm.py
@@ -91,8 +91,10 @@ class ReductionAlgorithm(PythonAlgorithm):
             "Applying Diffcal...", InstrumentWorkspace=raw_data, CalibrationWorkspace=diffCalPrefix + "_cal"
         )
 
-        self.mantidSnapper.DeleteWorkspace("Deleting DiffCal Mask", Workspace=diffCalPrefix + "_mask")
-        self.mantidSnapper.DeleteWorkspace("Deleting DiffCal Calibration", Workspace=diffCalPrefix + "_cal")
+        self.mantidSnapper.WashDishes(
+            "Deleting DiffCal Mask",
+            WorkspaceList=[diffCalPrefix + "_mask", diffCalPrefix + "_cal"],
+        )
 
         # 9 Does it have a container? Apply Container Attenuation Correction
         data = self.mantidSnapper.ConvertUnits(
@@ -140,7 +142,10 @@ class ReductionAlgorithm(PythonAlgorithm):
         self.mantidSnapper.NormaliseByCurrent("Normalizing Current ...", InputWorkspace=data, OutputWorkspace=data)
 
         # self.deleteWorkspace(Workspace=rebinned_data_before_focus)
-        self.mantidSnapper.DeleteWorkspace("Deleting Rebinned Data Before Focus...", Workspace="CommonRed")
+        self.mantidSnapper.WashDishes(
+            "Deleting Rebinned Data Before Focus...",
+            Workspace="CommonRed",
+        )
 
         # compress data
         # data = self.compressEvents(InputWorkspace=data, OutputWorkspace='event_compressed_data')
@@ -190,7 +195,7 @@ class ReductionAlgorithm(PythonAlgorithm):
                 Delta=focusGroups[workspaceIndex].dBin,
                 OutputWorkspace="data_rebinned_ragged_" + str(focusGroups[workspaceIndex].name),
             )
-        self.DeleteWorkspace(
+        self.mantidSnapper.WashDishes(
             "Freeing workspace...",
             Workspace="data_minus_vanadium",
         )

--- a/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
@@ -69,7 +69,9 @@ class SaveGroupingDefinition(PythonAlgorithm):
         if grouping_file_name != "":  # create grouping workspace from file
             grouping_ws_name = "gr_ws_name"
             self.mantidSnapper.LoadGroupingDefinition(
-                "Loading grouping definition...", GroupingFilename=grouping_file_name, OutputWorkspace=grouping_ws_name
+                "Loading grouping definition...", 
+                GroupingFilename=grouping_file_name, 
+                OutputWorkspace=grouping_ws_name,
             )
             self.mantidSnapper.executeQueue()
         else:  # retrieve grouping workspace from analysis data service

--- a/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
@@ -88,6 +88,10 @@ class SaveGroupingDefinition(PythonAlgorithm):
             GroupingWorkspace=grouping_ws_name,
             Filename=outputFilename,
         )
+        self.mantidSnapper.WashDishes(
+            f"Cleanup the zero calibration workspace {cal_ws_name}",
+            Workspace=cal_ws_name,
+        )
         self.mantidSnapper.executeQueue()
 
     def CreateZeroCalibrationWorkspace(self, cal_ws_name) -> None:

--- a/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
@@ -69,8 +69,8 @@ class SaveGroupingDefinition(PythonAlgorithm):
         if grouping_file_name != "":  # create grouping workspace from file
             grouping_ws_name = "gr_ws_name"
             self.mantidSnapper.LoadGroupingDefinition(
-                "Loading grouping definition...", 
-                GroupingFilename=grouping_file_name, 
+                "Loading grouping definition...",
+                GroupingFilename=grouping_file_name,
                 OutputWorkspace=grouping_ws_name,
             )
             self.mantidSnapper.executeQueue()

--- a/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
@@ -98,7 +98,10 @@ class SmoothDataExcludingPeaks(PythonAlgorithm):
 
             outputWorkspace.setY(index, smoothing_results)
 
-        self.mantidSnapper.DeleteWorkspace("Cleaning up weight workspace...", Workspace=weight_ws_name)
+        self.mantidSnapper.WashDishes(
+            "Cleaning up weight workspace...",
+            Workspace=weight_ws_name,
+        )
         self.mantidSnapper.executeQueue()
 
         self.setProperty("OutputWorkspace", outputWorkspaceName)

--- a/src/snapred/backend/recipe/algorithm/VanadiumFocussedReductionAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/VanadiumFocussedReductionAlgorithm.py
@@ -87,11 +87,10 @@ class VanadiumFocussedReductionAlgorithm(PythonAlgorithm):
                 OutputWorkspace="smooth_ws",
             )
 
-        self.mantidSnapper.DeleteWorkspace("Clean up workspace...", workspace="idf")
-        self.mantidSnapper.DeleteWorkspace("Clean up workspace...", workspace="weight_ws")
-        self.mantidSnapper.DeleteWorkspace("Clean up workspace...", workspace="vanadium")
-        self.mantidSnapper.DeleteWorkspace("Clean up workspace...", workspace="vanadium_dspacing")
-        self.mantidSnapper.DeleteWorkspace("Clean up workspace...", workspace="CommonRed")
+        self.mantidSnapper.WashDishes(
+            "Clean up workspaces...",
+            WorkspaceList=["idf", "weight_ws", "vanadium", "vanadium_dspacing", "CommonRed"],
+        )
         self.mantidSnapper.executeQueue()
 
         self.log().notice("Execution of VanadiumFocussedReduction COMPLETE!")

--- a/tests/unit/backend/recipe/algorithm/test_VanadiumFocussedReductionAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_VanadiumFocussedReductionAlgorithm.py
@@ -61,11 +61,7 @@ with mock.patch.dict(
                 call().ConvertUnits,
                 call().DiffractionFocussing,
                 call().executeQueue,
-                call().DeleteWorkspace,
-                call().DeleteWorkspace,
-                call().DeleteWorkspace,
-                call().DeleteWorkspace,
-                call().DeleteWorkspace,
+                call().WashDishes,
                 call().executeQueue,
             ]
 


### PR DESCRIPTION
### Description of work

There was an extra workspace leftover in the `SaveGroupingDefinition` algorithm.  This needed to be deleted.

For the sake of CIS testing, workspaces should be removed with `WashDishes` instead of `DeleteWorkspace`, to ensure that they are *not* deleted when the CIS is running testing, so the CIS can properly inspect the intermediate output.

I went ahead and changed all uses of `DeleteWorkspace` to `WashDishes`.

### To test

Run t he below script:
``` python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
import pathlib
import os.path

from snapred.backend.recipe.algorithm.LoadGroupingDefinition import LoadGroupingDefinition as LoadingAlgo
from snapred.backend.recipe.algorithm.SaveGroupingDefinition import SaveGroupingDefinition as SavingAlgo
from snapred.meta.Config import Config, Resource

PGDDir = '/SNS/SNAP/shared/Calibration_old/PixelGroupingDefinitions/'
groupingFile = PGDDir + "SNAPFocGrp_Column.lite.xml"
output_file_name = pathlib.Path(groupingFile).stem + ".hdf"
outputFilePath = os.path.join(PGDDir, output_file_name)
outputFilePath = "~/Documents/testoutput.hdf" # <<--- DELETE THIS IF YOU HAVE CIS WRITING PERMISSIONS

# Pre-load the instrument before passing to load algorithm
# Then run the save algo with the workspace from load

LoadEmptyInstrument(
    OutputWorkspace="_sampleWS",
    InstrumentName="SNAP",
)
loadAlgo = LoadingAlgo()
loadAlgo.initialize()
loadAlgo.setProperty("InstrumentDonor", "_sampleWS")
loadAlgo.setProperty("GroupingFilename", groupingFile)
loadAlgo.setProperty("OutputWorkspace", "_grpWS")
loadAlgo.execute()

#//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//
# RUN ONCE IN CIS MODE -- CAL_WS IS THERE!!!
#//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//
Config._config["cis_mode"] = True # 

savingAlgo = SavingAlgo()
savingAlgo.initialize()
savingAlgo.setProperty("GroupingWorkspace", "_grpWS")
savingAlgo.setProperty("OutputFilename", outputFilePath)
assert savingAlgo.execute()
#//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//


#//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//
# RUN AGAIN WITHOUT CIS MODE -- CAL_WS IS GONE!!!
#//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//
Config._config["cis_mode"] = False # 

savingAlgo = SavingAlgo()
savingAlgo.initialize()
savingAlgo.setProperty("GroupingWorkspace", "_grpWS")
savingAlgo.setProperty("OutputFilename", outputFilePath)
assert savingAlgo.execute()
#//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//_//
```

Set the `cis_mode` flag in `Config` to  true, and make sure nothing gets deleted.

Set the `cis_mode` flag in Config to false, and make sure the `cal_ws` that was causing the issue gets deleted.

<!--
There should be sufficient instructions for someone unfamiliar with the application to test
- unless a specific reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Link to EWM item
[EWM 2480](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2480)