### PR TITLE
Fetch Groceries :farmer: :shopping_cart: 

### DIFF
--- a/docs/source/api/snapred.backend.recipe.algorithm.rst
+++ b/docs/source/api/snapred.backend.recipe.algorithm.rst
@@ -68,6 +68,14 @@ snapred.backend.recipe.algorithm.DummyAlgo module
    :undoc-members:
    :show-inheritance:
 
+snapred.backend.recipe.algorithm.FetchGroceriesAlgorithm module
+---------------------------------------------------------------
+
+.. automodule:: snapred.backend.recipe.algorithm.FetchGroceriesAlgorithm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 snapred.backend.recipe.algorithm.FitMultiplePeaksAlgorithm module
 -----------------------------------------------------------------
 

--- a/docs/source/api/snapred.backend.recipe.rst
+++ b/docs/source/api/snapred.backend.recipe.rst
@@ -28,6 +28,14 @@ snapred.backend.recipe.DiffractionCalibrationRecipe module
    :undoc-members:
    :show-inheritance:
 
+snapred.backend.recipe.FetchGroceriesRecipe module
+--------------------------------------------------
+
+.. automodule:: snapred.backend.recipe.FetchGroceriesRecipe
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 snapred.backend.recipe.FitCalibrationWorkspaceRecipe module
 -----------------------------------------------------------
 

--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -15,6 +15,7 @@ class GroceryListItem(BaseModel):
     groupingScheme: Optional[str]
     instrumentPropertySource: Optional[Literal["InstrumentName", "InstrumentFilename", "InstrumentDonor"]]
     instrumentSource: Optional[str]
+    keepItClean: bool = True
 
     @root_validator(pre=True, allow_reuse=True)
     def validate_ingredients_for_gorceries(cls, v):

--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -10,7 +10,7 @@ class GroceryListItem(BaseModel):
 
     workspaceType: Literal["nexus", "grouping"]
     runConfig: Optional[RunConfig]
-    loader: Optional[Literal["LoadGroupingDefinition", "LoadNexus", "LoadEventNexus", "LoadNexusProcessed"]]
+    loader: Literal["", "LoadGroupingDefinition", "LoadNexus", "LoadEventNexus", "LoadNexusProcessed"] = ""
     isLite: Optional[bool]
     groupingScheme: Optional[str]
     instrumentPropertySource: Optional[Literal["InstrumentName", "InstrumentFilename", "InstrumentDonor"]]

--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -1,0 +1,32 @@
+from typing import Literal, Optional
+
+from pydantic import BaseModel, root_validator
+
+from snapred.backend.dao import RunConfig
+
+
+class GroceryListItem(BaseModel):
+    """Holds necessary information for a single item in grocery list"""
+
+    workspaceType: Literal["nexus", "grouping"]
+    runConfig: Optional[RunConfig]
+    loader: Optional[Literal["LoadGroupingDefinition", "LoadNexus", "LoadEventNexus", "LoadNexusProcessed"]]
+    isLite: Optional[bool]
+    groupingScheme: Optional[str]
+    instrumentPropertySource: Optional[Literal["InstrumentName", "InstrumentFilename", "InstrumentDonor"]]
+    instrumentSource: Optional[str]
+
+    @root_validator(pre=True, allow_reuse=True)
+    def validate_ingredients_for_gorceries(cls, v):
+        if v["workspaceType"] == "nexus" and v.get("runConfig") is None:
+            raise ValueError("you must set the run config to load nexus data")
+        if v["workspaceType"] == "grouping":
+            if v.get("isLite") is None:
+                raise ValueError("you must specify whether to use Lite mode for grouping workspace")
+            if v.get("groupingScheme") is None:
+                raise ValueError("you must specify the grouping scheme to use")
+            if v.get("instrumentPropertySource") is None:
+                raise ValueError("a grouping workspace requires an instrument source")
+            if v.get("instrumentSource") is None:
+                raise ValueError("a grouping workspace requries an instrument source")
+        return v

--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -1,0 +1,151 @@
+from typing import Any, Dict, List
+
+from mantid.api import AlgorithmManager
+
+from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
+from snapred.backend.dao.RunConfig import RunConfig
+from snapred.backend.log.logger import snapredLogger
+from snapred.backend.recipe.algorithm.FetchGroceriesAlgorithm import FetchGroceriesAlgorithm as FetchAlgo
+from snapred.meta.decorators.Singleton import Singleton
+
+logger = snapredLogger.getLogger(__name__)
+
+
+@Singleton
+class FetchGroceriesRecipe:
+    """
+    You need some data?  Yeah, I can get that for you.  Just send me a list.
+    """
+
+    def __init__(self):
+        self._loadedRuns: List[RunConfig] = []
+
+    def _createFilenameFromRunConfig(self, runConfig: RunConfig) -> str:
+        if runConfig.isLite:
+            return f"{runConfig.IPTS}shared/lite/SNAP_{runConfig.runNumber}.lite.nxs.h5"
+        else:
+            return f"{runConfig.IPTS}nexus/SNAP_{runConfig.runNumber}.nxs.h5"
+
+    def _createNexusWorkspaceName(self, runConfig) -> str:
+        name: str = f"_TOF_RAW_{runConfig.runNumber}"
+        if runConfig.isLite:
+            name = name + "_lite"
+        return name
+
+    def fetchNexusData(self, runConfig: RunConfig, loader: str = "") -> Dict[str, Any]:
+        """
+        Fetch just a nexus data file
+        inputs:
+        - runConfig, a RunConfig object corresponf to the data desired
+        - loader, the loading algorithm to use, if you think you already know
+        outputs:
+        - data, a dictionary with
+          - "result": true if everything ran correctly
+          - "loader": the loader that was used by the algorithm, use it next time
+          - "workspace": the name of the workspace created in the ADS
+        """
+
+        workspaceName = self._createNexusWorkspaceName(runConfig)
+        fileName = self._createFilenameFromRunConfig(runConfig)
+        data: Dict[str, Any] = {
+            "result": False,
+            "loader": loader,
+            "workspace": workspaceName,
+        }
+        if runConfig in self._loadedRuns:
+            logger.info("Data already loaded... continuing")
+            data["result"] = True
+            data["alreadyLoaded"] = True
+        else:
+            logger.info(f"Fetching nexus data for run {runConfig.runNumber} at {fileName}")
+            algo = FetchAlgo()
+            algo.initialize()
+            algo.setProperty("Filename", fileName)
+            algo.setProperty("Workspace", workspaceName)
+            algo.setProperty("LoaderType", loader)
+            try:
+                data["result"] = algo.execute()
+                data["loader"] = algo.getPropertyValue("LoaderType")
+            except RuntimeError as e:
+                errorString = str(e)
+                raise Exception(errorString.split("\n")[0])
+            logger.info("Finished loading nexus data")
+            self._loadedRuns.append(runConfig)
+        return data
+
+    def _createGroupingFilename(self, groupingScheme: str, isLite: bool = True):
+        filepath = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/"
+        if isLite:
+            return f"{filepath}SNAPFocGroup_{groupingScheme}.lite.nxs"
+        else:
+            return f"{filepath}SNAPFocGroup_{groupingScheme}.xml"
+
+    def _createGroupingWorkspaceName(self, groupingScheme: str, isLite: bool = True):
+        if isLite:
+            return f"SNAPLite_grouping_{groupingScheme}"
+        else:
+            return f"SNAP_grouping_{groupingScheme}"
+
+    def fetchGroupingDefinition(self, item: GroceryListItem) -> str:
+        """
+        Fetch just a grouping definition.
+        inputs:
+        - item, a GroceryListItem
+        outputs:
+        - data, a dictionayr with
+          - "result", true if everything ran correctly
+          - "loader", just "LoadGroupingDefinition" with no apologies
+          - "workspaceName", the name of the new grouping workspace in the ADS
+        """
+
+        workspaceName = self._createGroupingWorkspaceName(item.groupingScheme, item.isLite)
+        fileName = self._createGroupingFilename(item.groupingScheme, item.isLite)
+        logger.info("Fetching grouping definition: %s" % item.groupingScheme)
+        data: Dict[str, Any] = {
+            "result": False,
+            "loader": "LoadGroupingDefinition",
+            "workspace": workspaceName,
+        }
+        algo = FetchAlgo()
+        algo.initialize()
+        algo.setProperty("Filename", fileName)
+        algo.setProperty("Workspace", workspaceName)
+        algo.setProperty("LoaderType", "LoadGroupingDefinition")
+        algo.setProperty(item.instrumentPropertySource, item.instrumentSource)
+        try:
+            print(algo.execute())
+            data["result"] = algo.execute()
+        except RuntimeError as e:
+            errorString = str(e)
+            raise Exception(errorString.split("\n")[0])
+        logger.info("Finished loading grouping")
+        return data
+
+    def executeRecipe(self, groceries: List[GroceryListItem]) -> Dict[str, Any]:
+        """
+        inputs:
+        - groceries, a list of data files to create
+        outputs:
+        - data, a dictionary with:
+          - "result" (True if everything good, otherwise False)
+          - "workspaces" a list of strings with all workspace names created in the ADS
+        """
+
+        data: Dict[str, Any] = {
+            "result": True,
+            "workspaces": [],
+        }
+        for item in groceries:
+            if item.workspaceType == "nexus":
+                res = self.fetchNexusData(item.runConfig, item.loader)
+                data["result"] &= res["result"]
+                data["workspaces"].append(res["workspace"])
+            elif item.workspaceType == "grouping":
+                # if we intend to use the previously loaded workspace as the donor
+                if item.instrumentSource == "prev":
+                    item.instrumentPropertySource = "InstrumentDonor"
+                    item.instrumentSource = data["workspaces"][-1]
+                res = self.fetchGroupingDefinition(item)
+                data["result"] &= res["result"]
+                data["workspaces"].append(res["workspace"])
+        return data

--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -116,7 +116,7 @@ class FetchGroceriesRecipe:
         home = "instrument.calibration.powder.grouping.home"
         pre = "grouping.filename.prefix"
         ext = "grouping.filename." + instr + ".extension"
-        return Config[home] + Config[pre] + groupingScheme + Config[ext]
+        return Config[home] + "/" + Config[pre] + groupingScheme + Config[ext]
 
     def _createGroupingWorkspaceName(self, groupingScheme: str, isLite: bool = True):
         instr = "lite" if isLite else "native"

--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -67,18 +67,17 @@ class FetchGroceriesRecipe:
                 data["result"] = algo.execute()
                 data["loader"] = algo.getPropertyValue("LoaderType")
             except RuntimeError as e:
-                errorString = str(e)
-                raise Exception(errorString.split("\n")[0])
+                raise RuntimeError(str(e).split("\n")[0]) from e
             logger.info("Finished loading nexus data")
             self._loadedRuns.append(runConfig)
         return data
 
     def _createGroupingFilename(self, groupingScheme: str, isLite: bool = True):
-        filepath = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/"
+        location = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/"
         if isLite:
-            return f"{filepath}SNAPFocGroup_{groupingScheme}.lite.nxs"
+            return f"{location}SNAPFocGroup_{groupingScheme}.lite.nxs"
         else:
-            return f"{filepath}SNAPFocGroup_{groupingScheme}.xml"
+            return f"{location}SNAPFocGroup_{groupingScheme}.xml"
 
     def _createGroupingWorkspaceName(self, groupingScheme: str, isLite: bool = True):
         if isLite:
@@ -113,11 +112,9 @@ class FetchGroceriesRecipe:
         algo.setProperty("LoaderType", "LoadGroupingDefinition")
         algo.setProperty(item.instrumentPropertySource, item.instrumentSource)
         try:
-            print(algo.execute())
             data["result"] = algo.execute()
         except RuntimeError as e:
-            errorString = str(e)
-            raise Exception(errorString.split("\n")[0])
+            raise RuntimeError(str(e).split("\n")[0]) from e
         logger.info("Finished loading grouping")
         return data
 

--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 from mantid.simpleapi import CloneWorkspace
 
@@ -21,6 +21,9 @@ class FetchGroceriesRecipe:
     def __init__(self):
         self._loadedRuns: Dict[(str, str, bool), int] = {}
 
+    def _runKey(self, runConfig: RunConfig) -> Tuple[str, str, bool]:
+        return (runConfig.runNumber, runConfig.IPTS, runConfig.isLite)
+
     def _createFilenameFromRunConfig(self, runConfig: RunConfig) -> str:
         instr = "nexus.lite" if runConfig.isLite else "nexus.native"
         home = instr + ".home"
@@ -28,8 +31,14 @@ class FetchGroceriesRecipe:
         ext = instr + ".extension"
         return Config[home] + Config[pre] + str(runConfig.runNumber) + Config[ext]
 
-    def _createNexusWorkspaceName(self, runConfig) -> str:
-        name: str = f"_TOF_RAW_{runConfig.runNumber}"
+    def _createRawNexusWorkspaceName(self, runConfig) -> str:
+        name: str = f"_TOF_{runConfig.runNumber}_RAW"
+        if runConfig.isLite:
+            name = name + "_lite"
+        return name
+
+    def _createNexusWorkspaceName(self, runConfig: RunConfig, numCopies: int) -> str:
+        name: str = f"_TOF_{runConfig.runNumber}_copy_{numCopies}"
         if runConfig.isLite:
             name = name + "_lite"
         return name
@@ -45,40 +54,38 @@ class FetchGroceriesRecipe:
         - "loader": the loader that was used by the algorithm, use it next time
         - "workspace": the name of the workspace created in the ADS
         """
-
-        workspaceName = self._createNexusWorkspaceName(runConfig)
+        rawWorkspaceName = self._createRawNexusWorkspaceName(runConfig)
         fileName = self._createFilenameFromRunConfig(runConfig)
         data: Dict[str, Any] = {
             "result": False,
             "loader": loader,
-            "workspace": workspaceName,
         }
-        thisKey = (runConfig.runNumber, runConfig.IPTS, runConfig.isLite)
-        if self._loadedRuns.get(thisKey, 0) > 0:
-            newWorkspaceName = f"{workspaceName}_{self._loadedRuns[thisKey]}"
-            self._loadedRuns[thisKey] += 1
-            logger.info("Data already loaded... continuing")
-            # TODO: does this really need to be cloned?  If algo's always clone, not necessary here
-            CloneWorkspace(
-                InputWorkspace=workspaceName,
-                OutputWorkspace=newWorkspaceName,
-            )
-            data["result"] = True
-            data["workspace"] = newWorkspaceName
-        else:
+        thisKey = self._runKey(runConfig)
+        if self._loadedRuns.get(thisKey, 0) == 0:
             logger.info(f"Fetching nexus data for run {runConfig.runNumber} at {fileName}")
             algo = FetchAlgo()
             algo.initialize()
             algo.setProperty("Filename", fileName)
-            algo.setProperty("Workspace", workspaceName)
+            algo.setProperty("Workspace", rawWorkspaceName)
             algo.setProperty("LoaderType", loader)
             try:
                 data["result"] = algo.execute()
                 data["loader"] = algo.getPropertyValue("LoaderType")
             except RuntimeError as e:
                 raise RuntimeError(str(e).split("\n")[0]) from e
+
             logger.info("Finished loading nexus data")
             self._loadedRuns[thisKey] = 1
+        else:
+            logger.info("Data already loaded... continuing")
+            self._loadedRuns[thisKey] += 1
+            data["result"] = True
+        workspaceName = self._createNexusWorkspaceName(runConfig, self._loadedRuns[thisKey])
+        CloneWorkspace(
+            InputWorkspace=rawWorkspaceName,
+            OutputWorkspace=workspaceName,
+        )
+        data["workspace"] = workspaceName
         return data
 
     def _createGroupingFilename(self, groupingScheme: str, isLite: bool = True):

--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -54,7 +54,6 @@ class FetchGroceriesRecipe:
         if runConfig in self._loadedRuns:
             logger.info("Data already loaded... continuing")
             data["result"] = True
-            data["alreadyLoaded"] = True
         else:
             logger.info(f"Fetching nexus data for run {runConfig.runNumber} at {fileName}")
             algo = FetchAlgo()

--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -38,11 +38,10 @@ class FetchGroceriesRecipe:
         inputs:
         - runConfig, a RunConfig object corresponf to the data desired
         - loader, the loading algorithm to use, if you think you already know
-        outputs:
-        - data, a dictionary with
-          - "result": true if everything ran correctly
-          - "loader": the loader that was used by the algorithm, use it next time
-          - "workspace": the name of the workspace created in the ADS
+        outputsa dictionary with
+        - "result": true if everything ran correctly
+        - "loader": the loader that was used by the algorithm, use it next time
+        - "workspace": the name of the workspace created in the ADS
         """
 
         workspaceName = self._createNexusWorkspaceName(runConfig)
@@ -90,11 +89,10 @@ class FetchGroceriesRecipe:
         Fetch just a grouping definition.
         inputs:
         - item, a GroceryListItem
-        outputs:
-        - data, a dictionayr with
-          - "result", true if everything ran correctly
-          - "loader", just "LoadGroupingDefinition" with no apologies
-          - "workspaceName", the name of the new grouping workspace in the ADS
+        outputs a dictionayr with
+        - "result", true if everything ran correctly
+        - "loader", just "LoadGroupingDefinition" with no apologies
+        - "workspaceName", the name of the new grouping workspace in the ADS
         """
 
         workspaceName = self._createGroupingWorkspaceName(item.groupingScheme, item.isLite)
@@ -122,10 +120,9 @@ class FetchGroceriesRecipe:
         """
         inputs:
         - groceries, a list of data files to create
-        outputs:
-        - data, a dictionary with:
-          - "result" (True if everything good, otherwise False)
-          - "workspaces" a list of strings with all workspace names created in the ADS
+        outputs a dictionary with:
+        - "result" (True if everything good, otherwise False)
+        - "workspaces" a list of strings with all workspace names created in the ADS
         """
 
         data: Dict[str, Any] = {

--- a/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
@@ -1,0 +1,123 @@
+import json
+from typing import Dict, List, Tuple
+
+import numpy as np
+from mantid.api import (
+    AlgorithmFactory,
+    FileAction,
+    FileProperty,
+    MatrixWorkspaceProperty,
+    PropertyMode,
+    PythonAlgorithm,
+)
+from mantid.kernel import (
+    Direction,
+    StringListValidator,
+)
+
+from snapred.backend.recipe.algorithm.LoadGroupingDefinition import LoadGroupingDefinition
+from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
+
+
+class FetchGroceriesAlgorithm(PythonAlgorithm):
+    """
+    For general-purpose loading of nexus data, or grouping workspaces
+    """
+
+    def category(self):
+        return "LoadingData"
+
+    def PyInit(self):
+        # declare properties
+        self.declareProperty(
+            FileProperty(
+                "Filename",
+                defaultValue="",
+                action=FileAction.Load,
+                extensions=["xml", "h5", "nxs", "hd5"],
+                direction=Direction.Input,
+            ),
+            # propertyMode=PropertyMode.Mandatory,
+            doc="Path to file to be loaded",
+        )
+        self.declareProperty(
+            MatrixWorkspaceProperty("Workspace", "", Direction.Output, PropertyMode.Optional),
+            doc="Workspace containing the loaded data",
+        )
+        self.declareProperty(
+            "LoaderType",
+            "",
+            StringListValidator(["", "LoadGroupingDefinition", "LoadNexus", "LoadEventNexus", "LoadNexusProcessed"]),
+            direction=Direction.InOut,
+        )
+        self.declareProperty(
+            "InstrumentName",
+            defaultValue="",
+            direction=Direction.Input,
+            doc="Name of an associated instrument",
+        )
+        self.declareProperty(
+            "InstrumentFilename",
+            defaultValue="",
+            direction=Direction.Input,
+            doc="Path of an associated instrument definition file",
+        )
+        self.declareProperty(
+            MatrixWorkspaceProperty("InstrumentDonor", "", Direction.Input, PropertyMode.Optional),
+            doc="Workspace to optionally take the instrument from",
+        )
+        self.setRethrows(True)
+        self.mantidSnapper = MantidSnapper(self, __name__)
+
+    def validateInputs(self) -> Dict[str, str]:
+        # cannot load a grouping workspace with a nexus loader
+        issues: Dict[str, str] = {}
+        if self.getProperty("Workspace").isDefault:
+            issues["Workspace"] = "Must specify the Workspace to load into"
+        instrumentSources = [
+            self.getPropertyValue("InstrumentName"),
+            self.getPropertyValue("InstrumentFilename"),
+            self.getPropertyValue("InstrumentDonor"),
+        ]
+        if sum([1 for s in instrumentSources if s != ""]) > 1:
+            issue = "Only one of InstrumentName, InstrumentFilename, or InstrumentDonor can be set"
+            issues["InstrumentName"] = issue
+            issues["InstrumentFilename"] = issue
+            issues["InstrumentDonor"] = issue
+        return issues
+
+    def PyExec(self) -> None:
+        filename = self.getPropertyValue("Filename")
+        outWS = self.getPropertyValue("Workspace")
+        loaderType = self.getPropertyValue("LoaderType")
+        if not self.mantidSnapper.mtd.doesExist(outWS):
+            if loaderType == "":
+                _, loaderType, _ = self.mantidSnapper.Load(
+                    "Loading with unspecified loader",
+                    Filename=filename,
+                    OutputWorkspace=outWS,
+                    LoaderName=loaderType,
+                )
+            elif loaderType == "LoadGroupingDefinition":
+                for x in ["InstrumentName", "InstrumentFilename", "InstrumentDonor"]:
+                    if not self.getProperty(x).isDefault:
+                        instrumentPropertySource = x
+                        instrumentSource = self.getPropertyValue(x)
+                self.mantidSnapper.LoadGroupingDefinition(
+                    "Loading grouping definition",
+                    GroupingFilename=filename,
+                    OutputWorkspace=outWS,
+                    **{instrumentPropertySource: instrumentSource},
+                )
+            else:
+                getattr(self.mantidSnapper, loaderType)(
+                    f"Loading data using {loaderType}",
+                    Filename=filename,
+                    OutputWorkspace=outWS,
+                )
+        self.mantidSnapper.executeQueue()
+        self.setPropertyValue("LoaderType", str(loaderType))
+
+
+# Register algorithm with Mantid
+AlgorithmFactory.subscribe(FetchGroceriesAlgorithm)

--- a/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
@@ -122,7 +122,6 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
         else:
             # TODO: should this throw a warning?  Or warn in logger?
             logger.warning(f"A workspace with name {outWS} already exists in the ADS, and so will not be loaded")
-            loaderType = ""
         self.mantidSnapper.executeQueue()
         self.setPropertyValue("LoaderType", str(loaderType))
 

--- a/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
@@ -15,8 +15,11 @@ from mantid.kernel import (
     StringListValidator,
 )
 
+from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.LoadGroupingDefinition import LoadGroupingDefinition
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
+
+logger = snapredLogger.getLogger(__name__)
 
 
 class FetchGroceriesAlgorithm(PythonAlgorithm):
@@ -90,6 +93,7 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
         filename = self.getPropertyValue("Filename")
         outWS = self.getPropertyValue("Workspace")
         loaderType = self.getPropertyValue("LoaderType")
+        # TODO: do we need to guard this with an if?
         if not self.mantidSnapper.mtd.doesExist(outWS):
             if loaderType == "":
                 _, loaderType, _ = self.mantidSnapper.Load(
@@ -115,6 +119,10 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
                     Filename=filename,
                     OutputWorkspace=outWS,
                 )
+        else:
+            # TODO: should this throw a warning?  Or warn in logger?
+            logger.warning(f"A workspace with name {outWS} already exists in the ADS, and so will not be loaded")
+            loaderType = ""
         self.mantidSnapper.executeQueue()
         self.setPropertyValue("LoaderType", str(loaderType))
 

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -30,10 +30,28 @@ instrument:
       file: ${instrument.home}shared/Calibration/Powder/LiteGroupMap.hdf
 
 nexus:
-  home: nexus/
+  lite:
+    home: ${instrument.home}shared/lite/
+    prefix: SNAP_
+    extension: .lite.nxs.h5
+  native:
+    home: ${instrument.home}nexus/
+    prefix: SNAP_
+    extension: .nxs.h5
   file:
     extension: .nxs.h5
     prefix: SNAP_
+
+grouping:
+  filename:
+    prefix: SNAPFocGroup_
+    lite:
+      extension: .lite.nxs
+    native:
+      extension: .xml
+  workspacename:
+    lite: SNAPLite_grouping_
+    native: SNAP_grouping_
 
 calibration:
   file:

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -31,12 +31,10 @@ instrument:
 
 nexus:
   lite:
-    home: ${instrument.home}shared/lite/
-    prefix: SNAP_
+    prefix: shared/lite/SNAP_
     extension: .lite.nxs.h5
   native:
-    home: ${instrument.home}nexus/
-    prefix: SNAP_
+    prefix: nexus/SNAP_
     extension: .nxs.h5
   file:
     extension: .nxs.h5

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -26,12 +26,10 @@ instrument:
 
 nexus:
   lite:
-    home: ${instrument.home}shared/lite/
-    prefix: SNAP_
+    prefix: shared/lite/SNAP_
     extension: .lite.nxs.h5
   native:
-    home: ${instrument.home}nexus/
-    prefix: SNAP_
+    prefix: nexus/SNAP_
     extension: .nxs.h5
   home: nexus/
   file:

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -25,10 +25,30 @@ instrument:
       file: ${instrument.home}shared/Calibration/Powder/SNAPLite.xml
 
 nexus:
+  lite:
+    home: ${instrument.home}shared/lite/
+    prefix: SNAP_
+    extension: .lite.nxs.h5
+  native:
+    home: ${instrument.home}nexus/
+    prefix: SNAP_
+    extension: .nxs.h5
   home: nexus/
   file:
     extension: .nxs.h5
     prefix: SNAP_
+
+grouping:
+  filename:
+    prefix: SNAPFocGroup_
+    lite:
+      extension: .lite.nxs
+    native:
+      extension: .xml
+  workspacename:
+    lite: SNAPLite_grouping_
+    native: SNAP_grouping_
+
 
 calibration:
   file:
@@ -60,7 +80,7 @@ localdataservice:
     verifypaths: true
 
 logging:
-  level: 10
+  level: 40
   SNAP:
     format: '%(asctime)s - %(levelname)-8s - %(name)s - %(message)s'
   mantid:

--- a/tests/unit/backend/dao/test_GroceryListItem.py
+++ b/tests/unit/backend/dao/test_GroceryListItem.py
@@ -1,0 +1,128 @@
+# ruff: noqa: E722, PT011, PT012
+
+import unittest
+
+import pytest
+from mantid.simpleapi import (
+    DeleteWorkspace,
+    LoadEmptyInstrument,
+)
+from pydantic.error_wrappers import ValidationError
+from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
+from snapred.backend.dao.RunConfig import RunConfig
+from snapred.meta.Config import Resource
+
+
+class TestGroceryListItem(unittest.TestCase):
+    def setUp(self):
+        self.runConfig = RunConfig(
+            runNumber=555,
+            IPTS=Resource.getPath("inputs"),
+        )
+        self.instrumentFilename = Resource.getPath("inputs/diffcal/fakeSNAPLite.xml")
+        self.instrumentDonor = f"_test_grocerylistitem_{self.runConfig.runNumber}"
+        LoadEmptyInstrument(
+            OutputWorkspace=self.instrumentDonor,
+            Filename=self.instrumentFilename,
+        )
+
+    def tearDown(self) -> None:
+        DeleteWorkspace(self.instrumentDonor)
+        return super().tearDown()
+
+    def test_make_correct(self):
+        """
+        Test that valid grocery list items can be made, so that below negative tests can be trusted
+        """
+        # make a nexus item
+        try:
+            GroceryListItem(
+                workspaceType="nexus",
+                runConfig=self.runConfig,
+            )
+        except:
+            pytest.fail("Failed to make a valid GroceryListItem for nexus")
+        # make a grouping item
+        try:
+            GroceryListItem(
+                workspaceType="grouping",
+                isLite=True,
+                groupingScheme="Column",
+                instrumentPropertySource="InstrumentDonor",
+                instrumentSource=self.instrumentDonor,
+            )
+        except:
+            pytest.fail("Failed to make a valid GroceryListItem for grouping")
+
+    def test_literals(self):
+        with pytest.raises(ValidationError) as e:
+            GroceryListItem(
+                workspaceType="fruitcake",
+                runConfig=self.runConfig,
+            )
+            assert "'nexus', 'grouping'" in e.msg()
+        with pytest.raises(ValidationError) as e:
+            GroceryListItem(
+                workspaceType="nexus",
+                runConfig=self.runConfig,
+                loader="fruitcake",
+            )
+            assert "'LoadGroupingDefinition', 'LoadNexus', 'LoadEventNexus', 'LoadNexusProcessed'" in e.msg()
+        with pytest.raises(ValidationError) as e:
+            GroceryListItem(
+                workspaceType="grouping",
+                isLite=True,
+                groupingScheme="Column",
+                instrumentPropertySource="fruitcake",
+                instrumentSource=self.instrumentDonor,
+            )
+            assert "'InstrumentName', 'InstrumentFilename', 'InstrumentDonor'" in e.msg()
+
+    def test_nexus_needs_runconfig(self):
+        with pytest.raises(ValueError) as e:
+            GroceryListItem(
+                workspaceType="nexus",
+                loader="LoadEventNexus",
+                isLite=True,
+                instrumentPropertySource="InstrumentDonor",
+                instrumentSource=self.instrumentDonor,
+            )
+            assert "you must set the run config" in e.msg()
+
+    def test_grouping_needs_stuff(self):
+        # test needs isLite
+        with pytest.raises(ValueError) as e:
+            GroceryListItem(
+                workspaceType="grouping",
+                groupingScheme="Column",
+                instrumentPropertySource="InstrumentDonor",
+                instrumentSource=self.instrumentDonor,
+            )
+            assert "Lite mode" in e.msg()
+        # test needs grouping scheme
+        with pytest.raises(ValueError) as e:
+            GroceryListItem(
+                workspaceType="grouping",
+                isLite=True,
+                instrumentPropertySource="InstrumentDonor",
+                instrumentSource=self.instrumentDonor,
+            )
+            assert "grouping scheme" in e.msg()
+        # test needs instrument property source
+        with pytest.raises(ValueError) as e:
+            GroceryListItem(
+                workspaceType="grouping",
+                isLite=True,
+                groupingScheme="Column",
+                instrumentSource=self.instrumentDonor,
+            )
+            assert "instrument source" in e.msg()
+        # test needs instrument source
+        with pytest.raises(ValueError) as e:
+            GroceryListItem(
+                workspaceType="grouping",
+                isLite=True,
+                groupingScheme="Column",
+                instrumentPropertySource="InstrumentDonor",
+            )
+            assert "instrument source" in e.msg()

--- a/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
@@ -44,18 +44,13 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         cls.fetchedWS = f"_{cls.runNumber}_fetched"
         # create some sample data
         cls.sampleWS = f"_{cls.runNumber}_grocery_to_fetch"
-        CreateSampleWorkspace(
+        # create some sample data
+        cls.sampleWS = "_grocery_to_fetch"
+        CreateWorkspace(
             OutputWorkspace=cls.sampleWS,
-            # WorkspaceType="Histogram",
-            Function="User Defined",
-            UserDefinedFunction="name=Gaussian,Height=10,PeakCentre=30,Sigma=1",
-            Xmin=10,
-            Xmax=1000,
-            BinWidth=0.01,
-            XUnit="TOF",
-            NumBanks=4,  # must produce same number of pixels as fake instrument
-            BankPixelWidth=2,  # each bank has 4 pixels, 4 banks, 16 total
-            Random=True,
+            DataX=[1] * 16,
+            DataY=[1] * 16,
+            NSpec=16,
         )
         # load an instrument into sample data
         LoadInstrument(

--- a/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
@@ -36,6 +36,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         )
         cls.filepath = Resource.getPath(f"inputs/test_{cls.runNumber}_fetchgroceriesalgo.nxs")
         cls.instrumentFilepath = Resource.getPath("inputs/diffcal/fakeSNAPLite.xml")
+        cls.fetchedWS = f"_{cls.runNumber}_fetched"
         # create some sample data
         cls.sampleWS = f"_{cls.runNumber}_grocery_to_fetch"
         CreateSampleWorkspace(
@@ -66,7 +67,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
 
     def tearDown(self) -> None:
         try:
-            DeleteWorkspace(f"_{self.runNumber}_fetched")
+            DeleteWorkspace(self.fetchedWS)
         except:  # noqa: E722
             pass
         return super().tearDown()
@@ -92,7 +93,6 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
             assert "FileProperty" in e.msg()
         algo.setPropertyValue("Filename", self.filepath)
         assert self.filepath == algo.getPropertyValue("Filename")
-        print(algo.getPropertyValue("Filename"))
 
         # chek failure if no workspace property given
         fetched_groceries = f"_fetched_groceries_{self.runNumber}"
@@ -150,10 +150,10 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.initialize()
         algo.setPropertyValue("Filename", self.filepath)
         algo.setPropertyValue("LoaderType", "")
-        algo.setPropertyValue("Workspace", f"_{self.runNumber}_fetched")
+        algo.setPropertyValue("Workspace", self.fetchedWS)
         assert algo.execute()
         assert CompareWorkspaces(
-            Workspace1=f"_{self.runNumber}_fetched",
+            Workspace1=self.fetchedWS,
             Workspace2=self.sampleWS,
         )
         assert "LoadNexusProcessed" == algo.getPropertyValue("LoaderType")
@@ -163,10 +163,10 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.initialize()
         algo.setPropertyValue("Filename", self.filepath)
         algo.setPropertyValue("LoaderType", "LoadNexus")
-        algo.setPropertyValue("Workspace", f"_{self.runNumber}_fetched")
+        algo.setPropertyValue("Workspace", self.fetchedWS)
         assert algo.execute()
         assert CompareWorkspaces(
-            Workspace1=f"_{self.runNumber}_fetched",
+            Workspace1=self.fetchedWS,
             Workspace2=self.sampleWS,
         )
         assert "LoadNexus" == algo.getPropertyValue("LoaderType")
@@ -180,10 +180,10 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.initialize()
         algo.setPropertyValue("Filename", self.filepath)
         algo.setPropertyValue("LoaderType", "LoadNexusProcessed")
-        algo.setPropertyValue("Workspace", f"_{self.runNumber}_fetched")
+        algo.setPropertyValue("Workspace", self.fetchedWS)
         assert algo.execute()
         assert CompareWorkspaces(
-            Workspace1=f"_{self.runNumber}_fetched",
+            Workspace1=self.fetchedWS,
             Workspace2=self.sampleWS,
         )
         assert "LoadNexusProcessed" == algo.getPropertyValue("LoaderType")
@@ -214,6 +214,18 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
             Workspace1=f"_{self.runNumber}_grouping_file",
             Workspace2=f"_{self.runNumber}_grouping_donor",
         )
+
+    def test_loadGroupingTwice(self):
+        algo = Algo()
+        algo.initialize()
+        algo.setPropertyValue("Filename", self.filepath)
+        algo.setPropertyValue("LoaderType", "LoadGroupingDefinition")
+        algo.setPropertyValue("Workspace", self.fetchedWS)
+        algo.setPropertyValue("InstrumentFilename", self.instrumentFilepath)
+        assert algo.execute()
+        assert algo.getPropertyValue("LoaderType") == "LoadGroupingDefinition"
+        assert algo.execute()
+        assert algo.getPropertyValue("LoaderType") == ""
 
 
 # this at teardown removes the loggers, eliminating logger error printouts

--- a/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
@@ -1,0 +1,230 @@
+# ruff: noqa: PT012
+
+import os
+import unittest
+
+import pytest
+from mantid.simpleapi import (
+    CompareWorkspaces,
+    CreateSampleWorkspace,
+    DeleteWorkspace,
+    LoadInstrument,
+    SaveNexusProcessed,
+    mtd,
+)
+
+# needed to make mocked ingredients
+from snapred.backend.dao.RunConfig import RunConfig
+
+# the algorithm to test
+from snapred.backend.recipe.algorithm.FetchGroceriesAlgorithm import (
+    FetchGroceriesAlgorithm as Algo,  # noqa: E402
+)
+from snapred.meta.Config import Resource
+
+TheAlgorithmManager: str = "snapred.backend.recipe.algorithm.MantidSnapper.AlgorithmManager"
+
+
+class TestFetchGroceriesAlgorithm(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Create a set of mocked ingredients for calculating DIFC corrected by offsets"""
+        cls.runNumber = "555"
+        cls.runConfig = RunConfig(
+            runNumber=str(cls.runNumber),
+            IPTS=Resource.getPath("inputs/"),
+        )
+        cls.filepath = Resource.getPath(f"inputs/test_{cls.runNumber}_fetchgroceriesalgo.nxs")
+        cls.instrumentFilepath = Resource.getPath("inputs/diffcal/fakeSNAPLite.xml")
+        # create some sample data
+        cls.sampleWS = f"_{cls.runNumber}_grocery_to_fetch"
+        CreateSampleWorkspace(
+            OutputWorkspace=cls.sampleWS,
+            # WorkspaceType="Histogram",
+            Function="User Defined",
+            UserDefinedFunction="name=Gaussian,Height=10,PeakCentre=30,Sigma=1",
+            Xmin=10,
+            Xmax=1000,
+            BinWidth=0.01,
+            XUnit="TOF",
+            NumBanks=4,  # must produce same number of pixels as fake instrument
+            BankPixelWidth=2,  # each bank has 4 pixels, 4 banks, 16 total
+            Random=True,
+        )
+        # load an instrument into sample data
+        LoadInstrument(
+            Workspace=cls.sampleWS,
+            Filename=cls.instrumentFilepath,
+            InstrumentName="fakeSNAPLite",
+            RewriteSpectraMap=False,
+        )
+        SaveNexusProcessed(
+            InputWorkspace=cls.sampleWS,
+            Filename=cls.filepath,
+        )
+        assert os.path.exists(cls.filepath)
+
+    def tearDown(self) -> None:
+        try:
+            DeleteWorkspace(f"_{self.runNumber}_fetched")
+        except:  # noqa: E722
+            pass
+        return super().tearDown()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        for ws in mtd.getObjectNames():
+            try:
+                DeleteWorkspace(ws)
+            except:  # noqa: E722
+                pass
+        os.remove(cls.filepath)
+        return super().tearDownClass()
+
+    def test_init_properties(self):
+        """Test that the properties of the algorithm can be initialized"""
+        algo = Algo()
+        algo.initialize()
+
+        # check failure if no file property given
+        with pytest.raises(RuntimeError) as e:
+            algo.execute()
+            assert "FileProperty" in e.msg()
+        algo.setPropertyValue("Filename", self.filepath)
+        assert self.filepath == algo.getPropertyValue("Filename")
+        print(algo.getPropertyValue("Filename"))
+
+        # chek failure if no workspace property given
+        fetched_groceries = f"_fetched_groceries_{self.runNumber}"
+        with pytest.raises(RuntimeError) as e:
+            algo.execute()
+            assert "Must specify the Workspace to load into" in e.msg()
+        algo.setPropertyValue("Workspace", fetched_groceries)
+        assert fetched_groceries == algo.getPropertyValue("Workspace")
+        algo.setPropertyValue("LoaderType", "LoadNexus")
+        assert "LoadNexus" == algo.getPropertyValue("LoaderType")
+
+        # set instrument name
+        algo.setPropertyValue("InstrumentName", "SNAP")
+        assert "SNAP" == algo.getPropertyValue("InstrumentName")
+
+        # set instrument filename
+        algo.setPropertyValue("InstrumentFilename", self.instrumentFilepath)
+        assert self.instrumentFilepath == algo.getPropertyValue("InstrumentFileName")
+
+        # check errors if more than one instrument source set
+        errors = algo.validateInputs()
+        assert errors.get("InstrumentName") is not None
+        assert errors.get("InstrumentFilename") is not None
+        assert errors.get("InstrumentDonor") is not None
+        with pytest.raises(RuntimeError) as e:
+            algo.execute()
+            assert "invalid Properties found" in e.msg()
+            assert "InsturmentDonor" in e.msg()
+            assert "InstrumentName" in e.msg()
+            assert "InstrumentFilename" in e.msg()
+        # unset the instrument name
+        algo.setPropertyValue("InstrumentName", "")
+        assert len(algo.validateInputs()) == 0
+
+        # set instrument donor
+        algo.setPropertyValue("InstrumentDonor", self.sampleWS)
+        assert self.sampleWS == algo.getPropertyValue("InstrumentDonor")
+        # check errors if two instrument sources
+        errors = algo.validateInputs()
+        assert errors.get("InstrumentName") is not None
+        assert errors.get("InstrumentFilename") is not None
+        assert errors.get("InstrumentDonor") is not None
+        with pytest.raises(RuntimeError) as e:
+            algo.execute()
+            assert "invalid Properties found" in e.msg()
+            assert "InsturmentDonor" in e.msg()
+            assert "InstrumentName" in e.msg()
+            assert "InstrumentFilename" in e.msg()
+        # unset the instrument name
+        algo.setPropertyValue("InstrumentFilename", "")
+        assert len(algo.validateInputs()) == 0
+
+    def test_loadNexusNoLoader(self):
+        algo = Algo()
+        algo.initialize()
+        algo.setPropertyValue("Filename", self.filepath)
+        algo.setPropertyValue("LoaderType", "")
+        algo.setPropertyValue("Workspace", f"_{self.runNumber}_fetched")
+        assert algo.execute()
+        assert CompareWorkspaces(
+            Workspace1=f"_{self.runNumber}_fetched",
+            Workspace2=self.sampleWS,
+        )
+        assert "LoadNexusProcessed" == algo.getPropertyValue("LoaderType")
+
+    def test_loadNexusLoader(self):
+        algo = Algo()
+        algo.initialize()
+        algo.setPropertyValue("Filename", self.filepath)
+        algo.setPropertyValue("LoaderType", "LoadNexus")
+        algo.setPropertyValue("Workspace", f"_{self.runNumber}_fetched")
+        assert algo.execute()
+        assert CompareWorkspaces(
+            Workspace1=f"_{self.runNumber}_fetched",
+            Workspace2=self.sampleWS,
+        )
+        assert "LoadNexus" == algo.getPropertyValue("LoaderType")
+
+    def test_loadNexusEventLoader(self):
+        # TODO save data in a way that can be loaded by LoadEventNexus
+        pass
+
+    def test_loadNexusProcessedLoader(self):
+        algo = Algo()
+        algo.initialize()
+        algo.setPropertyValue("Filename", self.filepath)
+        algo.setPropertyValue("LoaderType", "LoadNexusProcessed")
+        algo.setPropertyValue("Workspace", f"_{self.runNumber}_fetched")
+        assert algo.execute()
+        assert CompareWorkspaces(
+            Workspace1=f"_{self.runNumber}_fetched",
+            Workspace2=self.sampleWS,
+        )
+        assert "LoadNexusProcessed" == algo.getPropertyValue("LoaderType")
+
+    def test_loadGroupings(self):
+        algo = Algo()
+        algo.initialize()
+        algo.setPropertyValue("Filename", self.filepath)
+        algo.setPropertyValue("LoaderType", "LoadGroupingDefinition")
+        algo.setPropertyValue("Workspace", f"_{self.runNumber}_grouping_file")
+        algo.setPropertyValue("InstrumentFilename", self.instrumentFilepath)
+        assert algo.execute()
+        algo.setProperty("InstrumentFilename", "")
+
+        algo.setPropertyValue("Workspace", f"_{self.runNumber}_grouping_name")
+        algo.setPropertyValue("InstrumentName", "fakeSNAPLite")
+        assert algo.execute()
+        assert CompareWorkspaces(
+            Workspace1=f"_{self.runNumber}_grouping_file",
+            Workspace2=f"_{self.runNumber}_grouping_name",
+        )
+        algo.setProperty("InstrumentName", "")
+
+        algo.setPropertyValue("Workspace", f"_{self.runNumber}_grouping_donor")
+        algo.setPropertyValue("InstrumentDonor", self.sampleWS)
+        assert algo.execute()
+        assert CompareWorkspaces(
+            Workspace1=f"_{self.runNumber}_grouping_file",
+            Workspace2=f"_{self.runNumber}_grouping_donor",
+        )
+
+
+# this at teardown removes the loggers, eliminating logger error printouts
+# see https://github.com/pytest-dev/pytest/issues/5502#issuecomment-647157873
+@pytest.fixture(autouse=True)
+def clear_loggers():  # noqa: PT004
+    """Remove handlers from all loggers"""
+    import logging
+
+    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
+    for logger in loggers:
+        handlers = getattr(logger, "handlers", [])
+        for handler in handlers:
+            logger.removeHandler(handler)

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -1,0 +1,216 @@
+# ruff: noqa: PT012
+
+import os
+import unittest
+from unittest import mock
+
+import pytest
+from mantid.simpleapi import (
+    AddSampleLog,
+    CalculateDIFC,
+    CloneWorkspace,
+    CompareWorkspaces,
+    CreateEmptyTableWorkspace,
+    CreateSampleWorkspace,
+    CreateWorkspace,
+    DeleteWorkspace,
+    DeleteWorkspaces,
+    LoadEventNexus,
+    LoadInstrument,
+    Plus,
+    Rebin,
+    SaveNexusPD,
+    SaveNexusProcessed,
+    mtd,
+)
+from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
+
+# needed to make mocked ingredients
+from snapred.backend.dao.RunConfig import RunConfig
+
+# the algorithm to test
+from snapred.backend.recipe.algorithm.FetchGroceriesAlgorithm import (
+    FetchGroceriesAlgorithm as Algo,  # noqa: E402
+)
+from snapred.backend.recipe.FetchGroceriesRecipe import (
+    FetchGroceriesRecipe as Recipe,  # noqa: E402
+)
+from snapred.meta.Config import Resource
+
+TheAlgorithmManager: str = "snapred.backend.recipe.algorithm.MantidSnapper.AlgorithmManager"
+
+
+class TestFetchGroceriesRecipe(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Create a set of mocked ingredients for calculating DIFC corrected by offsets"""
+        cls.runNumber = "555"
+        cls.runConfigLite = RunConfig(
+            runNumber=str(cls.runNumber),
+            IPTS=Resource.getPath("inputs/"),
+            isLite=True,
+        )
+        cls.runConfigNonlite = RunConfig(
+            runNumber=str(cls.runNumber),
+            IPTS=Resource.getPath("inputs/"),
+            isLite=False,
+        )
+        cls.filepath = Resource.getPath(f"inputs/test_{cls.runNumber}_fetchgroceriesrx.nxs")
+        cls.instrumentFilepath = Resource.getPath("inputs/diffcal/fakeSNAPLite.xml")
+        # create some sample data
+        cls.sampleWS = f"_{cls.runNumber}_grocery_to_fetch"
+        CreateSampleWorkspace(
+            OutputWorkspace=cls.sampleWS,
+            # WorkspaceType="Histogram",
+            Function="User Defined",
+            UserDefinedFunction="name=Gaussian,Height=10,PeakCentre=30,Sigma=1",
+            Xmin=10,
+            Xmax=1000,
+            BinWidth=0.01,
+            XUnit="TOF",
+            NumBanks=4,  # must produce same number of pixels as fake instrument
+            BankPixelWidth=2,  # each bank has 4 pixels, 4 banks, 16 total
+            Random=True,
+        )
+        # load an instrument into sample data
+        LoadInstrument(
+            Workspace=cls.sampleWS,
+            Filename=cls.instrumentFilepath,
+            InstrumentName="fakeSNAPLite",
+            RewriteSpectraMap=False,
+        )
+        SaveNexusProcessed(
+            InputWorkspace=cls.sampleWS,
+            Filename=cls.filepath,
+        )
+        assert os.path.exists(cls.filepath)
+        cls.groceryListItemGrouping = GroceryListItem(
+            workspaceType="grouping",
+            runConfig=cls.runConfigLite,
+            isLite=True,
+            groupingScheme="Column",
+            instrumentPropertySource="InstrumentDonor",
+            instrumentSource=cls.sampleWS,
+        )
+        cls.groceryListItemNexus = GroceryListItem(
+            workspaceType="nexus",
+            runConfig=cls.runConfigLite,
+            loader="LoadNexusProcessed",
+        )
+        cls.groceryList = [
+            cls.groceryListItemNexus,
+            cls.groceryListItemGrouping,
+        ]
+
+    def tearDown(self) -> None:
+        try:
+            DeleteWorkspace(f"_{self.runNumber}_fetched")
+        except:  # noqa: E722
+            pass
+        return super().tearDown()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        for ws in mtd.getObjectNames():
+            try:
+                DeleteWorkspace(ws)
+            except:  # noqa: E722
+                pass
+        os.remove(cls.filepath)
+        return super().tearDownClass()
+
+    def test_create_filename(self):
+        rx = Recipe()
+        res = rx._createFilenameFromRunConfig(self.runConfigLite)
+        assert res == f"{self.runConfigLite.IPTS}shared/lite/SNAP_{self.runConfigLite.runNumber}.lite.nxs.h5"
+        res = rx._createFilenameFromRunConfig(self.runConfigNonlite)
+        assert res == f"{self.runConfigNonlite.IPTS}nexus/SNAP_{self.runConfigNonlite.runNumber}.nxs.h5"
+
+    def test_create_workspace_name(self):
+        rx = Recipe()
+        res = rx._createNexusWorkspaceName(self.runConfigLite)
+        assert res == f"_TOF_RAW_{self.runConfigLite.runNumber}_lite"
+        res = rx._createNexusWorkspaceName(self.runConfigNonlite)
+        assert res == f"_TOF_RAW_{self.runConfigNonlite.runNumber}"
+
+    @mock.patch.object(Recipe, "_createFilenameFromRunConfig")
+    def test_fetch_nexus(self, mockFilename):
+        mockFilename.return_value = self.filepath
+        rx = Recipe()
+        res = rx.fetchNexusData(self.runConfigLite)
+        assert len(res) > 0
+        assert res["result"]
+        assert res["loader"] == "LoadNexusProcessed"
+        assert res["workspace"] == rx._createNexusWorkspaceName(self.runConfigLite)
+        assert res.get("alreadyLoaded") is None
+        assert rx._loadedRuns == [self.runConfigLite]
+
+        res = rx.fetchNexusData(self.runConfigLite)
+        assert res.get("alreadyLoaded") is not None
+
+        res = rx.fetchNexusData(self.runConfigNonlite)
+        assert len(res) > 0
+        assert res["result"]
+        assert res["loader"] == "LoadNexusProcessed"
+        assert res["workspace"] == rx._createNexusWorkspaceName(self.runConfigNonlite)
+        assert rx._loadedRuns == [self.runConfigLite, self.runConfigNonlite]
+        assert res.get("alreadyLoaded") is None
+
+    @mock.patch.object(Recipe, "_createFilenameFromRunConfig")
+    def test_singleton_rx(self, mockFilename):
+        mockFilename.return_value = self.filepath
+        rx1 = Recipe()
+        rx1.fetchNexusData(self.runConfigLite)
+        assert rx1._loadedRuns == [self.runConfigLite]
+        rx2 = Recipe()
+        rx2.fetchNexusData(self.runConfigLite)
+        assert rx2._loadedRuns == [self.runConfigLite]
+
+    def test_grouping_workspacename(self):
+        rx = Recipe()
+        res = rx._createGroupingWorkspaceName("Column", True)
+        assert res == "SNAPLite_grouping_Column"
+        res = rx._createGroupingWorkspaceName("Column", False)
+        assert res == "SNAP_grouping_Column"
+
+    @mock.patch.object(Recipe, "_createGroupingFilename")
+    def test_grouping(self, mockFilename):
+        mockFilename.return_value = Resource.getPath("inputs/diffcal/fakeSNAPFocGroup_Column.xml")
+        rx = Recipe()
+        res = rx.fetchGroupingDefinition(self.groceryListItemGrouping)
+        assert res["result"]
+        assert res["loader"] == "LoadGroupingDefinition"
+        assert res["workspace"] == rx._createGroupingWorkspaceName(
+            self.groceryListItemGrouping.groupingScheme,
+            self.groceryListItemGrouping.isLite,
+        )
+
+    @mock.patch.object(Recipe, "_createGroupingFilename")
+    @mock.patch.object(Recipe, "_createFilenameFromRunConfig")
+    def test_grocery_list(self, mockNexusFilename, mockGroupFilename):
+        mockNexusFilename.return_value = self.filepath
+        mockGroupFilename.return_value = Resource.getPath("inputs/diffcal/fakeSNAPFocGroup_Column.xml")
+        rx = Recipe()
+        res = rx.executeRecipe(self.groceryList)
+        assert res["result"]
+        assert res.get("workspaces") is not None
+        assert len(res["workspaces"]) == len(self.groceryList)
+        assert res["workspaces"][0] == rx._createNexusWorkspaceName(self.runConfigLite)
+        assert res["workspaces"][1] == rx._createGroupingWorkspaceName(
+            self.groceryListItemGrouping.groupingScheme,
+            self.groceryListItemGrouping.isLite,
+        )
+
+
+# this at teardown removes the loggers, eliminating logger error printouts
+# see https://github.com/pytest-dev/pytest/issues/5502#issuecomment-647157873
+@pytest.fixture(autouse=True)
+def clear_loggers():  # noqa: PT004
+    """Remove handlers from all loggers"""
+    import logging
+
+    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
+    for logger in loggers:
+        handlers = getattr(logger, "handlers", [])
+        for handler in handlers:
+            logger.removeHandler(handler)

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -19,7 +19,7 @@ from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.recipe.FetchGroceriesRecipe import (
     FetchGroceriesRecipe as Recipe,  # noqa: E402
 )
-from snapred.meta.Config import Resource
+from snapred.meta.Config import Config, Resource
 
 TheAlgorithmManager: str = "snapred.backend.recipe.algorithm.MantidSnapper.AlgorithmManager"
 
@@ -130,9 +130,9 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         """Test the creation of the nexus filename"""
         rx = Recipe()
         res = rx._createFilenameFromRunConfig(self.runConfigLite)
-        assert res == f"{self.runConfigLite.IPTS}shared/lite/SNAP_{self.runConfigLite.runNumber}.lite.nxs.h5"
+        assert res == f"{Config['nexus.lite.home']}SNAP_{self.runConfigLite.runNumber}.lite.nxs.h5"
         res = rx._createFilenameFromRunConfig(self.runConfigNonlite)
-        assert res == f"{self.runConfigNonlite.IPTS}nexus/SNAP_{self.runConfigNonlite.runNumber}.nxs.h5"
+        assert res == f"{Config['nexus.native.home']}SNAP_{self.runConfigNonlite.runNumber}.nxs.h5"
 
     def test_nexus_workspacename(self):
         """Test the creation of the nexus workspace name"""

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -6,20 +6,9 @@ from unittest import mock
 
 import pytest
 from mantid.simpleapi import (
-    AddSampleLog,
-    CalculateDIFC,
-    CloneWorkspace,
-    CompareWorkspaces,
-    CreateEmptyTableWorkspace,
     CreateSampleWorkspace,
-    CreateWorkspace,
     DeleteWorkspace,
-    DeleteWorkspaces,
-    LoadEventNexus,
     LoadInstrument,
-    Plus,
-    Rebin,
-    SaveNexusPD,
     SaveNexusProcessed,
     mtd,
 )
@@ -27,11 +16,6 @@ from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
 
 # needed to make mocked ingredients
 from snapred.backend.dao.RunConfig import RunConfig
-
-# the algorithm to test
-from snapred.backend.recipe.algorithm.FetchGroceriesAlgorithm import (
-    FetchGroceriesAlgorithm as Algo,  # noqa: E402
-)
 from snapred.backend.recipe.FetchGroceriesRecipe import (
     FetchGroceriesRecipe as Recipe,  # noqa: E402
 )
@@ -57,6 +41,8 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         )
         cls.filepath = Resource.getPath(f"inputs/test_{cls.runNumber}_fetchgroceriesrx.nxs")
         cls.instrumentFilepath = Resource.getPath("inputs/diffcal/fakeSNAPLite.xml")
+        cls.fetchedWSname = f"_{cls.runNumber}_fetched"
+        cls.groupingScheme = "Column"
         # create some sample data
         cls.sampleWS = f"_{cls.runNumber}_grocery_to_fetch"
         CreateSampleWorkspace(
@@ -88,7 +74,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
             workspaceType="grouping",
             runConfig=cls.runConfigLite,
             isLite=True,
-            groupingScheme="Column",
+            groupingScheme=cls.groupingScheme,
             instrumentPropertySource="InstrumentDonor",
             instrumentSource=cls.sampleWS,
         )
@@ -102,11 +88,23 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
             cls.groceryListItemGrouping,
         ]
 
+    def clearoutWorkspaces(self) -> None:
+        rx = Recipe()
+        names = [
+            self.fetchedWSname,
+            rx._createNexusWorkspaceName(self.runConfigLite),
+            rx._createNexusWorkspaceName(self.runConfigNonlite),
+            rx._createGroupingWorkspaceName(self.groupingScheme, True),
+            rx._createGroupingWorkspaceName(self.groupingScheme, False),
+        ]
+        for ws in names:
+            try:
+                DeleteWorkspace(ws)
+            except:  # noqa: E722
+                pass
+
     def tearDown(self) -> None:
-        try:
-            DeleteWorkspace(f"_{self.runNumber}_fetched")
-        except:  # noqa: E722
-            pass
+        self.clearoutWorkspaces()
         return super().tearDown()
 
     @classmethod
@@ -119,31 +117,49 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         os.remove(cls.filepath)
         return super().tearDownClass()
 
-    def test_create_filename(self):
+    def test_nexus_filename(self):
         rx = Recipe()
         res = rx._createFilenameFromRunConfig(self.runConfigLite)
         assert res == f"{self.runConfigLite.IPTS}shared/lite/SNAP_{self.runConfigLite.runNumber}.lite.nxs.h5"
         res = rx._createFilenameFromRunConfig(self.runConfigNonlite)
         assert res == f"{self.runConfigNonlite.IPTS}nexus/SNAP_{self.runConfigNonlite.runNumber}.nxs.h5"
 
-    def test_create_workspace_name(self):
+    def test_nexus_workspacename(self):
         rx = Recipe()
         res = rx._createNexusWorkspaceName(self.runConfigLite)
         assert res == f"_TOF_RAW_{self.runConfigLite.runNumber}_lite"
         res = rx._createNexusWorkspaceName(self.runConfigNonlite)
         assert res == f"_TOF_RAW_{self.runConfigNonlite.runNumber}"
 
+    def test_grouping_filename(self):
+        rx = Recipe()
+        res = rx._createGroupingFilename("Fancy", True)
+        assert "_Fancy.lite" in res
+        res = rx._createGroupingFilename("Fancy", False)
+        assert "_Fancy" in res
+        assert "lite" not in res
+
+    def test_grouping_workspacename(self):
+        rx = Recipe()
+        res = rx._createGroupingWorkspaceName(self.groupingScheme, True)
+        assert res == f"SNAPLite_grouping_{self.groupingScheme}"
+        res = rx._createGroupingWorkspaceName(self.groupingScheme, False)
+        assert res == f"SNAP_grouping_{self.groupingScheme}"
+
+    @mock.patch.object(Recipe, "_createNexusWorkspaceName")
     @mock.patch.object(Recipe, "_createFilenameFromRunConfig")
-    def test_fetch_nexus(self, mockFilename):
+    def test_fetch_nexus(self, mockFilename, mockWorkspaceName):
         mockFilename.return_value = self.filepath
+        mockWorkspaceName.return_value = f"_{self.runNumber}_fetched"
         rx = Recipe()
         res = rx.fetchNexusData(self.runConfigLite)
         assert len(res) > 0
         assert res["result"]
         assert res["loader"] == "LoadNexusProcessed"
-        assert res["workspace"] == rx._createNexusWorkspaceName(self.runConfigLite)
+        assert res["workspace"] == mockWorkspaceName.return_value
         assert res.get("alreadyLoaded") is None
         assert rx._loadedRuns == [self.runConfigLite]
+        self.clearoutWorkspaces()
 
         res = rx.fetchNexusData(self.runConfigLite)
         assert res.get("alreadyLoaded") is not None
@@ -152,29 +168,20 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         assert len(res) > 0
         assert res["result"]
         assert res["loader"] == "LoadNexusProcessed"
-        assert res["workspace"] == rx._createNexusWorkspaceName(self.runConfigNonlite)
+        assert res["workspace"] == mockWorkspaceName.return_value
         assert rx._loadedRuns == [self.runConfigLite, self.runConfigNonlite]
         assert res.get("alreadyLoaded") is None
 
     @mock.patch.object(Recipe, "_createFilenameFromRunConfig")
-    def test_singleton_rx(self, mockFilename):
-        mockFilename.return_value = self.filepath
-        rx1 = Recipe()
-        rx1.fetchNexusData(self.runConfigLite)
-        assert rx1._loadedRuns == [self.runConfigLite]
-        rx2 = Recipe()
-        rx2.fetchNexusData(self.runConfigLite)
-        assert rx2._loadedRuns == [self.runConfigLite]
-
-    def test_grouping_workspacename(self):
+    def test_failed_fetch_nexus(self, mockFilename):
+        # this is some file that it can't load
+        mockFilename.return_value = Resource.getPath("inputs/crystalInfo/fake_file.cif")
         rx = Recipe()
-        res = rx._createGroupingWorkspaceName("Column", True)
-        assert res == "SNAPLite_grouping_Column"
-        res = rx._createGroupingWorkspaceName("Column", False)
-        assert res == "SNAP_grouping_Column"
+        with pytest.raises(RuntimeError):
+            rx.fetchNexusData(self.runConfigLite)
 
     @mock.patch.object(Recipe, "_createGroupingFilename")
-    def test_grouping(self, mockFilename):
+    def test_fetch_grouping(self, mockFilename):
         mockFilename.return_value = Resource.getPath("inputs/diffcal/fakeSNAPFocGroup_Column.xml")
         rx = Recipe()
         res = rx.fetchGroupingDefinition(self.groceryListItemGrouping)
@@ -185,9 +192,20 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
             self.groceryListItemGrouping.isLite,
         )
 
+    def test_name_with_many_underscores_in_it(self):
+        pass
+
+    @mock.patch.object(Recipe, "_createGroupingFilename")
+    def test_failed_fetch_grouping(self, mockFilename):
+        # this is some file that it can't load
+        mockFilename.return_value = Resource.getPath("inputs/crystalInfo/fake_file.cif")
+        rx = Recipe()
+        with pytest.raises(RuntimeError):
+            rx.fetchGroupingDefinition(self.groceryListItemGrouping)
+
     @mock.patch.object(Recipe, "_createGroupingFilename")
     @mock.patch.object(Recipe, "_createFilenameFromRunConfig")
-    def test_grocery_list(self, mockNexusFilename, mockGroupFilename):
+    def test_fetch_grocery_list(self, mockNexusFilename, mockGroupFilename):
         mockNexusFilename.return_value = self.filepath
         mockGroupFilename.return_value = Resource.getPath("inputs/diffcal/fakeSNAPFocGroup_Column.xml")
         rx = Recipe()
@@ -200,6 +218,32 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
             self.groceryListItemGrouping.groupingScheme,
             self.groceryListItemGrouping.isLite,
         )
+
+    @mock.patch.object(Recipe, "_createGroupingFilename")
+    @mock.patch.object(Recipe, "_createFilenameFromRunConfig")
+    def test_fetch_grocery_list_with_prev(self, mockNexusFilename, mockGroupFilename):
+        mockNexusFilename.return_value = self.filepath
+        mockGroupFilename.return_value = Resource.getPath("inputs/diffcal/fakeSNAPFocGroup_Column.xml")
+        groceryList = [
+            GroceryListItem(
+                workspaceType="nexus",
+                runConfig=self.runConfigLite,
+                loader="LoadNexusProcessed",
+            ),
+            GroceryListItem(
+                workspaceType="grouping",
+                isLite=True,
+                groupingScheme=self.groupingScheme,
+                instrumentPropertySource="InstrumentDonor",
+                instrumentSource="prev",
+            ),
+        ]
+        rx = Recipe()
+        res = rx.executeRecipe(groceryList)
+        assert res["result"]
+        assert res.get("workspaces") is not None
+        assert len(res["workspaces"]) == len(groceryList)
+        assert groceryList[1].instrumentSource == res["workspaces"][0]
 
 
 # this at teardown removes the loggers, eliminating logger error printouts


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

Creates an algo/recipe that is capable of loading a list of needed files, either nexus data or grouping files.

This can be called from various services to populate the needed data.

It also takes a first step in tracking already-loaded data, so that data is not re-loaded.

## Explanation of work

This is a new algorithm that just calls one of mantid's load methods, or SNAPRed's `LoadGroupingDefinition` if a grouping workspace.

Also a recipe, which can take a grocery list of items to load, and load all of them.

Also a DAO `GroceryListItem` which describes the item to load and some properties to help SNAPRed locate it.

This is a first step -- the loading directory is currently hardwired, when it should instead be pulling from `Config`.

## To test

### Dev testing

The unit tests should be pretty convincing.

Try, in workbench, creating a small workspace, saving it as a nexus file, then try loading it using this algorithm.  For neutron data, this should be straightforward.

For grouping data, you will need to specify an instrument source.

Try running the recipe as well.  You will need to create a `RunConfig` object, then a `GroceryListItem` object.

**To consider**:  The algorithm has all the loading enclosed in an `if` that will only execute if the expected output workspace name is not found already in the ADS.  Is that desired behavior?

### CIS testing

This script should illustrate the behavior

``` python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from snapred.backend.dao.RunConfig import RunConfig
from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
from snapred.backend.recipe.algorithm.FetchGroceriesAlgorithm import FetchGroceriesAlgorithm as FetchAlgo
from snapred.backend.recipe.FetchGroceriesRecipe import FetchGroceriesRecipe as FetchRx
from snapred.meta.Config import Config, Resource
Config._config['cis_mode'] = True
Resource._resourcesPath = os.path.expanduser("~/SNAPRed/tests/resources/")

from snapred.backend.data.DataFactoryService import DataFactoryService

runNumber = 58882

dataFactoryService=DataFactoryService()
runConfig = dataFactoryService.getRunConfig(runNumber)

groceryList = [
    GroceryListItem(
        workspaceType="nexus",
        runConfig=runConfig,
    ),
]


rx = FetchRx()
rx.executeRecipe(groceryList)

# loading the same workspace again should do nothing
rx.executeRecipe(groceryList)

# load a grouping file
groceryList = [
    GroceryListItem(
        workspaceType="nexus",
        runConfig=runConfig,
    ),
    GroceryListItem(
        workspaceType="grouping",
        groupingScheme="Column",
        isLite=True,
        instrumentPropertySource="InstrumentDonor",
        instrumentSource="prev", ## this will use the previous workspace as instrument donor
    ),   
]
rx.executeRecipe(groceryList)

rx2 = FetchRx()
assert rx == rx2
assert rx._loadedRuns == rx2._loadedRuns
```

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

 - [EWM#2794](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2794)
 - [EWM#2481](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2481)

Grew out of the infamous PR #139 