### PR TITLE
Make a Dirty Dish :plate_with_cutlery: 

### DIFF
--- a/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
+++ b/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
@@ -1,0 +1,36 @@
+import json
+from typing import Dict, List, Tuple
+
+import numpy as np
+from mantid.api import AlgorithmFactory, PythonAlgorithm
+from mantid.kernel import Direction, StringArrayProperty
+from mantid.simpleapi import CloneWorkspace, mtd
+
+from snapred.meta.Config import Config
+
+
+class MakeDirtyDish(PythonAlgorithm):
+    """
+    Record a workspace in a state for the CIS to view later
+    """
+
+    def PyInit(self):
+        # declare properties
+        self.declareProperty("InputWorkspace", defaultValue="", direction=Direction.Input)  # noqa: F821
+        self.declareProperty("OutputWorkspace", defaultValue="", direction=Direction.Output)  # noqa: F821
+        self.setRethrows(True)
+        self._CISmode: bool = Config["cis_mode"]
+
+    def PyExec(self) -> None:
+        inWS = self.getProperty("InputWorkspace").value
+        outWS = self.getProperty("OutputWorkspace").value
+        self.log().notice(f"Dirtying up dish {inWS} --> {outWS}")
+        if self._CISmode:
+            CloneWorkspace(
+                InputWorkspace=inWS,
+                OutputWorkspace=outWS,
+            )
+
+
+# Register algorithm with Mantid
+AlgorithmFactory.subscribe(MakeDirtyDish)

--- a/tests/unit/backend/recipe/algorithm/test_PixelGroupingParametersCalculationAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_PixelGroupingParametersCalculationAlgorithm.py
@@ -342,7 +342,7 @@ with mock.patch.dict(
                 referenceParametersFile=referenceParametersFile,
             )
         assert 'Instrument file name "junk" has an invalid extension' in str(excinfo.value)
-        
+
     def test_local_wrong_grouping_file():
         isLocalTest = True
         isLiteInstrument = True

--- a/tests/unit/backend/recipe/algorithm/test_PixelGroupingParametersCalculationAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_PixelGroupingParametersCalculationAlgorithm.py
@@ -341,8 +341,8 @@ with mock.patch.dict(
                 groupingFile=groupingFile,
                 referenceParametersFile=referenceParametersFile,
             )
-        assert "File 'junk' does not exist" in str(excinfo.value)
-
+        assert 'Instrument file name "junk" has an invalid extension' in str(excinfo.value)
+        
     def test_local_wrong_grouping_file():
         isLocalTest = True
         isLiteInstrument = True


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

It is often desired to save states of a workspace at intervals in an interval, so the CIS can inspect how the calculation is proceeding and spot errors when they occur.

The algo `WashDishes` was made to replace `DeleteWorkspaces` to be optional when in CIS mode.  This algo does the same thing, but for `CloneWorkspace`.

It can be used to clone a workspace in a state.  When not in CIS mode, it will do nothing.

## Explanation of work

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

The code is very simple, just `CloneWorkspace` only when in CIS mode.

## To test

### Dev testing

<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing

``` python
from snapred.meta.Config import Config, Resource

CreateWorkspace(
  OutputWorkspace="_test_",
  DataX = [1],
  DataY = [1],
)

Config._config['cis_mode'] = True
mdd = MakeDirtyDish()
mdd.initialize()
mdd.setProperty("InputWorkspace", "_test_),
mdd.setProperty("OutoutWorkspace", "_test2_")
mdd.execute()

Config._config['cis_mode'] = False
mdd.setProperty("InputWorkspace", "_test_),
mdd.setProperty("OutoutWorkspace", "_test2_")
mdd.execute()
```

You should see `_test2_` in the ADS, but not `_test3_`.

Probably the algo can't be called like a function and needs to be built.

## Link to EWM item

No EWM, this is part of some refactor work.
