### PR TITLE
update calibration home references to one spot

### DIFF
--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -78,7 +78,7 @@ class LocalDataService:
             raise _createFileNotFoundError("Config['instrument.home']", self.dataPath)
 
         # look for the config file and verify it exists
-        self.instrumentConfigPath = self.dataPath / Config["instrument.config"]
+        self.instrumentConfigPath = Config["instrument.config"]
 
     def readInstrumentConfig(self) -> InstrumentConfig:
         self._determineInstrConfigPaths()

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -19,7 +19,7 @@ instrument:
         home: ${instrument.calibration.powder.home}/PixelGroupingDefinitions
         extensions:
           - lite.hdf
-  config: ${instrument.calibration.home}SNAPInstPrm.json
+  config: ${instrument.calibration.home}/SNAPInstPrm.json
   native:
     pixelResolution: 1179648
     definition:

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -19,7 +19,7 @@ instrument:
         home: ${instrument.calibration.powder.home}/PixelGroupingDefinitions
         extensions:
           - lite.hdf
-  config: shared/Calibration/SNAPInstPrm.json
+  config: ${instrument.calibration.home}SNAPInstPrm.json
   native:
     pixelResolution: 1179648
     definition:
@@ -27,9 +27,9 @@ instrument:
   lite:
     pixelResolution: 18432
     definition:
-      file: ${instrument.home}shared/Calibration/Powder/SNAPLite.xml
+      file: ${instrument.calibration.home}/Powder/SNAPLite.xml
     map:
-      file: ${instrument.home}shared/Calibration/Powder/LiteGroupMap.hdf
+      file: ${instrument.calibration.home}/Powder/LiteGroupMap.hdf
 
 nexus:
   lite:
@@ -109,6 +109,6 @@ logging:
     format: '%(asctime)s - %(levelname)-8s - %(name)s - %(message)s'
 
 samples:
-  home: /SNS/SNAP/shared/Calibration/CalibrantSamples
+  home: ${instrument.calibration.home}/CalibrantSamples
 
 cis_mode: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ mockSingleton.Singleton = mock_decorator
 mock.patch.dict("sys.modules", {"snapred.meta.decorators.Singleton": mockSingleton}).start()
 
 # manually alter the config to point to the test resources
-Config._config["instrument"]["home"] = Resource.getPath(Config["instrument.home"])
+Config._config["instrument"]["home"] = Resource.getPath("inputs")
 Config._config["samples"]["home"] = Resource.getPath("outputs/sample/")
 mantidConfig = config = ConfigService.Instance()
 mantidConfig["CheckMantidVersion.OnStartup"] = "0"

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -21,7 +21,7 @@ instrument:
           - xml
           - nxs
           - hdf
-  config: shared/Calibration/SNAPInstPrm.json
+  config: ${instrument.calibration.home}/SNAPInstPrm.json
   native:
     pixelResolution: 1179648
     definition:
@@ -29,9 +29,9 @@ instrument:
   lite:
     pixelResolution: 18432
     definition:
-      file: ${instrument.home}shared/Calibration/Powder/SNAPLite.xml
+      file: ${instrument.calibration.home}/Powder/SNAPLite.xml
     map:
-      file: ${instrument.home}shared/Calibration/Powder/LiteGroupMap.hdf
+      file: ${instrument.calibration.home}/Powder/LiteGroupMap.hdf
 
 nexus:
   lite:
@@ -111,7 +111,7 @@ logging:
     format: '%Y-%m-%d %H:%M:%S,%i - %p - %s - %t'
 
 samples:
-  home: /SNS/SNAP/shared/Calibration/CalibrantSamples
+  home: ${instrument.calibration.home}/CalibrantSamples
 
 
 cis_mode: true

--- a/tests/resources/test.yml
+++ b/tests/resources/test.yml
@@ -1,5 +1,7 @@
 instrument:
-  config: ${instrument.calibration.home}/inputs/SNAPInstPrm.json
+  config: ${instrument.calibration.home}/SNAPInstPrm.json
+  calibration:
+    home: ${instrument.home}
 
 localdataservice:
   config:

--- a/tests/resources/test.yml
+++ b/tests/resources/test.yml
@@ -1,5 +1,4 @@
 instrument:
-  home: ""
   config: inputs/SNAPInstPrm.json
 
 localdataservice:

--- a/tests/resources/test.yml
+++ b/tests/resources/test.yml
@@ -1,5 +1,5 @@
 instrument:
-  config: inputs/SNAPInstPrm.json
+  config: ${instrument.calibration.home}/inputs/SNAPInstPrm.json
 
 localdataservice:
   config:

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -531,9 +531,11 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         # get a handle on the service
         service = LocalDataService()
         service.verifyPaths = True  # override test setting
+        prevInstrumentHome = Config._config["instrument"]["home"]
+        Config._config["instrument"]["home"] = "/this/path/does/not/exist"
         with pytest.raises(FileNotFoundError):
             service.readInstrumentConfig()
-
+        Config._config["instrument"]["home"] = prevInstrumentHome
         service.verifyPaths = False  # put the setting back
 
     def test_readSamplePaths():

--- a/tests/unit/meta/test_config.py
+++ b/tests/unit/meta/test_config.py
@@ -12,7 +12,7 @@ def test_find_root_dir():
 
 def test_instrument_home():
     # test verifies that the end of the path is correct
-    correctPathEnding = "/tests/resources/"
+    correctPathEnding = "/tests/resources/inputs"
     assert Config["instrument.home"].endswith(correctPathEnding)
 
 


### PR DESCRIPTION
## Description of work

Cleans up some references in the `application.yml` to the calibration.home that didnt actually refer to the calibration home value
## To test
CI passes



**TODO**
Make EWM ticket
[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
