### PR TITLE
Fix AddSampleLog in PGP calculation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - python=3.10
 - pip
 - pydantic>=1.10,<2
-- mantidworkbench>=6.7
+- mantidworkbench>=6.8.20231213
 - qtpy
 - pre-commit
 - pytest

--- a/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
@@ -148,6 +148,11 @@ class PixelGroupingParametersCalculationAlgorithm(PythonAlgorithm):
         detectorState = instrumentState.detectorState
 
         # add sample logs with detector "arc" and "lin" parameters to the workspace
+        # NOTE after adding the logs, it is necessary to update the instrument to
+        #  factor in these new parameters, or else calculations will be inconsistent.
+        #  This is done with a call to `ws->populateInstrumentParameters()` from within mantid.
+        #  This call only needs to happen with the last log
+        logsAdded = 0
         for param_name in ["arc", "lin"]:
             for index in range(2):
                 self.mantidSnapper.AddSampleLog(
@@ -156,17 +161,9 @@ class PixelGroupingParametersCalculationAlgorithm(PythonAlgorithm):
                     LogName="det_" + param_name + str(index + 1),
                     LogText=str(getattr(detectorState, param_name)[index]),
                     LogType="Number Series",
+                    UpdateInstrumentParameters=(logsAdded >= 3),
                 )
-
-        # NOTE after adding the logs, it is necessary to update the instrument to
-        #  factor in these new parameters, or else calculations will be inconsistent.
-        #  This is done with a call to `ws->populateInstrumentParameters()` from within mantid.
-        self.mantidSnapper.AddSampleLog(
-            "Update the instrument",
-            Workspace=ws_name,
-            LogName="update_instrument",
-            UpdateInstrumentParameters=True,
-        )
+                logsAdded += 1
         self.mantidSnapper.executeQueue()
 
 

--- a/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
@@ -161,20 +161,11 @@ class PixelGroupingParametersCalculationAlgorithm(PythonAlgorithm):
         # NOTE after adding the logs, it is necessary to update the instrument to
         #  factor in these new parameters, or else calculations will be inconsistent.
         #  This is done with a call to `ws->populateInstrumentParameters()` from within mantid.
-        # TODO use this sample log, after Mantid PR 36524 has gone into main
-        # https://github.com/mantidproject/mantid/pull/36524
-        # self.mantidSnapper.AddSampleLog(
-        #     "Update the instrument",
-        #     Workspace=ws_name,
-        #     LogName="update_instrument",
-        #     UpdateInstrumentParameters=True,
-        # )
-        # TODO remove the below after uncommenting above.
-        minimalXML = "<parameter-file>></parameter-file>"
-        self.mantidSnapper.LoadParameterFile(
-            "Calling an algorithm that includes a populateInstrumentParamters and no file load",
+        self.mantidSnapper.AddSampleLog(
+            "Update the instrument",
             Workspace=ws_name,
-            ParameterXML=minimalXML,
+            LogName="update_instrument",
+            UpdateInstrumentParameters=True,
         )
         self.mantidSnapper.executeQueue()
 


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

In `PixelGroupingParametersCalculationAlgorithm`, it was necessary to make a call to `ws->populateInstrumentParameters()` from within mantid.  The only algorithms which achieved this were loading algorithms.  As a temporary solution, a mantid algorithm which could load instrument parameters from a "file" (the file here being an empty XML string) was used as a kludge.

Since [Mantid PR #36539](https://github.com/mantidproject/mantid/pull/36539), it is now possible to use `AddSampleLog` directly to update the instrument parameters.

## Explanation of work

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

It does nothing but call `AddSampleLog` with the parameter set to update the instrument, and deletes the previous kludgey call.

## To test

### Dev testing

If PGP calculation tests run, then the instrument was successfully updated, giving the correct values in the comparison calculation.

### CIS testing

This is internal and does not need CIS testing.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#3301](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3301)

Also related to 
[EWM#3280](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3280)

Useswork from [Mantid PR#36539](https://github.com/mantidproject/mantid/pull/36539)


<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
