### PR TITLE
do not extrapolate smoothed data

### DIFF
--- a/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
@@ -20,7 +20,7 @@ from mantid.api import (
     PythonAlgorithm,
 )
 from mantid.kernel import Direction
-from scipy.interpolate import make_smoothing_spline, splev
+from scipy.interpolate import make_smoothing_spline
 
 from snapred.backend.dao.ingredients import SmoothDataExcludingPeaksIngredients as Ingredients
 from snapred.backend.recipe.algorithm.DiffractionSpectrumWeightCalculator import DiffractionSpectrumWeightCalculator
@@ -98,8 +98,10 @@ class SmoothDataExcludingPeaksAlgo(PythonAlgorithm):
         for index in range(numSpec):
             x = inputWorkspace.readX(index)
             y = inputWorkspace.readY(index)
+
             weightX = weight_ws.readX(index)
             weightY = weight_ws.readY(index)
+
             weightXMidpoints = (weightX[:-1] + weightX[1:]) / 2
             xMidpoints = (x[:-1] + x[1:]) / 2
 
@@ -108,7 +110,7 @@ class SmoothDataExcludingPeaksAlgo(PythonAlgorithm):
             # Generate spline with purged dataset
             tck = make_smoothing_spline(weightXMidpoints, y, lam=self.lam)
             # fill in the removed data using the spline function and original datapoints
-            smoothing_results = splev(xMidpoints, tck)
+            smoothing_results = tck(xMidpoints, extrapolate=False)
             outputWorkspace.setY(index, smoothing_results)
 
         self.mantidSnapper.WashDishes(


### PR DESCRIPTION
peaks removed at the edges of data causes weird artifacts when extrapolated

## Description of work

This should take care of the artifacting we were seeing at the ends of smoothed workspaces.  
It seems to be caused by some limitation of the spline, where if you request data outside its expected range on either of the ends of the spline, it sort of just follows where the line was going, or nan, or however the periodic version calculates them.

I think the artifacts I had seen were because peaks were removed at the start of a spectrum and thus didnt have 2 points to connect, it just did its best to guess.

We may want to consider a slightly more complicated approach where we instead harshly smooth the each of the found peaks out of existence instead of just removing them and guessing with a spline.

## Explanation of work

Turns out the spline returned by make_smooth_spline has a way to determine how to treat data outside its intended range.

## To test

### Dev testing

tests still pass

### CIS testing

Observe rebinSmoothed vs tof_all_lite_58810_copy1_beforeRebin

``` python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from pydantic import parse_file_as
import json

from snapred.backend.recipe.algorithm.CalibrationNormalizationAlgo import CalibrationNormalizationAlgo
from snapred.backend.dao.ingredients.NormalizationCalibrationIngredients import NormalizationCalibrationIngredients
from snapred.backend.dao.ingredients.SmoothDataExcludingPeaksIngredients import SmoothDataExcludingPeaksIngredients
from snapred.backend.recipe.algorithm.SmoothDataExcludingPeaksAlgo import SmoothDataExcludingPeaksAlgo

from snapred.backend.dao.ingredients.PixelGroupingIngredients import PixelGroupingIngredients
from snapred.backend.dao.state.PixelGroup import PixelGroup
from snapred.backend.service.CrystallographicInfoService import CrystallographicInfoService
from snapred.backend.data.DataFactoryService import DataFactoryService
from snapred.backend.service.CalibrationService import CalibrationService
from snapred.backend.dao.state.CalibrantSample.CalibrantSamples import CalibrantSamples
from snapred.backend.dao.calibration import CalibrationRecord, Calibration

from snapred.backend.recipe.FetchGroceriesRecipe import FetchGroceriesRecipe as FetchRx
from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem

from snapred.backend.recipe.PixelGroupingParametersCalculationRecipe import PixelGroupingParametersCalculationRecipe
from snapred.meta.Config import Config

# for loading data
from snapred.backend.recipe.FetchGroceriesRecipe import FetchGroceriesRecipe as FetchRx
from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem


#User input ###############################################################################################
isLite = True
runNumber = "58810"
backgroundRunNumber = "58813"
samplePath = "/SNS/SNAP/shared/Calibration_dynamic/CalibrantSamples/Silicon_NIST_640D_001.json"
cifPath = "/SNS/SNAP/shared/Calibration/CalibrantSamples/Silicon_NIST_640d.cif"
groupPath = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGrp_Column.lite.xml"
calibrationWorkspace = "/SNS/users/dzj/Desktop/58810_calibration_ws.nxs" # need to create this using diffc_test.py with run number 58810
smoothingParam = 0.5
groupingScheme = "Column"
calibrationStatePath = "/SNS/SNAP/shared/Calibration/Powder/04bd2c53f6bf6754/57514/v_1/CalibrationParameters.json" # need to change this!!!!!!
###########################################################################################################
def getCalibrantSample(samplePath):
    with open(samplePath, 'r') as file:
        sampleJson = json.load(file)
    del sampleJson["material"]["packingFraction"]
    for atom in sampleJson["crystallography"]["atoms"]:
        atom["symbol"] = atom.pop("atom_type")
        atom["coordinates"] = atom.pop("atom_coordinates")
        atom["siteOccupationFactor"] = atom.pop("site_occupation_factor")
    sample = CalibrantSamples.parse_raw(json.dumps(sampleJson))
    return sample
###########################################################################################################

DFS = DataFactoryService()
instrumentState = DFS.getCalibrationState(runNumber).instrumentState


### FETCH GROCERIES ##################
groceryList = [
    GroceryListItem.makeLiteNexusItem(runNumber).toggleLiteMode(isLite),
    GroceryListItem.makeLiteNexusItem(backgroundRunNumber).toggleLiteMode(isLite),
    GroceryListItem.makeLiteGroupingItemFrom(groupingScheme, "prev").toggleLiteMode(isLite),
]
groceries = FetchRx().executeRecipe(groceryList)["workspaces"]

pgpIngredients = PixelGroupingIngredients(
    instrumentState = instrumentState,
    instrumentDefinitionFile = Config["instrument.lite.definition.file"],
    groupingWorkspace=groceries[2],
)

pgp = PixelGroupingParametersCalculationRecipe().executeRecipe(pgpIngredients, groceries[2])["parameters"]
instrumentState.pixelGroup = PixelGroup(pixelGroupingParameters=pgp)
reductionIngredients = DFS.getReductionIngredients(runNumber, instrumentState.pixelGroup)

calibrantSample = getCalibrantSample(samplePath)

crystalInfo = CrystallographicInfoService().ingest(cifPath)["crystalInfo"]
smoothDataIngredients = SmoothDataExcludingPeaksIngredients(
    smoothingParameter=smoothingParam,
    instrumentState=instrumentState,
    crystalInfo=crystalInfo,
)

backgroundReductionIngredients = reductionIngredients
backgroundReductionIngredients.runConfig.runNumber = backgroundRunNumber

ingredients = NormalizationCalibrationIngredients(
    reductionIngredients=reductionIngredients,
    backgroundReductionIngredients=backgroundReductionIngredients,
    calibrantSample=calibrantSample,
    smoothDataIngredients=smoothDataIngredients,
)



CNA = CalibrationNormalizationAlgo()
CNA.initialize()
CNA.setProperty("InputWorkspace", groceries[0])
CNA.setProperty("BackgroundWorkspace", groceries[1])
CNA.setProperty("GroupingWorkspace", groceries[2])
CNA.setProperty("OutputWorkspace", groceries[0])
CNA.setProperty("Ingredients", ingredients.json())
CNA.execute()

smoothingParam=0.05
smoothDataIngredients = SmoothDataExcludingPeaksIngredients(
    smoothingParameter=smoothingParam,
    instrumentState=instrumentState,
    crystalInfo=crystalInfo,
)

RebinToWorkspace("tof_all_lite_58810_copy1_beforeRebin", "tof_all_lite_58810_copy1_beforeRebin", OutputWorkspace="rebin", PreserveEvents=False)

algo = SmoothDataExcludingPeaksAlgo()
algo.initialize()
algo.setProperty("Ingredients", smoothDataIngredients.json())
algo.setProperty("InputWorkspace", "rebin")
algo.setProperty("OutputWorkspace", f"rebinSmoothed{smoothingParam}")
algo.execute()
```

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#3144](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3144)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
