### PR TITLE
Revert Calibrant Samples to using dictionary

### DIFF
--- a/src/snapred/backend/dao/state/CalibrantSample/Geometry.py
+++ b/src/snapred/backend/dao/state/CalibrantSample/Geometry.py
@@ -16,8 +16,7 @@ class Geometry(BaseModel):
     center: Tuple[float, float, float] = (0, 0, 0)
     axis: Tuple[float, float, float] = (0, 1, 0)
 
-    @property
-    def geometryDictionary(self) -> Dict[str, Any]:
+    def json(self) -> str:
         ans = {
             "Shape": self.shape,
             "Radius": self.radius,
@@ -26,7 +25,7 @@ class Geometry(BaseModel):
         if self.shape == "Cylinder":
             ans["Height"] = self.height
             ans["Axis"] = list(self.axis)
-        return ans
+        return str(ans).replace("'", '"')
 
     @root_validator(pre=True, allow_reuse=True)
     def validate_form(cls, v):

--- a/src/snapred/backend/dao/state/CalibrantSample/Geometry.py
+++ b/src/snapred/backend/dao/state/CalibrantSample/Geometry.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Dict, Optional, Tuple
 
 from pydantic import BaseModel, root_validator
@@ -25,7 +26,7 @@ class Geometry(BaseModel):
         if self.shape == "Cylinder":
             ans["Height"] = self.height
             ans["Axis"] = list(self.axis)
-        return str(ans).replace("'", '"')
+        return json.dumps(ans)
 
     @root_validator(pre=True, allow_reuse=True)
     def validate_form(cls, v):

--- a/src/snapred/backend/dao/state/CalibrantSample/Material.py
+++ b/src/snapred/backend/dao/state/CalibrantSample/Material.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, root_validator, validator
@@ -23,7 +24,7 @@ class Material(BaseModel):
             ans["PackingFraction"] = self.packingFraction
         if self.massDensity is not None:
             ans["MassDensity"] = self.massDensity
-        return str(ans).replace("'", '"')
+        return json.dumps(ans)
 
     @validator("packingFraction", allow_reuse=True)
     def validate_packingFraction(cls, v):

--- a/src/snapred/backend/dao/state/CalibrantSample/Material.py
+++ b/src/snapred/backend/dao/state/CalibrantSample/Material.py
@@ -15,8 +15,7 @@ class Material(BaseModel):
     massDensity: Optional[float]
     chemicalFormula: str
 
-    @property
-    def materialDictionary(self) -> Dict[str, Any]:
+    def json(self) -> str:
         ans = {
             "ChemicalFormula": self.chemicalFormula,
         }
@@ -24,7 +23,7 @@ class Material(BaseModel):
             ans["PackingFraction"] = self.packingFraction
         if self.massDensity is not None:
             ans["MassDensity"] = self.massDensity
-        return ans
+        return str(ans).replace("'", '"')
 
     @validator("packingFraction", allow_reuse=True)
     def validate_packingFraction(cls, v):

--- a/tests/cis_tests/calibrant_samples_script.py
+++ b/tests/cis_tests/calibrant_samples_script.py
@@ -1,3 +1,5 @@
+# note: this runs the same checks as the unit test of CalibrantSample
+
 from mantid.simpleapi import CreateWorkspace, SetSample
 from mantid.geometry import CrystalStructure
 from snapred.backend.dao.state.CalibrantSample.CalibrantSamples import CalibrantSamples
@@ -5,7 +7,6 @@ from snapred.backend.dao.state.CalibrantSample.Crystallography import Crystallog
 from snapred.backend.dao.state.CalibrantSample.Geometry import Geometry
 from snapred.backend.dao.state.CalibrantSample.Material import Material
 from snapred.backend.dao.state.CalibrantSample.Atom import Atom
-from snapred.meta.redantic import list_to_raw_pretty
 
 mat = Material(chemicalFormula="(Li7)2-C-H4-N-Cl6", massDensity=4.4, packingFraction=0.9)
 geo = Geometry(shape="Cylinder", radius=0.1, height=3.6, center=[0.0, 0.0, 0.0])

--- a/tests/unit/backend/dao/test_CalibrantSample.py
+++ b/tests/unit/backend/dao/test_CalibrantSample.py
@@ -1,0 +1,156 @@
+# note: this runs the same checks as the calibrant_samples_script CIS test
+
+import unittest
+
+import pytest
+from mantid.geometry import CrystalStructure
+from mantid.simpleapi import CreateWorkspace, DeleteWorkspace, SetSample
+from snapred.backend.dao.state.CalibrantSample.Atom import Atom
+from snapred.backend.dao.state.CalibrantSample.CalibrantSamples import CalibrantSamples
+from snapred.backend.dao.state.CalibrantSample.Crystallography import Crystallography
+from snapred.backend.dao.state.CalibrantSample.Geometry import Geometry
+from snapred.backend.dao.state.CalibrantSample.Material import Material
+from snapred.meta.Config import Resource
+
+
+class TestCalibrantSamples(unittest.TestCase):
+    def setUp(self):
+        self.geo = Geometry(shape="Cylinder", radius=0.1, height=3.6, center=[0.0, 0.0, 0.0])
+        self.mat = Material(chemicalFormula="(Li7)2-C-H4-N-Cl6", massDensity=4.4, packingFraction=0.9)
+        self.atom = Atom(symbol="Si", coordinates=[0.125, 0.125, 0.125], siteOccupationFactor=1.0)
+        self.xtal = Crystallography(
+            cifFile=Resource.getPath("inputs/crystalInfo/example.cif"),
+            spaceGroup="F d -3 m",
+            latticeParameters=[5.43159, 5.43159, 5.43159, 90.0, 90.0, 90.0],
+            atoms=[self.atom, self.atom, self.atom],
+        )
+        self.sample = CalibrantSamples(
+            name="NIST_640D",
+            unique_id="001",
+            geometry=self.geo,
+            material=self.mat,
+            crystallography=self.xtal,
+        )
+        ws = CreateWorkspace(DataX=1, DataY=1)
+        self.ws = ws
+
+    def tearDown(self) -> None:
+        DeleteWorkspace(self.ws)
+        return super().tearDown()
+
+    def test_setCalibrantSample(self):
+        SetSample(
+            self.ws,
+            Geometry=self.sample.geometry.json(),
+            Material=self.sample.material.json(),
+        )
+
+        # make sure it worked
+        ref = f"""
+        <type name="userShape">
+            <{self.geo.shape.lower()} id="sample-shape">
+                <centre-of-bottom-base x="0" y="{-round(self.geo.height*0.005,3)}" z="0"/>
+                <axis x="0" y="1" z="0"/>
+                <height val="{round(self.geo.height*0.01,3)}"/>
+                <radius val="{round(self.geo.radius*0.01,3)}"/>
+            </{self.geo.shape.lower()}>
+        </type>
+        """
+        ans = self.ws.sample().getShape().getShapeXML()
+        ref = ref.replace("\n", "").replace(" ", "")
+        ans = ans.replace("\n", "").replace(" ", "")
+        assert ref == ans
+
+        material = self.ws.sample().getMaterial()
+        assert material.chemicalFormula()[0][0].symbol == "Li"
+        assert material.chemicalFormula()[0][1].symbol == "C"
+        assert material.chemicalFormula()[0][2].symbol == "H"
+        assert material.chemicalFormula()[0][3].symbol == "N"
+        assert material.chemicalFormula()[0][4].symbol == "Cl"
+        assert material.packingFraction == self.mat.packingFraction
+
+    def testSetCrystalStructure(self):
+        crystalStruct = CrystalStructure(
+            self.xtal.unitCellString,
+            self.xtal.spaceGroupString,
+            self.xtal.scattererString,
+        )
+
+        # make sure it worked
+        assert self.xtal.spaceGroup == crystalStruct.getSpaceGroup().getHMSymbol()
+        for i, atom in enumerate(self.xtal.atoms):
+            atomstring = atom.getString.split(" ")
+            xtalstring = crystalStruct.getScatterers()[i].split(" ")
+            assert len(atomstring) == len(xtalstring)
+            assert atomstring[0] == xtalstring[0]
+            for a, x in zip(atomstring[1:], xtalstring[1:]):
+                assert float(a) == float(x)
+
+    def test_chop_calibrant_sample(self):
+        # removed from test of Raw Vanadium Correction
+
+        # create some nonsense material and crystallography
+        fakeMaterial = Material(
+            packingFraction=0.3,
+            massDensity=1.0,
+            chemicalFormula="V B",
+        )
+        vanadiumAtom = Atom(
+            symbol="V",
+            coordinates=[0, 0, 0],
+            siteOccupationFactor=0.5,
+        )
+        boronAtom = Atom(
+            symbol="B",
+            coordinates=[0, 1, 0],
+            siteOccupationFactor=1.0,
+        )
+        fakeXtal = Crystallography(
+            cifFile=Resource.getPath("inputs/crystalInfo/example.cif"),
+            spaceGroup="I m -3 m",
+            latticeParameters=[1, 2, 3, 4, 5, 6],
+            atoms=[vanadiumAtom, boronAtom],
+        )
+        # create two mock geometries for calibrant samples
+        sphere = Geometry(
+            shape="Sphere",
+            radius=1.0,
+        )
+        cylinder = Geometry(
+            shape="Cylinder",
+            radius=1.5,
+            height=5.0,
+        )
+        # not create two differently shaped calibrant sample entries
+        sphereSample = CalibrantSamples(
+            name="fake sphere sample",
+            unique_id="123fakest",
+            geometry=sphere,
+            material=fakeMaterial,
+            crystallography=fakeXtal,
+        )
+        cylinderSample = CalibrantSamples(
+            name="fake cylinder sample",
+            unique_id="435elmst",
+            geometry=cylinder,
+            material=fakeMaterial,
+            crystallography=fakeXtal,
+        )
+
+        # chop and verify the spherical sample
+        sampleGeometry = sphereSample.geometry.dict()
+        sampleMaterial = sphereSample.material.dict()
+        assert sampleGeometry["shape"] == "Sphere"
+        assert sampleGeometry["radius"] == sphere.radius
+        assert sampleGeometry["center"] == (0, 0, 0)
+        assert sampleMaterial["chemicalFormula"] == fakeMaterial.chemicalFormula
+
+        # chop and verify the cylindrical sample
+        sampleGeometry = cylinderSample.geometry.dict()
+        sampleMaterial = cylinderSample.material.dict()
+        assert sampleGeometry["shape"] == "Cylinder"
+        assert sampleGeometry["radius"] == cylinder.radius
+        assert sampleGeometry["height"] == cylinder.height
+        assert sampleGeometry["center"] == (0, 0, 0)
+        assert sampleGeometry["axis"] == (0, 1, 0)
+        assert sampleMaterial["chemicalFormula"] == fakeMaterial.chemicalFormula

--- a/tests/unit/backend/dao/test_Geometry.py
+++ b/tests/unit/backend/dao/test_Geometry.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 
 import pytest
@@ -18,26 +19,26 @@ class TestGeometry(unittest.TestCase):
         )
 
     def test_cylinderGeometry(self):
-        # ensure that the geometryDictionary object
+        # ensure that the geometry json object
         # returns correct dictionary for cylinder
         ref = {
             "Shape": self.cylinder.shape,
             "Radius": self.cylinder.radius,
-            "Height": self.cylinder.height,
             "Center": [0, 0, 0],
+            "Height": self.cylinder.height,
             "Axis": [0, 1, 0],
         }
-        assert self.cylinder.geometryDictionary == ref
+        assert json.loads(self.cylinder.json()) == ref
 
     def test_sphereGeometry(self):
-        # ensure that the geometryDictionary object
+        # ensure that the geometry json object
         # returns correct dictionary for sphere
         ref = {
             "Shape": self.sphere.shape,
             "Radius": self.sphere.radius,
             "Center": [0, 0, 0],
         }
-        assert self.sphere.geometryDictionary == ref
+        assert json.loads(self.sphere.json()) == ref
 
     def test_invalidSphere(self):
         with pytest.raises(Warning):
@@ -73,7 +74,10 @@ class TestGeometry(unittest.TestCase):
         )
         # test setting with a cylinder, compare output XML
         # will have center-of-bottom-base, axis, height, and radius
-        SetSample(InputWorkspace=sampleWS, Geometry=self.cylinder.geometryDictionary)
+        SetSample(
+            InputWorkspace=sampleWS,
+            Geometry=self.cylinder.json(),
+        )
         ref = f"""
         <type name="userShape">
             <{self.cylinder.shape.lower()} id="sample-shape">
@@ -92,7 +96,7 @@ class TestGeometry(unittest.TestCase):
         # will have center and radius
         SetSample(
             InputWorkspace=sampleWS,
-            Geometry=self.sphere.geometryDictionary,
+            Geometry=self.sphere.json(),
         )
         ref = f"""
         <type name="userShape">

--- a/tests/unit/backend/dao/test_Material.py
+++ b/tests/unit/backend/dao/test_Material.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 
 import pytest
@@ -5,7 +6,7 @@ from mantid.simpleapi import CreateWorkspace, SetSample
 from snapred.backend.dao.state.CalibrantSample.Material import Material
 
 
-class TestGeometry(unittest.TestCase):
+class TestMaterial(unittest.TestCase):
     def setUp(self):
         self.vanadium = Material(
             packingFraction=0.3,
@@ -27,21 +28,21 @@ class TestGeometry(unittest.TestCase):
         )
 
     def test_singleElementMaterial(self):
-        # ensure that the materialDictionary object
-        # returns correct dictionary for single element
+        # ensure that the material json object
+        # returns correct json for single element
 
         # single element with packing fraction
         ref = {
             "ChemicalFormula": self.vanadium.chemicalFormula,
             "PackingFraction": self.vanadium.packingFraction,
         }
-        assert self.vanadium.materialDictionary == ref
+        assert json.loads(self.vanadium.json()) == ref
         # try single element with mass density
         ref = {
             "ChemicalFormula": self.vanadiumMD.chemicalFormula,
             "MassDensity": self.vanadiumMD.massDensity,
         }
-        assert self.vanadiumMD.materialDictionary == ref
+        assert json.loads(self.vanadiumMD.json()) == ref
 
     def test_invalidSingleElementMaterial(self):
         with pytest.raises(Warning):
@@ -59,18 +60,18 @@ class TestGeometry(unittest.TestCase):
             )
 
     def test_twoElementMaterial(self):
-        # ensure that the materialDictionary object
+        # ensure that the material json object
         # returns correct dictionary for two elements
         ref = {
             "ChemicalFormula": self.vanadiumBoron.chemicalFormula,
             "MassDensity": self.vanadiumBoron.massDensity,
             "PackingFraction": self.vanadiumBoron.packingFraction,
         }
-        assert self.vanadiumBoron.materialDictionary == ref
+        assert json.loads(self.vanadiumBoron.json()) == ref
 
     def test_settableInMantid(self):
         # test that these can be used to set the sample in mantid
-        # run SetSample with the dictionary to set shape
+        # run SetSample with the json to set shape
         # then get output XML of the sample shape
         # note that the XML converts from cm to m
         sampleWS = CreateWorkspace(
@@ -80,7 +81,7 @@ class TestGeometry(unittest.TestCase):
         # test setting with a single-element crystal
         SetSample(
             InputWorkspace=sampleWS,
-            Material=self.vanadium.materialDictionary,
+            Material=self.vanadium.json(),
         )
         material = sampleWS.sample().getMaterial()
         assert material.chemicalFormula()[0][0].symbol == "V"
@@ -89,7 +90,7 @@ class TestGeometry(unittest.TestCase):
         # test setting with a single-element crystal with mass density
         SetSample(
             InputWorkspace=sampleWS,
-            Material=self.vanadiumMD.materialDictionary,
+            Material=self.vanadiumMD.json(),
         )
         material = sampleWS.sample().getMaterial()
         assert material.chemicalFormula()[0][0].symbol == "V"
@@ -97,7 +98,7 @@ class TestGeometry(unittest.TestCase):
         # test setting with a mutli-element crystal
         SetSample(
             InputWorkspace=sampleWS,
-            Material=self.vanadiumBoron.materialDictionary,
+            Material=self.vanadiumBoron.json(),
         )
         material = sampleWS.sample().getMaterial()
         assert material.chemicalFormula()[0][0].symbol == "V"
@@ -106,7 +107,7 @@ class TestGeometry(unittest.TestCase):
 
         SetSample(
             InputWorkspace=sampleWS,
-            Material=self.vanadiumBoronDash.materialDictionary,
+            Material=self.vanadiumBoronDash.json(),
         )
         material = sampleWS.sample().getMaterial()
         assert material.chemicalFormula()[0][0].symbol == "V"


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

The pydantic classes `Geometry` and `Material` had been setup with a dictionary property to return for use in mantid's `SetSample`.  However, this is not necessary, as the string returned from `json()` works just fine, with some adjustments.

The `json()` method is more pydantic-thonic, so it is preferable to use this instead.

This overrides the pydantic `json()` method to return a correct json string that works with mantid's `SetSample` algo, so that the pydantic object can be more natively used with mantid.

## Explanation of work

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

Changed 

``` python
    def geometryDictionary(self) -> Dict[str, Any]:
        ans = {
            "Shape": self.shape,
            "Radius": self.radius,
            "Center": list(self.center),
        }
        if self.shape == "Cylinder":
            ans["Height"] = self.height
            ans["Axis"] = list(self.axis)
        return ans
```
to
``` python
    def json(self) -> str:
        ans = {
            "Shape": self.shape,
            "Radius": self.radius,
            "Center": list(self.center),
        }
        if self.shape == "Cylinder":
            ans["Height"] = self.height
            ans["Axis"] = list(self.axis)
        return json.dumps(ans)
```

## To test

### Dev testing

There are unit tests for geometry, material, and calibrant sample, which create these pydantic objects and call `SetSample`, then ensure the sample was properly set.

### CIS testing

<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

Run the `calibrant_samples_script` in the CIS test folder.  Probably not really necessary, as this is internal.

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#2696](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2696)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
