### PR TITLE
Gave SaveGroupingDefinition more input options

### DIFF
--- a/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
@@ -111,6 +111,7 @@ class LoadGroupingDefinition(PythonAlgorithm):
                 instrument_donor = self.mantidSnapper.LoadEmptyInstrument(
                     "Loading instrument definition file...",
                     Filename=self.getProperty("InstrumentFilename").value,
+                    InstrumentName=self.getProperty("InstrumentName").value,
                     OutputWorkspace="idf",
                 )
             self.mantidSnapper.LoadDetectorsGroupingFile(

--- a/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
@@ -1,6 +1,6 @@
 import pathlib
 
-from mantid.api import AlgorithmFactory, PythonAlgorithm
+from mantid.api import AlgorithmFactory, MatrixWorkspaceProperty, PropertyMode, PythonAlgorithm
 from mantid.kernel import Direction
 from mantid.simpleapi import mtd
 
@@ -34,6 +34,23 @@ class SaveGroupingDefinition(PythonAlgorithm):
         )
         self.declareProperty("OutputFilename", defaultValue="", direction=Direction.Input, doc="Path of an output file")
 
+        self.declareProperty(
+            "InstrumentName",
+            defaultValue="",
+            direction=Direction.Input,
+            doc="Name of an associated instrument",
+        )
+        self.declareProperty(
+            "InstrumentFilename",
+            defaultValue="",
+            direction=Direction.Input,
+            doc="Path of an associated instrument definition file",
+        )
+        self.declareProperty(
+            MatrixWorkspaceProperty("InstrumentDonor", "", Direction.Input, PropertyMode.Optional),
+            doc="Workspace to optionally take the instrument from, when GroupingFilename is in XML format",
+        )
+
         self.setRethrows(True)
         self.mantidSnapper = MantidSnapper(self, name)
 
@@ -62,6 +79,21 @@ class SaveGroupingDefinition(PythonAlgorithm):
         if file_extension not in self.supported_calib_file_extensions:
             raise Exception(f"OutputFilename has an unsupported file name extension {file_extension}")
 
+        instrumentName = self.getProperty("InstrumentName").value
+        instrumentFileName = self.getProperty("InstrumentFileName").value
+        instrumentDonor = self.getProperty("InstrumentDonor").value
+        instrumentPropertiesCount = sum(not prop for prop in [instrumentName, instrumentFileName])
+        if instrumentDonor:
+            instrumentPropertiesCount += 1
+        if instrumentPropertiesCount == 0 or instrumentPropertiesCount > 1:
+            print(instrumentPropertiesCount)
+            print(instrumentName)
+            print(instrumentFileName)
+            print(instrumentDonor)
+            raise Exception(
+                "Either InstrumentName, InstrumentFileName, or InstrumentDonor must be specified, but not all three."
+            )
+
     def PyExec(self) -> None:
         self.validateInput()
 
@@ -72,6 +104,9 @@ class SaveGroupingDefinition(PythonAlgorithm):
                 "Loading grouping definition...",
                 GroupingFilename=grouping_file_name,
                 OutputWorkspace=grouping_ws_name,
+                InstrumentFileName=self.getProperty("InstrumentFileName").value,
+                InstrumentName=self.getProperty("InstrumentName").value,
+                InstrumentDonor=self.getProperty("InstrumentDonor").value,
             )
             self.mantidSnapper.executeQueue()
         else:  # retrieve grouping workspace from analysis data service

--- a/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
@@ -79,17 +79,11 @@ class SaveGroupingDefinition(PythonAlgorithm):
         if file_extension not in self.supported_calib_file_extensions:
             raise Exception(f"OutputFilename has an unsupported file name extension {file_extension}")
 
-        instrumentName = self.getProperty("InstrumentName").value
-        instrumentFileName = self.getProperty("InstrumentFileName").value
-        instrumentDonor = self.getProperty("InstrumentDonor").value
-        instrumentPropertiesCount = sum(not prop for prop in [instrumentName, instrumentFileName])
-        if instrumentDonor:
-            instrumentPropertiesCount += 1
+        instrumentName = bool(self.getProperty("InstrumentName").value)
+        instrumentFileName = bool(self.getProperty("InstrumentFileName").value)
+        instrumentDonor = bool(self.getProperty("InstrumentDonor").value)
+        instrumentPropertiesCount = sum(prop for prop in [instrumentName, instrumentFileName, instrumentDonor])
         if instrumentPropertiesCount == 0 or instrumentPropertiesCount > 1:
-            print(instrumentPropertiesCount)
-            print(instrumentName)
-            print(instrumentFileName)
-            print(instrumentDonor)
             raise Exception(
                 "Either InstrumentName, InstrumentFileName, or InstrumentDonor must be specified, but not all three."
             )

--- a/tests/unit/backend/recipe/algorithm/test_SaveGroupingDefinition.py
+++ b/tests/unit/backend/recipe/algorithm/test_SaveGroupingDefinition.py
@@ -173,6 +173,7 @@ with mock.patch.dict(
             savingAlgo.initialize()
             savingAlgo.setProperty("GroupingWorkspace", ldgf_ws_name)
             savingAlgo.setProperty("OutputFilename", outputFilePath)
+            savingAlgo.setProperty("InstrumentName", "SNAP")
             assert savingAlgo.execute()
 
             # load the saved grouping definition as a workspace


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

This is to fix the issue of SaveGroupDefinition crashing when supplying an XML file.

## Explanation of work

Inputs were added to SaveGroupingDefinition that can be passed onto LoadGroupingDefiniton. The failure was happening because LoadGroupDefinition did not have InstrumentName specified.



## To test

### Dev testing

Make sure unit tests pass.

### CIS testing

Run the following script in the mantid workbench to verify. Running this before would result in a crash, but it will now finish executing. You should probably update localDir to be a local directory to you.

``` python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
import pathlib
import os.path

from snapred.backend.recipe.algorithm.LoadGroupingDefinition import LoadGroupingDefinition as LoadingAlgo
from snapred.backend.recipe.algorithm.SaveGroupingDefinition import SaveGroupingDefinition as SavingAlgo
from snapred.meta.Config import Config, Resource

localDir = '/SNS/users/8l2/Documents/'
PGDDir = '/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/'
groupingFile = PGDDir + "SNAPFocGroup_Column.xml"

Config._config["cis_mode"] = False # <<-- change to True and rerun

output_file_name = pathlib.Path(groupingFile).stem + ".hdf"
outputFilePath = os.path.join(localDir, output_file_name)
# save the input grouping file in the calibration format
savingAlgo = SavingAlgo()
savingAlgo.initialize()
savingAlgo.setProperty("GroupingFilename", groupingFile)
savingAlgo.setProperty("OutputFilename", outputFilePath)
savingAlgo.setProperty("InstrumentName", "SNAP")
assert savingAlgo.execute()
```


## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#2638](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2638)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
