### PR TITLE
Fix ragged rebin without touching focus group

### DIFF
--- a/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
@@ -77,7 +77,7 @@ class GroupDiffractionCalibration(PythonAlgorithm):
                 allPeakBoundaries.append(peak.maximum)
             self.groupedPeaks[peakList.groupID] = allPeaks
             self.groupedPeakBoundaries[peakList.groupID] = allPeakBoundaries
-        self.groupIDs = sorted(self.groupIDs)
+        # self.groupIDs = sorted(self.groupIDs)
 
         self.inputWStof: str = self.getProperty("InputWorkspace").value
         self.calibrationTable: str = self.getProperty("PreviousCalibrationTable").value

--- a/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
@@ -6,10 +6,14 @@ from mantid.kernel import Direction
 
 from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients as Ingredients
 from snapred.backend.recipe.algorithm.LoadGroupingDefinition import LoadGroupingDefinition
+from snapred.backend.recipe.algorithm.MakeDirtyDish import MakeDirtyDish
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 
 
 class GroupDiffractionCalibration(PythonAlgorithm):
+    def category(self):
+        return "SNAPRed Diffraction Calibration"
+
     def PyInit(self):
         # declare properties
         self.declareProperty("Ingredients", defaultValue="", direction=Direction.Input)  # noqa: F821
@@ -45,17 +49,15 @@ class GroupDiffractionCalibration(PythonAlgorithm):
             )
 
         # from grouping parameters, read the overall min/max d-spacings
-        self.overallDMin: float = max(ingredients.focusGroup.dMin)
-        self.overallDMax: float = min(ingredients.focusGroup.dMax)
-        self.dBin: float = min([abs(dbin) for dbin in ingredients.focusGroup.dBin])
-        self.maxDSpaceShifts: float = 2.5 * max(ingredients.focusGroup.FWHM)
-        self.dSpaceParams = (self.overallDMin, self.dBin, self.overallDMax)
+        self.dMin: List[float] = ingredients.focusGroup.dMin
+        self.dMax: List[float] = ingredients.focusGroup.dMax
+        self.dBin: List[float] = ingredients.focusGroup.dBin
 
         # from the instrument state, read the overall min/max TOF
         self.TOFMin: float = ingredients.instrumentState.particleBounds.tof.minimum
         self.TOFMax: float = ingredients.instrumentState.particleBounds.tof.maximum
-        self.TOFBin: float = self.dBin
-        self.TOFParams = (self.TOFMin, self.TOFBin, self.TOFMax)
+        self.TOFBin: float = min([abs(db) for db in self.dBin])
+        self.TOFParams = (self.TOFMin, -abs(self.TOFBin), self.TOFMax)
 
         # path to grouping file, specifying group IDs of pixels
         self.groupingFile: str = ingredients.focusGroup.definition
@@ -75,36 +77,11 @@ class GroupDiffractionCalibration(PythonAlgorithm):
                 allPeakBoundaries.append(peak.maximum)
             self.groupedPeaks[peakList.groupID] = allPeaks
             self.groupedPeakBoundaries[peakList.groupID] = allPeakBoundaries
+        self.groupIDs = sorted(self.groupIDs)
 
         self.inputWStof: str = self.getProperty("InputWorkspace").value
         self.calibrationTable: str = self.getProperty("PreviousCalibrationTable").value
         self.diffractionfocusedWStof: str = f"_TOF_{self.runNumber}_diffoc"
-
-    def convertUnitsAndRebin(self, inputWS: str, outputWS: str, target: str = "dSpacing") -> None:
-        """
-        Convert units to target (either TOF or dSpacing) and then rebin logarithmically.
-        If 'converting' from and to the same units, will only rebin.
-        """
-        self.mantidSnapper.ConvertUnits(
-            f"Convert units to {target}",
-            InputWorkspace=inputWS,
-            OutputWorkspace=outputWS,
-            Target=target,
-        )
-
-        rebinParams: Tuple[float, float, float]
-        if target == "dSpacing":
-            rebinParams = self.dSpaceParams
-        elif target == "TOF":
-            rebinParams = self.TOFParams
-        self.mantidSnapper.Rebin(
-            "Rebin the workspace logarithmically",
-            InputWorkspace=outputWS,
-            OutputWorkspace=outputWS,
-            Params=rebinParams,
-            BinningMode="Logarithmic",
-        )
-        self.mantidSnapper.executeQueue()
 
     def raidPantry(self):
         """Load required data, if not already loaded, and process it"""
@@ -119,9 +96,6 @@ class GroupDiffractionCalibration(PythonAlgorithm):
                 FilterByTofMax=self.TOFMax,
                 BlockList="Phase*,Speed*,BL*:Chop:*,chopper*TDC",
             )
-        # also find d-spacing data and rebin logarithmically
-        inputWSdsp: str = f"_DSP_{self.runNumber}"
-        self.convertUnitsAndRebin(self.inputWStof, inputWSdsp, "dSpacing")
 
         # now diffraction focus the d-spacing data and convert to TOF
         self.focusWSname = f"_{self.runNumber}_focusGroup"
@@ -131,21 +105,7 @@ class GroupDiffractionCalibration(PythonAlgorithm):
             InstrumentDonor=self.inputWStof,
             OutputWorkspace=self.focusWSname,
         )
-
-        diffractionfocusedWSdsp: str = f"_DSP_{self.runNumber}_diffoc_before"
-        self.mantidSnapper.DiffractionFocussing(
-            "Refocus with offset-corrections",
-            InputWorkspace=inputWSdsp,
-            GroupingWorkspace=self.focusWSname,
-            OutputWorkspace=diffractionfocusedWSdsp,
-        )
-        self.convertUnitsAndRebin(diffractionfocusedWSdsp, self.diffractionfocusedWStof, "TOF")
-        # clean up d-spacing workspaces
-        self.mantidSnapper.WashDishes(
-            "Clean up d-spacing data",
-            WorkspaceList=[inputWSdsp, diffractionfocusedWSdsp],
-        )
-        self.mantidSnapper.executeQueue()
+        self.convertAndFocusAndReturn(self.inputWStof, self.diffractionfocusedWStof, "before")
 
     def restockPantry(self) -> None:
         """
@@ -194,14 +154,12 @@ class GroupDiffractionCalibration(PythonAlgorithm):
         if nHist != len(self.groupIDs):
             raise RuntimeError("error, the number of spectra in focused workspace, and number of groups, do not match")
 
-        # remove overlapping peaks
-
         for index in range(nHist):
             groupID = self.groupIDs[index]
             self.mantidSnapper.PDCalibration(
                 f"Perform PDCalibration on subgroup {groupID}",
                 InputWorkspace=self.diffractionfocusedWStof,
-                TofBinning=(self.TOFMin, -abs(self.TOFBin), self.TOFMax),
+                TofBinning=self.TOFParams,
                 PeakFunction="Gaussian",
                 BackgroundType="Linear",
                 PeakPositions=self.groupedPeaks[groupID],
@@ -236,27 +194,53 @@ class GroupDiffractionCalibration(PythonAlgorithm):
             InstrumentWorkspace=self.inputWStof,
             CalibrationWorkspace=self.calibrationTable,
         )
-        self.mantidSnapper.WashDishes(
-            "Clean up pd group calibration table",
-            Workspace=pdcalibratedWorkspace,
-        )
-        diffractionfocusedWSdsp: str = f"_DSP_{self.runNumber}_diffoc_after"
-        self.convertUnitsAndRebin(self.inputWStof, diffractionfocusedWSdsp, "dSpacing")
-        self.mantidSnapper.DiffractionFocussing(
-            "Diffraction focus with final calibrated values",
-            InputWorkspace=diffractionfocusedWSdsp,
-            GroupingWorkspace=self.focusWSname,
-            OutputWorkspace=diffractionfocusedWSdsp,
-        )
-        self.convertUnitsAndRebin(diffractionfocusedWSdsp, self.diffractionfocusedWStof, "dSpacing")
-        self.mantidSnapper.WashDishes(
-            "Clean up d-spacing diffraction focused ws",
-            WorkspaceList=[self.focusWSname, diffractionfocusedWSdsp],
-        )
+        self.convertAndFocusAndReturn(self.inputWStof, self.diffractionfocusedWStof, "after")
+
         # save the data
         self.setProperty("OutputWorkspace", self.diffractionfocusedWStof)
         self.setProperty("FinalCalibrationTable", self.calibrationTable)
         self.restockPantry()
+
+    def convertAndFocusAndReturn(self, inputWS: str, outputWS: str, note: str):
+        tmpWStof = f"_TOF_{self.runNumber}_diffoc_{note}"
+        tmpWSdsp = f"_DSP_{self.runNumber}_diffoc_{note}"
+        self.mantidSnapper.ConvertUnits(
+            "Convert thr raw TOf data to d-spacing",
+            InputWorkspace=inputWS,
+            OutputWorkspace=tmpWSdsp,
+            Target="dSpacing",
+        )
+        self.mantidSnapper.DiffractionFocussing(
+            "Diffraction-focus the d-spacing data",
+            InputWorkspace=tmpWSdsp,
+            GroupingWorkspace=self.focusWSname,
+            OutputWorkspace=tmpWSdsp,
+        )
+        self.mantidSnapper.RebinRagged(
+            "Ragged rebin the diffraction-focused data",
+            InputWorkspace=tmpWSdsp,
+            OutputWorkspace=tmpWSdsp,
+            XMin=self.dMin,
+            XMax=self.dMax,
+            Delta=self.dBin,
+        )
+        self.mantidSnapper.ConvertUnits(
+            "Convert the focused and rebined data back to TOF",
+            InputWorkspace=tmpWSdsp,
+            OutputWorkspace=outputWS,
+            Target="TOF",
+        )
+        # for inspection, save diffraction focused data before calculation
+        self.mantidSnapper.MakeDirtyDish(
+            "save diffraction-focused TOF data",
+            InputWorkspace=outputWS,
+            OutputWorkspace=tmpWStof,
+        )
+        self.mantidSnapper.WashDishes(
+            "save diffraction-focused d-spacing data",
+            Workspace=tmpWSdsp,
+        )
+        self.mantidSnapper.executeQueue()
 
 
 # Register algorithm with Mantid

--- a/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
@@ -43,8 +43,8 @@ class PixelDiffractionCalibration(PythonAlgorithm):
         self.isLite: bool = False
 
         # from grouping parameters, read the overall min/max d-spacings
-        self.overallDMin: float = max(ingredients.focusGroup.dMin)
-        self.overallDMax: float = min(ingredients.focusGroup.dMax)
+        self.overallDMin: float = min(ingredients.focusGroup.dMin)
+        self.overallDMax: float = max(ingredients.focusGroup.dMax)
         self.dBin: float = min([abs(dbin) for dbin in ingredients.focusGroup.dBin])
         self.maxDSpaceShifts: Dict[int, float] = {}
         for peakList in ingredients.groupedPeakLists:

--- a/tests/cis_tests/diffcal_script.py
+++ b/tests/cis_tests/diffcal_script.py
@@ -44,7 +44,7 @@ peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 
 # SET TO TRUE TO STOP WASHING DISHES
-Config._config['cis_mode'] = False
+Config._config['cis_mode'] = True
 ####################################################################################
 
 # CREATE NEEDED INGREDIENTS ########################################################

--- a/tests/cis_tests/lazy_rebin_ragged.py
+++ b/tests/cis_tests/lazy_rebin_ragged.py
@@ -40,6 +40,15 @@ fakeInstrumentState.particleBounds.tof.maximum = TOFMax
 fakeFocusGroupFile = "inputs/diffcal/fakeFocusGroup.json"
 fakeFocusGroup = FocusGroup.parse_raw(Resource.read(fakeFocusGroupFile))
 fakeFocusGroup.definition = Resource.getPath(fakeFocusGroupFile)
+fakeFocusGroup = FocusGroup(
+    name = "natural",
+    nHst = 4,
+    FWHM = [5,5,5,5],
+    dBin = [-0.00130, -0.00086, -0.00130, -0.00117],
+    dMin = [0.01, 0.05, 0.10, 0.10],
+    dMax = [0.30, 0.35, 0.50, 0.40],
+    definition = Resource.getPath(fakeFocusGroupFile),
+)
 print(fakeFocusGroup.json(indent=2))
 
 peakList3 = [

--- a/tests/cis_tests/lazy_rebin_ragged.py
+++ b/tests/cis_tests/lazy_rebin_ragged.py
@@ -47,11 +47,11 @@ peakList3 = [
 ]
 group3 = GroupPeakList(groupID=3, peaks=peakList3)
 peakList7 = [
-    DetectorPeak.parse_obj({"position": {"value": 0.3, "minimum": 0.20, "maximum": 0.40}}),
+    DetectorPeak.parse_obj({"position": {"value": 0.33, "minimum": 0.25, "maximum": 0.40}}),
 ]
 group7 = GroupPeakList(groupID=7, peaks=peakList7)
 peakList2 = [
-    DetectorPeak.parse_obj({"position": {"value": 0.18, "minimum": 0.10, "maximum": 0.25}}),
+    DetectorPeak.parse_obj({"position": {"value": 0.18, "minimum": 0.15, "maximum": 0.25}}),
 ]
 group2 = GroupPeakList(groupID=2, peaks=peakList2)
 peakList11 = [

--- a/tests/cis_tests/lazy_rebin_ragged.py
+++ b/tests/cis_tests/lazy_rebin_ragged.py
@@ -1,0 +1,169 @@
+import json
+import random
+import unittest
+import unittest.mock as mock
+
+import pytest
+from mantid.simpleapi import *
+import matplotlib.pyplot as plt
+from snapred.backend.dao.DetectorPeak import DetectorPeak
+from snapred.backend.dao.GroupPeakList import GroupPeakList
+from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients
+
+# needed to make mocked ingredients
+from snapred.backend.dao.RunConfig import RunConfig
+from snapred.backend.dao.state.FocusGroup import FocusGroup
+from snapred.backend.dao.state.InstrumentState import InstrumentState
+from snapred.backend.recipe.algorithm.CalculateDiffCalTable import CalculateDiffCalTable
+
+# the algorithm to test
+from snapred.backend.recipe.algorithm.GroupDiffractionCalibration import (
+    GroupDiffractionCalibration as Algo,  # noqa: E402
+)
+from snapred.meta.Config import Config, Resource
+Config._config['cis_mode'] = True
+Resource._resourcesPath = os.path.expanduser("~/SNAPRed/tests/resources/")
+
+#### CREATE INGREDIENTS
+fakeRunNumber = "555"
+fakeRunConfig = RunConfig(runNumber=str(fakeRunNumber))
+
+# fake instrument state
+TOFMin = 10
+TOFMax = 1000
+TOFBin = 0.001
+fakeInstrumentState = InstrumentState.parse_raw(Resource.read("inputs/diffcal/fakeInstrumentState.json"))
+fakeInstrumentState.particleBounds.tof.minimum = TOFMin
+fakeInstrumentState.particleBounds.tof.maximum = TOFMax
+
+# fake focus group
+fakeFocusGroupFile = "inputs/diffcal/fakeFocusGroup.json"
+fakeFocusGroup = FocusGroup.parse_raw(Resource.read(fakeFocusGroupFile))
+fakeFocusGroup.definition = Resource.getPath(fakeFocusGroupFile)
+print(fakeFocusGroup.json(indent=2))
+
+peakList3 = [
+    DetectorPeak.parse_obj({"position": {"value": 0.2, "minimum": 0.15, "maximum": 0.25}}),
+]
+group3 = GroupPeakList(groupID=3, peaks=peakList3)
+peakList7 = [
+    DetectorPeak.parse_obj({"position": {"value": 0.3, "minimum": 0.20, "maximum": 0.40}}),
+]
+group7 = GroupPeakList(groupID=7, peaks=peakList7)
+peakList2 = [
+    DetectorPeak.parse_obj({"position": {"value": 0.18, "minimum": 0.10, "maximum": 0.25}}),
+]
+group2 = GroupPeakList(groupID=2, peaks=peakList2)
+peakList11 = [
+    DetectorPeak.parse_obj({"position": {"value": 0.24, "minimum": 0.18, "maximum": 0.30}}),
+]
+group11 = GroupPeakList(groupID=11, peaks=peakList11)
+
+fakeIngredients = DiffractionCalibrationIngredients(
+    runConfig=fakeRunConfig,
+    focusGroup=fakeFocusGroup,
+    instrumentState=fakeInstrumentState,
+    groupedPeakLists=[group3, group7, group2, group11],
+    calPath=Resource.getPath("outputs/calibration/"),
+    convergenceThreshold=1.0,
+)
+
+#### CREATE DATA
+inputWStof = f"_TOF_{fakeRunNumber}"
+inputWSdsp = f"_DSP_{fakeRunNumber}"
+diffocWSdsp = f"_DSP_{fakeRunNumber}_diffoc"
+diffocWStof = f"_TOF_{fakeRunNumber}_diffoc"
+groupingWS = f"grouping_ws"
+DIFCpixel = "DIFCpixel"
+
+midpoint = (TOFMax + TOFMin) / 2.0
+CreateSampleWorkspace(
+    OutputWorkspace = inputWStof,
+    Function = "User Defined",
+    UserDefinedFunction=f"name=Gaussian,Height=10,PeakCentre={midpoint},Sigma={midpoint/10}",
+    XMin = TOFMin,
+    XMax = TOFMax,
+    BinWidth = 0.001,
+    XUnit = "TOF",
+    NumBanks = 4,
+    BankPixelWidth=2,
+    Random=True,
+)
+LoadInstrument(
+    Workspace=inputWStof,
+    Filename=Resource.getPath("inputs/diffcal/fakeSNAPLite.xml"),
+    RewriteSpectraMap=True,
+)
+Rebin(
+    InputWorkspace=inputWStof,
+    OutputWorkspace=inputWStof,
+    Params=(TOFMin, 0.001, TOFMax),
+    BinningMode = "Logarithmic",
+)
+
+# load the detector groupings
+LoadDetectorsGroupingFile(
+    "Loading grouping definition from detectors grouping file...",
+    InputFile=Resource.getPath("/inputs/diffcal/fakeSNAPFocGroup_Column.xml"),
+    InputWorkspace=inputWStof,
+    OutputWorkspace=groupingWS,
+)
+
+
+# create a DIFC table
+cc = CalculateDiffCalTable()
+cc.initialize()
+cc.setProperty("InputWorkspace", inputWStof)
+cc.setProperty("CalibrationTable", DIFCpixel)
+cc.setProperty("OffsetMode", "Signed")
+cc.setProperty("BinWidth", TOFBin)
+cc.execute()
+
+
+# create the diffoc TOF data
+ConvertUnits(
+    InputWorkspace = inputWStof,
+    OutputWorkspace = inputWSdsp,
+    Target = "dSpacing",
+)
+DiffractionFocussing(
+    InputWorkspace = inputWSdsp,
+    OutputWorkspace = diffocWSdsp,
+    GroupingWorkspace = groupingWS,
+)
+RebinRagged(
+    InputWorkspace = diffocWSdsp,
+    OutputWorkspace = diffocWSdsp,
+    XMin = fakeFocusGroup.dMin,
+    XMax = fakeFocusGroup.dMax,
+    Delta = fakeFocusGroup.dBin,
+)
+ConvertUnits(
+    InputWorkspace = diffocWSdsp,
+    OutputWorkspace = diffocWStof,
+    Target = "TOF",
+)
+
+print(fakeIngredients.groupedPeakLists)
+
+# now run the algorithm
+with mock.patch.object(Algo, "raidPantry", mock.Mock()):
+    algo = Algo()
+    algo.initialize()
+    algo.setProperty("Ingredients", fakeIngredients.json())
+    algo.setProperty("InputWorkspace", inputWStof)
+    algo.setProperty("OutputWorkspace", f"_test_out_{fakeRunNumber}")
+    algo.setProperty("PreviousCalibrationTable", DIFCpixel)
+    algo.chopIngredients(fakeIngredients)
+    algo.focusWSname = groupingWS
+    assert algo.execute()
+
+## print graph, check all groups fit the peak
+fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
+ax.plot(mtd[diffocWStof], wkspIndex=0, label="original peak")
+ax.plot(mtd["_PDCal_diag_2_fitted"], wkspIndex=0, label="group2")
+ax.plot(mtd["_PDCal_diag_3_fitted"], wkspIndex=1, label="group3")
+ax.plot(mtd["_PDCal_diag_7_fitted"], wkspIndex=2, label="group7")
+ax.plot(mtd["_PDCal_diag_11_fitted"], wkspIndex=3, label="group11")
+ax.legend() # show the legend
+fig.show()

--- a/tests/resources/inputs/diffcal/fakeFocusGroup.json
+++ b/tests/resources/inputs/diffcal/fakeFocusGroup.json
@@ -8,22 +8,22 @@
   ],
   "nHst": 6,
   "dBin": [
-    0.00086,
-    0.00096,
-    0.0013,
-    0.00117
+    -0.00086,
+    -0.00096,
+    -0.0013,
+    -0.00117
   ],
   "dMax": [
-    5.15,
-    5.43,
-    5.77,
-    5.95
+    0.35,
+    0.50,
+    0.30,
+    0.40
   ],
   "dMin": [
-    0.65,
-    0.65,
-    0.65,
-    0.65
+    0.05,
+    0.10,
+    0.05,
+    0.10
   ],
   "definition": "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGrp_Column.lite.xml"
 }

--- a/tests/resources/inputs/diffcal/fakeInstrumentState.json
+++ b/tests/resources/inputs/diffcal/fakeInstrumentState.json
@@ -49,8 +49,8 @@
       "maximum": 2.6
     },
     "tof": {
-      "minimum": 0,
-      "maximum": 10186.800131442584
+      "minimum": 10,
+      "maximum": 1000
     }
   },
   "pixelGroupingInstrumentParameters": null,

--- a/tests/resources/inputs/diffcal/fakeSNAPFocGroup_Column.xml
+++ b/tests/resources/inputs/diffcal/fakeSNAPFocGroup_Column.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0"?>
 <detector-grouping idf-date="2018-05-01T00:00:01" instrument="fakeSNAPLite">
 	<group ID="3">
-		<detids>0-8</detids>
+		<detids>0,5,10,15</detids>
 	</group>
 	<group ID="7">
-		<detids>9-15</detids>
+		<detids>1,7,8,13</detids>
+	</group>
+	<group ID="2">
+		<detids>2,4,11,14</detids>
+	</group>
+	<group ID="11">
+		<detids>3,6,9,12</detids>
 	</group>
 </detector-grouping>

--- a/tests/resources/inputs/diffcal/fakeSNAPLite.xml
+++ b/tests/resources/inputs/diffcal/fakeSNAPLite.xml
@@ -4,10 +4,7 @@
 <instrument xmlns="http://www.mantidproject.org/IDF/1.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
-            name="SNAP" valid-from   ="2018-05-01 00:00:01"
-                        valid-to     ="2100-01-31 23:59:59"
-		        last-modified="2019-05-03 11:30:00">
-  <!--Data taken from /SNS/SNAP/2010_2_3_CAL/calibrations/SNAP_geom_2010_03_22.xml-->
+            name="fakeSNAP" valid-from="1970-01-01 00:00:00">
   <!--THIS IS A FAKE INSTRUMENT DEFINITION FOR TESTING ONLY-->
   <!--DEFAULTS-->
   <defaults>
@@ -22,14 +19,14 @@
   </defaults>
 
   <!--SOURCE-->
-  <component type="moderator">
-    <location z="-15.0"/>
+  <component type="source">
+    <location z="15.0"/>
   </component>
-  <type name="moderator" is="Source"/>
+  <type name="source" is="Source"/>
 
   <!--SAMPLE-->
   <component type="sample-position">
-    <location y="0.0" x="0.0" z="-5.0"/>
+    <location y="0.0" x="0.0" z="0.0"/>
   </component>
   <type name="sample-position" is="SamplePos"/>
 
@@ -39,77 +36,54 @@
   -->
 
   <!--DETECTORS-->
-  <component type="East">
-    <location >
-      <parameter name="roty">
-        <logfile id="det_arc2" eq="180.0+value"/>
-      </parameter>
-      <parameter name="r-position">
-        <logfile id="det_lin2" eq="0.5+value" />
-      </parameter>
-      <parameter name="t-position">
-        <logfile id="det_arc2" />
-      </parameter>
-    </location>
+  <component type="Column1">
+    <location x="-2.0+value" z="-5.0+value"/>
+  </component>
+  <component type="Column2">
+    <location x="+2.0+value" z="-5.0+value"/>
   </component>
 
-  <type name="East">
-    <component type="Column1">
-      <location/>
-    </component>
-  </type>
-
   <type name="Column1">
-    <component type="panel" idstart="0" idfillbyfirst="y" idstepbyrow="2" >
-      <location name="bank1">  <!-- was bank4 - 655360 -->
-        <trans x="0.0" y="0.0" />
+    <component type="panel" idstart="0" idfillbyfirst="x" idstepbyrow="2" >
+      <location name="bank1">
+        <trans x="0.0" y="+1" />
       </location>
     </component>
     <component type="panel" idstart="4" idfillbyfirst="y" idstepbyrow="2" >
-      <location name="bank2">  <!-- was bank4 - 655360 -->
-        <trans x="1.0" y="0.0" />
+      <location name="bank2">
+        <trans x="0.0" y="-1" />
       </location>
     </component>
+  </type>
+
+  <type name="Column2">
     <component type="panel" idstart="8" idfillbyfirst="y" idstepbyrow="2" >
-      <location name="bank3">  <!-- was bank4 - 655360 -->
-        <trans x="0.0" y="1.0" />
+      <location name="bank3">
+        <trans x="0.0" y="+1" />
       </location>
     </component>
     <component type="panel" idstart="12" idfillbyfirst="y" idstepbyrow="2" >
-      <location name="bank4">  <!-- was bank4 - 655360 -->
-        <trans x="1.0" y="1.0" />
+      <location name="bank4">
+        <trans x="0.0" y="-1" />
       </location>
     </component>
   </type>
 
 <!-- Rectangular Detector Panel -->
 <type name="panel" is="rectangular_detector" type="pixel"
-    xpixels="2" xstart="0.0" xstep="+0.001"
-    ypixels="2" ystart="0.0" ystep="+0.001" >
+    xpixels="2" xstart="-0.5" xstep="+1"
+    ypixels="2" ystart="-0.5" ystep="+1" >
   <properties/>
 </type>
 
 <!-- Pixel for Detectors-->
-<type is="detector" name="pixel">
+<type name="pixel" is="detector">
   <cuboid id="pixel-shape">
-    <left-front-bottom-point  y="0.0" x="0.0" z="0.0"/>
-    <left-front-top-point     y="1.0" x="0.0" z="0.0"/>
-    <left-back-bottom-point   y="0.0" x="0.0" z="-0.0001"/>
-    <right-front-bottom-point y="0.0" x="1.0" z="0.0"/>
+    <left-front-bottom-point  y="-0.25" x="-0.25" z="0.0"/>
+    <left-front-top-point     y="+0.25" x="-0.25" z="0.0"/>
+    <left-back-bottom-point   y="-0.25" x="-0.25" z="0.01"/>
+    <right-front-bottom-point y="-0.25" x="+0.25" z="0.0"/>
   </cuboid>
   <algebra val="pixel-shape"/>
 </type>
-
-<!-- Shape for Monitors-->
-<!-- TODO: Update to real shape -->
-<type is="monitor" name="monitor">
-  <cylinder id="some-shape">
-    <centre-of-bottom-base p="0.0" r="0.0" t="0.0"/>
-    <axis y="0.0" x="0.0" z="1.0"/>
-    <radius val="1.00"/>
-    <height val="1.00"/>
-  </cylinder>
-  <algebra val="some-shape"/>
-</type>
-
 </instrument>

--- a/tests/unit/backend/recipe/algorithm/test_GroupDiffractionCalibration.py
+++ b/tests/unit/backend/recipe/algorithm/test_GroupDiffractionCalibration.py
@@ -137,9 +137,7 @@ class TestGroupDiffractionCalibration(unittest.TestCase):
         assert algo.runNumber == self.fakeRunNumber
         assert algo.TOFMin == self.fakeIngredients.instrumentState.particleBounds.tof.minimum
         assert algo.TOFMax == self.fakeIngredients.instrumentState.particleBounds.tof.maximum
-        assert algo.overallDMin == max(self.fakeIngredients.focusGroup.dMin)
-        assert algo.overallDMax == min(self.fakeIngredients.focusGroup.dMax)
-        assert algo.TOFBin == algo.dBin
+        assert algo.TOFBin == min([abs(db) for db in algo.dBin])
 
     def test_init_properties(self):
         """Test that the properties of the algorithm can be initialized"""

--- a/tests/unit/backend/recipe/test_DiffractionCalibrationRecipe.py
+++ b/tests/unit/backend/recipe/test_DiffractionCalibrationRecipe.py
@@ -45,6 +45,8 @@ class TestDiffractionCalibtationRecipe(unittest.TestCase):
             groupedPeakLists=[
                 GroupPeakList(groupID=3, peaks=peakList, maxfwhm=0.01),
                 GroupPeakList(groupID=7, peaks=peakList, maxfwhm=0.02),
+                GroupPeakList(groupID=2, peaks=peakList, maxfwhm=0.02),
+                GroupPeakList(groupID=11, peaks=peakList, maxfwhm=0.02),
             ],
             convergenceThreshold=0.5,
             calPath=Resource.getPath("outputs/calibration/"),


### PR DESCRIPTION
## Description of work

During testing of diffraction calibration, it was noted that within d-spacing, the min/max/bin values are different for each group, so that d-spacing should instead use a `RebinRagged` method.  

In PR #154 I implemented a fix, but this fix also included changes to `FocusGroup`, which led to issues with CIS testing due to incompatible prior saved files.

This is meant to get this over with quickly so I can move on, without waiting to resolve the problems with the new `FocusGroup` definition.

## Explanation of work

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

The primary change is that within `GroupDiffractionCalibration`, instead of using single values to rebin all of the pixels in d-spacing, rebinning is only performed on d-space focused data, using `RebinRagged` with values of min/max/bin for each focus group, like so:
``` python
self.mantidSnapper.ConvertUnits(
     "Convert thr raw TOf data to d-spacing",
     InputWorkspace=inputWS,
     OutputWorkspace=tmpWSdsp,
     Target="dSpacing",
)
self.mantidSnapper.DiffractionFocussing(
     "Diffraction-focus the d-spacing data",
     InputWorkspace=tmpWSdsp,
     GroupingWorkspace=self.focusWSname,
     OutputWorkspace=tmpWSdsp,
)
self.mantidSnapper.RebinRagged(
    "Ragged rebin the diffraction-focused data",
    InputWorkspace=tmpWSdsp,
    OutputWorkspace=tmpWSdsp,
    XMin=self.dMin,
    XMax=self.dMax,
    Delta=self.dBin,
)
self.mantidSnapper.ConvertUnits(
    "Convert the focused and rebined data back to TOF",
    InputWorkspace=tmpWSdsp,
    OutputWorkspace=outputWS,
    Target="TOF",
)
```

The other major change is a redefintion of the test instrument ("fakeSNAPLite") and related files to be self-consistent and lead to better test data.

## To test

### Dev testing

This is a straightforward defect fix, so only requires CIS approval.  Just check that the unit tests are passing, or try running the CIS script.

Check out the `lazy_ragged_rebin` script to see what this does.

Also run the following to ensure the different group boundaries are applied to the correct groups
``` python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

# # needed to make mocked ingredients
from snapred.backend.dao.RunConfig import RunConfig
from snapred.backend.dao.DetectorPeak import DetectorPeak
from snapred.backend.dao.state.FocusGroup import FocusGroup
from snapred.backend.dao.state.InstrumentState import InstrumentState
from snapred.meta.Config import Config, Resource
Config._config['cis_mode'] = True
Resource._resourcesPath = os.path.expanduser("~/SNAPRed/tests/resources/")

#### CREATE INGREDIENTS
fakeRunNumber = "555"
fakeRunConfig = RunConfig(runNumber=str(fakeRunNumber))

# fake instrument state
TOFMin = 10
TOFMax = 1000
fakeFocusGroup = FocusGroup(
    name = "natural",
    nHst = 4,
    FWHM = [5, 5, 5, 5],
    dMin = [0.05, 0.10, 0.05, 0.10],
    dMax = [0.35, 0.50, 0.30, 0.40],
    dBin = [-0.0086, -0.0096, -0.00130, -0.0017],
    definition = Resource.getPath("inputs/diffcal/fakeFocusGroup.json"),
)

#### CREATE DATA
inputWStof = f"_TOF_{fakeRunNumber}"
inputWSdsp = f"_DSP_{fakeRunNumber}"
groupingWS = "grouping_ws"
midpoint = (TOFMax + TOFMin) / 2.0
CreateSampleWorkspace(
    OutputWorkspace = inputWStof,
    Function = "User Defined",
    UserDefinedFunction=f"name=Gaussian,Height=10,PeakCentre={midpoint},Sigma={midpoint/10}",
    XMin = TOFMin,
    XMax = TOFMax,
    BinWidth = 0.001,
    XUnit = "TOF",
    NumBanks = 4,
    BankPixelWidth=2,
    Random=False,
)
LoadInstrument(
    Workspace=inputWStof,
    Filename=Resource.getPath("inputs/diffcal/fakeSNAPLite.xml"),
    RewriteSpectraMap=True,
)

LoadDetectorsGroupingFile(
    "Loading grouping definition from detectors grouping file...",
    InputFile=Resource.getPath("/inputs/diffcal/fakeSNAPFocGroup_Column.xml"),
    InputWorkspace=inputWStof,
    OutputWorkspace=groupingWS,
)


#### PERFORM OPERATIIONS
Rebin(
    InputWorkspace=inputWStof,
    OutputWorkspace=inputWStof,
    Params=(TOFMin, 0.001, TOFMax),
)
ConvertUnits(
    InputWorkspace=inputWStof,
    OutputWorkspace=inputWSdsp,
    Target="dSpacing",
)
DiffractionFocussing(
    InputWorkspace = inputWSdsp,
    OutputWorkspace = f"_DSP_{fakeRunNumber}_diffoc",
    GroupingWorkspace = "grouping_ws",
)
RebinRagged(
    InputWorkspace = f"_DSP_{fakeRunNumber}_diffoc",
    OutputWorkspace = f"_DSP_{fakeRunNumber}_diffoc",
    XMin = fakeFocusGroup.dMin,
    XMax = fakeFocusGroup.dMax,
    Delta = fakeFocusGroup.dBin,
)

#### VERIFY CORRECT BINNING BOUNDS
print(fakeFocusGroup.json(indent=2))
diffocWS = mtd["_DSP_555_diffoc"]
for index in range(fakeFocusGroup.nHst):
    print(f"index {index}, {min(diffocWS.readX(index))}, {max(diffocWS.readX(index))}")
    assert min(diffocWS.readX(index)) == fakeFocusGroup.dMin[index]
    assert max(diffocWS.readX(index)) == fakeFocusGroup.dMax[index]
```

### CIS testing

<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

Run the `diffcal_script` test, then look at `_DSP_5882_diffoc_after`.  This is the ragged rebinned and diffraction focused dataset.  Right click and select to look at data, and verify that the X values are raggedly rebinned.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#2826](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2826)

[EWM#2777](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=2777)


