### PR TITLE
Add Workspace Name Standardization

### DIFF
--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -8,6 +8,8 @@ from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.FetchGroceriesAlgorithm import FetchGroceriesAlgorithm as FetchAlgo
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Singleton import Singleton
+from snapred.meta.mantid.WorkspaceNameGenerator import NameBuilder
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 
 logger = snapredLogger.getLogger(__name__)
 
@@ -30,17 +32,19 @@ class FetchGroceriesRecipe:
         ext = instr + ".extension"
         return runConfig.IPTS + Config[pre] + str(runConfig.runNumber) + Config[ext]
 
-    def _createNexusWorkspaceName(self, runConfig: RunConfig) -> str:
-        name: str = f"_TOF_{runConfig.runNumber}"
+    def _createNexusWorkspaceNameBuilder(self, runConfig: RunConfig) -> NameBuilder:
+        runNameBuilder = wng.run().runNumber(runConfig.runNumber)
         if runConfig.isLite:
-            name = name + "_lite"
-        return name
+            runNameBuilder.lite(wng.Lite.TRUE)
+
+    def _createNexusWorkspaceName(self, runConfig: RunConfig) -> str:
+        return self._createNexusWorkspaceNameBuilder(runConfig).build()
 
     def _createRawNexusWorkspaceName(self, runConfig: RunConfig) -> str:
-        return self._createNexusWorkspaceName(runConfig) + "_RAW"
+        return self._createNexusWorkspaceNameBuilder(runConfig).auxilary("Raw").build()
 
     def _createCopyNexusWorkspaceName(self, runConfig: RunConfig, numCopies: int) -> str:
-        return self._createNexusWorkspaceName(runConfig) + "_copy_" + str(numCopies)
+        return self._createNexusWorkspaceNameBuilder(runConfig).auxilary(f"Copy{numCopies}").build()
 
     def _fetch(self, filename: str, workspace: str, loader: str = "") -> Dict[str, Any]:
         """

--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -45,7 +45,7 @@ class FetchGroceriesRecipe:
         return self._createNexusWorkspaceNameBuilder(runConfig).auxilary("Raw").build()
 
     def _createCopyNexusWorkspaceName(self, runConfig: RunConfig, numCopies: int) -> str:
-        return self._createNexusWorkspaceNameBuilder(runConfig).auxilary(f"Copy{numCopies}").build()
+        return self._createNexusWorkspaceNameBuilder(runConfig).auxilary(f"-Copy{numCopies}-").build()
 
     def _fetch(self, filename: str, workspace: str, loader: str = "") -> Dict[str, Any]:
         """

--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -45,7 +45,7 @@ class FetchGroceriesRecipe:
         return self._createNexusWorkspaceNameBuilder(runConfig).auxilary("Raw").build()
 
     def _createCopyNexusWorkspaceName(self, runConfig: RunConfig, numCopies: int) -> str:
-        return self._createNexusWorkspaceNameBuilder(runConfig).auxilary(f"-Copy{numCopies}-").build()
+        return self._createNexusWorkspaceNameBuilder(runConfig).auxilary(f"Copy{numCopies}").build()
 
     def _fetch(self, filename: str, workspace: str, loader: str = "") -> Dict[str, Any]:
         """

--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -62,7 +62,7 @@ class FetchGroceriesRecipe:
         algo = FetchAlgo()
         algo.initialize()
         algo.setProperty("Filename", filename)
-        algo.setProperty("Workspace", workspace)
+        algo.setProperty("OutputWorkspace", workspace)
         algo.setProperty("LoaderType", loader)
         try:
             data["result"] = algo.execute()
@@ -175,7 +175,7 @@ class FetchGroceriesRecipe:
         algo = FetchAlgo()
         algo.initialize()
         algo.setProperty("Filename", fileName)
-        algo.setProperty("Workspace", workspaceName)
+        algo.setProperty("OutputWorkspace", workspaceName)
         algo.setProperty("LoaderType", "LoadGroupingDefinition")
         algo.setProperty(item.instrumentPropertySource, item.instrumentSource)
         try:

--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -36,6 +36,7 @@ class FetchGroceriesRecipe:
         runNameBuilder = wng.run().runNumber(runConfig.runNumber)
         if runConfig.isLite:
             runNameBuilder.lite(wng.Lite.TRUE)
+        return runNameBuilder
 
     def _createNexusWorkspaceName(self, runConfig: RunConfig) -> str:
         return self._createNexusWorkspaceNameBuilder(runConfig).build()

--- a/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
@@ -44,7 +44,7 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
             doc="Path to file to be loaded",
         )
         self.declareProperty(
-            MatrixWorkspaceProperty("Workspace", "", Direction.Output, PropertyMode.Optional),
+            MatrixWorkspaceProperty("OutputWorkspace", "", Direction.Output, PropertyMode.Optional),
             doc="Workspace containing the loaded data",
         )
         self.declareProperty(
@@ -75,8 +75,8 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
     def validateInputs(self) -> Dict[str, str]:
         # cannot load a grouping workspace with a nexus loader
         issues: Dict[str, str] = {}
-        if self.getProperty("Workspace").isDefault:
-            issues["Workspace"] = "Must specify the Workspace to load into"
+        if self.getProperty("OutputWorkspace").isDefault:
+            issues["OutputWorkspace"] = "Must specify the Workspace to load into"
         instrumentSources = [
             self.getPropertyValue("InstrumentName"),
             self.getPropertyValue("InstrumentFilename"),
@@ -91,7 +91,7 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
 
     def PyExec(self) -> None:
         filename = self.getPropertyValue("Filename")
-        outWS = self.getPropertyValue("Workspace")
+        outWS = self.getPropertyValue("OutputWorkspace")
         loaderType = self.getPropertyValue("LoaderType")
         # TODO: do we need to guard this with an if?
         if not self.mantidSnapper.mtd.doesExist(outWS):

--- a/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
@@ -9,6 +9,7 @@ from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients as
 from snapred.backend.recipe.algorithm.CalculateDiffCalTable import CalculateDiffCalTable
 from snapred.backend.recipe.algorithm.LoadGroupingDefinition import LoadGroupingDefinition
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 
 
 class PixelDiffractionCalibration(PythonAlgorithm):
@@ -59,9 +60,10 @@ class PixelDiffractionCalibration(PythonAlgorithm):
         self.groupingFile: str = ingredients.focusGroup.definition
 
         # create string names of workspaces that will be used by algorithm
-        self.inputWStof: str = f"_TOF_{self.runNumber}_raw"
-        self.inputWSdsp: str = f"_DSP_{self.runNumber}_raw"
-        self.difcWS: str = f"_DIFC_{self.runNumber}"
+
+        self.inputWStof: str = wng.diffCalInput(self.runNumber)
+        self.inputWSdsp: str = wng.diffCalInput(self.runNumber, unit=wng.Units.DSP)
+        self.difcWS: str = wng.diffCalTable(self.runNumber)
         self.maxOffset = float(self.getProperty("MaxOffset").value)
 
     def raidPantry(self) -> None:

--- a/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
@@ -61,9 +61,9 @@ class PixelDiffractionCalibration(PythonAlgorithm):
 
         # create string names of workspaces that will be used by algorithm
 
-        self.inputWStof: str = wng.diffCalInput(self.runNumber)
-        self.inputWSdsp: str = wng.diffCalInput(self.runNumber, unit=wng.Units.DSP)
-        self.difcWS: str = wng.diffCalTable(self.runNumber)
+        self.inputWStof: str = wng.diffCalInput().runNumber(self.runNumber).build()
+        self.inputWSdsp: str = wng.diffCalInput().runNumber(self.runNumber).unit(wng.Units.DSP).build()
+        self.difcWS: str = wng.diffCalTable().runNumber(self.runNumber).build()
         self.maxOffset = float(self.getProperty("MaxOffset").value)
 
     def raidPantry(self) -> None:

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -1,0 +1,42 @@
+from snapred.meta.Config import Config
+
+
+class WorkspaceName(str):
+    def __str__(self):
+        return self
+
+
+class _WorkspaceNameGenerator:
+    _templateRoot = "mantid.workspace.nameTemplate"
+    _runTemplate = Config[f"{_templateRoot}.run"]
+    _diffCalInputTemplate = Config[f"{_templateRoot}.diffCal.input"]
+    _diffCalTableTemplate = Config[f"{_templateRoot}.diffCal.table"]
+
+    class Units:
+        _templateRoot = "mantid.workspace.nameTemplate.units"
+        DSP = Config[f"{_templateRoot}.dSpacing"]
+        TOF = Config[f"{_templateRoot}.timeOfFlight"]
+
+    class Groups:
+        _templateRoot = "mantid.workspace.nameTemplate.groups"
+        ALL = Config[f"{_templateRoot}.all"]
+        COLUMN = Config[f"{_templateRoot}.column"]
+        BANK = Config[f"{_templateRoot}.bank"]
+
+    @property
+    def unit():
+        return _WorkspaceNameGenerator.Units
+
+    # TODO: Return abstract WorkspaceName type to help facilitate control over workspace names
+    #       and discourage non-standard names.
+    def run(self, runNumber, auxilary="", unit=Units.TOF, group=Groups.ALL):
+        return WorkspaceName(self._runTemplate.format(unit=unit, group=group, auxilary=auxilary, runNumber=runNumber))
+
+    def diffCalInput(self, runNumber, unit=Units.TOF):
+        return WorkspaceName(self._diffCalInputTemplate.format(unit=unit, runNumber=runNumber))
+
+    def diffCalTable(self, runNumber):
+        return WorkspaceName(self._diffCalTableTemplate.format(runNumber=runNumber))
+
+
+WorkspaceNameGenerator = _WorkspaceNameGenerator()

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -8,7 +8,7 @@ class WorkspaceName(str):
         return self
 
 
-class _NameBuilder:
+class NameBuilder:
     def __init__(self, template: str, keys: List[str], **kwargs):
         self.template = template
         self.keys = keys
@@ -31,7 +31,7 @@ class _NameBuilder:
 class _WorkspaceNameGenerator:
     _templateRoot = "mantid.workspace.nameTemplate"
     _runTemplate = Config[f"{_templateRoot}.run"]
-    _runTemplateKeys = ["runNumber", "auxilary", "unit", "group"]
+    _runTemplateKeys = ["runNumber", "auxilary", "lite", "unit", "group"]
     _diffCalInputTemplate = Config[f"{_templateRoot}.diffCal.input"]
     _diffCalInputTemplateKeys = ["runNumber", "unit"]
     _diffCalTableTemplate = Config[f"{_templateRoot}.diffCal.table"]
@@ -48,18 +48,27 @@ class _WorkspaceNameGenerator:
         COLUMN = Config[f"{_templateRoot}.column"]
         BANK = Config[f"{_templateRoot}.bank"]
 
+    class Lite:
+        TRUE = "lite"
+        FALSE = ""
+
     # TODO: Return abstract WorkspaceName type to help facilitate control over workspace names
     #       and discourage non-standard names.
     def run(self):
-        return _NameBuilder(
-            self._runTemplate, self._runTemplateKeys, auxilary="", unit=self.Units.TOF, group=self.Groups.ALL
+        return NameBuilder(
+            self._runTemplate,
+            self._runTemplateKeys,
+            auxilary="",
+            unit=self.Units.TOF,
+            group=self.Groups.ALL,
+            lite=self.Lite.FALSE,
         )
 
     def diffCalInput(self):
-        return _NameBuilder(self._diffCalInputTemplate, self._diffCalInputTemplateKeys, unit=self.Units.TOF)
+        return NameBuilder(self._diffCalInputTemplate, self._diffCalInputTemplateKeys, unit=self.Units.TOF)
 
     def diffCalTable(self):
-        return _NameBuilder(self._diffCalTableTemplate, self._diffCalTableTemplateKeys)
+        return NameBuilder(self._diffCalTableTemplate, self._diffCalTableTemplateKeys)
 
 
 WorkspaceNameGenerator = _WorkspaceNameGenerator()

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -23,14 +23,6 @@ class _WorkspaceNameGenerator:
         COLUMN = Config[f"{_templateRoot}.column"]
         BANK = Config[f"{_templateRoot}.bank"]
 
-    @property
-    def unit():
-        return _WorkspaceNameGenerator.Units
-
-    @property
-    def group():
-        return _WorkspaceNameGenerator.Groups
-
     # TODO: Return abstract WorkspaceName type to help facilitate control over workspace names
     #       and discourage non-standard names.
     def run(self, runNumber, auxilary="", unit=Units.TOF, group=Groups.ALL):

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -49,7 +49,7 @@ class _WorkspaceNameGenerator:
         BANK = Config[f"{_templateRoot}.bank"]
 
     class Lite:
-        TRUE = "lite"
+        TRUE = "Lite"
         FALSE = ""
 
     # TODO: Return abstract WorkspaceName type to help facilitate control over workspace names

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -27,6 +27,10 @@ class _WorkspaceNameGenerator:
     def unit():
         return _WorkspaceNameGenerator.Units
 
+    @property
+    def group():
+        return _WorkspaceNameGenerator.Groups
+
     # TODO: Return abstract WorkspaceName type to help facilitate control over workspace names
     #       and discourage non-standard names.
     def run(self, runNumber, auxilary="", unit=Units.TOF, group=Groups.ALL):

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -76,6 +76,21 @@ calibration:
         - 2.0
       peakTailCoefficient: 2.0
 
+mantid:
+    workspace:
+      nameTemplate:
+        run: "{unit}{group}{auxilary}{runNumber}"
+        diffCal:
+          input: "_{unit}_{runNumber}_raw"
+          table: "_DIFC_{runNumber}"
+        units:
+          dSpacing: DSP
+          timeOfFlight: TOF
+        groups:
+          all: All
+          column: Column
+          bank: Bank
+
 localdataservice:
   config:
     verifypaths: true

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -79,7 +79,7 @@ calibration:
 mantid:
     workspace:
       nameTemplate:
-        run: "{unit}{group}{auxilary}{runNumber}"
+        run: "{unit}{group}{lite}{auxilary}{runNumber}"
         diffCal:
           input: "_{unit}_{runNumber}_raw"
           table: "_DIFC_{runNumber}"

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -79,14 +79,16 @@ calibration:
 mantid:
     workspace:
       nameTemplate:
-        run: "{unit}{group}{lite}{runNumber}{auxilary}"
+        delimiter: "_"
+        run: "{unit},{group},{lite},{runNumber},{auxilary}"
         diffCal:
-          input: "_{unit}_{runNumber}_raw"
-          table: "_DIFC_{runNumber}"
+          input: "_{unit},{runNumber},raw"
+          table: "_DIFC,{runNumber}"
         units:
           dSpacing: DSP
           timeOfFlight: TOF
         groups:
+          unfocussed: Unfoc
           all: All
           column: Column
           bank: Bank

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -79,7 +79,7 @@ calibration:
 mantid:
     workspace:
       nameTemplate:
-        run: "{unit}{group}{lite}{auxilary}{runNumber}"
+        run: "{unit}{group}{lite}{runNumber}{auxilary}"
         diffCal:
           input: "_{unit}_{runNumber}_raw"
           table: "_DIFC_{runNumber}"

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -73,6 +73,21 @@ calibration:
         - 2
       peakTailCoefficient: 2.0
 
+mantid:
+    workspace:
+      nameTemplate:
+        run: "{unit}{group}{auxilary}{runNumber}"
+        diffCal:
+          input: "_{unit}_{runNumber}_raw"
+          table: "_DIFC_{runNumber}"
+        units:
+          dSpacing: DSP
+          timeOfFlight: TOF
+        groups:
+          all: All
+          column: Column
+          bank: Bank
+
 localdataservice:
   config:
     verifypaths: true

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -76,7 +76,7 @@ calibration:
 mantid:
     workspace:
       nameTemplate:
-        run: "{unit}{group}{auxilary}{runNumber}"
+        run: "{unit}{group}{lite}{auxilary}{runNumber}"
         diffCal:
           input: "_{unit}_{runNumber}_raw"
           table: "_DIFC_{runNumber}"

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -76,17 +76,19 @@ calibration:
 mantid:
     workspace:
       nameTemplate:
-        run: "{unit}{group}{lite}{auxilary}{runNumber}"
+        delimiter: "_"
+        run: "{unit},{group},{lite},{runNumber},{auxilary}"
         diffCal:
-          input: "_{unit}_{runNumber}_raw"
-          table: "_DIFC_{runNumber}"
+          input: "_{unit},{runNumber},raw"
+          table: "_DIFC,{runNumber}"
         units:
-          dSpacing: DSP
-          timeOfFlight: TOF
+          dSpacing: dsp
+          timeOfFlight: tof
         groups:
-          all: All
-          column: Column
-          bank: Bank
+          unfocussed: unfoc
+          all: all
+          column: column
+          bank: bank
 
 localdataservice:
   config:

--- a/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
@@ -104,8 +104,8 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         with pytest.raises(RuntimeError) as e:
             algo.execute()
             assert "Must specify the Workspace to load into" in e.msg()
-        algo.setPropertyValue("Workspace", fetched_groceries)
-        assert fetched_groceries == algo.getPropertyValue("Workspace")
+        algo.setPropertyValue("OutputWorkspace", fetched_groceries)
+        assert fetched_groceries == algo.getPropertyValue("OutputWorkspace")
         algo.setPropertyValue("LoaderType", "LoadNexus")
         assert "LoadNexus" == algo.getPropertyValue("LoaderType")
 
@@ -156,7 +156,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.initialize()
         algo.setPropertyValue("Filename", self.filepath)
         algo.setPropertyValue("LoaderType", "")
-        algo.setPropertyValue("Workspace", self.fetchedWS)
+        algo.setPropertyValue("OutputWorkspace", self.fetchedWS)
         assert algo.execute()
         assert CompareWorkspaces(
             Workspace1=self.fetchedWS,
@@ -170,7 +170,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.initialize()
         algo.setPropertyValue("Filename", self.filepath)
         algo.setPropertyValue("LoaderType", "LoadNexus")
-        algo.setPropertyValue("Workspace", self.fetchedWS)
+        algo.setPropertyValue("OutputWorkspace", self.fetchedWS)
         assert algo.execute()
         assert CompareWorkspaces(
             Workspace1=self.fetchedWS,
@@ -193,7 +193,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.initialize()
         algo.setPropertyValue("Filename", self.filepath)
         algo.setPropertyValue("LoaderType", "LoadNexusProcessed")
-        algo.setPropertyValue("Workspace", self.fetchedWS)
+        algo.setPropertyValue("OutputWorkspace", self.fetchedWS)
         assert algo.execute()
         assert CompareWorkspaces(
             Workspace1=self.fetchedWS,
@@ -210,12 +210,12 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.initialize()
         algo.setPropertyValue("Filename", self.filepath)
         algo.setPropertyValue("LoaderType", "LoadGroupingDefinition")
-        algo.setPropertyValue("Workspace", f"_{self.runNumber}_grouping_file")
+        algo.setPropertyValue("OutputWorkspace", f"_{self.runNumber}_grouping_file")
         algo.setPropertyValue("InstrumentFilename", self.instrumentFilepath)
         assert algo.execute()
         algo.setProperty("InstrumentFilename", "")
 
-        algo.setPropertyValue("Workspace", f"_{self.runNumber}_grouping_name")
+        algo.setPropertyValue("OutputWorkspace", f"_{self.runNumber}_grouping_name")
         algo.setPropertyValue("InstrumentName", "fakeSNAPLite")
         assert algo.execute()
         assert CompareWorkspaces(
@@ -224,7 +224,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         )
         algo.setProperty("InstrumentName", "")
 
-        algo.setPropertyValue("Workspace", f"_{self.runNumber}_grouping_donor")
+        algo.setPropertyValue("OutputWorkspace", f"_{self.runNumber}_grouping_donor")
         algo.setPropertyValue("InstrumentDonor", self.sampleWS)
         assert algo.execute()
         assert CompareWorkspaces(
@@ -263,7 +263,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.mantidSnapper = mockSnapper
         algo.setPropertyValue("Filename", self.filepath)
         algo.setPropertyValue("LoaderType", "LoadGroupingDefinition")
-        algo.setPropertyValue("Workspace", self.fetchedWS)
+        algo.setPropertyValue("OutputWorkspace", self.fetchedWS)
         algo.setPropertyValue("InstrumentFilename", self.instrumentFilepath)
         assert algo.execute()
         algo.mantidSnapper.mtd.doesExist.assert_called_once()

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -144,24 +144,24 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         """Test the creation of a plain nexus workspace name"""
         rx = Recipe()
         res = rx._createNexusWorkspaceName(self.runConfigLite)
-        assert res == f"_TOF_{self.runConfigLite.runNumber}_lite"
+        assert res == f"TOFAllLite{self.runConfigLite.runNumber}"
         res = rx._createNexusWorkspaceName(self.runConfigNonlite)
-        assert res == f"_TOF_{self.runConfigNonlite.runNumber}"
+        assert res == f"TOFAll{self.runConfigNonlite.runNumber}"
 
     def test_nexus_workspacename_raw(self):
         """Test the creation of a raw nexus workspace name"""
         rx = Recipe()
         res = rx._createRawNexusWorkspaceName(self.runConfigLite)
-        plain = rx._createNexusWorkspaceName(self.runConfigLite)
-        assert res == plain + "_RAW"
+        rx._createNexusWorkspaceName(self.runConfigLite)
+        assert res == "TOFAllLiteRaw555"
 
     def test_nexus_workspacename_copy(self):
         """Test the creation of a copy nexus workspace name"""
         rx = Recipe()
         fakeCopies = 117
         res = rx._createCopyNexusWorkspaceName(self.runConfigLite, fakeCopies)
-        plain = rx._createNexusWorkspaceName(self.runConfigLite)
-        assert res == plain + "_copy_" + str(fakeCopies)
+        rx._createNexusWorkspaceName(self.runConfigLite)
+        assert res == f"TOFAllLite-Copy{fakeCopies}-555"
 
     def test_grouping_filename(self):
         """Test the creation of the grouping filename"""

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -144,16 +144,16 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         """Test the creation of a plain nexus workspace name"""
         rx = Recipe()
         res = rx._createNexusWorkspaceName(self.runConfigLite)
-        assert res == f"TOFAllLite{self.runConfigLite.runNumber}"
+        assert res == f"tof_all_lite_{self.runConfigLite.runNumber}"
         res = rx._createNexusWorkspaceName(self.runConfigNonlite)
-        assert res == f"TOFAll{self.runConfigNonlite.runNumber}"
+        assert res == f"tof_all_{self.runConfigNonlite.runNumber}"
 
     def test_nexus_workspacename_raw(self):
         """Test the creation of a raw nexus workspace name"""
         rx = Recipe()
         res = rx._createRawNexusWorkspaceName(self.runConfigLite)
         rx._createNexusWorkspaceName(self.runConfigLite)
-        assert res == "TOFAllLiteRaw555"
+        assert res == "tof_all_lite_555_raw"
 
     def test_nexus_workspacename_copy(self):
         """Test the creation of a copy nexus workspace name"""
@@ -161,7 +161,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         fakeCopies = 117
         res = rx._createCopyNexusWorkspaceName(self.runConfigLite, fakeCopies)
         rx._createNexusWorkspaceName(self.runConfigLite)
-        assert res == f"TOFAllLite-Copy{fakeCopies}-555"
+        assert res == f"tof_all_lite_555_copy{fakeCopies}"
 
     def test_grouping_filename(self):
         """Test the creation of the grouping filename"""

--- a/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
+++ b/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
@@ -6,7 +6,7 @@ def testRunNames():
     assert "dsp_all_123" == wng.run().runNumber(123).unit(wng.Units.DSP).build()
     assert "dsp_column_123" == wng.run().runNumber(123).unit(wng.Units.DSP).group(wng.Groups.COLUMN).build()
     assert (
-        "dsp_column_123_Test"
+        "dsp_column_123_test"
         == wng.run().runNumber(123).unit(wng.Units.DSP).group(wng.Groups.COLUMN).auxilary("Test").build()
     )
 
@@ -17,4 +17,4 @@ def testDiffCalInputNames():
 
 
 def testDiffCalTableName():
-    assert "_DIFC_123" == wng.diffCalTable().runNumber(123).build()
+    assert "_difc_123" == wng.diffCalTable().runNumber(123).build()

--- a/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
+++ b/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
@@ -3,15 +3,15 @@ from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as
 
 def testRunNames():
     assert "TOFAll123" == wng.run(123)
-    assert "DSPAll123" == wng.run(123, unit=wng.unit.DSP)
-    assert "DSPColumn123" == wng.run(123, unit=wng.unit.DSP, group=wng.group.COLUMN)
-    assert "DSPColumnTest123" == wng.run(123, unit=wng.unit.DSP, auxilary="Test", group=wng.group.COLUMN)
+    assert "DSPAll123" == wng.run(123, unit=wng.Units.DSP)
+    assert "DSPColumn123" == wng.run(123, unit=wng.Units.DSP, group=wng.Groups.COLUMN)
+    assert "DSPColumnTest123" == wng.run(123, unit=wng.Units.DSP, auxilary="Test", group=wng.Groups.COLUMN)
 
 
 def testDiffCalInputNames():
     assert "_TOF_123_raw" == wng.diffCalInput(123)
-    assert "_DSP_123_raw" == wng.diffCalInput(123, unit=wng.unit.DSP)
+    assert "_DSP_123_raw" == wng.diffCalInput(123, unit=wng.Units.DSP)
 
 
 def testDiffCalTableName():
-    assert "_DIFC_123" == wng.diffCalInput(123)
+    assert "_DIFC_123" == wng.diffCalTable(123)

--- a/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
+++ b/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
@@ -2,16 +2,19 @@ from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as
 
 
 def testRunNames():
-    assert "TOFAll123" == wng.run(123)
-    assert "DSPAll123" == wng.run(123, unit=wng.Units.DSP)
-    assert "DSPColumn123" == wng.run(123, unit=wng.Units.DSP, group=wng.Groups.COLUMN)
-    assert "DSPColumnTest123" == wng.run(123, unit=wng.Units.DSP, auxilary="Test", group=wng.Groups.COLUMN)
+    assert "TOFAll123" == wng.run().runNumber(123).build()
+    assert "DSPAll123" == wng.run().runNumber(123).unit(wng.Units.DSP).build()
+    assert "DSPColumn123" == wng.run().runNumber(123).unit(wng.Units.DSP).group(wng.Groups.COLUMN).build()
+    assert (
+        "DSPColumnTest123"
+        == wng.run().runNumber(123).unit(wng.Units.DSP).group(wng.Groups.COLUMN).auxilary("Test").build()
+    )
 
 
 def testDiffCalInputNames():
-    assert "_TOF_123_raw" == wng.diffCalInput(123)
-    assert "_DSP_123_raw" == wng.diffCalInput(123, unit=wng.Units.DSP)
+    assert "_TOF_123_raw" == wng.diffCalInput().runNumber(123).build()
+    assert "_DSP_123_raw" == wng.diffCalInput().runNumber(123).unit(wng.Units.DSP).build()
 
 
 def testDiffCalTableName():
-    assert "_DIFC_123" == wng.diffCalTable(123)
+    assert "_DIFC_123" == wng.diffCalTable().runNumber(123).build()

--- a/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
+++ b/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
@@ -2,18 +2,18 @@ from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as
 
 
 def testRunNames():
-    assert "TOFAll123" == wng.run().runNumber(123).build()
-    assert "DSPAll123" == wng.run().runNumber(123).unit(wng.Units.DSP).build()
-    assert "DSPColumn123" == wng.run().runNumber(123).unit(wng.Units.DSP).group(wng.Groups.COLUMN).build()
+    assert "tof_all_123" == wng.run().runNumber(123).build()
+    assert "dsp_all_123" == wng.run().runNumber(123).unit(wng.Units.DSP).build()
+    assert "dsp_column_123" == wng.run().runNumber(123).unit(wng.Units.DSP).group(wng.Groups.COLUMN).build()
     assert (
-        "DSPColumnTest123"
+        "dsp_column_123_Test"
         == wng.run().runNumber(123).unit(wng.Units.DSP).group(wng.Groups.COLUMN).auxilary("Test").build()
     )
 
 
 def testDiffCalInputNames():
-    assert "_TOF_123_raw" == wng.diffCalInput().runNumber(123).build()
-    assert "_DSP_123_raw" == wng.diffCalInput().runNumber(123).unit(wng.Units.DSP).build()
+    assert "_tof_123_raw" == wng.diffCalInput().runNumber(123).build()
+    assert "_dsp_123_raw" == wng.diffCalInput().runNumber(123).unit(wng.Units.DSP).build()
 
 
 def testDiffCalTableName():

--- a/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
+++ b/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
@@ -1,0 +1,17 @@
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
+
+
+def testRunNames():
+    assert "TOFAll123" == wng.run(123)
+    assert "DSPAll123" == wng.run(123, unit=wng.unit.DSP)
+    assert "DSPColumn123" == wng.run(123, unit=wng.unit.DSP, group=wng.group.COLUMN)
+    assert "DSPColumnTest123" == wng.run(123, unit=wng.unit.DSP, auxilary="Test", group=wng.group.COLUMN)
+
+
+def testDiffCalInputNames():
+    assert "_TOF_123_raw" == wng.diffCalInput(123)
+    assert "_DSP_123_raw" == wng.diffCalInput(123, unit=wng.unit.DSP)
+
+
+def testDiffCalTableName():
+    assert "_DIFC_123" == wng.diffCalInput(123)


### PR DESCRIPTION
## Description of work

This unifies our understanding and expectations for workspace names and what they refer to.  This enables us to inspect workspaces managed by SNAPRed and consistently at a glance know the what/how/where about it, which then in turn lets us manage them easily.  This also allows users to easily browse their workspaces in a categorically sorted order, collecting worspaces of similar units, groups, and types together in the gui.

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work

This is implemented through a meta service that constructs the names according to some `application.yml` properties, returning a `WorkspaceName` type that is a child of the base `str` type.  This lets it operate as a string but lets us typecheck workspace names to ensure their source of truth was the WorkspaceNameGenerator and not some arbitrary string.

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing

See that unit tests pass basically.

<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing

This is an enabler mostly and has only been added to the PixelDiffractionCalibration Algo

<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

``` python
# replace with your test script below
```

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->
Probably
[EWM#2986](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2986)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
