### PR TITLE
fix setuptools for deploy/pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ license = { text = "GPL3.0" }
 
 [tools.setuptools.dynamic.dependecies]
 
+[project.scripts]
+snapred = "snapred.__main__:main"
 
 [build-system]
 requires = ["setuptools", "wheel", "toml", "versioningit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,13 @@
 [project]
 name = "SNAPRed"
 description = "A desktop application for Lifecycle Managment of data collected from the SNAP instrument."
-dynamic = ["version"]
+dynamic = ["version", 'dependencies', 'optional-dependencies']
 requires-python = ">=3.8"
-dependencies = [
-    "mantidworkbench"
-]
+readme = "README.md"
+license = { text = "GPL3.0" }
+
+[tools.setuptools.dynamic.dependecies]
+
 
 [build-system]
 requires = ["setuptools", "wheel", "toml", "versioningit"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,6 @@ description = A package for performing SNAPRed analysis.
 long_description = file: README.md, LICENSE
 long_description_content_type = text/markdown
 url = https://github.com/neutrons/SNAPRed
-license = GPL3.0
 
 [options]
 package_dir=


### PR DESCRIPTION
## Description of work

Fixes setuptools so gui tests and deploys can pip install.

## Explanation of work

I added some missing props and removed the duplicate license members

## To test

### Dev testing

ci passes

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#3115](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3115)
