### PR TITLE
fixes to calibrant sample DAOs for mantid API

### DIFF
--- a/src/snapred/backend/dao/state/CalibrantSample/Atom.py
+++ b/src/snapred/backend/dao/state/CalibrantSample/Atom.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Tuple
 
 from pydantic import BaseModel, validator
 
@@ -7,8 +7,8 @@ class Atom(BaseModel):
     """Class containing atomic paramaters used in Calibrant Samples
     atomic parameters:
 
-        atom type: string of chemical symbol
-        atom coordinates:
+        symbol: string of chemical symbol
+        coordinates:
 
             x coordinate: float in range [-1, 1]
             y coordinate: float in range [-1, 1]
@@ -17,18 +17,18 @@ class Atom(BaseModel):
         site occupation factor: float in range [0, 1]
         adp: positive float, default is 0.01"""
 
-    atom_type: str
-    atom_coordinates: List[float]
-    site_occupation_factor: float
+    symbol: str
+    coordinates: Tuple[float, float, float]
+    siteOccupationFactor: float
     adp: float = 0.1
 
-    @validator("atom_coordinates", allow_reuse=True)
+    @validator("coordinates", allow_reuse=True)
     def validate_atom_coordinates(cls, v):
-        if not all(-1 <= val <= 1 for val in v) and not len(v) == 3:
-            raise ValueError("atom coordinates must be 3 values (x, y, z) all in range [-1, 1]")
+        if not all(-1 <= val <= 1 for val in v):
+            raise ValueError("atom coordinates (x, y, z) must be all in range [-1, 1]")
         return v
 
-    @validator("site_occupation_factor", allow_reuse=True)
+    @validator("siteOccupationFactor", allow_reuse=True)
     def validate_site_occupation_factor(cls, v):
         if v < 0 or v > 1:
             raise ValueError("Site occupation factor must be a value in range [0, 1]")
@@ -42,10 +42,10 @@ class Atom(BaseModel):
 
     @property
     def getString(self) -> str:
-        atomicString = self.atom_type
-        atomicString += f" {self.atom_coordinates[0]}"
-        atomicString += f" {self.atom_coordinates[1]}"
-        atomicString += f" {self.atom_coordinates[2]}"
-        atomicString += f" {self.site_occupation_factor}"
+        atomicString = self.symbol
+        atomicString += f" {self.coordinates[0]}"
+        atomicString += f" {self.coordinates[1]}"
+        atomicString += f" {self.coordinates[2]}"
+        atomicString += f" {self.siteOccupationFactor}"
         atomicString += f" {self.adp}"
         return atomicString

--- a/src/snapred/backend/dao/state/CalibrantSample/Crystallography.py
+++ b/src/snapred/backend/dao/state/CalibrantSample/Crystallography.py
@@ -1,5 +1,5 @@
 import os
-from typing import List
+from typing import List, Tuple
 
 from mantid.geometry import SpaceGroupFactory
 from pydantic import BaseModel, validator
@@ -11,12 +11,12 @@ class Crystallography(BaseModel):
     """Class containing Crystallography paramaters used in Calibrant Samples
     cif file: string, full path to .cif file containing crystallographic properties
     space group: string, ITOC symbol for the space group
-    lattice parameters: List of 6 floats: a, b, c, alpha, beta, gamma
+    lattice parameters: Tuple of 6 floats: a, b, c, alpha, beta, gamma
     atoms: list of atomic parameters for each atom"""
 
     cifFile: str
     spaceGroup: str
-    latticeParameters: List[float]
+    latticeParameters: Tuple[float, float, float, float, float, float]
     atoms: List[Atom]
 
     @property
@@ -37,12 +37,6 @@ class Crystallography(BaseModel):
             raise ValueError("cif file must be full path to a valid cif file")
         if not v.endswith(".cif"):
             raise ValueError("cif_file must be a file with .cif extension")
-        return v
-
-    @validator("latticeParameters", allow_reuse=True)
-    def validate_latticeParameters(cls, v):
-        if len(v) != 6:
-            raise ValueError("lattice parameters must be a list of 6 floats: a, b, c, alpha, beta, gamma")
         return v
 
     @validator("spaceGroup", allow_reuse=True)

--- a/src/snapred/backend/dao/state/CalibrantSample/Geometry.py
+++ b/src/snapred/backend/dao/state/CalibrantSample/Geometry.py
@@ -36,6 +36,6 @@ class Geometry(BaseModel):
         elif shape == "Cylinder" and height is None:
             raise RuntimeError("height must be set in cylinder")
         elif shape == "Sphere" and height is not None:
-            v.set("height", None)
+            v["height"] = None
             raise Warning("height is not used with a sphere")
         return v

--- a/src/snapred/backend/dao/state/CalibrantSample/Material.py
+++ b/src/snapred/backend/dao/state/CalibrantSample/Material.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from pydantic import BaseModel, validator
 
 
@@ -14,7 +16,7 @@ class Material(BaseModel):
     chemicalFormula: str
 
     @property
-    def materialDictionary(self) -> str:
+    def materialDictionary(self) -> Dict[str, Any]:
         return {
             "ChemicalFormula": self.chemicalFormula,
             "PackingFraction": self.packingFraction,

--- a/src/snapred/backend/dao/state/CalibrantSample/Material.py
+++ b/src/snapred/backend/dao/state/CalibrantSample/Material.py
@@ -1,6 +1,6 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, root_validator, validator
 
 
 class Material(BaseModel):
@@ -12,19 +12,31 @@ class Material(BaseModel):
             convention: https://docs.mantidproject.org/nightly/concepts/Materials.html#id3"""
 
     packingFraction: float
-    massDensity: float
+    massDensity: Optional[float]
     chemicalFormula: str
 
     @property
     def materialDictionary(self) -> Dict[str, Any]:
-        return {
+        ans = {
             "ChemicalFormula": self.chemicalFormula,
             "PackingFraction": self.packingFraction,
-            "MassDensity": self.massDensity,
         }
+        if len(self.chemicalFormula.split()) > 1:
+            ans["MassDensity"] = self.massDensity
+        return ans
 
     @validator("packingFraction", allow_reuse=True)
     def validate_packingFraction(cls, v):
         if v < 0 or v > 1:
             raise ValueError("packingFraction must be a value in the range [0, 1]")
+        return v
+
+    @root_validator(pre=True, allow_reuse=True)
+    def validate_singleElement(cls, v):
+        symbols, md = v.get("chemicalFormula").split(), v.get("massDensity")
+        if (len(symbols) > 1) and md is None:
+            raise ValueError("for multi-element materials, must include mass density")
+        elif (len(symbols) == 1) and md is not None:
+            v.set("massDensity", 0)
+            raise Warning("can't specify mass density for single-element materials; ignored")
         return v

--- a/src/snapred/backend/dao/state/CalibrantSample/Material.py
+++ b/src/snapred/backend/dao/state/CalibrantSample/Material.py
@@ -13,6 +13,14 @@ class Material(BaseModel):
     massDensity: float
     chemicalFormula: str
 
+    @property
+    def materialDictionary(self) -> str:
+        return {
+            "ChemicalFormula": self.chemicalFormula,
+            "PackingFraction": self.packingFraction,
+            "MassDensity": self.massDensity,
+        }
+
     @validator("packingFraction", allow_reuse=True)
     def validate_packingFraction(cls, v):
         if v < 0 or v > 1:

--- a/tests/cis_tests/calibrant_samples_script.py
+++ b/tests/cis_tests/calibrant_samples_script.py
@@ -1,4 +1,4 @@
-from mantid.simpleapi import *
+from mantid.simpleapi import CreateWorkspace, SetSample
 from mantid.geometry import CrystalStructure
 from snapred.backend.dao.state.CalibrantSample.CalibrantSamples import CalibrantSamples
 from snapred.backend.dao.state.CalibrantSample.Crystallography import Crystallography
@@ -8,7 +8,7 @@ from snapred.backend.dao.state.CalibrantSample.Atom import Atom
 
 mat = Material(chemicalFormula="(Li7)2-C-H4-N-Cl6", massDensity=4.4, packingFraction=0.9)
 geo = Geometry(shape="Cylinder", radius=0.1, height=3.6, center=[0.0, 0.0, 0.0])
-atom = Atom(atom_type="Si", atom_coordinates=[0.125, 0.125, 0.125], site_occupation_factor=1.0)
+atom = Atom(symbol="Si", coordinates=[0.125, 0.125, 0.125], siteOccupationFactor=1.0)
 crystal = Crystallography(
     cifFile="/SNS/SNAP/shared/Calibration/CalibrantSamples/Silicon_NIST_640d.cif",
     spaceGroup="F d -3 m",

--- a/tests/cis_tests/calibrant_samples_script.py
+++ b/tests/cis_tests/calibrant_samples_script.py
@@ -5,6 +5,7 @@ from snapred.backend.dao.state.CalibrantSample.Crystallography import Crystallog
 from snapred.backend.dao.state.CalibrantSample.Geometry import Geometry
 from snapred.backend.dao.state.CalibrantSample.Material import Material
 from snapred.backend.dao.state.CalibrantSample.Atom import Atom
+from snapred.meta.redantic import list_to_raw_pretty
 
 mat = Material(chemicalFormula="(Li7)2-C-H4-N-Cl6", massDensity=4.4, packingFraction=0.9)
 geo = Geometry(shape="Cylinder", radius=0.1, height=3.6, center=[0.0, 0.0, 0.0])
@@ -16,9 +17,36 @@ crystal = Crystallography(
     atoms=[atom, atom, atom],
 )
 sample = CalibrantSamples(name="NIST_640D", unique_id="001", geometry=geo, material=mat, crystallography=crystal)
+
 # Calling SetSample() with Geometry and Material from CalibrantSamples object should not fail
 ws = CreateWorkspace(DataX=1, DataY=1)
 SetSample(ws, Geometry=sample.geometry.json(), Material=sample.material.json())
 
+# make sure it worked
+ref = f"""
+<type name="userShape">
+    <{geo.shape.lower()} id="sample-shape">
+        <centre-of-bottom-base x="0" y="{-round(geo.height*0.005,3)}" z="0"/>
+        <axis x="0" y="1" z="0"/>
+        <height val="{round(geo.height*0.01,3)}"/>
+        <radius val="{round(geo.radius*0.01,3)}"/>
+    </{geo.shape.lower()}>
+</type>
+"""
+ans = ws.sample().getShape().getShapeXML()
+ref = ref.replace("\n", "").replace(" ", "")
+ans = ans.replace("\n", "").replace(" ", "")
+assert ref == ans
+
 # Creating a CrystalStructure from info from Crystallography object should not fail
 crystalStruct = CrystalStructure(crystal.unitCellString, crystal.spaceGroupString, crystal.scattererString)
+
+# make sure it worked
+assert crystal.spaceGroup == crystalStruct.getSpaceGroup().getHMSymbol()
+for i, atom in enumerate(crystal.atoms):
+    atomstring = atom.getString.split(' ')
+    xtalstring = crystalStruct.getScatterers()[i].split(' ')
+    assert len(atomstring) == len(xtalstring)
+    assert atomstring[0] == xtalstring[0]
+    for a,x in zip(atomstring[1:],xtalstring[1:]):
+        assert float(a)==float(x)

--- a/tests/resources/outputs/sample/testid.json
+++ b/tests/resources/outputs/sample/testid.json
@@ -30,23 +30,23 @@
         ],
         "atoms": [
             {
-                "atom_type": "La",
-                "atom_coordinates": [
+                "symbol": "La",
+                "coordinates": [
                     0.0,
                     0.0,
                     0.0
                 ],
-                "site_occupation_factor": 1.0,
+                "siteOccupationFactor": 1.0,
                 "adp": 0.0052
             },
             {
-                "atom_type": "11B",
-                "atom_coordinates": [
+                "symbol": "11B",
+                "coordinates": [
                     0.1975,
                     0.1975,
                     0.1975
                 ],
-                "site_occupation_factor": 0.5,
+                "siteOccupationFactor": 0.5,
                 "adp": 0.0041
             }
         ]

--- a/tests/unit/backend/dao/test_Atom.py
+++ b/tests/unit/backend/dao/test_Atom.py
@@ -1,6 +1,14 @@
+import pytest
 from snapred.backend.dao.state.CalibrantSample.Atom import Atom
 
 
 def testGetString():
-    atom = Atom(atom_type="Si", atom_coordinates=[0.125, 0.125, 0.125], site_occupation_factor=1.0)
+    atom = Atom(symbol="Si", coordinates=[0.125, 0.125, 0.125], siteOccupationFactor=1.0)
     assert atom.getString == "Si 0.125 0.125 0.125 1.0 0.1"
+
+
+def testThreeCoordinates():
+    with pytest.raises(Exception):  # noqa: PT011
+        Atom(symbol="V", coordinates=[1.0], siteOccupationFactor=1.0)
+    with pytest.raises(Exception):  # noqa: PT011
+        Atom(symbol="V", coordinates=[1.0, 2.0, 3.0, 4.0], siteOccupationFactor=1.0)

--- a/tests/unit/backend/dao/test_Crystallography.py
+++ b/tests/unit/backend/dao/test_Crystallography.py
@@ -1,14 +1,16 @@
 import unittest
 
+import pytest
 from snapred.backend.dao.state.CalibrantSample.Atom import Atom
 from snapred.backend.dao.state.CalibrantSample.Crystallography import Crystallography
+from snapred.meta.Config import Resource
 
 
 class TestCrystallography(unittest.TestCase):
     def setUp(self):
-        atom = Atom(atom_type="Si", atom_coordinates=[0.125, 0.125, 0.125], site_occupation_factor=1.0)
+        atom = Atom(symbol="Si", coordinates=[0.125, 0.125, 0.125], siteOccupationFactor=1.0)
         self.crystal = Crystallography(
-            cifFile="tests/resources/inputs/crystalInfo/example.cif",
+            cifFile=Resource.getPath("/inputs/crystalInfo/example.cif"),
             spaceGroup="F d -3 m",
             latticeParameters=[5.43159, 5.43159, 5.43159, 90.0, 90.0, 90.0],
             atoms=[atom, atom, atom],
@@ -25,3 +27,20 @@ class TestCrystallography(unittest.TestCase):
 
     def test_spaceGroupString(self):
         assert self.crystal.spaceGroupString == "F d -3 m"
+
+    def test_SixLatticeParams(self):
+        for i in range(1, 5):
+            with pytest.raises(Exception):  # noqa: PT011
+                Crystallography(
+                    cifFile=Resource.getPath("/inputs/crystalInfo/example.cif"),
+                    spaceGroup="BCC",
+                    latticeParameters=range(1, i + 1),
+                    atoms=[Atom(symbol="Si", coordinates=[0.125, 0.125, 0.125], siteOccupationFactor=1.0)],
+                )
+        with pytest.raises(Exception):  # noqa: PT011
+            Crystallography(
+                cifFile=Resource.getPath("/inputs/crystalInfo/example.cif"),
+                spaceGroup="BCC",
+                latticeParameters=range(6),
+                atoms=[Atom(symbol="Si", coordinates=[0.125, 0.125, 0.125], siteOccupationFactor=1.0)],
+            )

--- a/tests/unit/backend/dao/test_Geometry.py
+++ b/tests/unit/backend/dao/test_Geometry.py
@@ -1,5 +1,6 @@
 import unittest
 
+import pytest
 from mantid.simpleapi import CreateWorkspace, SetSample
 from snapred.backend.dao.state.CalibrantSample.Geometry import Geometry
 
@@ -37,6 +38,29 @@ class TestGeometry(unittest.TestCase):
             "Center": [0, 0, 0],
         }
         assert self.sphere.geometryDictionary == ref
+
+    def test_invalidSphere(self):
+        with pytest.raises(Warning):
+            Geometry(
+                shape="Sphere",
+                radius=3,
+                height=3,
+            )
+
+    def test_invalidCylinder(self):
+        with pytest.raises(RuntimeError):
+            Geometry(
+                shape="Cylinder",
+                radius=3,
+            )
+
+    def test_invalidShape(self):
+        with pytest.raises(ValueError):  # noqa: PT011
+            Geometry(
+                shape="Duckface",
+                radius=3,
+                height=3,
+            )
 
     def test_settableInMantid(self):
         # test that these can be used to set the sample in mantid

--- a/tests/unit/backend/dao/test_Geometry.py
+++ b/tests/unit/backend/dao/test_Geometry.py
@@ -1,0 +1,84 @@
+import unittest
+
+from mantid.simpleapi import CreateWorkspace, SetSample
+from snapred.backend.dao.state.CalibrantSample.Geometry import Geometry
+
+
+class TestGeometry(unittest.TestCase):
+    def setUp(self):
+        self.cylinder = Geometry(
+            shape="Cylinder",
+            radius=2,
+            height=5,
+        )
+        self.sphere = Geometry(
+            shape="Sphere",
+            radius=3,
+        )
+
+    def test_cylinderGeometry(self):
+        # ensure that the geometryDictionary object
+        # returns correct dictionary for cylinder
+        ref = {
+            "Shape": self.cylinder.shape,
+            "Radius": self.cylinder.radius,
+            "Height": self.cylinder.height,
+            "Center": [0, 0, 0],
+            "Axis": [0, 1, 0],
+        }
+        assert self.cylinder.geometryDictionary == ref
+
+    def test_sphereGeometry(self):
+        # ensure that the geometryDictionary object
+        # returns correct dictionary for sphere
+        ref = {
+            "Shape": self.sphere.shape,
+            "Radius": self.sphere.radius,
+            "Center": [0, 0, 0],
+        }
+        assert self.sphere.geometryDictionary == ref
+
+    def test_settableInMantid(self):
+        # test that these can be used to set the sample in mantid
+        # run SetSample with the dictionary to set shape
+        # then get output XML of the sample shape
+        # note that the XML converts from cm to m
+        sampleWS = CreateWorkspace(
+            DataX=1,
+            DataY=1,
+        )
+        # test setting with a cylinder, compare output XML
+        # will have center-of-bottom-base, axis, height, and radius
+        SetSample(InputWorkspace=sampleWS, Geometry=self.cylinder.geometryDictionary)
+        ref = f"""
+        <type name="userShape">
+            <{self.cylinder.shape.lower()} id="sample-shape">
+                <centre-of-bottom-base x="0" y="{-self.cylinder.height*0.005}" z="0"/>
+                <axis x="0" y="1" z="0"/>
+                <height val="{self.cylinder.height*0.01}"/>
+                <radius val="{self.cylinder.radius*0.01}"/>
+            </{self.cylinder.shape.lower()}>
+        </type>
+        """
+        ans = sampleWS.sample().getShape().getShapeXML()
+        ref = ref.replace("\n", "").replace(" ", "")
+        ans = ans.replace("\n", "").replace(" ", "")
+        assert ref == ans
+        # test setting with a sphere, compare output XML
+        # will have center and radius
+        SetSample(
+            InputWorkspace=sampleWS,
+            Geometry=self.sphere.geometryDictionary,
+        )
+        ref = f"""
+        <type name="userShape">
+            <{self.sphere.shape.lower()} id="sphere">
+                <center x="0" y="0" z="0"/>
+                <radius val="{self.sphere.radius*0.01}"/>
+            </{self.sphere.shape.lower()}>
+        </type>
+        """
+        ans = sampleWS.sample().getShape().getShapeXML()
+        ref = ref.replace("\n", "").replace(" ", "")
+        ans = ans.replace("\n", "").replace(" ", "")
+        assert ref == ans

--- a/tests/unit/backend/dao/test_Material.py
+++ b/tests/unit/backend/dao/test_Material.py
@@ -1,5 +1,6 @@
 import unittest
 
+import pytest
 from mantid.simpleapi import CreateWorkspace, SetSample
 from snapred.backend.dao.state.CalibrantSample.Material import Material
 
@@ -10,20 +11,52 @@ class TestGeometry(unittest.TestCase):
             packingFraction=0.3,
             chemicalFormula="V",
         )
+        self.vanadiumMD = Material(
+            massDensity=0.7,
+            chemicalFormula="V",
+        )
         self.vanadiumBoron = Material(
             packingFraction=0.3,
-            massDensity=0.3,
+            massDensity=0.9,
             chemicalFormula="V B",
+        )
+        self.vanadiumBoronDash = Material(
+            packingFraction=0.3,
+            massDensity=0.9,
+            chemicalFormula="V-B",
         )
 
     def test_singleElementMaterial(self):
         # ensure that the materialDictionary object
         # returns correct dictionary for single element
+
+        # single element with packing fraction
         ref = {
             "ChemicalFormula": self.vanadium.chemicalFormula,
             "PackingFraction": self.vanadium.packingFraction,
         }
         assert self.vanadium.materialDictionary == ref
+        # try single element with mass density
+        ref = {
+            "ChemicalFormula": self.vanadiumMD.chemicalFormula,
+            "MassDensity": self.vanadiumMD.massDensity,
+        }
+        assert self.vanadiumMD.materialDictionary == ref
+
+    def test_invalidSingleElementMaterial(self):
+        with pytest.raises(Warning):
+            Material(
+                packingFraction=0.3,
+                massDensity=0.9,
+                chemicalFormula="V",
+            )
+
+    def test_invalidTwoElementMaterial(self):
+        with pytest.raises(ValueError):  # noqa: PT011
+            Material(
+                packingFraction=0.3,
+                chemicalFormula="V B",
+            )
 
     def test_twoElementMaterial(self):
         # ensure that the materialDictionary object
@@ -50,9 +83,16 @@ class TestGeometry(unittest.TestCase):
             Material=self.vanadium.materialDictionary,
         )
         material = sampleWS.sample().getMaterial()
-        print(dir(material.chemicalFormula()[0][0]))
         assert material.chemicalFormula()[0][0].symbol == "V"
         assert material.packingFraction == self.vanadium.packingFraction
+
+        # test setting with a single-element crystal with mass density
+        SetSample(
+            InputWorkspace=sampleWS,
+            Material=self.vanadiumMD.materialDictionary,
+        )
+        material = sampleWS.sample().getMaterial()
+        assert material.chemicalFormula()[0][0].symbol == "V"
 
         # test setting with a mutli-element crystal
         SetSample(
@@ -60,7 +100,15 @@ class TestGeometry(unittest.TestCase):
             Material=self.vanadiumBoron.materialDictionary,
         )
         material = sampleWS.sample().getMaterial()
-        print(dir(material.chemicalFormula()[0][0]))
         assert material.chemicalFormula()[0][0].symbol == "V"
         assert material.chemicalFormula()[0][1].symbol == "B"
         assert material.packingFraction == self.vanadiumBoron.packingFraction
+
+        SetSample(
+            InputWorkspace=sampleWS,
+            Material=self.vanadiumBoronDash.materialDictionary,
+        )
+        material = sampleWS.sample().getMaterial()
+        assert material.chemicalFormula()[0][0].symbol == "V"
+        assert material.chemicalFormula()[0][1].symbol == "B"
+        assert material.packingFraction == self.vanadiumBoronDash.packingFraction

--- a/tests/unit/backend/dao/test_Material.py
+++ b/tests/unit/backend/dao/test_Material.py
@@ -1,0 +1,66 @@
+import unittest
+
+from mantid.simpleapi import CreateWorkspace, SetSample
+from snapred.backend.dao.state.CalibrantSample.Material import Material
+
+
+class TestGeometry(unittest.TestCase):
+    def setUp(self):
+        self.vanadium = Material(
+            packingFraction=0.3,
+            chemicalFormula="V",
+        )
+        self.vanadiumBoron = Material(
+            packingFraction=0.3,
+            massDensity=0.3,
+            chemicalFormula="V B",
+        )
+
+    def test_singleElementMaterial(self):
+        # ensure that the materialDictionary object
+        # returns correct dictionary for single element
+        ref = {
+            "ChemicalFormula": self.vanadium.chemicalFormula,
+            "PackingFraction": self.vanadium.packingFraction,
+        }
+        assert self.vanadium.materialDictionary == ref
+
+    def test_twoElementMaterial(self):
+        # ensure that the materialDictionary object
+        # returns correct dictionary for two elements
+        ref = {
+            "ChemicalFormula": self.vanadiumBoron.chemicalFormula,
+            "MassDensity": self.vanadiumBoron.massDensity,
+            "PackingFraction": self.vanadiumBoron.packingFraction,
+        }
+        assert self.vanadiumBoron.materialDictionary == ref
+
+    def test_settableInMantid(self):
+        # test that these can be used to set the sample in mantid
+        # run SetSample with the dictionary to set shape
+        # then get output XML of the sample shape
+        # note that the XML converts from cm to m
+        sampleWS = CreateWorkspace(
+            DataX=1,
+            DataY=1,
+        )
+        # test setting with a single-element crystal
+        SetSample(
+            InputWorkspace=sampleWS,
+            Material=self.vanadium.materialDictionary,
+        )
+        material = sampleWS.sample().getMaterial()
+        print(dir(material.chemicalFormula()[0][0]))
+        assert material.chemicalFormula()[0][0].symbol == "V"
+        assert material.packingFraction == self.vanadium.packingFraction
+
+        # test setting with a mutli-element crystal
+        SetSample(
+            InputWorkspace=sampleWS,
+            Material=self.vanadiumBoron.materialDictionary,
+        )
+        material = sampleWS.sample().getMaterial()
+        print(dir(material.chemicalFormula()[0][0]))
+        assert material.chemicalFormula()[0][0].symbol == "V"
+        assert material.chemicalFormula()[0][1].symbol == "B"
+        assert material.packingFraction == self.vanadiumBoron.packingFraction


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

This came out of PR #96, which needs to interact with mantid's `SetSamples` algorithm.  This adds properties to the DAOs to easily generate the needed dictionaries, and also runs some tests to ensure these work with mantid.

I changed uses of `List[float]` where the size of the list was known (3 or 6, say), and replaced with an appropriate `Tuple`.

The `Material` DAO would fail setting in mantid for single-element materials.  This is because mantid can use the fact that it is a single element to predict the number density (see [L333 in mantid's `MaterialBuilder`](https://github.com/mantidproject/mantid/blob/c1daec527052e9b88866bece07e6fadf35d6030c/Framework/Kernel/src/MaterialBuilder.cpp#L333)), leading to an over-determination of densities.  For this reason, single-element materials can only have _one_ of `packingFraction` and `massDensity`.

In `Atom`, it seemed redundant to refer to `atom_type` and `atom_coordinates`.  These were changed to `symbol` (to better reflect what it is), and `coordinates`.

I also put in camel case where snake case was used.

## Explanation of work

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

The main changes are the addition of this to `Geometry`:
``` python
    @property
    def geometryDictionary(self) -> Dict[str, Any]:
        ans = {
            "Shape": self.shape,
            "Radius": self.radius,
            "Center": list(self.center),
        }
        if self.shape == "Cylinder":
            ans["Height"] = self.height
            ans["Axis"] = list(self.axis)
        return ans
```
and this to `Material`:
``` python
    @property
    def materialDictionary(self) -> Dict[str, Any]:
        ans = {
            "ChemicalFormula": self.chemicalFormula,
        }
        if self.packingFraction is not None:
            ans["PackingFraction"] = self.packingFraction
        if self.massDensity is not None:
            ans["MassDensity"] = self.massDensity
        return ans
```

## To test

### Dev testing

The unit tests added for `Geometry`, `Material`, `Crystallography`, and `Atom` will test all of this new behavior.

### CIS testing

This does not need a CIS test, as it only involves internals.

If you want to run in workbench:
``` python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

import sys
sys.path.append("/SNS/users/4rx/SNAPRed")
from snapred.backend.dao.state.CalibrantSample.Geometry import Geometry
from snapred.backend.dao.state.CalibrantSample.Material import Material

# test that these can be used to set the sample in mantid
# run SetSample with the dictionary to set shape
# then get output XML of the sample shape
# note that the XML converts from cm to m
sampleWS = CreateWorkspace(
    DataX=1,
    DataY=1,
)

cylinder = Geometry(
    shape="Cylinder",
    radius=2,
    height=5,
)
sphere = Geometry(
    shape="Sphere",
    radius=3,
)

# test setting with a cylinder, compare output XML
# will have center-of-bottom-base, axis, height, and radius
SetSample(InputWorkspace=sampleWS, Geometry=cylinder.geometryDictionary)
ref = f"""
<type name="userShape">
    <{cylinder.shape.lower()} id="sample-shape">
        <centre-of-bottom-base x="0" y="{-cylinder.height*0.005}" z="0"/>
        <axis x="0" y="1" z="0"/>
        <height val="{cylinder.height*0.01}"/>
        <radius val="{cylinder.radius*0.01}"/>
    </{cylinder.shape.lower()}>
</type>
"""
ans = sampleWS.sample().getShape().getShapeXML()
ref = ref.replace("\n", "").replace(" ", "")
ans = ans.replace("\n", "").replace(" ", "")
assert ref == ans
# test setting with a sphere, compare output XML
# will have center and radius
SetSample(
    InputWorkspace=sampleWS,
    Geometry=sphere.geometryDictionary,
)
ref = f"""
<type name="userShape">
    <{sphere.shape.lower()} id="sphere">
        <center x="0" y="0" z="0"/>
        <radius val="{sphere.radius*0.01}"/>
    </{sphere.shape.lower()}>
</type>
"""
ans = sampleWS.sample().getShape().getShapeXML()
ref = ref.replace("\n", "").replace(" ", "")
ans = ans.replace("\n", "").replace(" ", "")
assert ref == ans

vanadium = Material(
            packingFraction=0.3,
            chemicalFormula="V",
        )
SetSample(
    InputWorkspace=sampleWS,
    Material=vanadium.materialDictionary,
)
material = sampleWS.sample().getMaterial()
assert material.chemicalFormula()[0][0].symbol == "V"
assert material.packingFraction == vanadium.packingFraction

vanadiumBoron = Material(
            packingFraction=0.3,
            massDensity=0.3,
            chemicalFormula="V B",
        )
SetSample(
    InputWorkspace=sampleWS,
    Material=vanadiumBoron.materialDictionary,
)
material = sampleWS.sample().getMaterial()
assert material.chemicalFormula()[0][0].symbol == "V"
assert material.chemicalFormula()[0][1].symbol == "B"
assert material.packingFraction == vanadium.packingFraction
```

This will only duplicate the unit tests for Material and Geometry.

In addition to this, run the `calibrant_samples_script.py` in the CIS tests.  This has been updated with tests of behavior.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

This work is related  to: 

[EWM#780](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=780)


