### PR TITLE
Calculate table of DIFC values

### DIFF
--- a/src/snapred/backend/recipe/algorithm/CalculateDiffCalTable.py
+++ b/src/snapred/backend/recipe/algorithm/CalculateDiffCalTable.py
@@ -1,0 +1,86 @@
+import json
+from typing import Dict, List, Tuple
+
+import numpy as np
+from mantid.api import (
+    AlgorithmFactory,
+    ITableWorkspaceProperty,
+    MatrixWorkspaceProperty,
+    PropertyMode,
+    PythonAlgorithm,
+)
+from mantid.kernel import Direction, StringListValidator
+from mantid.simpleapi import (
+    CalculateDIFC,
+    CreateEmptyTableWorkspace,
+    DeleteWorkspace,
+    mtd,
+)
+
+
+class CalculateDiffCalTable(PythonAlgorithm):
+    """
+    Record a workspace in a state for the CIS to view later
+    """
+
+    def PyInit(self):
+        # declare properties
+        self.declareProperty(
+            MatrixWorkspaceProperty("InputWorkspace", "", Direction.Input, PropertyMode.Mandatory),
+            doc="Workspace containing the instrument definition",
+        )
+        self.declareProperty(
+            ITableWorkspaceProperty("CalibrationTable", "", Direction.Output, PropertyMode.Optional),
+            doc="test doc",
+        )
+        validOffsetModes = ["Signed", "Relative", "Absolute"]
+        self.declareProperty("OffsetMode", "Signed", StringListValidator(validOffsetModes), direction=Direction.Input)
+        self.declareProperty("BinWidth", 0.0, direction=Direction.Input)
+        self.setRethrows(True)
+
+    def PyExec(self) -> None:
+        """
+        Use the instrument in the input workspace to create an initial DIFC table
+        Because the created DIFC is inside a matrix workspace, it must
+        be manually loaded into a table workspace
+        """
+        self.log().notice("Creating DIFC table")
+
+        # prepare initial diffraction calibration workspace
+        tmpDifc = "_tmp_matrixworkspace"
+        CalculateDIFC(
+            InputWorkspace=self.getPropertyValue("InputWorkspace"),
+            OutputWorkspace=tmpDifc,
+            OffsetMode=self.getPropertyValue("OffsetMode"),
+            BinWidth=abs(self.getProperty("BinWidth").value),
+        )
+        tmpDifcWS = mtd[tmpDifc]
+        difcs = [float(x) for x in tmpDifcWS.extractY()]
+
+        # convert the calibration workspace into a calibration table
+        DIFCtable = CreateEmptyTableWorkspace(
+            OutputWorkspace=self.getPropertyValue("CalibrationTable"),
+        )
+        DIFCtable.addColumn(type="int", name="detid", plottype=6)
+        DIFCtable.addColumn(type="double", name="difc", plottype=6)
+        DIFCtable.addColumn(type="double", name="difa", plottype=6)
+        DIFCtable.addColumn(type="double", name="tzero", plottype=6)
+
+        for wkspIndx, difc in enumerate(difcs):
+            detids = tmpDifcWS.getSpectrum(wkspIndx).getDetectorIDs()
+            for detid in detids:
+                DIFCtable.addRow(
+                    {
+                        "detid": int(detid),
+                        "difc": float(difc),
+                        "difa": 0.0,
+                        "tzero": 0.0,
+                    }
+                )
+        DeleteWorkspace(
+            Workspace=tmpDifc,
+        )
+
+
+# Register algorithm with Mantid
+AlgorithmFactory.subscribe(CalculateDiffCalTable)

--- a/tests/unit/backend/recipe/algorithm/test_CalculateDiffCalTable.py
+++ b/tests/unit/backend/recipe/algorithm/test_CalculateDiffCalTable.py
@@ -1,0 +1,70 @@
+import unittest
+
+from mantid.simpleapi import (
+    DeleteWorkspace,
+    mtd,
+)
+
+# the algorithm to test
+from snapred.backend.recipe.algorithm.CalculateDiffCalTable import (
+    CalculateDiffCalTable as Algo,  # noqa: E402
+)
+from snapred.meta.Config import Resource
+
+
+class TestCalculateDiffCalTable(unittest.TestCase):
+    def setUp(self):
+        """Create a set of mocked ingredients for calculating DIFC"""
+        self.dBin = 0.001
+        self.fakeRawData = "_test_difc_table_raw"
+        self.makeFakeNeutronData(self.fakeRawData)
+
+    def tearDown(self) -> None:
+        for ws in mtd.getObjectNames():
+            try:
+                DeleteWorkspace(ws)
+            except:  # noqa: E722
+                pass
+        return super().tearDown()
+
+    def makeFakeNeutronData(self, rawWsName: str):
+        from mantid.simpleapi import (
+            CreateSampleWorkspace,
+            LoadInstrument,
+        )
+
+        # prepare with test data
+        CreateSampleWorkspace(
+            OutputWorkspace=rawWsName,
+            # WorkspaceType="Histogram",
+            Function="User Defined",
+            UserDefinedFunction="name=Gaussian,Height=10,PeakCentre=1.2,Sigma=0.2",
+            Xmin=0,
+            Xmax=5,
+            BinWidth=self.dBin,
+            XUnit="dSpacing",
+            NumBanks=4,  # must produce same number of pixels as fake instrument
+            BankPixelWidth=2,  # each bank has 4 pixels, 4 banks, 16 total
+        )
+        LoadInstrument(
+            Workspace=rawWsName,
+            Filename=Resource.getPath("inputs/diffcal/fakeSNAPLite.xml"),
+            RewriteSpectraMap=True,
+        )
+
+    def test_init_difc_table(self):
+        difcTableWS = "_test_make_difc_table"
+
+        algo = Algo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", self.fakeRawData)
+        algo.setProperty("CalibrationTable", difcTableWS)
+        algo.setProperty("OffsetMode", "Signed")
+        algo.setProperty("BinWidth", abs(self.dBin))
+        algo.execute()
+
+        difcTable = mtd[difcTableWS]
+        for i, row in enumerate(difcTable.column("detid")):
+            assert row == i
+        for difc in difcTable.column("difc"):
+            print(f"{difc},")


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

The diffraction calibration steps frequently require a `CalibrationWorkspace` object, which is a `TableWorkspace` with columns for `detid`, `difc`, `difa`, and `tzero`.

However, the mantid `CalculateDIFC` algorithm stupidly returns only a `MatrixWorkspace` object, which cannot be used in the other diffraction calibration algorithms, nor easily converted into the needed table.

This algorithm calls `CalculateDIFC` and creates the table, so that this block of code does not need to be repeated several times inside the diffraction calibration process.

## Explanation of work

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

It's a very simple new algorithm.  It calls `CalculateDIFC`, creates an empty table workspace, stores the `detid` and `difc` values from the `MatrixWorkspace`, then populates the empty table workspace, using `difa`=0 and `tzero`=0 for all detectors.

## To test

### Dev testing

There is a unit test for this.  It will create sample neutron data with a fake instrument definition, then create the DIFC table from this instrument, then check the detector IDs.

Run this algo in workbench, and verify that the DIFC values are non-zero.

### CIS testing

Not needed, because this is an internal issues.

## Link to EWM item

No associated EWM
