### PR TITLE
[Defect] Fix LiteDataCreationAlgo

### DIFF
--- a/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
@@ -1,3 +1,4 @@
+import os
 import json
 
 from mantid.api import *
@@ -5,7 +6,7 @@ from mantid.api import AlgorithmFactory, PythonAlgorithm, mtd
 from mantid.kernel import Direction
 
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
-from snapred.meta.Config import Resource
+from snapred.meta.Config import Config
 
 name = "LiteDataCreationAlgo"
 
@@ -13,20 +14,22 @@ name = "LiteDataCreationAlgo"
 class LiteDataCreationAlgo(PythonAlgorithm):
     def PyInit(self):
         self.declareProperty("InputWorkspace", defaultValue="", direction=Direction.Input)
+        self.declareProperty("RunNumber", defaultValue="", direction=Direction.Input)
         self.declareProperty("OutputWorkspace", defaultValue="", direction=Direction.Output)
         self.setRethrows(True)
         self.mantidSnapper = MantidSnapper(self, name)
 
     def PyExec(self):
         self.log().notice("Lite Data Creation START!")
-        # define super pixel dimensions
-        superPixel = [8, 8]
 
         # get output workspace name
         outputWorkspaceName = self.getProperty("OutputWorkspace").value
 
         # load input workspace
         inputWorkspace = self.getProperty("InputWorkspace").value
+
+        # load run number
+        runNumber = self.getProperty("RunNumber").value
 
         # clone the workspace
         self.mantidSnapper.CloneWorkspace(
@@ -36,63 +39,24 @@ class LiteDataCreationAlgo(PythonAlgorithm):
         )
         self.mantidSnapper.executeQueue()
         outputWorkspace = self.mantidSnapper.mtd[outputWorkspaceName]
-
-        # IEventWorkspace ID is equivalent to spec ID
-        numSpec = outputWorkspace.getNumberHistograms()
-
-        # array to hold spectrum data
-        spectrumData = []
-
-        # iterate over IEventWorkspace IDs
-        for spec in range(numSpec):
-            # get event list per workspace
-            spectrum = outputWorkspace.getSpectrum(workspaceIndex=spec)
-            spectrumData.append(spectrum)
-
-        # allocate array of event IDs
-        for spectrum in spectrumData:
-            eventIDs = spectrum.getDetectorIDs()
-            for event in eventIDs:
-                superID = self.getSuperID(nativeID=event, xdim=superPixel[0], ydim=superPixel[1])
-
-                # clear detector IDs and then add the new modified super ID
-                spectrum.clearDetectorIDs()
-                spectrum.addDetectorID(superID)
-
+        liteWorkspacename = f'{runNumber}_lite'
+        # use group detector with specific grouping file to create lite data
+        self.mantidSnapper.GroupDetectors(
+            "Creating lite version...",
+            InputWorkspace=outputWorkspace,
+            outputWorkspace=liteWorkspacename,
+            MapFile=str(Config["instrument.lite.definition.grouping"]),
+        )
         self.mantidSnapper.LoadInstrument(
-            "Loading instrument...",
-            Workspace=outputWorkspace,
-            Filename=Resource.getPath("/inputs/pixel_grouping/SNAPLite_Definition.xml"),
+            "Updating instrument definition...",
+            Workspace=liteWorkspacename,
+            Filename=str(Config["instrument.lite.definition.file"]),
             RewriteSpectraMap=False,
         )
         self.mantidSnapper.executeQueue()
-
-        self.setProperty("OutputWorkspace", outputWorkspaceName)
-        return outputWorkspaceName
-
-    def getSuperID(self, nativeID, xdim, ydim):
-        # Constants
-        Nx, Ny = 256, 256  # Native number of horizontal and vertical pixels
-        NNat = Nx * Ny  # Native number of pixels per panel
-
-        # Calculate super panel basics
-        superNx = Nx // xdim
-        superNy = Ny // ydim
-        superN = superNx * superNy
-
-        # Calculate reduced ID and native (reduced) coordinates on pixel face
-        firstPix = nativeID // NNat * NNat
-        redID = nativeID % NNat
-        i, j = divmod(redID, Ny)
-
-        # Calculate super pixel IDs
-        superi = i // xdim
-        superj = j // ydim
-        superFirstPix = firstPix // NNat * superN
-        superIDs = superi * superNy + superj + superFirstPix
-
-        return superIDs
-
+        liteWorkspace = self.mantidSnapper.mtd[liteWorkspacename]
+        self.setProperty("OutputWorkspace", liteWorkspacename)
+        return liteWorkspacename
 
 # Register algorithm with Mantid
 AlgorithmFactory.subscribe(LiteDataCreationAlgo)

--- a/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
@@ -1,5 +1,5 @@
-import os
 import json
+import os
 
 from mantid.api import *
 from mantid.api import AlgorithmFactory, PythonAlgorithm, mtd
@@ -39,7 +39,7 @@ class LiteDataCreationAlgo(PythonAlgorithm):
         )
         self.mantidSnapper.executeQueue()
         outputWorkspace = self.mantidSnapper.mtd[outputWorkspaceName]
-        liteWorkspacename = f'{runNumber}_lite'
+        liteWorkspacename = f"{runNumber}_lite"
         # use group detector with specific grouping file to create lite data
         self.mantidSnapper.GroupDetectors(
             "Creating lite version...",
@@ -54,9 +54,10 @@ class LiteDataCreationAlgo(PythonAlgorithm):
             RewriteSpectraMap=False,
         )
         self.mantidSnapper.executeQueue()
-        liteWorkspace = self.mantidSnapper.mtd[liteWorkspacename]
+        self.mantidSnapper.mtd[liteWorkspacename]
         self.setProperty("OutputWorkspace", liteWorkspacename)
         return liteWorkspacename
+
 
 # Register algorithm with Mantid
 AlgorithmFactory.subscribe(LiteDataCreationAlgo)

--- a/src/snapred/backend/service/LiteDataService.py
+++ b/src/snapred/backend/service/LiteDataService.py
@@ -29,7 +29,9 @@ class LiteDataService(Service):
         for run in runs:
             inputWorkspace = "SNAP_" + str(run.runNumber) + ".nxs"
             try:
-                data[str(run.runNumber)] = Recipe().executeRecipe(inputWorkspace=inputWorkspace, runNumber=run.runNumber)
+                data[str(run.runNumber)] = Recipe().executeRecipe(
+                    inputWorkspace=inputWorkspace, runNumber=run.runNumber
+                )
             except Exception as e:
                 raise e
         return data

--- a/src/snapred/backend/service/LiteDataService.py
+++ b/src/snapred/backend/service/LiteDataService.py
@@ -29,7 +29,7 @@ class LiteDataService(Service):
         for run in runs:
             inputWorkspace = "SNAP_" + str(run.runNumber) + ".nxs"
             try:
-                data[str(run.runNumber)] = Recipe().executeRecipe(inputWorkspace=inputWorkspace)
+                data[str(run.runNumber)] = Recipe().executeRecipe(inputWorkspace=inputWorkspace, runNumber=run.runNumber)
             except Exception as e:
                 raise e
         return data

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -23,6 +23,7 @@ instrument:
   lite:
     definition:
       file: ${instrument.home}shared/Calibration/Powder/SNAPLite.xml
+      grouping: ${instrument.home}shared/Calibration_dynamic/Powder/PixelGroupingDefinitions/SNAPFocGroup_AllPixels_LiteGrouping.xml
 
 nexus:
   home: nexus/

--- a/tests/cis_tests/lite_data_creation.py
+++ b/tests/cis_tests/lite_data_creation.py
@@ -1,0 +1,13 @@
+# Use this script to test LiteDataCreationAlgo.py
+from mantid.simpleapi import *
+import matplotlib.pyplot as plt
+import numpy as np
+
+from snapred.backend.recipe.algorithm.LiteDataCreationAlgo import LiteDataCreationAlgo
+
+LDCA = LiteDataCreationAlgo()
+LDCA.initialize()
+LDCA.setProperty("InputWorkspace", "47278_raw")
+LDCA.setProperty("RunNumber", "47278")
+LDCA.setProperty("OutputWorkspace", "47278_lite")
+LDCA.execute()

--- a/tests/unit/backend/recipe/algorithm/test_LiteDataCreationAlgo.py
+++ b/tests/unit/backend/recipe/algorithm/test_LiteDataCreationAlgo.py
@@ -1,5 +1,6 @@
 import os
 import unittest.mock as mock
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -26,41 +27,6 @@ def _setup_teardown():
             DeleteWorkspace(workspace)
         except ValueError:
             print(f"Workspace {workspace} doesn't exist!")
-
-
-@pytest.mark.mount_snap()
-@pytest.mark.skipif(not HAVE_MOUNT_SNAP, reason="Mount SNAP not available")
-def test_LiteDataCreationAlgo_basic_functionality():
-    testWorkspaceFile = "/SNS/SNAP/IPTS-26687/nexus/SNAP_51877.nxs.h5"
-    test_ws_name = "test_ws"
-    Load(Filename=testWorkspaceFile, OutputWorkspace=test_ws_name)
-
-    assert test_ws_name in mtd.getObjectNames()
-
-    output_ws_name = "output_ws"
-    liteDataCreationAlgo = LiteDataCreationAlgo()
-    liteDataCreationAlgo.initialize()
-    liteDataCreationAlgo.setProperty("InputWorkspace", test_ws_name)
-    liteDataCreationAlgo.setProperty("OutputWorkspace", output_ws_name)
-    result = liteDataCreationAlgo.execute()
-
-    assert result
-    assert output_ws_name in mtd.getObjectNames()
-    output_ws = mtd[output_ws_name]
-
-    original_ws = mtd[test_ws_name]
-    orig_specs = []
-    modified_specs = []
-    for idx in range(original_ws.getNumberHistograms()):
-        orig_spec = original_ws.getSpectrum(idx)
-        orig_specs.append(orig_spec)
-        modified_spec = output_ws.getSpectrum(idx)
-        modified_specs.append(modified_spec)
-
-    assert len(orig_specs) == len(modified_specs)
-
-    DeleteWorkspace(output_ws_name)
-
 
 @pytest.mark.mount_snap()
 @pytest.mark.skipif(not HAVE_MOUNT_SNAP, reason="Mount SNAP not available")

--- a/tests/unit/backend/recipe/algorithm/test_LiteDataCreationAlgo.py
+++ b/tests/unit/backend/recipe/algorithm/test_LiteDataCreationAlgo.py
@@ -28,6 +28,7 @@ def _setup_teardown():
         except ValueError:
             print(f"Workspace {workspace} doesn't exist!")
 
+
 @pytest.mark.mount_snap()
 @pytest.mark.skipif(not HAVE_MOUNT_SNAP, reason="Mount SNAP not available")
 def test_LiteDataCreationAlgo_invalid_input():

--- a/tests/unit/backend/service/test_LiteDataService.py
+++ b/tests/unit/backend/service/test_LiteDataService.py
@@ -1,23 +1,29 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from snapred.backend.dao.RunConfig import RunConfig
 
 
 class TestLiteDataService(unittest.TestCase):
     @patch("snapred.backend.data.DataFactoryService.DataFactoryService", autospec=True)
-    @patch("snapred.backend.recipe.GenericRecipe.GenericRecipe.executeRecipe")
+    @patch("snapred.backend.recipe.GenericRecipe.LiteDataRecipe.executeRecipe")
     def test_reduceLiteData_calls_executeRecipe_with_correct_arguments(
         self, mock_executeRecipe, mock_dataFactoryService  # noqa: ARG002
     ):
+        # Set the mock return value
         mock_executeRecipe.return_value = {}
 
+        # Create a mock run configuration
         mock_runConfig = RunConfig(runNumber="12345")
 
+        # Import the service to test
         from snapred.backend.service.LiteDataService import LiteDataService
 
+        # Instantiate the service
         liteDataService = LiteDataService()
 
+        # Call the method to test
         liteDataService.reduceLiteData([mock_runConfig])
 
-        mock_executeRecipe.assert_called_with(inputWorkspace="SNAP_12345.nxs")
+        # Assert the method was called with the correct arguments
+        mock_executeRecipe.assert_called_with(inputWorkspace="SNAP_12345.nxs", runNumber="12345")

--- a/tests/unit/backend/service/test_LiteDataService.py
+++ b/tests/unit/backend/service/test_LiteDataService.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from snapred.backend.dao.RunConfig import RunConfig
 


### PR DESCRIPTION
## Description of work
Upon testing of the new `LiteDataCreationAlgo`, the algo executed successfully. Upon inspection of the output workspace, it was found the the updating of the instrument definition worked properly but the reduction of the number of histograms (reduction by a factor of 64) did not occur. The input and output workspaces for a given test run had the same number of histograms.

Solution suggested by Andrei:

suggested fix:
a) create a grouping file reflecting the 8x8 grouping of SNAPLite
b) use GroupDetectors, using this grouping information to create the the necessary output file.
<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work
The first piece of this puzzle was to produce a new grouping file to facilitate the grouping of pixels in transforming raw data into lite data. This was done using this script:
```python
import csv
import h5py


def create_detector_bank(rows, columns, bank_start_id):
    bank = []
    for i in range(columns):
        column = []
        for j in range(rows):
            column.append(bank_start_id + i * rows + j)
        bank.append(column)
    return bank


def create_detector_array(rows, columns, num_banks):
    detector = {}
    start_id = 0
    bank_counter = 11
    for _ in range(num_banks // 3):
        for j in range(1, 4):
            bank_label = f"bank{bank_counter}{j}"
            detector[bank_label] = create_detector_bank(rows, columns, start_id)
            start_id += rows * columns
        bank_counter += 10
    return detector


def generate_super_pixel_mappings(rows, columns, detector_banks):
    group_counter = 0
    super_pixel_mappings = {}

    for bank_label, bank in detector_banks.items():
        for i in range(0, rows, 8):
            for j in range(0, columns, 8):
                group_counter += 1
                for x in range(8):
                    for y in range(8):
                        pixel_id = bank[j + x][i + y]
                        super_pixel_mappings[pixel_id] = group_counter

    return super_pixel_mappings


rows = 256
columns = 256
num_banks = 18

detector_banks = create_detector_array(rows, columns, num_banks)
super_pixel_mappings = generate_super_pixel_mappings(rows, columns, detector_banks)

with open('super_pixel_mappings.csv', 'w', newline='') as file:
    writer = csv.writer(file)
    writer.writerow(["bank", "pixel_id", "group_number"])
    for bank_label, bank in detector_banks.items():
        for row in bank:
            for pixel_id in row:
                writer.writerow([bank_label, pixel_id, super_pixel_mappings[pixel_id]])

file_path = '/SNS/users/dzj/Desktop/SNAPFocGroup_All_modified.hdf'
with h5py.File(file_path, 'r+') as file:
    group_dataset = file['calibration/group']
    for pixel_id in range(1179648):
        group_dataset[pixel_id] = super_pixel_mappings[pixel_id]


print("Script has completed!")
```
A csv file is outputted with values for insuring correctness and then the script modifies the pixel ID's within a .hdf file that Malcolm has given me. After finding out that `GroupDetectors` takes only `.map` or `.xml`. I produced another script to facilitate the modification of the full resolution grouping file for SNAP (which was in .xml format). Here is that script:

```python
import xml.etree.ElementTree as ET

def generate_super_pixel_mappings():
    total_pixels = 1179648
    super_pixel_size = 64
    super_pixel_mappings = {}
    
    for i in range(0, total_pixels, super_pixel_size):
        for j in range(super_pixel_size):
            pixel_id = i + j
            group_id = i // super_pixel_size
            super_pixel_mappings[pixel_id] = group_id

    return super_pixel_mappings

def update_xml(xml_path, output_path):
    tree = ET.parse(xml_path)
    root = tree.getroot()
    
    for group in root.findall('group'):
        root.remove(group)
    
    mappings = generate_super_pixel_mappings()
    
    grouped_mappings = {}
    for pixel_id, group_id in mappings.items():
        if group_id not in grouped_mappings:
            grouped_mappings[group_id] = []
        grouped_mappings[group_id].append(str(pixel_id))
    
    for group_id, pixel_ids in grouped_mappings.items():
        group_element = ET.SubElement(root, 'group', ID=str(group_id))
        detids_element = ET.SubElement(group_element, 'detids')
        detids_element.text = '-'.join([pixel_ids[0], pixel_ids[-1]])
    
    tree.write(output_path)

xml_path = '/SNS/users/dzj/Desktop/SNAPFocGroup_All.xml'
output_path = '/SNS/users/dzj/Desktop/SNAPFocGroup_All_modified.xml'

update_xml(xml_path, output_path)
```
After this was done, it was a matter of having Malcolm saving this new grouping file within the analysis cluster and updating the algo, service and the associated tests while testing within the workbench.
<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing
For Dev testing, pull this branch and insure using `Pytest` that all tests pass.
<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing
For CIS testing, please pull this branch from within analysis. Within the `SNAPRed/tests/cis_tests/` directory, there is a new simple test for this script called `lite_data_creation.py`. Run this script from within workbench. The run number I used is `47278`. Any run can be used just update the information within the test script. Also make sure to run `LoadEventNexus` before running this script.
<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

``` python
# Use this script to test LiteDataCreationAlgo.py
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from snapred.backend.recipe.algorithm.LiteDataCreationAlgo import LiteDataCreationAlgo

LDCA = LiteDataCreationAlgo()
LDCA.initialize()
LDCA.setProperty("InputWorkspace", "47278_raw")
LDCA.setProperty("RunNumber", "47278")
LDCA.setProperty("OutputWorkspace", "47278_lite")
LDCA.execute()
```

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM# 2782](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=2782)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
