### PR TITLE
Limit iterations of PixelDiffractionCalibration

### DIFF
--- a/src/snapred/backend/dao/ingredients/DiffractionCalibrationIngredients.py
+++ b/src/snapred/backend/dao/ingredients/DiffractionCalibrationIngredients.py
@@ -20,4 +20,4 @@ class DiffractionCalibrationIngredients(BaseModel):
     groupedPeakLists: List[GroupPeakList]
     calPath: str
     convergenceThreshold: float
-    maxOffset: float = 2.0
+    maxOffset: float = 10.0

--- a/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
+++ b/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
@@ -20,3 +20,4 @@ class DiffractionCalibrationRequest(BaseModel):
     convergenceThreshold: Optional[float] = Config["calibration.diffraction.convergenceThreshold"]
     peakIntensityThreshold: Optional[float] = Config["calibration.diffraction.peakIntensityThreshold"]
     nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]
+    maximumOffset: float = Config["calibration.diffraction.maximumOffset"]

--- a/src/snapred/backend/recipe/DiffractionCalibrationRecipe.py
+++ b/src/snapred/backend/recipe/DiffractionCalibrationRecipe.py
@@ -63,8 +63,8 @@ class DiffractionCalibrationRecipe:
         except RuntimeError as e:
             errorString = str(e)
             raise Exception(errorString.split("\n")[0])
-        counter = 0
-        while abs(medianOffsets[-1]) > self.threshold:
+        counter = 1
+        while abs(medianOffsets[-1]) > self.threshold and counter < 5:
             counter = counter + 1
             logger.info(f"... converging to answer; step {counter}, {medianOffsets[-1]} > {self.threshold}")
             try:

--- a/src/snapred/backend/recipe/DiffractionCalibrationRecipe.py
+++ b/src/snapred/backend/recipe/DiffractionCalibrationRecipe.py
@@ -6,6 +6,7 @@ from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.GroupDiffractionCalibration import GroupDiffractionCalibration
 from snapred.backend.recipe.algorithm.PixelDiffractionCalibration import PixelDiffractionCalibration
 from snapred.backend.recipe.algorithm.WashDishes import WashDishes
+from snapred.meta.Config import Config
 from snapred.meta.decorators.Singleton import Singleton
 
 logger = snapredLogger.getLogger(__name__)
@@ -23,6 +24,7 @@ class DiffractionCalibrationRecipe:
         self.runNumber = ingredients.runConfig.runNumber
         self.threshold = ingredients.convergenceThreshold
         self.calPath = ingredients.calPath
+        self.maxIterations = Config["calibration.diffraction.maximumIterations"]
 
     def unbagGroceries(self, groceries: Dict[str, Any]):
         """
@@ -64,7 +66,7 @@ class DiffractionCalibrationRecipe:
             errorString = str(e)
             raise Exception(errorString.split("\n")[0])
         counter = 1
-        while abs(medianOffsets[-1]) > self.threshold and counter < 5:
+        while abs(medianOffsets[-1]) > self.threshold and counter < self.maxIterations:
             counter = counter + 1
             logger.info(f"... converging to answer; step {counter}, {medianOffsets[-1]} > {self.threshold}")
             try:

--- a/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
@@ -256,8 +256,9 @@ class PixelDiffractionCalibration(PythonAlgorithm):
         offsets = list(self.mantidSnapper.mtd[totalOffsetWS].extractY().ravel())
         offsets = [abs(x) for x in offsets]  # ignore negative
         data["medianOffset"] = abs(np.median(offsets))
+        data["meanOffset"] = abs(np.mean(offsets))
 
-        if data["medianOffset"] < self._prevMedianOffset:
+        if data["medianOffset"] <= self._prevMedianOffset:
             # get difcal corrected by offsets
             self.mantidSnapper.ConvertDiffCal(
                 "Correct previous calibration constants by offsets",

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -183,6 +183,7 @@ class CalibrationService(Service):
             calPath=calpath,
             convergenceThreshold=convergenceThreshold,
             pixelGroup=instrumentState.pixelGroup,
+            maxOffset=request.maximumOffset,
         )
         focusFile = request.focusGroupPath.split("/")[-1]
         focusName = focusFile.split(".")[0]

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -62,6 +62,7 @@ calibration:
       extension: .nxs
       format: "{}_calibration_reduction_result"
   diffraction:
+    maximumIterations: 5
     convergenceThreshold: 0.05
     peakIntensityThreshold: 0.05
     nBinsAcrossPeakWidth: 10

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -63,9 +63,10 @@ calibration:
       format: "{}_calibration_reduction_result"
   diffraction:
     maximumIterations: 5
-    convergenceThreshold: 0.05
+    convergenceThreshold: 0.5
     peakIntensityThreshold: 0.05
     nBinsAcrossPeakWidth: 10
+    maximumOffset: 10
   parameters:
     default:
       # degrees

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -69,6 +69,7 @@ calibration:
     convergenceThreshold: 0.05
     peakIntensityThreshold: 0.05
     nBinsAcrossPeakWidth: 10
+    maximumIterations: 5
   parameters:
     default:
       # degrees

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -66,10 +66,11 @@ calibration:
       extension: .nxs
       format: "{}_calibration_reduction_result"
   diffraction:
-    convergenceThreshold: 0.05
+    convergenceThreshold: 0.5
     peakIntensityThreshold: 0.05
     nBinsAcrossPeakWidth: 10
     maximumIterations: 5
+    maximumOffset: 10
   parameters:
     default:
       # degrees

--- a/tests/unit/backend/recipe/test_DiffractionCalibrationRecipe.py
+++ b/tests/unit/backend/recipe/test_DiffractionCalibrationRecipe.py
@@ -275,12 +275,12 @@ class TestDiffractionCalibtationRecipe(unittest.TestCase):
     @mock.patch(GroupCalAlgo)
     def test_ensure_monotonic(self, mockGroupAlgo, mockPixelAlgo):
         mockAlgo = mock.Mock()
-        mockAlgo.getPropertyValue.side_effect = [f'{{"medianOffset": {i}}}' for i in [4, 3, 2, 1, 4, 0]]
+        mockAlgo.getPropertyValue.side_effect = [f'{{"medianOffset": {i}}}' for i in [2, 1, 2, 0]]
         mockPixelAlgo.return_value = mockAlgo
         mockGroupAlgo.return_value.getPropertyValue.return_value = "fake"
         result = self.recipe.executeRecipe(self.fakeIngredients, self.groceryList)
         assert result["result"]
-        assert result["steps"] == [{"medianOffset": i} for i in [4, 3, 2, 1]]
+        assert result["steps"] == [{"medianOffset": i} for i in [2, 1]]
         assert result["calibrationTable"] == "fake"
         assert result["outputWorkspace"] == "fake"
 

--- a/tests/unit/backend/recipe/test_DiffractionCalibrationRecipe.py
+++ b/tests/unit/backend/recipe/test_DiffractionCalibrationRecipe.py
@@ -324,6 +324,19 @@ class TestDiffractionCalibtationRecipe(unittest.TestCase):
         assert res["result"]
         assert res["steps"][-1]["medianOffset"] <= self.fakeIngredients.convergenceThreshold
 
+    @mock.patch(PixelCalAlgo)
+    @mock.patch(GroupCalAlgo)
+    def test_hard_cap_at_five(self, mockGroupAlgo, mockPixelAlgo):
+        mockDict = mock.Mock()
+        mockDict.value = {"medianOffset": 1}
+        mockAlgo = mock.Mock()
+        mockAlgo.getProperty.return_value = mockDict
+        mockPixelAlgo.return_value = mockAlgo
+        mockGroupAlgo.getPropertyValue.return_value = "fake"
+        result = self.recipe.executeRecipe(self.fakeIngredients, self.groceryList)
+        assert result["result"]
+        assert result["steps"] == [{"medianOffset": 1} for i in range(5)]
+
 
 # this at teardown removes the loggers, eliminating logger error printouts
 # see https://github.com/pytest-dev/pytest/issues/5502#issuecomment-647157873

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -446,6 +446,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             calPath="~/tmp/",
             convergenceThreshold=request.convergenceThreshold,
             pixelGroup=mockFocusGroupInstrumentState[1].pixelGroup,
+            maxOffset=request.maximumOffset,
         )
         mockDiffractionCalibrationRecipe().executeRecipe.assert_called_once_with(
             mockDiffractionCalibrationIngredients.return_value,


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

For some reason, when running `new_diffcal_script.py` with run 58882, the part of the recipe checking for convergence of the pixel offsets never converges and simply runs forever until manually shut down.

This work prevents this runaway behavior.  The loop which re-computes offsets is hard-capped at 5 iterations.

Further, there are checks to make sure the median offset is monotonically decreasing with each iteration, and rejects the offsets if not.

I also made some updates to simplify the tests of the recipe.

## Explanation of work

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

The recipe keeps track of number of times the algorithm is run, and stops if it exceeds a maximum (set through `application.yml`, currently 5).

The recipe also tracks that the median converges in each step, and breaks from the loop if not.

The pixel calibration algorithm will remember its previous median offset, and make sure the offsets have decreased before updating the DIFC values.  This prevents the bad offsets from impacting the DIFC values.

The previous tests of the diffcal recipe used dummy algorithms defined inside the test suite that imitated converging/diverging cases of the underlying algorithms.  This same behavior can be achieved with mocks instead, using the `side_effect` property with an iterable.  This greatly simplifies the test file.

The process retains the use of the median.  I investigated if the mean might be better, and found there really is no difference.  In a case where the offsets do not converge, neither number converges more than the other.

## To test

### Dev testing

There are two additional unit tests.  One checks that the loop is capped at 5 iterations.  The other checks that the loop ends if the process does not converge.

**Check Codecov** -- the test `test_execute_unsuccessful_later_calls` should cover **all** try blocks inside the diffcal recipe.  The diffcal recipe should retain 100% test coverage.

### CIS testing

Run `new_diffcal_script.py`.  Run the very last block, testing the diffcal process through the service.  It should converge within 5 steps, but with a warning message.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#3405](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3405)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
