### PR TITLE
minimal change should auto switch between vals based on guide

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -110,6 +110,12 @@ Glossary
         A single collection of diffraction data that was collected at a specific point in time.
         It is identified by a unique ID, and is associated with a specific Instrument State and Calibration.
 
+    Run Number
+        The unique integer identifier of a Run.
+
+    Run ID
+        a Run Number, they are synonymous.
+
     Service Component
         The architectural Component that provides the individual units of backend fuctionality that a user may interact with.
         Examples include: Data Reduction, Calibration Quality Assessment, Instrument State Initialization, etc.

--- a/src/snapred/backend/dao/state/DetectorState.py
+++ b/src/snapred/backend/dao/state/DetectorState.py
@@ -7,6 +7,7 @@ class DetectorState(BaseModel):
     arc: Tuple[float, float]
     wav: float
     freq: float
+    # Expected to only be 0 or 1, potentially should be a bool
     guideStat: int
     # two additional values that don't define state, but are useful
     lin: Tuple[float, float]

--- a/src/snapred/backend/dao/state/InstrumentState.py
+++ b/src/snapred/backend/dao/state/InstrumentState.py
@@ -19,3 +19,7 @@ class InstrumentState(BaseModel):
     defaultGroupingSliceValue: float
     fwhmMultiplierLimit: Limit[float]
     peakTailCoefficient: float
+
+    @property
+    def delTh(self) -> float:
+        return self.detectorState.guideStat == 1 if self.hasGuide else self.instrumentConfig.delThNoGuide

--- a/src/snapred/backend/dao/state/InstrumentState.py
+++ b/src/snapred/backend/dao/state/InstrumentState.py
@@ -22,4 +22,8 @@ class InstrumentState(BaseModel):
 
     @property
     def delTh(self) -> float:
-        return self.detectorState.guideStat == 1 if self.hasGuide else self.instrumentConfig.delThNoGuide
+        return (
+            self.instrumentConfig.delThWithGuide
+            if self.detectorState.guideStat == 1
+            else self.instrumentConfig.delThNoGuide
+        )

--- a/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
@@ -43,7 +43,7 @@ class PixelGroupingParametersCalculationAlgorithm(PythonAlgorithm):
         self.delLOverL = instrumentState.instrumentConfig.delLOverL
         self.L = instrumentState.instrumentConfig.L1 + instrumentState.instrumentConfig.L2
         self.delL = self.delLOverL * self.L
-        self.delTheta = instrumentState.instrumentConfig.delThWithGuide
+        self.delTheta = instrumentState.instrumentConfig.delTh
         self.grouping_ws_name = "pgpca_grouping_ws"
         self.grouped_ws_name = "pgpca_grouped_ws"
         self.resolution_ws_name = "pgpca_resolution_ws"


### PR DESCRIPTION
## Description of work

Depending on whether or not the instrument has a guide in place, the delTh needs to switch between two configured values.  This should be the most minimal solution to enable such.
<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work

I use the guideStat value stored on DetectorState to decide which delTh to return.

## To test

### Dev testing

pytests pass as normal

### CIS testing

TODO

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#3225](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3225)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
