### PR TITLE
minor cleanup of algos

### DIFF
--- a/src/snapred/backend/recipe/algorithm/WashDishes.py
+++ b/src/snapred/backend/recipe/algorithm/WashDishes.py
@@ -8,8 +8,6 @@ from mantid.simpleapi import DeleteWorkspace, DeleteWorkspaces, mtd
 
 from snapred.meta.Config import Config
 
-name = "CalculateOffsetDIFC"
-
 
 class WashDishes(PythonAlgorithm):
     """
@@ -17,12 +15,15 @@ class WashDishes(PythonAlgorithm):
     But not unless the CIS wants to investigate the mess first.
     """
 
+    def category(self):
+        return "SNAPRed Internal"
+
     def PyInit(self):
         # declare properties
         self.declareProperty("Workspace", defaultValue="", direction=Direction.Input)  # noqa: F821
         self.declareProperty(StringArrayProperty(name="WorkspaceList", values=[], direction=Direction.Input))
         self.setRethrows(True)
-        self._CISmode: bool = Config["cis_mode"]
+        self._CISmode: bool = Config._config.get("cis_mode", False)
 
     def PyExec(self) -> None:
         self.log().notice("Washing the dishes...")

--- a/tests/unit/backend/recipe/algorithm/test_RawVanadiumCorrection.py
+++ b/tests/unit/backend/recipe/algorithm/test_RawVanadiumCorrection.py
@@ -1,14 +1,8 @@
 # TODO: figure out how to run snapred algos like python functions
 
-import json
-import random
 import unittest
-import unittest.mock as mock
-from typing import Dict, List
 
 import pytest
-from mantid.api import PythonAlgorithm
-from mantid.kernel import Direction
 from mantid.simpleapi import (
     AddSampleLog,
     CalculateDIFC,
@@ -23,8 +17,6 @@ from mantid.simpleapi import (
     Rebin,
     mtd,
 )
-from snapred.backend.dao.DetectorPeak import DetectorPeak
-from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.ingredients import ReductionIngredients as Ingredients
 
 # needed to make mocked ingredients
@@ -34,10 +26,6 @@ from snapred.backend.dao.state.CalibrantSample.CalibrantSamples import Calibrant
 from snapred.backend.dao.state.CalibrantSample.Crystallography import Crystallography
 from snapred.backend.dao.state.CalibrantSample.Geometry import Geometry
 from snapred.backend.dao.state.CalibrantSample.Material import Material
-from snapred.backend.dao.state.FocusGroup import FocusGroup
-from snapred.backend.dao.state.InstrumentState import InstrumentState
-from snapred.backend.recipe.algorithm.ConvertDiffCalLog import ConvertDiffCalLog  # noqa
-from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 
 # the algorithm to test
 from snapred.backend.recipe.algorithm.RawVanadiumCorrectionAlgorithm import (


### PR DESCRIPTION
## Description of work

This removes some unnecessary imports that were inappropriately copied over, and slightly refactors `WashDishes` to be a bit more safe.

## Explanation of work

The two files changed had unneeded imports.  One of the unneeded imports was to an algo that is slated for deletion, which created additional errors.

Inside `WashDishes`, it was setup to use `Config._config.get("cis_mode", False)` instead of `Config["cis_mode"]`, which enables safer access without key errors.  It also defaults to false, meaning the extra workspaces will be deleted by default.

## To test

### Dev testing

no need to test

### CIS testing

no need for CIS testing -- internal issue

## Link to EWM item

No associated EWM