### PR TITLE
warnings in workflows now create ui popups + Some grocery/lite fixes

### DIFF
--- a/src/snapred/backend/api/InterfaceController.py
+++ b/src/snapred/backend/api/InterfaceController.py
@@ -14,11 +14,15 @@ class InterfaceController:
         # make a singleton instance if one doesnt exist
         self.logger = snapredLogger.getLogger(self.__class__.__name__)
 
+    def getWarnings(self):
+        return "\n".join(snapredLogger.getWarnings())
+
     def executeRequest(self, request: SNAPRequest) -> SNAPResponse:
         # execute the recipe
         # return the result
         try:
             self.logger.debug(f"Request Received: {request.json()}")
+            snapredLogger.clearWarnings()
             # leaving this a separate line makes stack traces make more sense
             service = self.serviceFactory.getService(request.path)
             # run the recipe
@@ -27,7 +31,7 @@ class InterfaceController:
 
             message = None
             if snapredLogger.hasWarnings():
-                message = "\n".join(snapredLogger.getWarnings())
+                message = self.getWarnings()
                 snapredLogger.clearWarnings()
             response = SNAPResponse(code=200, message=message, data=result)
         except Exception as e:  # noqa BLE001

--- a/src/snapred/backend/api/InterfaceController.py
+++ b/src/snapred/backend/api/InterfaceController.py
@@ -24,7 +24,12 @@ class InterfaceController:
             # run the recipe
             result = service.orchestrateRecipe(request)
             # convert the response into object to communicate with
-            response = SNAPResponse(code=200, message=None, data=result)
+
+            message = None
+            if snapredLogger.hasWarnings():
+                message = "\n".join(snapredLogger.getWarnings())
+                snapredLogger.clearWarnings()
+            response = SNAPResponse(code=200, message=message, data=result)
         except Exception as e:  # noqa BLE001
             # handle exceptions, inform client if recoverable
             self.logger.exception("Failed to call service")

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -21,9 +21,10 @@ class GroceryService:
     Just send me a list.
     """
 
-    _loadedRuns: Dict[Tuple[str, bool], int] = {}
-    _loadedGroupings: Dict[Tuple[str, bool], str] = {}
-    grocer = FetchGroceriesRecipe()
+    def __init__(self):
+        self._loadedRuns: Dict[Tuple[str, bool], int] = {}
+        self._loadedGroupings: Dict[Tuple[str, bool], str] = {}
+        self.grocer = FetchGroceriesRecipe()
 
     def _key(self, using: str, useLiteMode: bool) -> Tuple[str, bool]:
         """

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -21,10 +21,9 @@ class GroceryService:
     Just send me a list.
     """
 
-    def __init__(self) -> None:
-        self._loadedRuns: Dict[(str, bool), int] = {}
-        self._loadedGroupings: Dict[(str, bool), str] = {}
-        self.grocer = FetchGroceriesRecipe()
+    _loadedRuns: Dict[Tuple[str, bool], int] = {}
+    _loadedGroupings: Dict[Tuple[str, bool], str] = {}
+    grocer = FetchGroceriesRecipe()
 
     def _key(self, using: str, useLiteMode: bool) -> Tuple[str, bool]:
         """

--- a/src/snapred/backend/log/logger.py
+++ b/src/snapred/backend/log/logger.py
@@ -44,6 +44,7 @@ class CustomFormatter(logging.Formatter):
 @Singleton
 class _SnapRedLogger:
     _level = Config["logging.level"]
+    _warnings = []
 
     def __init__(self):
         # Configure Mantid to send messages to Python
@@ -59,10 +60,26 @@ class _SnapRedLogger:
         logger.addHandler(ch)
         return logger
 
+    def _warning(self, message, vanillaWarn):
+        self._warnings.append(message)
+        vanillaWarn(message)
+
+    def getWarnings(self):
+        return self._warnings
+
+    def hasWarnings(self):
+        return len(self._warnings) > 0
+
+    def clearWarnings(self):
+        self._warnings = []
+
     def getLogger(self, name):
         logger = logging.getLogger(name)
         logger.setLevel(self._level)
         self._setFormatter(logger)
+        vanillaWarn = logger.warning
+        logger.warning = lambda message: self._warning(message, vanillaWarn)
+        logger.warn = lambda message: self._warning(message, vanillaWarn)
         return logger
 
 

--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -142,6 +142,9 @@ class MantidSnapper:
                 # this line is to appease mantid properties, idk where its pulling empty string from
                 if str(val.__class__) == str(callback(int).__class__):
                     val = val.get()
+                if val is None:
+                    continue
+
                 algorithm.setProperty(prop, val)
             if not algorithm.execute():
                 raise RuntimeError(f"{name} failed to execute")

--- a/src/snapred/backend/service/LiteDataService.py
+++ b/src/snapred/backend/service/LiteDataService.py
@@ -30,9 +30,9 @@ class LiteDataService(Service):
         self,
         inputWorkspace: WorkspaceName,
         outputWorkspace: WorkspaceName,
-        instrumentDefinition: str = "",
+        instrumentDefinition: str = None,
     ) -> Dict[Any, Any]:
-        liteDataMap = self._ensureLiteDataMap(self)
+        liteDataMap = self._ensureLiteDataMap()
         try:
             data = Recipe().executeRecipe(
                 InputWorkspace=inputWorkspace,

--- a/src/snapred/meta/decorators/Singleton.py
+++ b/src/snapred/meta/decorators/Singleton.py
@@ -5,6 +5,12 @@ def Singleton(orig_cls):
     orig_new = orig_cls.__new__
     instance = None
 
+    @wraps(orig_cls.__init__)
+    def __init__(self, *args, **kwargs):
+        if instance is not None:
+            return
+        orig_cls.__init__(self, *args, **kwargs)
+
     @wraps(orig_cls.__new__)
     def __new__(cls, *args, **kwargs):
         nonlocal instance

--- a/src/snapred/meta/decorators/Singleton.py
+++ b/src/snapred/meta/decorators/Singleton.py
@@ -3,14 +3,17 @@ from functools import wraps
 
 def Singleton(orig_cls):
     orig_new = orig_cls.__new__
+    orig_init = orig_cls.__init__
     instance = None
+    initialized = False
 
     @wraps(orig_cls.__init__)
     def __init__(self, *args, **kwargs):
-        nonlocal instance
-        if instance is not None:
+        nonlocal initialized
+        if initialized is True:
             return
-        orig_cls.__init__(self, *args, **kwargs)
+        initialized = True
+        orig_init(self, *args, **kwargs)
 
     @wraps(orig_cls.__new__)
     def __new__(cls, *args, **kwargs):
@@ -20,4 +23,5 @@ def Singleton(orig_cls):
         return instance
 
     orig_cls.__new__ = __new__
+    orig_cls.__init__ = __init__
     return orig_cls

--- a/src/snapred/meta/decorators/Singleton.py
+++ b/src/snapred/meta/decorators/Singleton.py
@@ -7,6 +7,7 @@ def Singleton(orig_cls):
 
     @wraps(orig_cls.__init__)
     def __init__(self, *args, **kwargs):
+        nonlocal instance
         if instance is not None:
             return
         orig_cls.__init__(self, *args, **kwargs)

--- a/src/snapred/ui/presenter/WorkflowPresenter.py
+++ b/src/snapred/ui/presenter/WorkflowPresenter.py
@@ -52,12 +52,12 @@ class WorkflowPresenter(object):
         self.worker = self.worker_pool.createWorker(target=model.continueAction, args=(self))
         self.worker.finished.connect(lambda: self.view.continueButton.setEnabled(True))
         self.worker.finished.connect(lambda: self.view.cancelButton.setEnabled(True))
-        self.worker.result.connect(self._handleFailure)
+        self.worker.result.connect(self._handleComplications)
         self.worker.success.connect(lambda success: self.view.advanceWorkflow() if success else None)
 
         self.worker_pool.submitWorker(self.worker)
 
-    def _handleFailure(self, result):
+    def _handleComplications(self, result):
         if result.code - 200 > 100:
             QMessageBox.critical(
                 self.view,
@@ -66,3 +66,13 @@ class WorkflowPresenter(object):
                 QMessageBox.Ok,
                 QMessageBox.Ok,
             )
+        elif result.message:
+            messageBox = QMessageBox(
+                QMessageBox.Warning,
+                "Warning",
+                "Proccess completed successfully with warnings!",
+                QMessageBox.Ok,
+                self.view,
+            )
+            messageBox.setDetailedText(f"{result.message}")
+            messageBox.exec()

--- a/tests/unit/backend/api/test_InterfaceController.py
+++ b/tests/unit/backend/api/test_InterfaceController.py
@@ -1,5 +1,7 @@
 import unittest.mock as mock
 
+import pytest
+
 # Mock out of scope modules before importing InterfaceController
 with mock.patch.dict(
     "sys.modules",
@@ -16,6 +18,8 @@ with mock.patch.dict(
         """Mock InterfaceController"""
         interfaceController = InterfaceController()
         interfaceController.serviceFactory = mock.Mock()
+        interfaceController.getWarnings = mock.Mock()
+        interfaceController.getWarnings.return_value = None
         # when serviceFactory.getService is called with value 'Test Service', return a mock service
         mockService = mock.Mock()
         mockService.orchestrateRecipe.return_value = {"result": "Success!"}

--- a/tests/unit/backend/log/test_logger.py
+++ b/tests/unit/backend/log/test_logger.py
@@ -4,6 +4,7 @@ logger = snapredLogger.getLogger(__name__)
 
 
 def test_collectWarnings():
+    snapredLogger.clearWarnings()
     logger.warn("Warning 1")
     logger.warn("Warning 2")
     logger.warn("Warning 3")

--- a/tests/unit/backend/log/test_logger.py
+++ b/tests/unit/backend/log/test_logger.py
@@ -1,0 +1,13 @@
+from snapred.backend.log.logger import snapredLogger
+
+logger = snapredLogger.getLogger(__name__)
+
+
+def test_collectWarnings():
+    logger.warn("Warning 1")
+    logger.warn("Warning 2")
+    logger.warn("Warning 3")
+    assert snapredLogger.hasWarnings()
+    assert len(snapredLogger.getWarnings()) == 3
+    snapredLogger.clearWarnings()
+    assert not snapredLogger.hasWarnings()

--- a/tests/unit/backend/recipe/algorithm/test_SaveGroupingDefinition.py
+++ b/tests/unit/backend/recipe/algorithm/test_SaveGroupingDefinition.py
@@ -90,7 +90,7 @@ class TestSaveGroupingDefinition(unittest.TestCase):
             except ValueError:
                 print(f"Workspace {workspace} doesn't exist!")
 
-    def getInstrumentDefinitionFilePath(isLocalTest, isLiteInstrument):
+    def getInstrumentDefinitionFilePath(self, isLocalTest, isLiteInstrument):
         if isLocalTest:
             if isLiteInstrument:
                 return Resource.getPath("inputs/pixel_grouping/SNAPLite_Definition.xml")


### PR DESCRIPTION
also some fixes to groceryservice and litedataservice

## Description of work

I setup snapredlogger to track warns and return any that appear during backend processing.
I also fixed some bugs I ran into along the way.

## To test

Insert a warn statement somewhere in a call consumed by a workflow. Then run the workflow from the ui.

## Link to EWM item
TODO

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
