### PR TITLE
Added fixes and tests for Save/LoadGroupingDefinition

### DIFF
--- a/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
@@ -7,8 +7,6 @@ from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
 
-name = "LoadGroupingDefinition"
-
 logger = snapredLogger.getLogger(__name__)
 
 
@@ -56,7 +54,7 @@ class LoadGroupingDefinition(PythonAlgorithm):
         )
 
         self.setRethrows(True)
-        self.mantidSnapper = MantidSnapper(self, name)
+        self.mantidSnapper = MantidSnapper(self, __name__)
 
         # define supported file name extensions
         self.supported_calib_file_extensions = ["H5", "HD5", "HDF"]
@@ -91,9 +89,7 @@ class LoadGroupingDefinition(PythonAlgorithm):
         grouping_file_name = self.getProperty("GroupingFilename").value
         output_ws_name = self.getProperty("OutputWorkspace").value
         file_extension = pathlib.Path(grouping_file_name).suffix.upper()[1:]
-        isLite = False
-        if ".lite" in grouping_file_name:
-            isLite = True
+        isLite: bool = ".lite" in grouping_file_name
         if isLite and self.getProperty("InstrumentFilename").value == "":
             self.setProperty("InstrumentFilename", Config["instrument.lite.definition.file"])
         if file_extension in self.supported_calib_file_extensions:

--- a/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
@@ -1,4 +1,5 @@
 import pathlib
+from datetime import datetime
 
 from mantid.api import AlgorithmFactory, MatrixWorkspaceProperty, PropertyMode, PythonAlgorithm
 from mantid.kernel import Direction
@@ -114,11 +115,12 @@ class LoadGroupingDefinition(PythonAlgorithm):
             preserve_donor = True if instrument_donor else False
             if not instrument_donor:
                 # create one from the instrument definition file
-                instrument_donor = self.mantidSnapper.LoadEmptyInstrument(
+                instrument_donor = datetime.now().ctime() + "_idf"
+                self.mantidSnapper.LoadEmptyInstrument(
                     "Loading instrument definition file...",
                     Filename=self.getProperty("InstrumentFilename").value,
                     InstrumentName=self.getProperty("InstrumentName").value,
-                    OutputWorkspace="idf",
+                    OutputWorkspace=instrument_donor,
                 )
             self.mantidSnapper.LoadDetectorsGroupingFile(
                 "Loading grouping definition from detectors grouping file...",

--- a/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
@@ -3,9 +3,13 @@ import pathlib
 from mantid.api import AlgorithmFactory, MatrixWorkspaceProperty, PropertyMode, PythonAlgorithm
 from mantid.kernel import Direction
 
+from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
+from snapred.meta.Config import Config
 
 name = "LoadGroupingDefinition"
+
+logger = snapredLogger.getLogger(__name__)
 
 
 class LoadGroupingDefinition(PythonAlgorithm):
@@ -73,19 +77,25 @@ class LoadGroupingDefinition(PythonAlgorithm):
         if file_extension in self.supported_calib_file_extensions:
             instrument_name = self.getProperty("InstrumentName").value
             instrument_file_name = self.getProperty("InstrumentFilename").value
-            absent_input_properties_count = sum(not prop for prop in [instrument_name, instrument_file_name])
-            if absent_input_properties_count == 0 or absent_input_properties_count == 2:
-                raise Exception("Either InstrumentName or InstrumentFilename must be specified, but not both.")
+            if instrument_name + instrument_file_name != "":
+                if not (instrument_name == "" or instrument_file_name == ""):
+                    raise Exception("Either InstrumentName or InstrumentFilename must be specified, but not both.")
+
         if file_extension not in self.supported_xml_file_extensions:
             instrument_donor = self.getProperty("InstrumentDonor").value
             if instrument_donor:
-                raise Exception("InstrumentDonor only to be specified when GroupingFilename is in XML format.")
+                logger.warn("InstrumentDonor will only be used if GroupingFilename is in XML format.")
 
     def PyExec(self) -> None:
         self.validateInput()
         grouping_file_name = self.getProperty("GroupingFilename").value
         output_ws_name = self.getProperty("OutputWorkspace").value
         file_extension = pathlib.Path(grouping_file_name).suffix.upper()[1:]
+        isLite = False
+        if ".lite" in grouping_file_name:
+            isLite = True
+        if isLite and self.getProperty("InstrumentFilename").value == "":
+            self.setProperty("InstrumentFilename", Config["instrument.lite.definition.file"])
         if file_extension in self.supported_calib_file_extensions:
             self.mantidSnapper.LoadDiffCal(
                 "Loading grouping definition from calibration file...",

--- a/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
@@ -99,6 +99,7 @@ class LoadGroupingDefinition(PythonAlgorithm):
                 Filename=grouping_file_name,
                 InstrumentName=self.getProperty("InstrumentName").value,
                 InstrumentFilename=self.getProperty("InstrumentFilename").value,
+                InputWorkspace=self.getPropertyValue("InstrumentDonor"),
                 MakeGroupingWorkspace=True,
                 MakeCalWorkspace=False,
                 MakeMaskWorkspace=False,

--- a/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
@@ -123,6 +123,10 @@ class SaveGroupingDefinition(PythonAlgorithm):
             f"Cleanup the zero calibration workspace {cal_ws_name}",
             Workspace=cal_ws_name,
         )
+        self.mantidSnapper.WashDishes(
+            f"Cleanup the grouping workspace {grouping_ws_name}",
+            Workspace=grouping_ws_name,
+        )
         self.mantidSnapper.executeQueue()
 
     def CreateZeroCalibrationWorkspace(self, cal_ws_name) -> None:

--- a/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
@@ -128,10 +128,11 @@ class SaveGroupingDefinition(PythonAlgorithm):
             f"Cleanup the zero calibration workspace {cal_ws_name}",
             Workspace=cal_ws_name,
         )
-        self.mantidSnapper.WashDishes(
-            f"Cleanup the grouping workspace {grouping_ws_name}",
-            Workspace=grouping_ws_name,
-        )
+        if grouping_file_name != "":
+            self.mantidSnapper.WashDishes(
+                f"Cleanup the grouping workspace {grouping_ws_name}",
+                Workspace=grouping_ws_name,
+            )
         self.mantidSnapper.executeQueue()
 
     def CreateZeroCalibrationWorkspace(self, cal_ws_name) -> None:

--- a/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
@@ -113,30 +113,49 @@ class SaveGroupingDefinition(PythonAlgorithm):
             grouping_ws_name = self.getProperty("GroupingWorkspace").value
         self.grouping_ws = mtd[grouping_ws_name]
 
+        # To save the grouping workspace using Mantid SaveDiffCal algorithm
+        # we need to supply it with a calibration workspace
+        cal_ws_name = "cal_ws"
+        self.CreateZeroCalibrationWorkspace(cal_ws_name)
+
         outputFilename = self.getProperty("OutputFilename").value
-        groupIDs = self.grouping_ws.extractY()[:, 0]
-        nothing = [0] * len(groupIDs)  # np.zeros_like(detIDs)
-        instrument = self.grouping_ws.getInstrument()
-        detIDs = []
-        for groupID in self.grouping_ws.getGroupIDs():
-            detIDs.extend(self.grouping_ws.getDetectorIDsOfGroup(int(groupID)))
-
-        with h5py.File(outputFilename, "w") as f:
-            f.create_dataset("calibration/group", data=groupIDs)
-            f.create_dataset("calibration/detid", data=detIDs)
-            f.create_dataset("calibration/difa", data=nothing)
-            f.create_dataset("calibration/difc", data=nothing)
-            f.create_dataset("calibration/instrument/name", data=instrument.getName())
-            # f.create_dataset("calibration/instrument/instrument_source", data=grouping_file_name) # TODO
-            f.create_dataset("calibration/zero", data=nothing)
-            f.create_dataset("calibration/use", data=nothing)
-
+        self.mantidSnapper.SaveDiffCal(
+            f"Saving grouping workspace to {outputFilename}",
+            CalibrationWorkspace=cal_ws_name,
+            GroupingWorkspace=grouping_ws_name,
+            Filename=outputFilename,
+        )
+        self.mantidSnapper.WashDishes(
+            f"Cleanup the zero calibration workspace {cal_ws_name}",
+            Workspace=cal_ws_name,
+        )
         if grouping_file_name != "":
             self.mantidSnapper.WashDishes(
                 f"Cleanup the grouping workspace {grouping_ws_name}",
                 Workspace=grouping_ws_name,
             )
         self.mantidSnapper.executeQueue()
+
+    def CreateZeroCalibrationWorkspace(self, cal_ws_name) -> None:
+        self.mantidSnapper.CreateEmptyTableWorkspace(
+            "Creating empty table workspace...",
+            OutputWorkspace=cal_ws_name,
+        )
+        self.mantidSnapper.executeQueue()
+        cal_ws = mtd[cal_ws_name]
+
+        cal_ws.addColumn(type="int", name="detid", plottype=6)
+        cal_ws.addColumn(type="float", name="difc", plottype=6)
+        cal_ws.addColumn(type="float", name="difa", plottype=6)
+        cal_ws.addColumn(type="float", name="tzero", plottype=6)
+        cal_ws.addColumn(type="float", name="tofmin", plottype=6)
+
+        groupIDs = self.grouping_ws.getGroupIDs()
+        for groupID in groupIDs:
+            detIDs = self.grouping_ws.getDetectorIDsOfGroup(int(groupID))
+            for detID in detIDs:
+                nextRow = {"detid": int(detID), "difc": 0, "difa": 0, "tzero": 0, "tofmin": 0}
+                cal_ws.addRow(nextRow)
 
 
 # Register algorithm with Mantid

--- a/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
@@ -70,7 +70,12 @@ class SaveGroupingDefinition(PythonAlgorithm):
         # check that the input file name has a supported extension
         if grouping_file_name != "":
             file_extension = pathlib.Path(grouping_file_name).suffix.upper()[1:]
-            if file_extension not in self.supported_nexus_file_extensions + self.supported_xml_file_extensions:
+            supported_extensions = (
+                self.supported_nexus_file_extensions
+                + self.supported_xml_file_extensions
+                + self.supported_calib_file_extensions
+            )
+            if file_extension not in supported_extensions:
                 raise Exception(f"GroupingFilename has an unsupported file name extension {file_extension}")
 
         # check that the output file name has a supported extension

--- a/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
@@ -1,6 +1,6 @@
 import pathlib
-import h5py
 
+import h5py
 from mantid.api import AlgorithmFactory, MatrixWorkspaceProperty, PropertyMode, PythonAlgorithm
 from mantid.kernel import Direction
 from mantid.simpleapi import mtd
@@ -114,14 +114,14 @@ class SaveGroupingDefinition(PythonAlgorithm):
         self.grouping_ws = mtd[grouping_ws_name]
 
         outputFilename = self.getProperty("OutputFilename").value
-        groupIDs = self.grouping_ws.extractY()[:,0]
-        nothing = [0] * len(groupIDs) #np.zeros_like(detIDs)
+        groupIDs = self.grouping_ws.extractY()[:, 0]
+        nothing = [0] * len(groupIDs)  # np.zeros_like(detIDs)
         instrument = self.grouping_ws.getInstrument()
         detIDs = []
         for groupID in self.grouping_ws.getGroupIDs():
             detIDs.extend(self.grouping_ws.getDetectorIDsOfGroup(int(groupID)))
 
-        with h5py.File(outputFilename, 'w') as f:
+        with h5py.File(outputFilename, "w") as f:
             f.create_dataset("calibration/group", data=groupIDs)
             f.create_dataset("calibration/detid", data=detIDs)
             f.create_dataset("calibration/difa", data=nothing)
@@ -137,7 +137,6 @@ class SaveGroupingDefinition(PythonAlgorithm):
                 Workspace=grouping_ws_name,
             )
         self.mantidSnapper.executeQueue()
-
 
 
 # Register algorithm with Mantid

--- a/tests/cis_tests/save_grouping_definition_with_xml.py
+++ b/tests/cis_tests/save_grouping_definition_with_xml.py
@@ -4,41 +4,208 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pathlib
 import os.path
+import time
 
 from snapred.backend.recipe.algorithm.LoadGroupingDefinition import LoadGroupingDefinition as LoadingAlgo
 from snapred.backend.recipe.algorithm.SaveGroupingDefinition import SaveGroupingDefinition as SavingAlgo
 from snapred.meta.Config import Config, Resource
+
+from snapred.backend.log.logger import snapredLogger
+snapredLogger._level = 40
 
 localDir = '~/tmp/'
 PGDDir = '/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/'
 groupingFileXML = PGDDir + "SNAPFocGroup_Column.xml"
 groupingFileHDF = localDir + pathlib.Path(groupingFileXML).stem + ".hdf"
 
+instrumentName = "SNAP"
+instrumentFile = "/SNS/SNAP/shared/Malcolm/dataFiles/SNAP_Definition.xml"
+instrumentDonor = "instrument_donor"
+LoadEmptyInstrument(
+    OutputWorkspace = instrumentDonor,
+    Filename = instrumentFile,
+)
+assert mtd.doesExist(instrumentDonor)
+
 Config._config["cis_mode"] = False
 
-# save the input grouping file in the calibration format
+grwsXML = "gr_ws_from_XML"
+grwsHDF = "gr_ws_from_HDF"
+
+loads = {}
+saves = {}
+
+
+###### TESTS OF LOAD #######################################
+
+# load the data directly from the XML with instrument name
+loadingAlgo = LoadingAlgo()
+loadingAlgo.initialize()
+loadingAlgo.setProperty("GroupingFilename", groupingFileXML)
+loadingAlgo.setProperty("InstrumentName", instrumentName)
+loadingAlgo.setProperty("OutputWorkspace", grwsXML)
+start = time.time()
+assert loadingAlgo.execute()
+end = time.time()
+loads["XML and NAME"] = (end - start)
+
+# load the data directly from the XML with instrument file
+reload = "from xml and file"
+loadingAlgo = LoadingAlgo()
+loadingAlgo.initialize()
+loadingAlgo.setProperty("GroupingFilename", groupingFileXML)
+loadingAlgo.setProperty("InstrumentFilename", instrumentFile)
+loadingAlgo.setProperty("OutputWorkspace", reload)
+start = time.time()
+assert loadingAlgo.execute()
+end = time.time()
+loads["XML and FILE"] = (end - start)
+
+assert CompareWorkspaces(
+    Workspace1 = grwsXML,
+    Workspace2 = reload,
+)
+
+# load the data directly from the XML with instrument donor
+reload = "from xml and donor"
+loadingAlgo = LoadingAlgo()
+loadingAlgo.initialize()
+loadingAlgo.setProperty("GroupingFilename", groupingFileXML)
+loadingAlgo.setProperty("InstrumentDonor", instrumentDonor)
+loadingAlgo.setProperty("OutputWorkspace", reload)
+start = time.time()
+assert loadingAlgo.execute()
+end = time.time()
+loads["XML and DONOR"] = (end - start)
+
+assert CompareWorkspaces(
+    Workspace1 = grwsXML,
+    Workspace2 = reload,
+)
+
+###### TESTS OF SAVE #######################################
+
+###### save/load with XML file and instrument name
 savingAlgo = SavingAlgo()
 savingAlgo.initialize()
 savingAlgo.setProperty("GroupingFilename", groupingFileXML)
 savingAlgo.setProperty("OutputFilename", groupingFileHDF)
-savingAlgo.setProperty("InstrumentName", "SNAP")
+savingAlgo.setProperty("InstrumentName", instrumentName)
+start = time.time()
 assert savingAlgo.execute()
+end = time.time()
+saves["XML and NAME"] = (end - start)
 
 loadingAlgo = LoadingAlgo()
 loadingAlgo.initialize()
 loadingAlgo.setProperty("GroupingFilename", groupingFileHDF)
-loadingAlgo.setProperty("InstrumentName", "SNAP")
-loadingAlgo.setProperty("OutputWorkspace", "gr_ws_from_HDF")
+loadingAlgo.setProperty("InstrumentName", instrumentName)
+loadingAlgo.setProperty("OutputWorkspace", grwsHDF)
+start = time.time()
 assert loadingAlgo.execute()
-
-loadingAlgo2 = LoadingAlgo()
-loadingAlgo2.initialize()
-loadingAlgo2.setProperty("GroupingFilename", groupingFileXML)
-loadingAlgo2.setProperty("InstrumentName", "SNAP")
-loadingAlgo2.setProperty("OutputWorkspace", "gr_ws_from_XML")
-assert loadingAlgo2.execute()
+end = time.time()
+loads["HDF and NAME"] = (end - start)
 
 assert CompareWorkspaces(
-    Workspace1 = "gr_ws_from_HDF",
-    Workspace2 = "gr_ws_from_XML",
+    Workspace1 = grwsHDF,
+    Workspace2 = grwsXML,
 )
+
+###### save/load with XML file and instrument file
+savingAlgo = SavingAlgo()
+savingAlgo.initialize()
+savingAlgo.setProperty("GroupingFilename", groupingFileXML)
+savingAlgo.setProperty("OutputFilename", groupingFileHDF)
+savingAlgo.setProperty("InstrumentFilename", instrumentFile)
+start = time.time()
+assert savingAlgo.execute()
+end = time.time()
+saves["XML and FILE"] = (end - start)
+
+loadingAlgo = LoadingAlgo()
+loadingAlgo.initialize()
+loadingAlgo.setProperty("GroupingFilename", groupingFileHDF)
+loadingAlgo.setProperty("InstrumentFilename", instrumentFile)
+loadingAlgo.setProperty("OutputWorkspace", grwsHDF)
+start = time.time()
+assert loadingAlgo.execute()
+end = time.time()
+loads["HDF and FILE"] = (end - start)
+
+assert CompareWorkspaces(
+    Workspace1 = grwsXML,
+    Workspace2 = grwsHDF,
+)
+
+###### save/load with XML file and instrument donor
+result = "xml_and_instrument_donor"
+savingAlgo = SavingAlgo()
+savingAlgo.initialize()
+savingAlgo.setProperty("GroupingFilename", groupingFileXML)
+savingAlgo.setProperty("OutputFilename", groupingFileHDF)
+savingAlgo.setProperty("InstrumentDonor", instrumentDonor)
+start = time.time()
+assert savingAlgo.execute()
+end = time.time()
+saves["XML and DONOR"] = (end - start)
+
+start = time.time()
+loadingAlgo = LoadingAlgo()
+loadingAlgo.initialize()
+loadingAlgo.setProperty("GroupingFilename", groupingFileHDF)
+loadingAlgo.setProperty("InstrumentDonor", instrumentDonor)
+loadingAlgo.setProperty("OutputWorkspace", grwsHDF)
+start = time.time()
+assert loadingAlgo.execute()
+end = time.time()
+loads["HDF and DONOR"] = (end - start)
+
+assert CompareWorkspaces(
+    Workspace1 = grwsXML,
+    Workspace2 = grwsHDF,
+)
+
+###### save with HDF file and instrument name
+groupingFileHDF2 = localDir + pathlib.Path(groupingFileXML).stem + "2.hdf"
+savingAlgo = SavingAlgo()
+savingAlgo.initialize()
+savingAlgo.setProperty("GroupingFilename", groupingFileHDF)
+savingAlgo.setProperty("OutputFilename", groupingFileHDF2)
+savingAlgo.setProperty("InstrumentName", instrumentName)
+start = time.time()
+assert savingAlgo.execute()
+end = time.time()
+saves["HDF and NAME"] = (end - start)
+print(groupingFileHDF)
+print(savingAlgo.supported_calib_file_extensions)
+
+###### save with HDF file and instrument file
+savingAlgo = SavingAlgo()
+savingAlgo.initialize()
+savingAlgo.setProperty("GroupingFilename", groupingFileHDF)
+savingAlgo.setProperty("OutputFilename", groupingFileHDF2)
+savingAlgo.setProperty("InstrumentFilename", instrumentFile)
+start = time.time()
+assert savingAlgo.execute()
+end = time.time()
+saves["HDF and FILE"] = (end - start)
+
+###### save with HDF file and instrument donor
+savingAlgo = SavingAlgo()
+savingAlgo.initialize()
+savingAlgo.setProperty("GroupingFilename", groupingFileHDF)
+savingAlgo.setProperty("OutputFilename", groupingFileHDF2)
+savingAlgo.setProperty("InstrumentDonor", instrumentDonor)
+start = time.time()
+assert savingAlgo.execute()
+end = time.time()
+saves["HDF and DONOR"] = (end - start)
+
+
+
+##### PRINT TIME RESULTS
+for x,y in loads.items():
+    print(f"TIME FOR LOAD ALGO {x}: {y}")
+    
+for x,y in saves.items():
+    print(f"TIME FOR SAVE ALGO {x}: {y}")

--- a/tests/cis_tests/save_grouping_definition_with_xml.py
+++ b/tests/cis_tests/save_grouping_definition_with_xml.py
@@ -13,7 +13,7 @@ from snapred.meta.Config import Config, Resource
 from snapred.backend.log.logger import snapredLogger
 snapredLogger._level = 40
 
-localDir = '~/tmp/'
+localDir = os.path.expanduser('~/tmp/')
 PGDDir = '/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/'
 groupingFileXML = PGDDir + "SNAPFocGroup_Column.xml"
 groupingFileHDF = localDir + pathlib.Path(groupingFileXML).stem + ".hdf"
@@ -27,14 +27,13 @@ LoadEmptyInstrument(
 )
 assert mtd.doesExist(instrumentDonor)
 
-Config._config["cis_mode"] = False
+Config._config["cis_mode"] = True
 
 grwsXML = "gr_ws_from_XML"
 grwsHDF = "gr_ws_from_HDF"
 
 loads = {}
 saves = {}
-
 
 ###### TESTS OF LOAD #######################################
 

--- a/tests/cis_tests/save_grouping_definition_with_xml.py
+++ b/tests/cis_tests/save_grouping_definition_with_xml.py
@@ -9,18 +9,36 @@ from snapred.backend.recipe.algorithm.LoadGroupingDefinition import LoadGrouping
 from snapred.backend.recipe.algorithm.SaveGroupingDefinition import SaveGroupingDefinition as SavingAlgo
 from snapred.meta.Config import Config, Resource
 
-localDir = '/SNS/users/8l2/tmp/'
+localDir = '~/tmp/'
 PGDDir = '/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/'
-groupingFile = PGDDir + "SNAPFocGroup_Column.xml"
+groupingFileXML = PGDDir + "SNAPFocGroup_Column.xml"
+groupingFileHDF = localDir + pathlib.Path(groupingFileXML).stem + ".hdf"
 
-Config._config["cis_mode"] = True # <<-- change to True and rerun
+Config._config["cis_mode"] = False
 
-output_file_name = pathlib.Path(groupingFile).stem + ".hdf"
-outputFilePath = os.path.join(localDir, output_file_name)
 # save the input grouping file in the calibration format
 savingAlgo = SavingAlgo()
 savingAlgo.initialize()
-savingAlgo.setProperty("GroupingFilename", groupingFile)
-savingAlgo.setProperty("OutputFilename", outputFilePath)
+savingAlgo.setProperty("GroupingFilename", groupingFileXML)
+savingAlgo.setProperty("OutputFilename", groupingFileHDF)
 savingAlgo.setProperty("InstrumentName", "SNAP")
 assert savingAlgo.execute()
+
+loadingAlgo = LoadingAlgo()
+loadingAlgo.initialize()
+loadingAlgo.setProperty("GroupingFilename", groupingFileHDF)
+loadingAlgo.setProperty("InstrumentName", "SNAP")
+loadingAlgo.setProperty("OutputWorkspace", "gr_ws_from_HDF")
+assert loadingAlgo.execute()
+
+loadingAlgo2 = LoadingAlgo()
+loadingAlgo2.initialize()
+loadingAlgo2.setProperty("GroupingFilename", groupingFileXML)
+loadingAlgo2.setProperty("InstrumentName", "SNAP")
+loadingAlgo2.setProperty("OutputWorkspace", "gr_ws_from_XML")
+assert loadingAlgo2.execute()
+
+assert CompareWorkspaces(
+    Workspace1 = "gr_ws_from_HDF",
+    Workspace2 = "gr_ws_from_XML",
+)

--- a/tests/cis_tests/save_grouping_definition_with_xml.py
+++ b/tests/cis_tests/save_grouping_definition_with_xml.py
@@ -1,0 +1,26 @@
+# import mantid algorithms, numpy and matplotlib
+from mantid.simpleapi import *
+import matplotlib.pyplot as plt
+import numpy as np
+import pathlib
+import os.path
+
+from snapred.backend.recipe.algorithm.LoadGroupingDefinition import LoadGroupingDefinition as LoadingAlgo
+from snapred.backend.recipe.algorithm.SaveGroupingDefinition import SaveGroupingDefinition as SavingAlgo
+from snapred.meta.Config import Config, Resource
+
+localDir = '/SNS/users/8l2/tmp/'
+PGDDir = '/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/'
+groupingFile = PGDDir + "SNAPFocGroup_Column.xml"
+
+Config._config["cis_mode"] = True # <<-- change to True and rerun
+
+output_file_name = pathlib.Path(groupingFile).stem + ".hdf"
+outputFilePath = os.path.join(localDir, output_file_name)
+# save the input grouping file in the calibration format
+savingAlgo = SavingAlgo()
+savingAlgo.initialize()
+savingAlgo.setProperty("GroupingFilename", groupingFile)
+savingAlgo.setProperty("OutputFilename", outputFilePath)
+savingAlgo.setProperty("InstrumentName", "SNAP")
+assert savingAlgo.execute()


### PR DESCRIPTION
Fixed LoadGroupingDefinition.py by updating the input checks Added cis test for SaveGroupingDefinition

## Description of work
This is to fix the defect related to SaveGroupingDefintion and LoadGroupingDefinition
<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->
In LoadGroupingDefinition.py, input validation now correctly checks for InstrumentName and InstrumentFilename being set. A warning instead of an exception is now thrown if InstrumentDonor is set when it is not required. A lite mode check is now done to set the instrument file name.

## To test

### Dev testing

<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->
Make sure unit tests pass.

### CIS testing

<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->
Run the new script included called save_grouping_definition_with_xml.py on analysis.

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->
GUI Testing

In mantid workbench, open the SNAPRed GUI. Then open the test panel. In the test panel, give it a run number like 58882, and select a sample file. For the grouping file, select SNAPFocGroup_Column.lite.hdf and then hit continue. After some processing, there should be no errors. If the file does not show up in the selection box, application.yml needs to be changed.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM Defect #2621](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2621)

[EWM Task #2779](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2779)
<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
