### PR TITLE
diffraction calibration: xMin, xMax parameters

### DIFF
--- a/src/snapred/backend/recipe/algorithm/DiffractionSpectrumWeightCalculator.py
+++ b/src/snapred/backend/recipe/algorithm/DiffractionSpectrumWeightCalculator.py
@@ -122,6 +122,8 @@ class DiffractionSpectrumWeightCalculator(PythonAlgorithm):
                 weights[mask_indices] = 0.0
             weight_ws.setY(index, weights)
 
+        self.setProperty("WeightWorkspace", weight_ws)
+
         if isEventWorkspace:
             self.mantidSnapper.ConvertToEventWorkspace(
                 "Converting histogram workspace back to event workspace",

--- a/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
@@ -88,7 +88,8 @@ class LiteDataCreationAlgo(PythonAlgorithm):
             # add the word "Lite" to the comments for good measure
             outWS = self.mantidSnapper.mtd[outputWorkspaceName]
             outWS.setComment(outWS.getComment() + "\nLite")
-            return
+            self.setProperty("OutputWorkspace", outWS)
+            return  # NOTE EARLY
 
         # use group detector with specific grouping file to create lite data
         self.mantidSnapper.GroupDetectors(
@@ -121,12 +122,6 @@ class LiteDataCreationAlgo(PythonAlgorithm):
                 Workspace=inputWorkspaceName,
             )
 
-        if self.getProperty("LiteDataMapWorkspace").isDefault:
-            self.mantidSnapper.WashDishes(
-                "Removing lite map workspace",
-                Workspace=groupingWorkspaceName,
-            )
-
         # iterate over spectra in grouped workspace, delete old ids and replace
         self.mantidSnapper.executeQueue()
         liteWksp = self.mantidSnapper.mtd[outputWorkspaceName]
@@ -136,6 +131,7 @@ class LiteDataCreationAlgo(PythonAlgorithm):
             el.clearDetectorIDs()
             el.addDetectorID(i)
         liteWksp.setComment(liteWksp.getComment() + "\nLite")
+        self.setProperty("OutputWorkspace", liteWksp)
 
 
 # Register algorithm with Mantid

--- a/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
@@ -226,8 +226,9 @@ class PixelDiffractionCalibration(PythonAlgorithm):
                 f"Calculate offset workspace {wsoff}",
                 InputWorkspace=wscc + f"_group{groupID}",
                 OutputWorkspace=wsoff,
-                XMin=-100,
-                XMax=100,
+                # Scale the fitting ROI using the expected peak width (including a few possible peaks):
+                XMin=-(self.maxDSpaceShifts[groupID] / self.dBin) * 2.0,
+                XMax=(self.maxDSpaceShifts[groupID] / self.dBin) * 2.0,
                 OffsetMode="Signed",
                 MaxOffset=self.maxOffset,
             )

--- a/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
@@ -113,6 +113,8 @@ class SmoothDataExcludingPeaksAlgo(PythonAlgorithm):
             smoothing_results = tck(xMidpoints, extrapolate=False)
             outputWorkspace.setY(index, smoothing_results)
 
+        self.setProperty("OutputWorkspace", outputWorkspace)
+
         self.mantidSnapper.WashDishes(
             "Cleaning up weight workspace...",
             Workspace=self.weightWorkspaceName,

--- a/tests/cis_tests/new_diffcal_script.py
+++ b/tests/cis_tests/new_diffcal_script.py
@@ -124,15 +124,17 @@ assert False
 
 
 ### RUN RECIPE
+
 clerk = GroceryListItem.builder()
 clerk.name("inputWorkspace").neutron(runNumber).useLiteMode(isLite).add()
-clerk.name("groupingWorkspace").grouping(groupingScheme).fromPrev().add()
+clerk.name("groupingWorkspace").grouping(groupingScheme).useLiteMode(isLite).fromPrev().add()
 
-groceries = GroceryService.fetchGroceryDict(
-    clerk.buildDict(),
+groceries = GroceryService().fetchGroceryDict(
+    groceryDict=clerk.buildDict(),
     OutputWorkspace="_output_from_diffcal_recipe",
 )
 
+rx = Recipe()
 rx.executeRecipe(ingredients, groceries)
 
 

--- a/tests/unit/backend/recipe/algorithm/test_LiteDataCreationAlgo.py
+++ b/tests/unit/backend/recipe/algorithm/test_LiteDataCreationAlgo.py
@@ -372,6 +372,7 @@ def test_no_run_twice():
     )
     #
     liteDataCreationAlgo.mantidSnapper = mock.MagicMock()
+    liteDataCreationAlgo.setProperty = mock.MagicMock()
     liteDataCreationAlgo.setPropertyValue("InputWorkspace", inputWorkspace)
     assert liteDataCreationAlgo.execute()
     liteDataCreationAlgo.mantidSnapper.GroupDetectors.called_once()


### PR DESCRIPTION
## Description of work

During the diffraction-calibration process, the ROI used by `GetDetectorOffsets` was previously hard coded to [-100, 100] bins.  This setting works in many cases.  However, depending on the d-space shift limit of the preceeding `CrossCorrelation` step, and the expected peak width, this setting doesn't _always_ work. The changes of this commit allow the `xMin`, and `xMax` parameters to scale with the cross-correlation d-space shift.

Note that the specific scale factor used was found empirically using the synthetic test data.  As such, it might require some adjustment.  In most cases, this scale factor should produce an ROI approximately the same as that used previously.

## Explanation of work

The peak data actually fitted by `GetDetectorOffsets` are produced by the preceding `CrossCorrelation` step.  The width of these peaks depends both on the width of the _underlying_ peaks in the spectrum data, and also on the maximum shift used to calculate the cross correlation.  The decision to use a scale factor of the cross-correlation shift to set the `GetDetectorOffsets` ROI, is based on the fact that the cross-correlation shift itself is set based on the actual expected peak widths.  Further, note that this should be more robust than the ROI that was used in the original `mantid/scripts/Calibration/tofpd/group_calibration.py`, which was the _entire_ d-space range.
 
## To test
These changes are covered by our existing unit-test suite.  CIS-testing is required.

### Dev testing

No new unit tests have been added for this PR.  However, a number of new tests have been added in the _dependent_ story (see below), which was blocked by this defect.

### CIS testing
Please test this using the existing `tests/cis_tests/new_diffcal_script.py`.  This PR should _not_ induce any observable changes in the behavior of the diffraction-calibration process with real data.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[defect EWM#3397](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=3397)

[dependent story: EWM#3397](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=3464)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
