### PR TITLE
Multi config key sub

### DIFF
--- a/src/snapred/meta/Config.py
+++ b/src/snapred/meta/Config.py
@@ -135,18 +135,35 @@ class _Config:
             self.refresh(f"{env_name}.yml", clearPrevious)
 
     # method to regex for string pattern of ${key} and replace with value
-    def _replace(self, value: str) -> str:
+    def _replace(self, value: str, remainingKeys) -> str:
         # if the value is not a string, then just return it
         if not isinstance(value, str):
             return value
 
         # Regex all keys of the form ${key.subkey} and store in a list
         regex = r"\$\{([a-zA-Z0-9_\.]+)\}"
-        matches = re.finditer(regex, value, re.MULTILINE)
+        matches = [match for match in re.finditer(regex, value, re.MULTILINE)]
         # replace all keys with their values
-        for match in matches:
-            key = match.group()[2:-1]
-            value = value.replace(f"${{{key}}}", self[key])
+        if(len(remainingKeys) == 0):
+            for match in matches:
+                key = match.group()[2:-1]
+                if(isinstance(self[key], dict)):
+                    return value
+                value = value.replace(f"${{{key}}}", self[key])
+        else:
+            match = matches[0]
+            rootKey = match.group()[2:-1]
+            key = rootKey
+            val = self[key]
+
+            # while val is a dict, keep appending keys
+            while isinstance(val, dict):
+                key = key + f".{remainingKeys.pop(0)}"
+                val = self[key]
+
+            value = value.replace(f"${{{rootKey}}}", val)
+            if(len(remainingKeys) > 0):
+                value = self._replace(value, remainingKeys)
 
         return value
 
@@ -154,12 +171,17 @@ class _Config:
     def __getitem__(self, key):
         keys = key.split(".")
         val = self._config[keys[0]]
+        totalProcessed = 0
         for k in keys[1:]:
             if val is None:
                 break
+            if isinstance(val, str):
+                break;
+            totalProcessed += 1
             val = val[k]
+
         if val is not None:
-            val = self._replace(val)
+            val = self._replace(val, keys[1+totalProcessed:])
         return val
 
 

--- a/src/snapred/meta/Config.py
+++ b/src/snapred/meta/Config.py
@@ -144,10 +144,10 @@ class _Config:
         regex = r"\$\{([a-zA-Z0-9_\.]+)\}"
         matches = [match for match in re.finditer(regex, value, re.MULTILINE)]
         # replace all keys with their values
-        if(len(remainingKeys) == 0):
+        if len(remainingKeys) == 0:
             for match in matches:
                 key = match.group()[2:-1]
-                if(isinstance(self[key], dict)):
+                if isinstance(self[key], dict):
                     return value
                 value = value.replace(f"${{{key}}}", self[key])
         else:
@@ -162,8 +162,8 @@ class _Config:
                 val = self[key]
 
             value = value.replace(f"${{{rootKey}}}", val)
-            if(len(remainingKeys) > 0):
-                value = self._replace(value, remainingKeys)
+            # if(len(remainingKeys) > 0):
+            value = self._replace(value, remainingKeys)
 
         return value
 
@@ -176,12 +176,12 @@ class _Config:
             if val is None:
                 break
             if isinstance(val, str):
-                break;
+                break
             totalProcessed += 1
             val = val[k]
 
         if val is not None:
-            val = self._replace(val, keys[1+totalProcessed:])
+            val = self._replace(val, keys[1 + totalProcessed :])
         return val
 
 

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -7,11 +7,8 @@ orchestration:
 instrument:
   name: SNAP
   home: /SNS/SNAP/
-  persistence:
-    read: ${instrument.home}
-    write: ${instrument.home}write/${instrument}
   calibration:
-    home: ${instrument.persistence}shared/Calibration
+    home: ${instrument.home}shared/Calibration
     sample:
       home: ${instrument.calibration.home}/CalibrantSamples
     powder:
@@ -30,9 +27,9 @@ instrument:
   lite:
     pixelResolution: 18432
     definition:
-      file: ${instrument.calibration.powder.home}/SNAPLite.xml
+      file: ${instrument.home}shared/Calibration/Powder/SNAPLite.xml
     map:
-      file: ${instrument.calibration.powder.home}/LiteGroupMap.hdf
+      file: ${instrument.home}shared/Calibration/Powder/LiteGroupMap.hdf
 
 nexus:
   lite:

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -7,8 +7,11 @@ orchestration:
 instrument:
   name: SNAP
   home: /SNS/SNAP/
+  persistence:
+    read: ${instrument.home}
+    write: ${instrument.home}write/${instrument}
   calibration:
-    home: ${instrument.home}shared/Calibration
+    home: ${instrument.persistence}shared/Calibration
     sample:
       home: ${instrument.calibration.home}/CalibrantSamples
     powder:
@@ -27,9 +30,9 @@ instrument:
   lite:
     pixelResolution: 18432
     definition:
-      file: ${instrument.home}shared/Calibration/Powder/SNAPLite.xml
+      file: ${instrument.calibration.powder.home}/SNAPLite.xml
     map:
-      file: ${instrument.home}shared/Calibration/Powder/LiteGroupMap.hdf
+      file: ${instrument.calibration.powder.home}/LiteGroupMap.hdf
 
 nexus:
   lite:

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -116,7 +116,7 @@ test:
   config:
     name: test
     home: /some/path
-  perisistence:
+  persistence:
     read: ${test.config.home}
     write: ~/${test.config.home}
   data:

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -112,4 +112,14 @@ samples:
   home: /SNS/SNAP/shared/Calibration/CalibrantSamples
 
 
+test:
+  config:
+    name: test
+    home: /some/path
+  perisistence:
+    read: ${test.config.home}
+    write: ~/${test.config.home}
+  data:
+    home: ${test.persistence}/data/${test.config.name}
+
 cis_mode: true

--- a/tests/unit/meta/test_config.py
+++ b/tests/unit/meta/test_config.py
@@ -52,3 +52,8 @@ def test_key_substitution():
     Config._config["test"]["key"] = "value"
     Config._config["test"]["substitution"] = testString
     assert Config["test.substitution"] == "This is a test string with a value in it"
+
+
+def test_multi_level_substitution():
+    assert Config["test.data.home.write"] == f'~/{Config["test.config.home"]}{Config["test.config.name"]}'
+    assert Config["test.data.home.read"] == f'{Config["test.config.home"]}{Config["test.config.name"]}'

--- a/tests/unit/meta/test_config.py
+++ b/tests/unit/meta/test_config.py
@@ -55,5 +55,5 @@ def test_key_substitution():
 
 
 def test_multi_level_substitution():
-    assert Config["test.data.home.write"] == f'~/{Config["test.config.home"]}{Config["test.config.name"]}'
-    assert Config["test.data.home.read"] == f'{Config["test.config.home"]}{Config["test.config.name"]}'
+    assert Config["test.data.home.write"] == f'~/{Config["test.config.home"]}/data/{Config["test.config.name"]}'
+    assert Config["test.data.home.read"] == f'{Config["test.config.home"]}/data/{Config["test.config.name"]}'


### PR DESCRIPTION
## Description of work

This enables multilevel key substitution in the yaml.

What that means is if the supplied key terminates at a map for a given string, you may continue to add keys to the end of your lookup string to solve the true template value.

This is useful in the case that you want 2 roots for a given value uniformly across a set of keys, i.e. separate read and write directories.

## Explanation of work

As above, but see tests for concrete examples

## To test

### Dev testing

tests pass, try to make your own .

### CIS testing

none.

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->
