### PR TITLE
add fixes to parts of the workflow that failed

### DIFF
--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -135,7 +135,9 @@ class CalibrationService(Service):
         # 4c. PeakIntensityThreshold
         peakIntensityThreshold = request.peakIntensityThreshold
         detectorPeaks = DetectorPeakPredictorRecipe().executeRecipe(
-            InstrumentState=instrumentState, CrystalInfo=crystalInfo, PeakIntensityThreshold=peakIntensityThreshold
+            InstrumentState=instrumentState,
+            CrystalInfo=crystalInfo,
+            PeakIntensityFractionThreshold=peakIntensityThreshold,
         )
         detectorPeaks = parse_raw_as(List[GroupPeakList], detectorPeaks)
         # 5. cal path
@@ -289,7 +291,7 @@ class CalibrationService(Service):
         )
         if prevCalibration is not None:
             GenerateTableWorkspaceFromListOfDictRecipe().executeRecipe(
-                ListOfDict=list_to_raw(prevCalibration.focusGroupCalibrationMetrics[0].calibrationMetric),
+                ListOfDict=list_to_raw(prevCalibration.focusGroupCalibrationMetrics.calibrationMetric),
                 OutputWorkspace=f"{run.runNumber}_calibrationMetrics_v{prevCalibration.version}",
             )
         outputWorkspaces = [focussedData]

--- a/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
+++ b/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
@@ -123,9 +123,9 @@ class DiffractionCalibrationCreationWorkflow:
         calibrationRecord = self.responses[-1].data
         calibrationRecord.workspaceNames.append(self.responses[-2].data["calibrationTable"])
         calibrationIndexEntry = CalibrationIndexEntry(
-            runNumber=view.getFieldText("calibrationIndexEntry.runNumber"),
-            comments=view.getFieldText("calibrationIndexEntry.comments"),
-            author=view.getFieldText("calibrationIndexEntry.author"),
+            runNumber=view.fieldRunNumber.get(),
+            comments=view.fieldComments.get(),
+            author=view.fieldAuthor.get(),
         )
         payload = CalibrationExportRequest(
             calibrationRecord=calibrationRecord, calibrationIndexEntry=calibrationIndexEntry

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -307,7 +307,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         mockDetectorPeakPredictorRecipe().executeRecipe.assert_called_once_with(
             InstrumentState=mockFocusGroupInstrumentState[1],
             CrystalInfo=mockCrystallographicInfoService().ingest.return_value["crystalInfo"],
-            PeakIntensityThreshold=request.peakIntensityThreshold,
+            PeakIntensityFractionThreshold=request.peakIntensityThreshold,
         )
         mockDiffractionCalibrationIngredients.assert_called_once_with(
             runConfig=self.instance.dataFactoryService.getRunConfig.return_value,


### PR DESCRIPTION
## Description of work

This adds a couple line fixes to the Diffraction Calibration workflow that caused error, either due to a refactor or missing the persistence phase.

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work

This fixes were made organically as it was tested with Malcolm

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing
### CIS testing

Can/has been confirmed to complete when running in the gui.  Will supply the runid if needed.

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#2431](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2431)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
