### PR TITLE
update to diffcal script for entire process

### DIFF
--- a/tests/cis_tests/diffcal_script.py
+++ b/tests/cis_tests/diffcal_script.py
@@ -1,17 +1,12 @@
-## This script is to test EWM 1126 and EWM 2166
-#   https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=1126
-#   https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=2166
-# This tests that 
-#  1. the algorithm will run,
-#  2. the algorithm will create a calibration table, 
-#  #. the algorithm will convergence to within a threshold.
-# Adjust the convergenceThreshold parameter below, and compare to the "medianOffset" in the calData dictionary
-
 from mantid.simpleapi import *
 import matplotlib.pyplot as plt
 import numpy as np
 import json
+
+import sys
+sys.path.append("/SNS/users/4rx/SNAPRed")
 from snapred.backend.recipe.algorithm.DetectorPeakPredictor import DetectorPeakPredictor
+from snapred.backend.recipe.algorithm.PurgeOverlappingPeaksAlgorithm import PurgeOverlappingPeaksAlgorithm
 from snapred.backend.data.DataFactoryService import DataFactoryService
 from snapred.backend.service.CrystallographicInfoService import CrystallographicInfoService
 from snapred.backend.service.CalibrationService import CalibrationService
@@ -21,59 +16,117 @@ snapredLogger._level = 20
 
 #diffraction calibration imports
 from snapred.backend.recipe.algorithm.CalculateOffsetDIFC import CalculateOffsetDIFC
+from snapred.backend.recipe.algorithm.GroupByGroupCalibration import GroupByGroupCalibration
+from snapred.backend.recipe.DiffractionCalibrationRecipe import DiffractionCalibrationRecipe
 from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients
 from snapred.backend.dao import RunConfig, DetectorPeak, GroupPeakList
 from pydantic import parse_raw_as
 from typing import List
 
-#User inputs ###########################
-runNumber = '58882' #58409
-cifPath = '/SNS/SNAP/shared/Calibration/CalibrantSamples/Silicon_NIST_640d.cif'
-groupingFile = '/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGrp_Column.lite.xml'
-#######################################
+from snapred.meta.Config import Config
 
+from snapred.meta.redantic import list_to_raw_pretty
 
+# User inputs ######################################################################
+runNumber = "58882"  # 58409'
+cifPath = "/SNS/SNAP/shared/Calibration/CalibrantSamples/Silicon_NIST_640d.cif"
+groupingFile = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGrp_Column.lite.xml"
+peakThreshold = 0.05
+offsetConvergenceLimit = 0.1
+
+# SET TO TRUE TO STOP WASHING DISHES
+Config._config['cis_mode'] = False
+####################################################################################
+
+# CREATE NEEDED INGREDIENTS ########################################################
 dataFactoryService=DataFactoryService()
+runConfig = dataFactoryService.getRunConfig(runNumber)
+focusGroup=dataFactoryService.getFocusGroups(runNumber)[0] #column
+calibration = dataFactoryService.getCalibrationState(runNumber)
+
 calibrationService = CalibrationService()
 pixelGroupingParameters = calibrationService.retrievePixelGroupingParams(runNumber)
-calibration = dataFactoryService.getCalibrationState(runNumber)
-# focusGroups = reductionIngredients.reductionState.stateConfig.focusGroups
 
 instrumentState = calibration.instrumentState
-crystalInfoDict = CrystallographicInfoService().ingest(cifPath)
+calPath = instrumentState.instrumentConfig.calibrationDirectory
 instrumentState.pixelGroupingInstrumentParameters = pixelGroupingParameters[0]
 
-detectorAlgo = DetectorPeakPredictor()
+crystalInfoDict = CrystallographicInfoService().ingest(cifPath)
+
+detectorAlgo = PurgeOverlappingPeaksAlgorithm()
 detectorAlgo.initialize()
 detectorAlgo.setProperty("InstrumentState", instrumentState.json())
 detectorAlgo.setProperty("CrystalInfo", crystalInfoDict["crystalInfo"].json())
-detectorAlgo.setProperty("PeakIntensityThreshold", 0.01)
+detectorAlgo.setProperty("PeakIntensityThreshold", peakThreshold)
 detectorAlgo.execute()
-
-peakList = detectorAlgo.getProperty("DetectorPeaks").value
+peakList = detectorAlgo.getProperty("OutputPeakMap").value
 peakList = parse_raw_as(List[GroupPeakList], peakList)
+print(list_to_raw_pretty(peakList))
 
-runConfig = dataFactoryService.getRunConfig(runNumber)
+ingredients = DiffractionCalibrationIngredients(
+    runConfig=runConfig,
+    instrumentState=instrumentState,
+    focusGroup=focusGroup,
+    groupedPeakLists=peakList,
+    calPath=calPath,
+    convergenceThreshold=offsetConvergenceLimit,
+)
+####################################################################################
+# Run the individual steps of the recipe
+# Run the pixel offset calibration to converge
+# Run the PDCalibration step group-by-group
 
-focusGroup=dataFactoryService.getFocusGroups(runNumber)[0] #column
+data = {"result": False}
+dataSteps = []
+medianOffsets = []
 
-convergenceThreshold = 0.1
+runNumber = ingredients.runConfig.runNumber
+convergenceThreshold = ingredients.convergenceThreshold
+offsetAlgo = CalculateOffsetDIFC()
+offsetAlgo.initialize()
+offsetAlgo.setProperty("Ingredients", ingredients.json())
+offsetAlgo.execute()
 
-calPath = instrumentState.instrumentConfig.calibrationDirectory
+# save a permanent copy of the input data
+rawTOFInputWS = f'z_TOF_{runNumber}_raw'
+rawDSPInputWS = f'z_DSP_{runNumber}_raw'
+CloneWorkspace(
+    InputWorkspace=offsetAlgo.inputWStof,
+    OutputWorkspace=rawTOFInputWS,
+)
+CloneWorkspace(
+    InputWorkspace=offsetAlgo.inputWSdsp,
+    OutputWorkspace=rawDSPInputWS,
+)
 
-diffractionCalibrationIngredients = DiffractionCalibrationIngredients(
-        runConfig=runConfig,
-        instrumentState=instrumentState,
-        focusGroup=focusGroup,
-        groupedPeakLists=peakList,
-        calPath=calPath,
-        threshold=convergenceThreshold)
+# record the median offset used in convergence
+dataSteps.append(json.loads(offsetAlgo.getProperty("data").value))
+medianOffsets.append(dataSteps[-1]["medianOffset"])
+
+counter = 0
+while abs(medianOffsets[-1]) > convergenceThreshold:
+    counter = counter + 1
+    offsetAlgo.execute()
+    dataSteps.append(json.loads(offsetAlgo.getProperty("data").value))
+    medianOffsets.append(dataSteps[-1]["medianOffset"])
+
+data["steps"] = dataSteps
+print(data["steps"], counter)
+
+calibAlgo = GroupByGroupCalibration()
+calibAlgo.initialize()
+calibAlgo.setProperty("Ingredients", ingredients.json())
+calibAlgo.setProperty("InputWorkspace", offsetAlgo.getProperty("OutputWorkspace").value)
+calibAlgo.setProperty("PreviousCalibrationTable", offsetAlgo.getProperty("CalibrationTable").value)
+calibAlgo.execute()
+data["calibrationTable"] = calibrateAlgo.getProperty("FinalCalibrationTable").value
+data["result"] = True
+
+# Run the entire recipe #####################################################################
+rx = DiffractionCalibrationRecipe()
+res = rx.executeRecipe(ingredients)
+print(res["result"])
+print(res["steps"])
+#############################################################################################
 
 
-algo = CalculateOffsetDIFC()
-algo.initialize()
-algo.setProperty('Ingredients',diffractionCalibrationIngredients.json())
-algo.execute()
-calTable = algo.getProperty('CalibrationTable')
-wsOut = algo.getProperty('OutputWorkspace')
-calData = algo.getProperty('data')

--- a/tests/cis_tests/diffcal_script.py
+++ b/tests/cis_tests/diffcal_script.py
@@ -1,3 +1,12 @@
+## This script is to test EWM 1126 and EWM 2166
+#   https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=1126
+#   https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=2166
+# This tests that 
+#  1. the algorithm will run,
+#  2. the algorithm will create a calibration table, 
+#  #. the algorithm will convergence to within a threshold.
+# Adjust the convergenceThreshold parameter below, and compare to the "medianOffset" in the calData dictionary
+
 from mantid.simpleapi import *
 import matplotlib.pyplot as plt
 import numpy as np


### PR DESCRIPTION
## Description of work

This updates the CIS script for testing the diffraction calibration.  The previous script only ran the offset pixel calibration. This will run the pixel calibration until it converges, and then run the group calibration.  It will also then call the recipe, which should do all of this.

## Explanation of work

This is only editing a CIS script.  It only adds some more lines to the script, or rearranges things to be more streamlined.

Make sure to toggle the `Config._config['cis_mode']` flag to True to see the dirty dishes.

## To test

### Dev testing

This is a CIS test, no edits made to SNAPRed, so no dev tests to run.

### CIS testing

This is a CIS test, run the new script and inspect the results.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

following on work for 
[EWM#1126](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=1126)
