### PR TITLE
issue template from EWM story template

### DIFF
--- a/.github/ISSUE_TEMPLATE/workitem.md
+++ b/.github/ISSUE_TEMPLATE/workitem.md
@@ -1,0 +1,39 @@
+---
+name: Work Item
+about: Description of EWM work item
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Overview
+### PR's
+Where the pr's related to the story go.
+### I/O
+Expected Outputs: What the implemented story should produce (high level)
+Inputs: Exhaustive list of Mantid/SNAPRed data needed to implement story
+	ex. *user touches this button, focussed run data, PixelGroupingParameters, Nothing*
+
+This outlines the scaffolding of what needs to exist before the actual implementation begins.
+Working backwards often helps this because it lets you sus out inputs to make things happen.
+An Answer may apply to many questions but a Question may only need one good Answer.
+### Test Data
+
+A link/path to test data if required.
+### Abstract
+This section adds context to the story as well as calling out pain-points and unknowns at a high level.  This highlights the point of the story in case it gets lost in a sea of info.
+
+## Details
+
+### Description
+Where you go into detail about topics highlighted in the [Abstract](#Abstract) section.  Preferably headed by each topic.
+
+### Acceptance Criteria
+
+This section should contain an exhaustive list of items accomplished by the story.
+Please be mindful of non sequiturs, limiting the scope of the story to what one might infer from the title.
+If there are UI and Backend components to the Acceptance Criteria, please create separate stories.
+
+### Implementation Suggestions
+This Section is mostly for me(Michael Walsh) to outline some concrete steps if possible so that if it requires some orchestration there's less churn finding everything they need in the [I/O](#I/O) section.  This can probably be replaced with good Documentation.


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

Sometimes it is easier to write story descriptions in markdown.  Github's markdown also allows for embedding equation with $\LaTeX$ such as

$DIFC_{prev} = (1-|dX|)^{-offset}$

for directly typing syntax-highlighted code, such as

``` python
x = [1,2,3]
y = [4,5,6]
xy = {key:value for key,value in zip(x,y)}
print(xy)
```
and for directly embedding graphs like this one:
![Screenshot from 2023-10-23 12-19-46](https://github.com/neutrons/SNAPRed/assets/52183986/e71d52d1-c800-41ca-8bce-9fbb6258a19b)

which are all useful in describing the stories.  The issues can also be tracked directly to PRs that should close them.

All of this points to the u

sefulness of using github issues as a means of communicating needed work.

## Explanation of work

The issue template directly implements the story template for EWM stories developed by Michael and Malcolm.

## To test

### Dev testing
N/A

### CIS testing
N/A

## Link to EWM item
N/A
