### PR TITLE
Diffraction calibration: combine masks

### DIFF
--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -66,8 +66,7 @@ class GroceryListItem(BaseModel):
             case "diffcal_output" | "diffcal_table" | "diffcal_mask":
                 if v.get("runNumber") is None:
                     raise ValueError(f"diffraction-calibration {v['workspaceType']} output requires a run number")
-                if v.get("isOutput") == False:
-                    raise ValueError(f"diffraction-calibration {v['workspaceType']} output is special-order only")
-            case _:
-                raise ValueError(f"unrecognized 'workspaceType': '{v['workspaceType']}'")
+                if v.get("isOutput") is False:
+                    raise ValueError(f"diffraction-calibration {v['workspaceType']} is special-order only")
+            case _: raise ValueError(f"unrecognized \'workspaceType\': \'{v['workspaceType']}\'")
         return v

--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -10,7 +10,7 @@ class GroceryListItem(BaseModel):
     Holds necessary information for a single item in grocery list
     """
 
-    workspaceType: Literal["neutron", "grouping", "diffcal"]
+    workspaceType: Literal["neutron", "grouping", "diffcal", "diffcal_output", "diffcal_table", "diffcal_mask"]
     useLiteMode: bool  # indicates if data should be reduced to lite mode
     # optional loader:
     # -- "" tells FetchGroceries to choose the loader
@@ -27,6 +27,10 @@ class GroceryListItem(BaseModel):
     keepItClean: bool = True
     # name the property the workspace will be used for
     propertyName: Optional[str]
+    # flag to indicate if this is an _output_ workspace:
+    # an output workspace will not be loaded,
+    # it may or may not already exist in the ADS
+    isOutput: bool = False
 
     def builder():
         # NOTE this import is here to avoid circular dependencies -- don't bother trying to move it
@@ -36,22 +40,33 @@ class GroceryListItem(BaseModel):
 
     @root_validator(pre=True, allow_reuse=True)
     def validate_ingredients_for_groceries(cls, v):
-        if v["workspaceType"] == "neutron":
-            if v.get("runNumber") is None:
-                raise ValueError("Loading neutron data requires a run number")
-            if v.get("groupingScheme") is not None:
-                v["groupingScheme"] = None
-        if v["workspaceType"] == "grouping":
-            if v.get("groupingScheme") is None:
-                raise ValueError("you must specify the grouping scheme to use")
-            if v["groupingScheme"] == "Lite":
-                # the Lite grouping scheme reduces native resolution to Lite mode
-                v["instrumentPropertySource"] = "InstrumentFilename"
-                v["instrumentSource"] = str(Config["instrument.native.definition.file"])
-                v["useLiteMode"] = False  # the lite data map only works on native data
-            else:
-                if v.get("instrumentPropertySource") is None:
-                    raise ValueError("a grouping workspace requires an instrument source")
-                if v.get("instrumentSource") is None:
-                    raise ValueError("a grouping workspace requries an instrument source")
+        match v["workspaceType"]:
+            case "neutron":
+                if v.get("runNumber") is None:
+                    raise ValueError("Loading neutron data requires a run number")
+                if v.get("groupingScheme") is not None:
+                    v["groupingScheme"] = None
+            case "grouping":
+                if v.get("groupingScheme") is None:
+                    raise ValueError("you must specify the grouping scheme to use")
+                if v["groupingScheme"] == "Lite":
+                    # the Lite grouping scheme reduces native resolution to Lite mode
+                    v["instrumentPropertySource"] = "InstrumentFilename"
+                    v["instrumentSource"] = str(Config["instrument.native.definition.file"])
+                    v["useLiteMode"] = False  # the lite data map only works on native data
+                else:
+                    if v.get("instrumentPropertySource") is None:
+                        raise ValueError("a grouping workspace requires an instrument source")
+                    if v.get("instrumentSource") is None:
+                        raise ValueError("a grouping workspace requires an instrument source")
+            case "diffcal":
+                if v.get("runNumber") is None:
+                    raise ValueError(f"diffraction-calibration input table workspace requires a run number")            
+            # output (i.e. special-order) workspaces
+            case "diffcal_output" | "diffcal_table" | "diffcal_mask":
+                if v.get("runNumber") is None:
+                    raise ValueError(f"diffraction-calibration {v['workspaceType']} output requires a run number")
+                if v.get("isOutput") == False:
+                    raise ValueError(f"diffraction-calibration {v['workspaceType']} output is special-order only")
+            case _: raise ValueError(f"unrecognized \'workspaceType\': \'{v['workspaceType']}\'")
         return v

--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -68,5 +68,6 @@ class GroceryListItem(BaseModel):
                     raise ValueError(f"diffraction-calibration {v['workspaceType']} output requires a run number")
                 if v.get("isOutput") is False:
                     raise ValueError(f"diffraction-calibration {v['workspaceType']} is special-order only")
-            case _: raise ValueError(f"unrecognized \'workspaceType\': \'{v['workspaceType']}\'")
+            case _:
+                raise ValueError(f"unrecognized 'workspaceType': '{v['workspaceType']}'")
         return v

--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -61,12 +61,13 @@ class GroceryListItem(BaseModel):
                         raise ValueError("a grouping workspace requires an instrument source")
             case "diffcal":
                 if v.get("runNumber") is None:
-                    raise ValueError(f"diffraction-calibration input table workspace requires a run number")            
+                    raise ValueError("diffraction-calibration input table workspace requires a run number")
             # output (i.e. special-order) workspaces
             case "diffcal_output" | "diffcal_table" | "diffcal_mask":
                 if v.get("runNumber") is None:
                     raise ValueError(f"diffraction-calibration {v['workspaceType']} output requires a run number")
                 if v.get("isOutput") == False:
                     raise ValueError(f"diffraction-calibration {v['workspaceType']} output is special-order only")
-            case _: raise ValueError(f"unrecognized \'workspaceType\': \'{v['workspaceType']}\'")
+            case _:
+                raise ValueError(f"unrecognized 'workspaceType': '{v['workspaceType']}'")
         return v

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -389,7 +389,8 @@ class GroceryService:
                 case "diffcal":
                     res = {"result": True, "workspace": self._createDiffcalWorkspaceName(item.runNumber)}
                     raise RuntimeError(
-                        f"not implemented: no path available to fetch diffcal input table workspace: '{res['workspace']}'"
+                        f"not implemented: no path available to fetch diffcal " + 
+                        f"input table workspace: \'{res['workspace']}\'"
                     )
                 # for output (i.e. special-order) workspaces
                 case "diffcal_output":

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -389,8 +389,8 @@ class GroceryService:
                 case "diffcal":
                     res = {"result": True, "workspace": self._createDiffcalWorkspaceName(item.runNumber)}
                     raise RuntimeError(
-                        f"not implemented: no path available to fetch diffcal " + 
-                        f"input table workspace: \'{res['workspace']}\'"
+                        "not implemented: no path available to fetch diffcal "
+                        + f"input table workspace: '{res['workspace']}'"
                     )
                 # for output (i.e. special-order) workspaces
                 case "diffcal_output":

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -101,7 +101,7 @@ class GroceryService:
 
     def _createDiffcalMaskWorkspaceName(self, runId: str):
         return wng.diffCalMask().runNumber(runId).build()
-        
+
     ## WRITING TO DISK
 
     def writeWorkspace(self, path: str, name: WorkspaceName):
@@ -388,16 +388,18 @@ class GroceryService:
                     res = self.fetchGroupingDefinition(item)
                 case "diffcal":
                     res = {"result": True, "workspace": self._createDiffcalWorkspaceName(item.runNumber)}
-                    raise RuntimeError(f"not implemented: no path available to fetch diffcal input table workspace: \'{res['workspace']}\'")
+                    raise RuntimeError(
+                        f"not implemented: no path available to fetch diffcal input table workspace: '{res['workspace']}'"
+                    )
                 # for output (i.e. special-order) workspaces
                 case "diffcal_output":
                     res = {"result": True, "workspace": self._createDiffcalOutputWorkspaceName(item.runNumber)}
-                case "diffcal_table":   
+                case "diffcal_table":
                     res = {"result": True, "workspace": self._createDiffcalTableWorkspaceName(item.runNumber)}
-                case "diffcal_mask":    
+                case "diffcal_mask":
                     res = {"result": True, "workspace": self._createDiffcalMaskWorkspaceName(item.runNumber)}
                 case _:
-                    raise RuntimeError(f"unrecognized \'workspaceType\': \'{item.workspaceType}\'")
+                    raise RuntimeError(f"unrecognized 'workspaceType': '{item.workspaceType}'")
             # check that the fetch operation succeeded and if so append the workspace
             if res["result"] is True:
                 groceries.append(res["workspace"])

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -90,8 +90,8 @@ class GroceryService:
         instr = "lite" if useLiteMode else "native"
         return Config["grouping.workspacename." + instr] + groupingScheme
 
-    def _createDiffcalWorkspaceName(self, runId: str):
-        return wng.diffCal().runNumber(runId).build()
+    def _createDiffcalInputWorkspaceName(self, runId: str):
+        return wng.diffCalInput().runNumber(runId).build()
 
     def _createDiffcalOutputWorkspaceName(self, runId: str):
         return wng.diffCalOutput().runNumber(runId).build()
@@ -387,7 +387,7 @@ class GroceryService:
                         item.instrumentSource = prev
                     res = self.fetchGroupingDefinition(item)
                 case "diffcal":
-                    res = {"result": True, "workspace": self._createDiffcalWorkspaceName(item.runNumber)}
+                    res = {"result": True, "workspace": self._createDiffcalInputWorkspaceName(item.runNumber)}
                     raise RuntimeError(
                         "not implemented: no path available to fetch diffcal "
                         + f"input table workspace: '{res['workspace']}'"

--- a/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
@@ -185,7 +185,7 @@ class GroupDiffractionCalibration(PythonAlgorithm):
         with any new masked pixels detected during execution
         - FinalCalibrationTable: str -- the name of the final table of DIFC values
         """
-        
+
         # run the algo
         self.log().notice("Execution of group diffraction calibration START!")
 

--- a/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
@@ -180,11 +180,12 @@ class GroupDiffractionCalibration(PythonAlgorithm):
         output:
         - OutputWorkspace: str -- the name of the diffraction-focussed d-spacing data after the final calibration
         - MaskWorkspace: str -- the name of the mask workspace for detectors failing calibration
-          (1.0 => dead-pixel, 0.0 => live-pixel)
-          when the mask workspace already exists, the incoming pixel mask will be combined
-          with any new masked pixels detected during execution
+        (1.0 => dead-pixel, 0.0 => live-pixel)
+        when the mask workspace already exists, the incoming pixel mask will be combined
+        with any new masked pixels detected during execution
         - FinalCalibrationTable: str -- the name of the final table of DIFC values
         """
+        
         # run the algo
         self.log().notice("Execution of group diffraction calibration START!")
 

--- a/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
@@ -179,9 +179,10 @@ class GroupDiffractionCalibration(PythonAlgorithm):
         - PreviousCalibrationTable: str -- the name of the table workspace with previous DIFC values
         output:
         - OutputWorkspace: str -- the name of the diffraction-focussed d-spacing data after the final calibration
-        - MaskWorkspace: str -- the name of the mask workspace for detectors failing calibration (1.0 => dead-pixel, 0.0 => live-pixel)
-            when the mask workspace already exists, incoming masked values will be combined with any new masked values detected during
-            execution
+        - MaskWorkspace: str -- the name of the mask workspace for detectors failing calibration 
+          (1.0 => dead-pixel, 0.0 => live-pixel)
+          when the mask workspace already exists, the incoming pixel mask will be combined
+          with any new masked pixels detected during execution
         - FinalCalibrationTable: str -- the name of the final table of DIFC values
         """
         # run the algo

--- a/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
@@ -179,7 +179,7 @@ class GroupDiffractionCalibration(PythonAlgorithm):
         - PreviousCalibrationTable: str -- the name of the table workspace with previous DIFC values
         output:
         - OutputWorkspace: str -- the name of the diffraction-focussed d-spacing data after the final calibration
-        - MaskWorkspace: str -- the name of the mask workspace for detectors failing calibration 
+        - MaskWorkspace: str -- the name of the mask workspace for detectors failing calibration
           (1.0 => dead-pixel, 0.0 => live-pixel)
           when the mask workspace already exists, the incoming pixel mask will be combined
           with any new masked pixels detected during execution

--- a/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
@@ -9,6 +9,7 @@ from mantid.api import (
     PropertyMode,
     PythonAlgorithm,
 )
+from mantid.dataobjects import MaskWorkspaceProperty
 from mantid.kernel import Direction
 
 from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients as Ingredients
@@ -31,7 +32,7 @@ class PixelDiffractionCalibration(PythonAlgorithm):
     # therefore there is no reason not to deform the input workspace to this algorithm
     # instead, the original clean file is preserved in a separate location
 
-    MAX_DSPACE_SHIFT = Config["calibration.diffraction.maxDSpaceShift"]
+    MAX_DSPACE_SHIFT_FACTOR = Config["calibration.diffraction.maxDSpaceShiftFactor"]
 
     def category(self):
         return "SNAPRed Diffraction Calibration"
@@ -49,6 +50,10 @@ class PixelDiffractionCalibration(PythonAlgorithm):
         self.declareProperty(
             ITableWorkspaceProperty("CalibrationTable", "", Direction.Output, PropertyMode.Optional),
             doc="Workspace containing the corrected calibration constants",
+        )
+        self.declareProperty(
+            MaskWorkspaceProperty("MaskWorkspace", "", Direction.Output, PropertyMode.Optional),
+            doc="if mask workspace exists: incoming values will be used (1.0 => dead-pixel, 0.0 => live-pixel)",
         )
         self.declareProperty("Ingredients", defaultValue="", direction=Direction.Input)  # noqa: F821
         self.declareProperty("data", defaultValue="", direction=Direction.Output)
@@ -73,16 +78,23 @@ class PixelDiffractionCalibration(PythonAlgorithm):
         # from the grouped peak lists, find the maximum shift in d-spacing
         self.maxDSpaceShifts: Dict[int, float] = {}
         for peakList in ingredients.groupedPeakLists:
-            self.maxDSpaceShifts[peakList.groupID] = self.MAX_DSPACE_SHIFT * peakList.maxfwhm
+            self.maxDSpaceShifts[peakList.groupID] = self.MAX_DSPACE_SHIFT_FACTOR * peakList.maxfwhm
 
-        # create string name for output calibration table
-        # TODO: use workspace namer
+        # create a default name for output calibration table
         self.DIFCpixel: str = ""
         if self.getProperty("CalibrationTable").isDefault:
-            self.DIFCpixel = f"_DIFC_{self.runNumber}"
+            self.DIFCpixel = wng.diffCalTable().runNumber(self.runNumber).build()
             self.setProperty("CalibrationTable", self.DIFCpixel)
         else:
             self.DIFCpixel = self.getPropertyValue("CalibrationTable")
+
+        # create a default name for output mask workspace
+        self.maskWS: str = ""
+        if self.getProperty("MaskWorkspace").isDefault:
+            self.maskWS = wng.diffCalMask().runNumber(self.runNumber).build()
+            self.setProperty("MaskWorkspace", self.maskWS)
+        else:
+            self.maskWS = self.getPropertyValue("MaskWorkspace")
 
         # set the max offset
         self.maxOffset: float = ingredients.maxOffset
@@ -97,13 +109,14 @@ class PixelDiffractionCalibration(PythonAlgorithm):
         # TODO: use workspace namer
         self.wsDSP: str = self.wsTOF + "_dsp"
 
-        # for inspection, make a copy of initial data
         self.mantidSnapper.ConvertUnits(
             "Convert to d-spacing to diffraction focus",
             InputWorkspace=self.wsTOF,
             OutPutWorkspace=self.wsDSP,
             Target="dSpacing",
         )
+
+        # for inspection, make a copy of initial data
         self.mantidSnapper.MakeDirtyDish(
             "Creating copy of initial TOF data",
             InputWorkspace=self.wsTOF,
@@ -141,7 +154,7 @@ class PixelDiffractionCalibration(PythonAlgorithm):
             #     OutputWorkspace=self.wsDSP + "_pixelStripped",
             # )
 
-        # get handle to group focusing workspace and retrieve all workspace IDs in each group
+        # get handle to group focusing workspace and retrieve workspace indices for all detectors in each group
         focusWSname: str = str(self.getPropertyValue("GroupingWorkspace"))
         focusWS = self.mantidSnapper.mtd[focusWSname]
         self.groupIDs: List[int] = [int(x) for x in focusWS.getGroupIDs()]
@@ -216,6 +229,7 @@ class PixelDiffractionCalibration(PythonAlgorithm):
         for groupID, workspaceIndices in self.groupWorkspaceIndices.items():
             workspaceIndices = list(workspaceIndices)
             refID: int = self.getRefID(workspaceIndices)
+
             self.mantidSnapper.CrossCorrelate(
                 f"Cross-Correlating spectra for {wscc}",
                 InputWorkspace=self.wsDSP,
@@ -226,16 +240,19 @@ class PixelDiffractionCalibration(PythonAlgorithm):
                 XMax=self.overallDMax,
                 MaxDSpaceShift=self.maxDSpaceShifts[groupID],
             )
+
             self.mantidSnapper.GetDetectorOffsets(
                 f"Calculate offset workspace {wsoff}",
                 InputWorkspace=wscc + f"_group{groupID}",
                 OutputWorkspace=wsoff,
+                MaskWorkspace=self.maskWS,
                 # Scale the fitting ROI using the expected peak width (including a few possible peaks):
                 XMin=-(self.maxDSpaceShifts[groupID] / self.dBin) * 2.0,
                 XMax=(self.maxDSpaceShifts[groupID] / self.dBin) * 2.0,
                 OffsetMode="Signed",
                 MaxOffset=self.maxOffset,
             )
+
             # add in group offsets to total, or begin the sum if none
             if not self.mantidSnapper.mtd.doesExist(totalOffsetWS):
                 self.mantidSnapper.CloneWorkspace(
@@ -256,10 +273,10 @@ class PixelDiffractionCalibration(PythonAlgorithm):
             )
             self.mantidSnapper.executeQueue()
 
-        # offsets should converge to 0 with reexecution of the process
-        # use the median, to avoid issues with possible pathologic pixels
+        # Offsets should converge to zero with re-execution of the process.
+        # Testing uses the median, to avoid issues with possible pathologic pixels.
+        # (Warning: `median(abs(offsets))` vs. `abs(median(offsets)`: the former introduces oscillation artifacts.)
         offsets = list(self.mantidSnapper.mtd[totalOffsetWS].extractY().ravel())
-        offsets = [abs(x) for x in offsets]  # ignore negative
         data["medianOffset"] = abs(np.median(offsets))
         data["meanOffset"] = abs(np.mean(offsets))
 
@@ -291,7 +308,7 @@ class PixelDiffractionCalibration(PythonAlgorithm):
         # cleanup memory usage
         self.mantidSnapper.WashDishes(
             "Deleting temporary workspaces",
-            WorkspaceList=[wsoff, totalOffsetWS, self.wsDSP, "Mask"],
+            WorkspaceList=[wsoff, totalOffsetWS, self.wsDSP],
         )
         # now execute the queue
         self.mantidSnapper.executeQueue()

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -113,10 +113,16 @@ class CalibrationService(Service):
         self.groceryClerk.name("groupingWorkspace").grouping(request.focusGroup.name).useLiteMode(
             request.useLiteMode
         ).fromPrev().add()
-        self.groceryClerk.specialOrder().name("outputWorkspace").diffcal_output(request.runNumber).useLiteMode(request.useLiteMode).add()
-        self.groceryClerk.specialOrder().name("calibrationTable").diffcal_table(request.runNumber).useLiteMode(request.useLiteMode).add()
-        self.groceryClerk.specialOrder().name("maskWorkspace").diffcal_mask(request.runNumber).useLiteMode(request.useLiteMode).add()
-        
+        self.groceryClerk.specialOrder().name("outputWorkspace").diffcal_output(request.runNumber).useLiteMode(
+            request.useLiteMode
+        ).add()
+        self.groceryClerk.specialOrder().name("calibrationTable").diffcal_table(request.runNumber).useLiteMode(
+            request.useLiteMode
+        ).add()
+        self.groceryClerk.specialOrder().name("maskWorkspace").diffcal_mask(request.runNumber).useLiteMode(
+            request.useLiteMode
+        ).add()
+
         groceries = self.groceryService.fetchGroceryDict(self.groceryClerk.buildDict())
 
         # now have all ingredients and groceries, run recipe

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -113,6 +113,10 @@ class CalibrationService(Service):
         self.groceryClerk.name("groupingWorkspace").grouping(request.focusGroup.name).useLiteMode(
             request.useLiteMode
         ).fromPrev().add()
+        self.groceryClerk.specialOrder().name("outputWorkspace").diffcal_output(request.runNumber).useLiteMode(request.useLiteMode).add()
+        self.groceryClerk.specialOrder().name("calibrationTable").diffcal_table(request.runNumber).useLiteMode(request.useLiteMode).add()
+        self.groceryClerk.specialOrder().name("maskWorkspace").diffcal_mask(request.runNumber).useLiteMode(request.useLiteMode).add()
+        
         groceries = self.groceryService.fetchGroceryDict(self.groceryClerk.buildDict())
 
         # now have all ingredients and groceries, run recipe

--- a/src/snapred/meta/builder/GroceryListBuilder.py
+++ b/src/snapred/meta/builder/GroceryListBuilder.py
@@ -23,8 +23,27 @@ class GroceryListBuilder:
         self._tokens["groupingScheme"] = groupingScheme
         return self
 
+    def specialOrder(self):
+        self._tokens["isOutput"] = True
+        return self
+        
     def diffcal(self, runId: str):
         self._tokens["workspaceType"] = "diffcal"
+        self._tokens["runNumber"] = runId
+        return self
+        
+    def diffcal_output(self, runId: str):
+        self._tokens["workspaceType"] = "diffcal_output"
+        self._tokens["runNumber"] = runId
+        return self
+        
+    def diffcal_table(self, runId: str):
+        self._tokens["workspaceType"] = "diffcal_table"
+        self._tokens["runNumber"] = runId
+        return self
+        
+    def diffcal_mask(self, runId: str):
+        self._tokens["workspaceType"] = "diffcal_mask"
         self._tokens["runNumber"] = runId
         return self
 

--- a/src/snapred/meta/builder/GroceryListBuilder.py
+++ b/src/snapred/meta/builder/GroceryListBuilder.py
@@ -26,22 +26,22 @@ class GroceryListBuilder:
     def specialOrder(self):
         self._tokens["isOutput"] = True
         return self
-        
+
     def diffcal(self, runId: str):
         self._tokens["workspaceType"] = "diffcal"
         self._tokens["runNumber"] = runId
         return self
-        
+
     def diffcal_output(self, runId: str):
         self._tokens["workspaceType"] = "diffcal_output"
         self._tokens["runNumber"] = runId
         return self
-        
+
     def diffcal_table(self, runId: str):
         self._tokens["workspaceType"] = "diffcal_table"
         self._tokens["runNumber"] = runId
         return self
-        
+
     def diffcal_mask(self, runId: str):
         self._tokens["workspaceType"] = "diffcal_mask"
         self._tokens["runNumber"] = runId

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -40,6 +40,10 @@ class _WorkspaceNameGenerator:
     _diffCalInputTemplateKeys = ["runNumber", "unit"]
     _diffCalTableTemplate = Config[f"{_templateRoot}.diffCal.table"]
     _diffCalTableTemplateKeys = ["runNumber"]
+    _diffCalOutputTemplate = Config[f"{_templateRoot}.diffCal.output"]
+    _diffCalOutputTemplateKeys = ["runNumber", "unit"]
+    _diffCalMaskTemplate = Config[f"{_templateRoot}.diffCal.mask"]
+    _diffCalMaskTemplateKeys = ["runNumber"]
 
     class Units:
         _templateRoot = "mantid.workspace.nameTemplate.units"
@@ -77,6 +81,14 @@ class _WorkspaceNameGenerator:
 
     def diffCalTable(self):
         return NameBuilder(self._diffCalTableTemplate, self._diffCalTableTemplateKeys, self._delimiter)
+
+    def diffCalOutput(self):
+        return NameBuilder(
+            self._diffCalOutputTemplate, self._diffCalOutputTemplateKeys, self._delimiter, unit=self.Units.TOF
+        )
+
+    def diffCalMask(self):
+        return NameBuilder(self._diffCalMaskTemplate, self._diffCalMaskTemplateKeys, self._delimiter)
 
 
 WorkspaceNameGenerator = _WorkspaceNameGenerator()

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -67,7 +67,7 @@ calibration:
     peakIntensityThreshold: 0.05
     nBinsAcrossPeakWidth: 10
     maximumOffset: 10
-    maxDSpaceShift: 2.5
+    maxDSpaceShiftFactor: 2.5
   parameters:
     default:
       # degrees
@@ -94,6 +94,8 @@ mantid:
       diffCal:
         input: "{unit},{runNumber},raw"
         table: "DIFC,{runNumber}"
+        output: "{unit},{runNumber},diffoc"
+        mask: "DIFC,{runNumber},mask"
       normCal:
         rawVandium: "{runNumber},{backgroundRunNumber},RVC"
         focusedRawVanadium: "{runNumber},{backgroundRunNumber},RVC,{groupingScheme}"

--- a/tests/cis_tests/diffcal_masking_script.py
+++ b/tests/cis_tests/diffcal_masking_script.py
@@ -1,0 +1,305 @@
+# Use this script to test Diffraction Calibration
+
+from typing import List
+from pathlib import Path
+import json
+from pydantic import parse_raw_as
+import matplotlib.pyplot as plt
+import numpy as np
+
+from mantid.simpleapi import *
+
+import snapred
+SNAPRed_module_root = Path(snapred.__file__).parent.parent
+
+
+from snapred.backend.recipe.algorithm.PixelDiffractionCalibration import PixelDiffractionCalibration as PixelAlgo
+from snapred.backend.recipe.algorithm.GroupDiffractionCalibration import GroupDiffractionCalibration as GroupAlgo
+from snapred.backend.recipe.DiffractionCalibrationRecipe import DiffractionCalibrationRecipe as Recipe
+from snapred.backend.recipe.algorithm.DetectorPeakPredictor import DetectorPeakPredictor
+from snapred.backend.recipe.algorithm.PurgeOverlappingPeaksAlgorithm import PurgeOverlappingPeaksAlgorithm
+from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
+from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients
+from snapred.backend.dao import RunConfig, DetectorPeak, GroupPeakList
+from snapred.backend.dao.state.PixelGroup import PixelGroup
+from snapred.backend.dao.RunConfig import RunConfig
+from snapred.backend.data.DataFactoryService import DataFactoryService
+from snapred.backend.data.GroceryService import GroceryService
+from snapred.backend.service.CrystallographicInfoService import CrystallographicInfoService
+from snapred.backend.service.CalibrationService import CalibrationService
+from snapred.backend.dao.request.DiffractionCalibrationRequest import DiffractionCalibrationRequest
+from snapred.meta.Config import Config
+
+
+# Test helper utility routines:
+# -----------------------------
+#
+#  createCompatibleMask(maskWSName: str, templateWSName: str, instrumentFileName: str)
+#  #   A mask workspace will be created in the ADS, with no values masked: this workspace will have the
+#  #     format expected by the 'DiffractionCalibrationRecipe', 'PixelDiffractionCalibration', and
+#  #     'GroupDiffractionCalibration' algorithms, and can be used to mask detectors prior to the
+#  #     start of a diffraction-calibration sequence.
+#  #      * maskWSName: the name of the mask workspace to be created
+#  #      * templateWSName: a template workspace to be used for validation
+#  #      * instrumentFileName: a file specifying the instrument to be used to create the mask workspace
+#  #        (this instrument should match the instrument of the template workspace).
+#
+#  setSpectraToZero(inputWS: MatrixWorkspace, nss: Sequence[int])
+#  # Zero out all spectra in a list of spectra
+#  #    * inputWS: a MatrixWorkspace (_not_ a workspace name)
+#  #    * nss: a list of spectrum numbers
+#
+#  maskSpectra(maskWS: MatrixWorkspace, inputWS: MatrixWorkspace, nss: Sequence[int])
+#  # Set mask flags (as workspace values, _not_ as the detector masks themselves)
+#  #   for all detectors contributing to each spectrum in the list of spectra
+#  #    * maskWS: a MaskWorkspace (_not_ a workspace name)
+#  #    * nss: a list of spectrum numbers
+#
+#  setGroupSpectraToZero(inputWS: MatrixWorkspace, groupingWS: GroupingWorkspace, gids: Sequence[int])
+#  # Zero out all spectra contributing to each group in the list of groups
+#  #    * inputWS: a MatrixWorkspace (_not_ a workspace name)
+#  #    * gids: a list of group numbers
+#
+#  maskGroups(maskWS: MatrixWorkspace, groupingWS: GroupingWorkspace, gids: Sequence[int])
+#  # Set mask flags (as workspace values, _not_ as the detector masks themselves)
+#  #   for all detectors contributing to each group in the list of groups
+#  #    * maskWS: a MaskWorkspace (_not_ a workspace name)
+#  #    * gids: a list of group numbers
+#
+
+import sys
+sys.path.insert(0, str(Path(SNAPRed_module_root).parent / 'tests'))
+from util.helpers import (
+    createCompatibleMask,
+    setSpectraToZero,
+    maskSpectra,
+    setGroupSpectraToZero,
+    maskGroups
+)
+SNAPInstrumentFilePath = str(Path(mantid.__file__).parent / 'instrument' / 'SNAP_Definition.xml')
+SNAPLiteInstrumentFilePath = str(Path(SNAPRed_module_root).parent / 'tests' / 'resources' / 'inputs' / 'pixel_grouping' / 'SNAPLite_Definition.xml')
+
+#User input ###########################
+runNumber = "58882"
+groupingScheme = 'Column'
+cifPath = "/SNS/SNAP/shared/Calibration/CalibrantSamples/Silicon_NIST_640d.cif"
+calibrantSamplePath = "SNS/SNAP/shared/Calibration/CalibrationSamples/Silicon_NIST_640D_001.json"
+peakThreshold = 0.05
+offsetConvergenceLimit = 0.1
+isLite = True
+instrumentFilePath = SNAPLiteInstrumentFilePath if isLite else SNAPInstrumentFilePath
+Config._config["cis_mode"] = False
+#######################################
+
+### CREATE INGREDIENTS ################
+runConfig = RunConfig(
+    runNumber=runNumber,
+    IPTS=GetIPTS(RunNumber=runNumber,Instrument='SNAP'), 
+    useLiteMode=isLite,
+)
+dataFactoryService = DataFactoryService()
+focusGroup=dataFactoryService.getFocusGroups(runNumber)[0] #column
+calibration = dataFactoryService.getCalibrationState(runNumber)
+
+calibrationService = CalibrationService()
+pixelGroupingParameters = calibrationService.retrievePixelGroupingParams(runNumber)
+print(pixelGroupingParameters)
+
+instrumentState = calibration.instrumentState
+calPath = instrumentState.instrumentConfig.calibrationDirectory
+instrumentState.pixelGroup = PixelGroup(pixelGroupingParameters=pixelGroupingParameters[0])
+print(instrumentState.pixelGroup.json(indent=2))
+
+crystalInfoDict = CrystallographicInfoService().ingest(cifPath)
+
+detectorAlgo = PurgeOverlappingPeaksAlgorithm()
+detectorAlgo.initialize()
+detectorAlgo.setProperty("InstrumentState", instrumentState.json())
+detectorAlgo.setProperty("CrystalInfo", crystalInfoDict["crystalInfo"].json())
+detectorAlgo.setProperty("PeakIntensityFractionThreshold", peakThreshold)
+detectorAlgo.execute()
+peakList = detectorAlgo.getProperty("OutputPeakMap").value
+peakList = parse_raw_as(List[GroupPeakList], peakList)
+
+ingredients = DiffractionCalibrationIngredients(
+    runConfig=runConfig,
+    instrumentState=instrumentState,
+    focusGroup=focusGroup,
+    groupedPeakLists=peakList,
+    calPath=calPath,
+    convergenceThreshold=offsetConvergenceLimit,
+    maxOffset = 100.0,
+    pixelGroup=PixelGroup(pixelGroupingParameters=pixelGroupingParameters[0]),
+)
+
+### FETCH GROCERIES ##################
+
+clerk = GroceryListItem.builder()
+clerk.neutron(runNumber).useLiteMode(isLite).add()
+clerk.grouping(groupingScheme).useLiteMode(isLite).add()
+groceries = GroceryService().fetchGroceryList(clerk.buildList())
+
+### OPTIONAL: CREATE AN INPUT MASK, IF REQUIRED FOR TESTING. ##########
+inputWSName = groceries[0]
+groupingWSName = groceries[1]
+maskWSName = inputWSName + '_mask'
+createCompatibleMask(maskWSName, inputWSName, instrumentFilePath)
+
+### Here any specific spectra or isolated detectors can be masked in the input, if required for testing...
+# ---
+# maskWS = mtd[maskWSName]
+# inputWS = mtd[inputWSName]
+# groupingWS = mtd[groupingWSName]
+
+# # mask all detectors contributing to spectra 10, 20, and 30:
+# spectraToMask = (10, 20, 30)
+# maskSpectra(maskWS, inputWS, spectraToMask)
+
+# # mask detectors corresponding to several groups:
+# groupsToMask = (3, 7, 11)
+# maskGroups(maskWS, groupingWS, groupsToMask)
+
+# # mask detector #145 only:
+# maskWS.setMasked(145) 
+# ---
+### OR, specific spectra or groups can be initialized so that they will fail...
+
+# spectraToFail = (14, 24, 34)
+# setSpectraToZero(inputWS, spectraToFail)
+
+# # prepare specific groups to fail...
+# groupsToFail = (5, 9, 13)
+# setGroupSpectraToZero(inputWS, groupingWS, groupsToFail)
+# ---
+
+### RUN PIXEL CALIBRATION ##########
+
+pixelAlgo = PixelAlgo()
+pixelAlgo.initialize()
+pixelAlgo.setPropertyValue("Ingredients", ingredients.json())
+pixelAlgo.setPropertyValue("InputWorkspace",groceries[0])
+pixelAlgo.setPropertyValue("GroupingWorkspace", groceries[1])
+pixelAlgo.setPropertyValue("MaskWorkspace", maskWSName)
+pixelAlgo.execute()
+
+### PAUSE
+"""
+Stop here and examine the fits:
+  * Make sure that any failing pixels are masked.
+  * Make sure that any pixels masked at the original input are still masked.
+"""
+assert False
+
+median = json.loads(pixelAlgo.getPropertyValue("data"))["medianOffset"]
+print(median)
+
+count = 0
+while median > offsetConvergenceLimit or count < 5:
+    pixelAlgo.execute()
+    median = json.loads(pixelAlgo.getPropertyValue("data"))["medianOffset"]
+    count += 1
+
+### RUN GROUP CALIBRATION
+
+DIFCprev = pixelAlgo.getPropertyValue("CalibrationTable")
+
+groupAlgo = GroupAlgo()
+groupAlgo.initialize()
+groupAlgo.setPropertyValue("Ingredients", ingredients.json())
+groupAlgo.setPropertyValue("InputWorkspace", groceries[0])
+groupAlgo.setPropertyValue("GroupingWorkspace", groceries[1])
+groupAlgo.setPropertyValue("MaskWorkspace", maskWSName)
+groupAlgo.setPropertyValue("PreviousCalibrationTable", DIFCprev)
+groupAlgo.execute()
+
+### PAUSE
+"""
+Stop here and examine the fits:
+  * Make sure the diffraction focused TOF workspace looks as expected.
+  * Make sure the offsets workspace has converged, the DIFCpd only fit pixels inside the group,
+      and that the fits match with the TOF diffraction focused workspace.
+  * Make sure that any failing pixels are masked.
+  * Make sure that any pixels masked at the original input are still masked.
+"""
+assert False
+
+### IMPORTANT: remember to _remove_ any existing mask workspace here!! ######################
+try:
+    DeleteWorkspace(maskWSName)
+except:
+    pass
+
+### RUN RECIPE
+
+clerk = GroceryListItem.builder()
+clerk.name("inputWorkspace").neutron(runNumber).useLiteMode(isLite).add()
+clerk.name("groupingWorkspace").grouping(groupingScheme).useLiteMode(isLite).fromPrev().add()
+
+groceries = GroceryService().fetchGroceryDict(
+    groceryDict=clerk.buildDict(),
+    OutputWorkspace="_output_from_diffcal_recipe",
+)
+
+### DUPLICATED from previous section: ##########
+#### OPTIONAL: CREATE AN INPUT MASK, IF REQUIRED FOR TESTING. ##########
+inputWSName = groceries['inputWorkspace']
+groupingWSName = groceries['groupingWorkspace']
+maskWSName = inputWSName + '_mask'
+createCompatibleMask(maskWSName, inputWSName, instrumentFilePath)
+
+### Here any specific spectra or isolated detectors can be masked in the input, if required for testing...
+# ---
+# maskWS = mtd[maskWSName]
+# inputWS = mtd[inputWSName]
+# groupingWS = mtd[groupingWSName]
+
+# # mask all detectors contributing to spectra 10, 20, and 30:
+# spectraToMask = (10, 20, 30)
+# maskSpectra(maskWS, inputWS, spectraToMask)
+
+# # mask detectors corresponding to several groups:
+# groupsToMask = (3, 7, 11)
+# maskGroups(maskWS, groupingWS, groupsToMask)
+
+# # mask detector #145 only:
+# maskWS.setMasked(145) 
+# ---
+### OR, specific spectra or groups can be initialized so that they will fail...
+
+# spectraToFail = (14, 24, 34)
+# setSpectraToZero(inputWS, spectraToFail)
+
+# # prepare specific groups to fail...
+# groupsToFail = (5, 9, 13)
+# setGroupSpectraToZero(inputWS, groupingWS, groupsToFail)
+# ---
+
+rx = Recipe()
+groceries['maskWorkspace'] = maskWSName
+rx.executeRecipe(ingredients, groceries)
+
+### PAUSE
+"""
+Stop here and make sure everything still looks good.
+"""
+assert False
+
+### TODO: There may need to be a *story* about how the MASK interacts with 'DiffractionCalibrationRequest'.
+# #   At present, it's functioning as an implicit parameter which will automatically be created,
+# #   and the final mask can still be accessed by looking at the _saved_ calibration data.
+# #   As yet, there's no way to specify an initial incoming MASK argument.
+
+### CALL CALIBRATION SERVICE
+diffcalRequest = DiffractionCalibrationRequest(
+    runNumber = runNumber,
+    calibrantSamplePath = calibrantSamplePath,
+    useLiteMode = isLite,
+    focusGroupPath = ingredients.focusGroup.definition,
+    convergenceThreshold = offsetConvergenceLimit,
+    peakIntensityThreshold = peakThreshold,
+)
+
+calibrationService = CalibrationService()
+res = calibrationService.diffractionCalibration(diffcalRequest)
+print(json.dumps(res,indent=2))
+assert False

--- a/tests/cis_tests/new_diffcal_script.py
+++ b/tests/cis_tests/new_diffcal_script.py
@@ -70,10 +70,12 @@ assert False
 median = json.loads(pixelAlgo.getPropertyValue("data"))["medianOffset"]
 print(median)
 
-while median > offsetConvergenceLimit:
+count = 0
+while median > offsetConvergenceLimit or count < 5:
     pixelAlgo.execute()
     median = json.loads(pixelAlgo.getPropertyValue("data"))["medianOffset"]
-
+    count += 1
+    
 ### RUN GROUP CALIBRATION
 
 DIFCprev = pixelAlgo.getPropertyValue("CalibrationTable")

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -71,7 +71,7 @@ calibration:
     nBinsAcrossPeakWidth: 10
     maximumIterations: 5
     maximumOffset: 10
-    maxDSpaceShift: 2.5
+    maxDSpaceShiftFactor: 2.5
   parameters:
     default:
       # degrees
@@ -93,6 +93,8 @@ mantid:
         diffCal:
           input: "_{unit},{runNumber},raw"
           table: "_DIFC,{runNumber}"
+          output: "_{unit},{runNumber},diffoc"
+          mask: "_DIFC,{runNumber},mask"
         units:
           dSpacing: dsp
           timeOfFlight: tof
@@ -107,7 +109,8 @@ localdataservice:
     verifypaths: true
 
 logging:
-  level: 40
+  # logging.NOTSET: 0, logging.DEBUG: 10, logging.INFO: 20, logging:WARNING: 30, logging.ERROR: 40, logging.CRITICAL: 50
+  level: 10 # 40
   SNAP:
     format: '%(asctime)s - %(levelname)-8s - %(name)s - %(message)s'
   mantid:

--- a/tests/resources/inputs/testInstrument/fakeSNAPFocGroup_Bank.xml
+++ b/tests/resources/inputs/testInstrument/fakeSNAPFocGroup_Bank.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<detector-grouping idf-date="2018-05-01T00:00:01" instrument="fakeSNAP">
+	<group ID="2">
+		<detids>0,1,2,3</detids>
+	</group>
+	<group ID="3">
+		<detids>4,5,6,7</detids>
+	</group>
+	<group ID="7">
+		<detids>8,9,10,11</detids>
+	</group>
+	<group ID="11">
+		<detids>12,13,14,15</detids>
+	</group>
+</detector-grouping>

--- a/tests/unit/backend/dao/test_GroceryListBuilder.py
+++ b/tests/unit/backend/dao/test_GroceryListBuilder.py
@@ -45,19 +45,19 @@ class TestGroceryListBuilder(unittest.TestCase):
     def test_diffcal_output(self):
         item = GroceryListBuilder().specialOrder().diffcal_output(self.runNumber).lite().build()
         assert item.runNumber == self.runNumber
-        assert item.isOutput == True
+        assert item.isOutput is True
         assert item.workspaceType == "diffcal_output"
 
     def test_diffcal_table(self):
         item = GroceryListBuilder().specialOrder().diffcal_table(self.runNumber).lite().build()
         assert item.runNumber == self.runNumber
-        assert item.isOutput == True
+        assert item.isOutput is True
         assert item.workspaceType == "diffcal_table"
 
     def test_diffcal_mask(self):
         item = GroceryListBuilder().specialOrder().diffcal_mask(self.runNumber).lite().build()
         assert item.runNumber == self.runNumber
-        assert item.isOutput == True
+        assert item.isOutput is True
         assert item.workspaceType == "diffcal_mask"
 
     def test_nexus_native_lite(self):

--- a/tests/unit/backend/dao/test_GroceryListBuilder.py
+++ b/tests/unit/backend/dao/test_GroceryListBuilder.py
@@ -42,6 +42,24 @@ class TestGroceryListBuilder(unittest.TestCase):
         assert item.useLiteMode is False
         assert item.workspaceType == "diffcal"
 
+    def test_diffcal_output(self):
+        item = GroceryListBuilder().specialOrder().diffcal_output(self.runNumber).lite().build()
+        assert item.runNumber == self.runNumber
+        assert item.isOutput == True
+        assert item.workspaceType == "diffcal_output"
+
+    def test_diffcal_table(self):
+        item = GroceryListBuilder().specialOrder().diffcal_table(self.runNumber).lite().build()
+        assert item.runNumber == self.runNumber
+        assert item.isOutput == True
+        assert item.workspaceType == "diffcal_table"
+
+    def test_diffcal_mask(self):
+        item = GroceryListBuilder().specialOrder().diffcal_mask(self.runNumber).lite().build()
+        assert item.runNumber == self.runNumber
+        assert item.isOutput == True
+        assert item.workspaceType == "diffcal_mask"
+
     def test_nexus_native_lite(self):
         item = GroceryListBuilder().neutron(self.runNumber).native().build()
         assert item.runNumber == self.runNumber
@@ -214,3 +232,18 @@ class TestGroceryListBuilder(unittest.TestCase):
         # test the list built correctly
         assert len(groceryDict) == 1
         assert groceryDict["TestName"]
+
+
+# this at teardown removes the loggers, eliminating logger error printouts
+# see https://github.com/pytest-dev/pytest/issues/5502#issuecomment-647157873
+@pytest.fixture(autouse=True)
+def clear_loggers():  # noqa: PT004
+    """Remove handlers from all loggers"""
+    import logging
+
+    yield  # ... teardown follows:
+    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
+    for logger in loggers:
+        handlers = getattr(logger, "handlers", [])
+        for handler in handlers:
+            logger.removeHandler(handler)

--- a/tests/unit/backend/dao/test_GroceryListItem.py
+++ b/tests/unit/backend/dao/test_GroceryListItem.py
@@ -118,3 +118,18 @@ class TestGroceryListItem(unittest.TestCase):
         item1 = GroceryListItem.builder().native().neutron(self.runNumber).build()
         item2 = GroceryListBuilder().native().neutron(self.runNumber).build()
         assert item1 == item2
+
+
+# this at teardown removes the loggers, eliminating logger error printouts
+# see https://github.com/pytest-dev/pytest/issues/5502#issuecomment-647157873
+@pytest.fixture(autouse=True)
+def clear_loggers():  # noqa: PT004
+    """Remove handlers from all loggers"""
+    import logging
+
+    yield  # ... teardown follows:
+    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
+    for logger in loggers:
+        handlers = getattr(logger, "handlers", [])
+        for handler in handlers:
+            logger.removeHandler(handler)

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -248,7 +248,7 @@ class TestGroceryService(unittest.TestCase):
         assert "difc" in res
         assert "mask" in res
         assert self.runNumber in res
-                
+
     ## TESTS OF WRITING METHODS
 
     def test_writeWorkspace(self):

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -829,14 +829,6 @@ class TestGroceryService(unittest.TestCase):
             self.instance.fetchGroceryList(groceryList)
         print(str(e.value))
 
-    @mock.patch.object(GroceryService, "fetchNeutronDataSingleUse")
-    def test_fetch_grocery_list_fails(self, mockFetchDirty):
-        groceryList = GroceryListItem.builder().native().neutron(self.runNumber).dirty().buildList()
-        mockFetchDirty.return_value = {"result": False, "workspace": "unimportant"}
-        with pytest.raises(RuntimeError) as e:
-            self.instance.fetchGroceryList(groceryList)
-        print(str(e.value))
-
     def test_fetch_grocery_list_diffcal_fails(self):
         groceryList = GroceryListItem.builder().native().diffcal(self.runNumber).buildList()
         with pytest.raises(

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -229,6 +229,26 @@ class TestGroceryService(unittest.TestCase):
         res = self.instance._createGroupingWorkspaceName("Lite", True)
         assert res == "lite_grouping_map"
 
+    def test_diffcal_output_workspacename(self):
+        # Test name generation for diffraction-calibration output workspace
+        res = self.instance._createDiffcalOutputWorkspaceName(self.runNumber)
+        assert "tof" in res
+        assert "diffoc" in res
+        assert self.runNumber in res
+
+    def test_diffcal_table_workspacename(self):
+        # Test name generation for diffraction-calibration output workspace
+        res = self.instance._createDiffcalTableWorkspaceName(self.runNumber)
+        assert "difc" in res
+        assert self.runNumber in res
+
+    def test_diffcal_mask_workspacename(self):
+        # Test name generation for diffraction-calibration output workspace
+        res = self.instance._createDiffcalMaskWorkspaceName(self.runNumber)
+        assert "difc" in res
+        assert "mask" in res
+        assert self.runNumber in res
+                
     ## TESTS OF WRITING METHODS
 
     def test_writeWorkspace(self):
@@ -878,3 +898,18 @@ class TestGroceryService(unittest.TestCase):
         # assert that the lite data service was created and called
         assert mockLDS.called_once()
         assert mockLDS.reduceLiteData.called_once_with(workspacename, workspacename)
+
+
+# this at teardown removes the loggers, eliminating logger error printouts
+# see https://github.com/pytest-dev/pytest/issues/5502#issuecomment-647157873
+@pytest.fixture(autouse=True)
+def clear_loggers():  # noqa: PT004
+    """Remove handlers from all loggers"""
+    import logging
+
+    yield  # ... teardown follows:
+    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
+    for logger in loggers:
+        handlers = getattr(logger, "handlers", [])
+        for handler in handlers:
+            logger.removeHandler(handler)

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -852,6 +852,15 @@ class TestGroceryService(unittest.TestCase):
         items = self.instance.fetchGroceryList(groceryList)
         assert items[0] == wng.diffCalMask().runNumber(self.runNumber).build()
 
+    def test_fetch_grocery_list_unknown_type(self):
+        groceryList = GroceryListItem.builder().native().diffcal_mask(self.runNumber).buildList()
+        groceryList[0].workspaceType = "banana"
+        with pytest.raises(
+            RuntimeError,
+            match="unrecognized 'workspaceType': 'banana'",
+        ):
+            self.instance.fetchGroceryList(groceryList)
+
     @mock.patch.object(GroceryService, "fetchNeutronDataCached")
     @mock.patch.object(GroceryService, "fetchGroupingDefinition")
     def test_fetch_grocery_list_with_prev(self, mockFetchGroup, mockFetchClean):

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -17,10 +17,10 @@ from mantid.simpleapi import (
     mtd,
 )
 from pydantic import ValidationError
-from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
 from snapred.backend.data.GroceryService import GroceryService
 from snapred.meta.Config import Config, Resource
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 
 ThisService = "snapred.backend.data.GroceryService."
 
@@ -243,7 +243,7 @@ class TestGroceryService(unittest.TestCase):
         assert "tof" in res
         assert self.runNumber in res
         assert "diffoc" in res
-        
+
     def test_diffcal_table_workspacename(self):
         # Test name generation for diffraction-calibration output workspace
         res = self.instance._createDiffcalTableWorkspaceName(self.runNumber)

--- a/tests/unit/backend/recipe/algorithm/test_GroupDiffractionCalibration.py
+++ b/tests/unit/backend/recipe/algorithm/test_GroupDiffractionCalibration.py
@@ -1,37 +1,29 @@
-from typing import Any, Dict, List, Tuple
-from collections.abc import Sequence
-
 import unittest
+from collections.abc import Sequence
+from typing import Any, Dict, List, Tuple
 from unittest import mock
-import pytest
 
+import pytest
 from mantid.api import ITableWorkspace, MatrixWorkspace
 from mantid.dataobjects import GroupingWorkspace, MaskWorkspace
-
 from snapred.backend.dao.DetectorPeak import DetectorPeak
 from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients
-from snapred.meta.Config import Resource
-from snapred.backend.log.logger import snapredLogger
 
 # needed to make mocked ingredients
 from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.backend.dao.state.PixelGroup import PixelGroup
+from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.CalculateDiffCalTable import CalculateDiffCalTable
 
 # the algorithm to test
 from snapred.backend.recipe.algorithm.GroupDiffractionCalibration import (
     GroupDiffractionCalibration as ThisAlgo,  # noqa: E402
 )
-
-from util.helpers import (
-    deleteWorkspaceNoThrow,
-    mutableWorkspaceClones,
-    setGroupSpectraToZero,
-    maskGroups
-)
+from snapred.meta.Config import Resource
 from util.diffraction_calibration_synthetic_data import SyntheticData
+from util.helpers import deleteWorkspaceNoThrow, maskGroups, mutableWorkspaceClones, setGroupSpectraToZero
 
 logger = snapredLogger.getLogger(__name__)
 
@@ -69,7 +61,6 @@ class TestGroupDiffractionCalibration(unittest.TestCase):
         for ws in [cls.fakeRawData, cls.fakeGroupingWorkspace, cls.fakeMaskWorkspace, cls.difcWS]:
             deleteWorkspaceNoThrow(ws)
         return super().tearDownClass()
-
 
     def test_chop_ingredients(self):
         """Test that ingredients for algo are properly processed"""
@@ -141,7 +132,7 @@ class TestGroupDiffractionCalibration(unittest.TestCase):
         mask = mtd[maskWSName]
         assert mask.getNumberMasked() == 0
         deleteWorkspaceNoThrow(maskWSName)
-        
+
     def test_existing_mask_is_used(self):
         """Test that an existing mask workspace is not overwritten"""
         from mantid.simpleapi import mtd
@@ -219,7 +210,7 @@ class TestGroupDiffractionCalibration(unittest.TestCase):
                 assert maskWS.isMasked(int(det))
         deleteWorkspaceNoThrow(inputWSName)
         deleteWorkspaceNoThrow(maskWSName)
-            
+
     def test_masks_stay_masked(self):
         """Test that incoming masked spectra are still masked at output"""
         from mantid.simpleapi import mtd
@@ -256,7 +247,7 @@ class TestGroupDiffractionCalibration(unittest.TestCase):
                 assert maskWS.isMasked(int(det))
         deleteWorkspaceNoThrow(inputWSName)
         deleteWorkspaceNoThrow(maskWSName)
-            
+
     def test_masks_are_combined(self):
         """Test that masks for failing spectra are combined with any input mask"""
         from mantid.simpleapi import mtd
@@ -311,8 +302,8 @@ class TestGroupDiffractionCalibration(unittest.TestCase):
 def clear_loggers():  # noqa: PT004
     """Remove handlers from all loggers"""
     import logging
-    
-    yield # ... teardown follows:     
+
+    yield  # ... teardown follows:
     loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
     for logger in loggers:
         handlers = getattr(logger, "handlers", [])

--- a/tests/unit/backend/recipe/algorithm/test_GroupDiffractionCalibration.py
+++ b/tests/unit/backend/recipe/algorithm/test_GroupDiffractionCalibration.py
@@ -1,11 +1,18 @@
-import unittest
-from typing import Any, Dict, List
-from unittest import mock
+from typing import Any, Dict, List, Tuple
+from collections.abc import Sequence
 
+import unittest
+from unittest import mock
 import pytest
+
+from mantid.api import ITableWorkspace, MatrixWorkspace
+from mantid.dataobjects import GroupingWorkspace, MaskWorkspace
+
 from snapred.backend.dao.DetectorPeak import DetectorPeak
 from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients
+from snapred.meta.Config import Resource
+from snapred.backend.log.logger import snapredLogger
 
 # needed to make mocked ingredients
 from snapred.backend.dao.RunConfig import RunConfig
@@ -17,138 +24,66 @@ from snapred.backend.recipe.algorithm.CalculateDiffCalTable import CalculateDiff
 from snapred.backend.recipe.algorithm.GroupDiffractionCalibration import (
     GroupDiffractionCalibration as ThisAlgo,  # noqa: E402
 )
-from snapred.meta.Config import Resource
+
+from util.helpers import (
+    deleteWorkspaceNoThrow,
+    mutableWorkspaceClones,
+    setGroupSpectraToZero,
+    maskGroups
+)
+from util.diffraction_calibration_synthetic_data import SyntheticData
+
+logger = snapredLogger.getLogger(__name__)
 
 
 class TestGroupDiffractionCalibration(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Create a set of mocked ingredients for calculating DIFC corrected by offsets"""
-        cls.fakeDBin = abs(0.001)
-        cls.fakeRunNumber = "555"
-        fakeRunConfig = RunConfig(runNumber=str(cls.fakeRunNumber))
+        syntheticInputs = SyntheticData()
+        cls.fakeIngredients = syntheticInputs.ingredients
+        fakeDBin = max([abs(d) for d in cls.fakeIngredients.pixelGroup.dBin()])
 
-        fakePixelGroup = PixelGroup.parse_raw(Resource.read("inputs/diffcal/fakePixelGroup.json"))
-        fakeFocusGroup = FocusGroup(
-            name="natural",
-            definition=Resource.getPath("inputs/testInstrument/fakeSNAPFocGroup_Natural.xml"),
-        )
-        fakePixelGroup.focusGroup = fakeFocusGroup
+        runNumber = cls.fakeIngredients.runConfig.runNumber
+        cls.fakeRawData = f"_test_groupcal_{runNumber}"
+        cls.fakeGroupingWorkspace = f"_test_groupcal_difc_{runNumber}"
+        cls.fakeMaskWorkspace = f"_test_groupcal_difc_{runNumber}_mask"
+        cls.difcWS = f"_{runNumber}_difcs_test"
+        syntheticInputs.generateWorkspaces(cls.fakeRawData, cls.fakeGroupingWorkspace, cls.fakeMaskWorkspace)
 
-        peakLists: Dict[int, List[Any]] = {
-            3: [
-                DetectorPeak.parse_obj({"position": {"value": 0.37, "minimum": 0.35, "maximum": 0.39}}),
-                DetectorPeak.parse_obj({"position": {"value": 0.33, "minimum": 0.32, "maximum": 0.34}}),
-            ],
-            7: [
-                DetectorPeak.parse_obj({"position": {"value": 0.57, "minimum": 0.54, "maximum": 0.62}}),
-                DetectorPeak.parse_obj({"position": {"value": 0.51, "minimum": 0.49, "maximum": 0.53}}),
-            ],
-            2: [
-                DetectorPeak.parse_obj({"position": {"value": 0.33, "minimum": 0.31, "maximum": 0.35}}),
-                DetectorPeak.parse_obj({"position": {"value": 0.29, "minimum": 0.275, "maximum": 0.305}}),
-            ],
-            11: [
-                DetectorPeak.parse_obj({"position": {"value": 0.43, "minimum": 0.41, "maximum": 0.47}}),
-                DetectorPeak.parse_obj({"position": {"value": 0.39, "minimum": 0.37, "maximum": 0.405}}),
-            ],
-        }
-
-        cls.fakeIngredients = DiffractionCalibrationIngredients(
-            runConfig=fakeRunConfig,
-            groupedPeakLists=[GroupPeakList(groupID=key, peaks=peakLists[key], maxfwhm=5) for key in peakLists.keys()],
-            calPath=Resource.getPath("outputs/calibration/"),
-            convergenceThreshold=1.0,
-            pixelGroup=fakePixelGroup,
-        )
-
-        cls.fakeRawData = f"_test_groupcal_{cls.fakeRunNumber}"
-        cls.fakeGroupingWorkspace = f"_test_groupcal_difc_{cls.fakeRunNumber}"
-        cls.difcWS = f"_{cls.fakeRunNumber}_difcs_test"
-        cls.makeFakeNeutronData(cls.fakeRawData, cls.fakeGroupingWorkspace, cls.difcWS)
+        # create the DIFCprev table
+        cc = CalculateDiffCalTable()
+        cc.initialize()
+        cc.setProperty("InputWorkspace", cls.fakeRawData)
+        cc.setProperty("CalibrationTable", cls.difcWS)
+        cc.setProperty("OffsetMode", "Signed")
+        cc.setProperty("BinWidth", fakeDBin)
+        cc.execute()
 
     @classmethod
     def tearDownClass(cls) -> None:
-        from mantid.simpleapi import DeleteWorkspace
-
         """
-        Delete all workspaces created by this test, and remove the ceated filed.
+        Delete all workspaces created by this test, and remove any created files.
         This is run once at the end of this test suite.
         """
-        for ws in [cls.fakeRawData, cls.fakeGroupingWorkspace, cls.difcWS]:
-            try:
-                DeleteWorkspace(ws)
-            except:  # noqa: E722
-                pass
+        for ws in [cls.fakeRawData, cls.fakeGroupingWorkspace, cls.fakeMaskWorkspace, cls.difcWS]:
+            deleteWorkspaceNoThrow(ws)
         return super().tearDownClass()
 
-    @classmethod
-    def makeFakeNeutronData(cls, rawWSname, focusWSname, difcws):
-        """Will cause algorithm to execute with sample data, instead of loading from file"""
-        from mantid.simpleapi import (
-            CreateSampleWorkspace,
-            LoadDetectorsGroupingFile,
-            LoadInstrument,
-            Rebin,
-        )
-
-        TOFMin = cls.fakeIngredients.pixelGroup.timeOfFlight.minimum
-        TOFMax = cls.fakeIngredients.pixelGroup.timeOfFlight.maximum
-
-        # prepare with test data in TOF
-        CreateSampleWorkspace(
-            OutputWorkspace=rawWSname,
-            # WorkspaceType="Histogram",
-            Function="Powder Diffraction",
-            Xmin=TOFMin,
-            Xmax=TOFMax,
-            BinWidth=1,
-            XUnit="TOF",
-            NumBanks=4,  # must produce same number of pixels as fake instrument
-            BankPixelWidth=2,  # each bank has 4 pixels, 4 banks, 16 total
-            Random=True,
-        )
-        Rebin(
-            InputWorkspace=rawWSname,
-            Params=(TOFMin, -0.001, TOFMax),
-            BinningMode="Logarithmic",
-            OutputWorkspace=rawWSname,
-        )
-        # load the instrument and focus group
-        LoadInstrument(
-            Workspace=rawWSname,
-            Filename=Resource.getPath("inputs/testInstrument/fakeSNAP.xml"),
-            RewriteSpectraMap=True,
-        )
-        # also load the focus grouping workspace
-        LoadDetectorsGroupingFile(
-            InputFile=cls.fakeIngredients.pixelGroup.focusGroup.definition,
-            InputWorkspace=rawWSname,
-            OutputWorkspace=focusWSname,
-        )
-        # also create the DIFCprev table
-        cc = CalculateDiffCalTable()
-        cc.initialize()
-        cc.setProperty("InputWorkspace", rawWSname)
-        cc.setProperty("CalibrationTable", difcws)
-        cc.setProperty("OffsetMode", "Signed")
-        cc.setProperty("BinWidth", cls.fakeDBin)
-        cc.execute()
 
     def test_chop_ingredients(self):
         """Test that ingredients for algo are properly processed"""
         algo = ThisAlgo()
         algo.initialize()
         algo.chopIngredients(self.fakeIngredients)
-        assert algo.runNumber == self.fakeRunNumber
-        TOFMin = self.fakeIngredients.pixelGroup.timeOfFlight.minimum
-        TOFMax = self.fakeIngredients.pixelGroup.timeOfFlight.maximum
-        TOFBin = min([abs(db) for db in self.fakeIngredients.pixelGroup.dBin()])
-        assert algo.TOF.params == (TOFMin, -TOFBin, TOFMax)
+        assert algo.runNumber == self.fakeIngredients.runConfig.runNumber
+        assert algo.TOF.minimum == self.fakeIngredients.pixelGroup.timeOfFlight.minimum
+        assert algo.TOF.maximum == self.fakeIngredients.pixelGroup.timeOfFlight.maximum
+        assert algo.dBin == self.fakeIngredients.pixelGroup.dBin()
 
     def test_init_properties(self):
         """Test that the properties of the algorithm can be initialized"""
-        difcWS = f"_{self.fakeRunNumber}_difcs_test"
+        difcWS = f"_{self.fakeIngredients.runConfig.runNumber}_difcs_test"
         algo = ThisAlgo()
         algo.initialize()
         algo.setProperty("Ingredients", self.fakeIngredients.json())
@@ -158,18 +93,216 @@ class TestGroupDiffractionCalibration(unittest.TestCase):
 
     def test_execute(self):
         """Test that the algorithm executes"""
+        from mantid.simpleapi import mtd
+
+        uniquePrefix = "test_e_"
+        (maskWS,) = mutableWorkspaceClones((self.fakeMaskWorkspace,), uniquePrefix)
+        (maskWSName,) = mutableWorkspaceClones((self.fakeMaskWorkspace,), uniquePrefix, name_only=True)
+
+        algo = ThisAlgo()
+        algo.initialize()
+        algo.setProperty("Ingredients", self.fakeIngredients.json())
+        algo.setProperty("InputWorkspace", self.fakeRawData)
+        algo.setProperty("GroupingWorkspace", self.fakeGroupingWorkspace)
+        algo.setProperty("FinalCalibrationTable", "_final_DIFc_table")
+        algo.setProperty("MaskWorkspace", maskWSName)
+        algo.setProperty("OutputWorkspace", f"_test_out_{self.fakeIngredients.runConfig.runNumber}")
+        algo.setProperty("PreviousCalibrationTable", self.difcWS)
+        assert algo.execute()
+        assert maskWSName in mtd
+        assert maskWS.getNumberMasked() == 0
+        deleteWorkspaceNoThrow(maskWSName)
+
+    def test_mask_is_created(self):
+        """Test that a mask workspace is created if it doesn't already exist:
+        -- this method also verifies that none of the spectra in the synthetic data will be masked.
+        """
+        from mantid.simpleapi import mtd
+
+        uniquePrefix = "test_mic_"
+        maskWSName = uniquePrefix + "_mask"
+
+        # Ensure that the mask workspace doesn't already exist
+        assert maskWSName not in mtd
+
         # now run the algorithm
         algo = ThisAlgo()
         algo.initialize()
-        algo.setPropertyValue("Ingredients", self.fakeIngredients.json())
-        algo.setPropertyValue("InputWorkspace", self.fakeRawData)
-        algo.setPropertyValue("GroupingWorkspace", self.fakeGroupingWorkspace)
-        algo.setPropertyValue("FinalCalibrationTable", "_final_DIFc_table")
-        algo.setPropertyValue("OutputWorkspace", f"_test_out_{self.fakeRunNumber}")
-        algo.setPropertyValue("PreviousCalibrationTable", self.difcWS)
-        assert algo.execute()
+        algo.setProperty("Ingredients", self.fakeIngredients.json())
+        algo.setProperty("InputWorkspace", self.fakeRawData)
+        algo.setProperty("GroupingWorkspace", self.fakeGroupingWorkspace)
+        algo.setProperty("FinalCalibrationTable", "_final_DIFc_table")
+        algo.setProperty("MaskWorkspace", maskWSName)
+        algo.setProperty("OutputWorkspace", f"_test_out_{self.fakeIngredients.runConfig.runNumber}")
+        algo.setProperty("PreviousCalibrationTable", self.difcWS)
 
-    # TODO more and more better tests of behavior
+        algo.execute()
+        assert maskWSName in mtd
+        mask = mtd[maskWSName]
+        assert mask.getNumberMasked() == 0
+        deleteWorkspaceNoThrow(maskWSName)
+        
+    def test_existing_mask_is_used(self):
+        """Test that an existing mask workspace is not overwritten"""
+        from mantid.simpleapi import mtd
+
+        uniquePrefix = "test_miu_"
+        (maskWS,) = mutableWorkspaceClones((self.fakeMaskWorkspace,), uniquePrefix)
+        (maskWSName,) = mutableWorkspaceClones((self.fakeMaskWorkspace,), uniquePrefix, name_only=True)
+        maskTitle = "d35b4aae-93fe-421b-95f4-5eec635a70d1"
+
+        algo = ThisAlgo()
+        algo.initialize()
+        algo.setProperty("Ingredients", self.fakeIngredients.json())
+        algo.setProperty("InputWorkspace", self.fakeRawData)
+        algo.setProperty("GroupingWorkspace", self.fakeGroupingWorkspace)
+        algo.setProperty("FinalCalibrationTable", "_final_DIFc_table")
+        algo.setProperty("MaskWorkspace", maskWSName)
+        algo.setProperty("OutputWorkspace", f"_test_out_{self.fakeIngredients.runConfig.runNumber}")
+        algo.setProperty("PreviousCalibrationTable", self.difcWS)
+        assert maskWSName in mtd
+
+        # Note: for some reason using 'id' for this test does not work:
+        #   the 'id' of the mask workspace handle changes.
+        maskWS.setTitle(maskTitle)
+        assert maskWS.getTitle() == maskTitle
+
+        algo.execute()
+        assert maskWSName in mtd
+        maskWS = mtd[maskWSName]
+        assert maskWS.getTitle() == maskTitle
+        assert maskWS.getNumberMasked() == 0
+        deleteWorkspaceNoThrow(maskWSName)
+
+    def countDetectorsForGroups(self, groupingWS: GroupingWorkspace, gids: Sequence[int]) -> int:
+        count = 0
+        for gid in gids:
+            count += len(groupingWS.getDetectorIDsOfGroup(gid))
+        return count
+
+    def prepareGroupsToFail(self, ws: MatrixWorkspace, groupingWS: GroupingWorkspace, gids: Sequence[int]):
+        # Zero out all spectra contributing to each group
+        setGroupSpectraToZero(ws, groupingWS, gids)
+
+    def test_failures_are_masked(self):
+        """Test that failing spectra are masked"""
+        from mantid.simpleapi import mtd
+
+        uniquePrefix = "test_fam_"
+        inputWS, maskWS = mutableWorkspaceClones((self.fakeRawData, self.fakeMaskWorkspace), uniquePrefix)
+        inputWSName, maskWSName = mutableWorkspaceClones(
+            (self.fakeRawData, self.fakeMaskWorkspace), uniquePrefix, name_only=True
+        )
+
+        algo = ThisAlgo()
+        algo.initialize()
+        algo.setProperty("Ingredients", self.fakeIngredients.json())
+        algo.setProperty("InputWorkspace", inputWSName)
+        algo.setProperty("GroupingWorkspace", self.fakeGroupingWorkspace)
+        algo.setProperty("FinalCalibrationTable", "_final_DIFc_table")
+        algo.setProperty("MaskWorkspace", maskWSName)
+        algo.setProperty("OutputWorkspace", f"_test_out_{self.fakeIngredients.runConfig.runNumber}")
+        algo.setProperty("PreviousCalibrationTable", self.difcWS)
+
+        assert maskWS.getNumberMasked() == 0
+        groupsToFail = (3,)
+        groupingWS = mtd[self.fakeGroupingWorkspace]
+        self.prepareGroupsToFail(inputWS, groupingWS, groupsToFail)
+        # Verify that at least some spectra have been modified.
+        assert self.countDetectorsForGroups(groupingWS, groupsToFail) > 0
+
+        algo.execute()
+        assert maskWS.getNumberMasked() == self.countDetectorsForGroups(groupingWS, groupsToFail)
+        for gid in groupsToFail:
+            dets = groupingWS.getDetectorIDsOfGroup(gid)
+            for det in dets:
+                assert maskWS.isMasked(int(det))
+        deleteWorkspaceNoThrow(inputWSName)
+        deleteWorkspaceNoThrow(maskWSName)
+            
+    def test_masks_stay_masked(self):
+        """Test that incoming masked spectra are still masked at output"""
+        from mantid.simpleapi import mtd
+
+        uniquePrefix = "test_msm_"
+        inputWS, maskWS = mutableWorkspaceClones((self.fakeRawData, self.fakeMaskWorkspace), uniquePrefix)
+        inputWSName, maskWSName = mutableWorkspaceClones(
+            (self.fakeRawData, self.fakeMaskWorkspace), uniquePrefix, name_only=True
+        )
+
+        algo = ThisAlgo()
+        algo.initialize()
+        algo.setProperty("Ingredients", self.fakeIngredients.json())
+        algo.setProperty("InputWorkspace", inputWSName)
+        algo.setProperty("GroupingWorkspace", self.fakeGroupingWorkspace)
+        algo.setProperty("FinalCalibrationTable", "_final_DIFc_table")
+        algo.setProperty("MaskWorkspace", maskWSName)
+        algo.setProperty("OutputWorkspace", f"_test_out_{self.fakeIngredients.runConfig.runNumber}")
+        algo.setProperty("PreviousCalibrationTable", self.difcWS)
+
+        assert maskWS.getNumberMasked() == 0
+        groupsToMask = (11,)
+        groupingWS = mtd[self.fakeGroupingWorkspace]
+        maskGroups(maskWS, groupingWS, groupsToMask)
+        assert maskWS.getNumberMasked() == self.countDetectorsForGroups(groupingWS, groupsToMask)
+        # Verify that at least some detectors have been masked.
+        assert self.countDetectorsForGroups(groupingWS, groupsToMask) > 0
+
+        algo.execute()
+        assert maskWS.getNumberMasked() == self.countDetectorsForGroups(groupingWS, groupsToMask)
+        for gid in groupsToMask:
+            dets = groupingWS.getDetectorIDsOfGroup(gid)
+            for det in dets:
+                assert maskWS.isMasked(int(det))
+        deleteWorkspaceNoThrow(inputWSName)
+        deleteWorkspaceNoThrow(maskWSName)
+            
+    def test_masks_are_combined(self):
+        """Test that masks for failing spectra are combined with any input mask"""
+        from mantid.simpleapi import mtd
+
+        uniquePrefix = "test_mac_"
+        inputWS, maskWS = mutableWorkspaceClones((self.fakeRawData, self.fakeMaskWorkspace), uniquePrefix)
+        inputWSName, maskWSName = mutableWorkspaceClones(
+            (self.fakeRawData, self.fakeMaskWorkspace), uniquePrefix, name_only=True
+        )
+
+        algo = ThisAlgo()
+        algo.initialize()
+        algo.setProperty("Ingredients", self.fakeIngredients.json())
+        algo.setProperty("InputWorkspace", inputWSName)
+        algo.setProperty("GroupingWorkspace", self.fakeGroupingWorkspace)
+        algo.setProperty("FinalCalibrationTable", "_final_DIFc_table")
+        algo.setProperty("MaskWorkspace", maskWSName)
+        algo.setProperty("OutputWorkspace", f"_test_out_{self.fakeIngredients.runConfig.runNumber}")
+        algo.setProperty("PreviousCalibrationTable", self.difcWS)
+
+        assert maskWS.getNumberMasked() == 0
+        groupingWS = mtd[self.fakeGroupingWorkspace]
+        groupsToFail = (3,)
+        self.prepareGroupsToFail(inputWS, groupingWS, groupsToFail)
+        # Verify that at least some spectra have been modified.
+        assert self.countDetectorsForGroups(groupingWS, groupsToFail) > 0
+        groupsToMask = (11,)
+        maskGroups(maskWS, groupingWS, groupsToMask)
+        assert maskWS.getNumberMasked() == self.countDetectorsForGroups(groupingWS, groupsToMask)
+        # Verify that at least some detectors have been masked.
+        assert self.countDetectorsForGroups(groupingWS, groupsToMask) > 0
+
+        algo.execute()
+        assert maskWS.getNumberMasked() == self.countDetectorsForGroups(
+            groupingWS, groupsToFail
+        ) + self.countDetectorsForGroups(groupingWS, groupsToMask)
+        for gid in groupsToFail:
+            dets = groupingWS.getDetectorIDsOfGroup(gid)
+            for det in dets:
+                assert maskWS.isMasked(int(det))
+        for gid in groupsToMask:
+            dets = groupingWS.getDetectorIDsOfGroup(gid)
+            for det in dets:
+                assert maskWS.isMasked(int(det))
+        deleteWorkspaceNoThrow(inputWSName)
+        deleteWorkspaceNoThrow(maskWSName)
 
 
 # this at teardown removes the loggers, eliminating logger error printouts
@@ -178,7 +311,8 @@ class TestGroupDiffractionCalibration(unittest.TestCase):
 def clear_loggers():  # noqa: PT004
     """Remove handlers from all loggers"""
     import logging
-
+    
+    yield # ... teardown follows:     
     loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
     for logger in loggers:
         handlers = getattr(logger, "handlers", [])

--- a/tests/unit/backend/recipe/algorithm/test_PixelDiffractionCalibration.py
+++ b/tests/unit/backend/recipe/algorithm/test_PixelDiffractionCalibration.py
@@ -1,13 +1,17 @@
+from typing import Any, Dict, List, Tuple
+from collections.abc import Sequence
 import json
-import unittest
-from itertools import permutations
 
-import numpy as np
+import unittest
 import pytest
-from mantid.simpleapi import (
-    DeleteWorkspace,
-    mtd,
-)
+
+from itertools import permutations
+import numpy as np
+
+from mantid.api import MatrixWorkspace
+from mantid.dataobjects import MaskWorkspace
+from mantid.simpleapi import mtd
+
 from snapred.backend.dao.DetectorPeak import DetectorPeak
 from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients
@@ -15,134 +19,45 @@ from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients
 # needed to make mocked ingredients
 from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.dao.state.PixelGroup import PixelGroup
+from snapred.meta.Config import Resource
 
 # the algorithm to test
 from snapred.backend.recipe.algorithm.PixelDiffractionCalibration import (
     PixelDiffractionCalibration as ThisAlgo,  # noqa: E402
 )
-from snapred.meta.Config import Resource
+
+from util.helpers import (
+  deleteWorkspaceNoThrow,
+  setSpectraToZero,
+  maskSpectra
+)
+from util.diffraction_calibration_synthetic_data import SyntheticData
 
 
 class TestPixelDiffractionCalibration(unittest.TestCase):
     def setUp(self):
         """Create a set of mocked ingredients for calculating DIFC corrected by offsets"""
-        self.maxOffset = 2
-        self.fakeRunNumber = "555"
-        fakeRunConfig = RunConfig(runNumber=str(self.fakeRunNumber))
+        inputs = SyntheticData()
+        self.fakeIngredients = inputs.ingredients
 
-        fakePixelGroup = PixelGroup.parse_raw(Resource.read("/inputs/diffcal/fakePixelGroup.json"))
-        fakePixelGroup.focusGroup.definition = Resource.getPath("inputs/testInstrument/fakeSNAPFocGroup_Natural.xml")
-
-        peakLists = {
-            3: DetectorPeak.parse_obj({"position": {"value": 0.2, "minimum": 0.15, "maximum": 0.25}}),
-            7: DetectorPeak.parse_obj({"position": {"value": 0.3, "minimum": 0.20, "maximum": 0.40}}),
-            2: DetectorPeak.parse_obj({"position": {"value": 0.18, "minimum": 0.10, "maximum": 0.25}}),
-            11: DetectorPeak.parse_obj({"position": {"value": 0.24, "minimum": 0.18, "maximum": 0.30}}),
-        }
-        self.fakeIngredients = DiffractionCalibrationIngredients(
-            runConfig=fakeRunConfig,
-            groupedPeakLists=[
-                GroupPeakList(groupID=gid, peaks=[peakLists[gid]], maxfwhm=5) for gid in peakLists.keys()
-            ],
-            convergenceThreshold=1.0,
-            maxOffset=self.maxOffset,
-            pixelGroup=fakePixelGroup,
-        )
-
-        self.fakeRawData = f"_test_pixelcal_{self.fakeRunNumber}"
-        self.fakeGroupingWorkspace = f"_test_pixelcal_difc_{self.fakeRunNumber}"
-        self.makeFakeNeutronData(self.fakeRawData, self.fakeGroupingWorkspace)
+        runNumber = self.fakeIngredients.runConfig.runNumber
+        self.fakeRawData = f"_test_pixelcal_{runNumber}"
+        self.fakeGroupingWorkspace = f"_test_pixelcal_difc_{runNumber}"
+        self.fakeMaskWorkspace = f"_test_pixelcal_difc_{runNumber}_mask"
+        inputs.generateWorkspaces(self.fakeRawData, self.fakeGroupingWorkspace, self.fakeMaskWorkspace)
 
     def tearDown(self) -> None:
-        for ws in mtd.getObjectNames():
-            try:
-                DeleteWorkspace(ws)
-            except:  # noqa: E722
-                pass
+        # At present tests are not run in parallel, so cleanup the ADS:
+        mtd.clear()
+        assert len(mtd.getObjectNames()) == 0
         return super().tearDown()
-
-    def makeFakeNeutronData(self, rawWsName: str, focusWSname: str) -> None:
-        """Create sample data for test runs"""
-        from mantid.simpleapi import (
-            ConvertUnits,
-            CreateSampleWorkspace,
-            LoadDetectorsGroupingFile,
-            LoadInstrument,
-            Rebin,
-            RebinRagged,
-        )
-
-        TOFMin = self.fakeIngredients.pixelGroup.timeOfFlight.minimum
-        TOFMax = self.fakeIngredients.pixelGroup.timeOfFlight.maximum
-
-        dMin = self.fakeIngredients.pixelGroup.dMin()
-        dMax = self.fakeIngredients.pixelGroup.dMax()
-        DBin = self.fakeIngredients.pixelGroup.dBin()
-        overallDMax = max(dMax)
-        overallDMin = min(dMin)
-        dBin = min([abs(d) for d in DBin])
-
-        # prepare with test data
-        midpoint = (overallDMin + overallDMax) / 2.0
-        CreateSampleWorkspace(
-            OutputWorkspace=rawWsName,
-            # WorkspaceType="Histogram",
-            Function="User Defined",
-            UserDefinedFunction=f"name=Gaussian,Height=10,PeakCentre={midpoint},Sigma={midpoint/10}",
-            Xmin=overallDMin,
-            Xmax=overallDMax,
-            BinWidth=abs(dBin),
-            XUnit="dSpacing",
-            NumBanks=4,  # must produce same number of pixels as fake instrument
-            BankPixelWidth=2,  # each bank has 4 pixels, 4 banks, 16 total
-        )
-        LoadInstrument(
-            Workspace=rawWsName,
-            Filename=Resource.getPath("inputs/testInstrument/fakeSNAP.xml"),
-            RewriteSpectraMap=True,
-        )
-        # also load the focus grouping workspace
-        LoadDetectorsGroupingFile(
-            InputFile=Resource.getPath("inputs/testInstrument/fakeSNAPFocGroup_Natural.xml"),
-            InputWorkspace=rawWsName,
-            OutputWorkspace=focusWSname,
-        )
-        # # rebin and convert for DSP, TOF
-        focWS = mtd[focusWSname]
-        allXmins = [0] * 16
-        allXmaxs = [0] * 16
-        allDelta = [0] * 16
-        groupIDs = self.fakeIngredients.pixelGroup.groupIDs
-        for i, gid in enumerate(groupIDs):
-            for detid in focWS.getDetectorIDsOfGroup(int(gid)):
-                allXmins[detid] = dMin[i]
-                allXmaxs[detid] = dMax[i]
-                allDelta[detid] = DBin[i]
-        RebinRagged(
-            InputWorkspace=rawWsName,
-            OutputWorkspace=rawWsName,
-            XMin=allXmins,
-            XMax=allXmaxs,
-            Delta=allDelta,
-        )
-        ConvertUnits(
-            InputWorkspace=rawWsName,
-            OutputWorkspace=rawWsName,
-            Target="TOF",
-        )
-        Rebin(
-            InputWorkspace=rawWsName,
-            OutputWorkspace=rawWsName,
-            Params=(TOFMin, dBin, TOFMax),
-            BinningMode="Logarithmic",
-        )
 
     def test_chop_ingredients(self):
         """Test that ingredients for algo are properly processed"""
         algo = ThisAlgo()
         algo.initialize()
         algo.chopIngredients(self.fakeIngredients)
-        assert algo.runNumber == self.fakeRunNumber
+        assert algo.runNumber == self.fakeIngredients.runConfig.runNumber
         assert algo.overallDMin == min(self.fakeIngredients.pixelGroup.dMin())
         assert algo.overallDMax == max(self.fakeIngredients.pixelGroup.dMax())
         assert algo.dBin == max([abs(db) for db in self.fakeIngredients.pixelGroup.dBin()])
@@ -159,6 +74,7 @@ class TestPixelDiffractionCalibration(unittest.TestCase):
         algo = ThisAlgo()
         algo.initialize()
         algo.setProperty("InputWorkspace", self.fakeRawData)
+        algo.setProperty("MaskWorkspace", self.fakeMaskWorkspace)
         algo.setProperty("Groupingworkspace", self.fakeGroupingWorkspace)
         algo.setProperty("Ingredients", self.fakeIngredients.json())
         assert algo.execute()
@@ -168,15 +84,15 @@ class TestPixelDiffractionCalibration(unittest.TestCase):
         assert x is not None
         assert x != 0.0
         assert x > 0.0
-        assert x <= self.maxOffset
+        assert x <= self.fakeIngredients.maxOffset
 
     # patch to make the offsets of sample data non-zero
     def test_reexecution_and_convergence(self):
         """Test that the algorithm can run, and that it will converge to an answer"""
-
         algo = ThisAlgo()
         algo.initialize()
         algo.setProperty("InputWorkspace", self.fakeRawData)
+        algo.setProperty("MaskWorkspace", self.fakeMaskWorkspace)
         algo.setProperty("Groupingworkspace", self.fakeGroupingWorkspace)
         algo.setProperty("Ingredients", self.fakeIngredients.json())
         assert algo.execute()
@@ -186,12 +102,18 @@ class TestPixelDiffractionCalibration(unittest.TestCase):
         assert x is not None
         assert x != 0.0
         assert x > 0.0
-        assert x <= self.maxOffset
+        assert x <= self.fakeIngredients.maxOffset
 
         # check that value converges
-        numIter = 5
+        # WARNING: testing for three iterations seems to be about the limit here.
+        #   At greater than 3 iterations, there are small oscillations about a limit value.
+        maxIter = 3
         allOffsets = [data["medianOffset"]]
-        for i in range(numIter):
+
+        # The following assertion will fail if the convergence behavior is oversimplified:
+        #   an initial fast convergence (two iterations or so) followed by minor oscillations
+        #   should still be considered to be a passing result.
+        for i in range(maxIter - 1):
             algo.execute()
             data = json.loads(algo.getProperty("data").value)
             allOffsets.append(data["medianOffset"])
@@ -262,6 +184,162 @@ class TestPixelDiffractionCalibration(unittest.TestCase):
         for N_group in range(1, 5):
             for gids in permutations(dids, N_group):
                 assert algo.getRefID(gids) in gids
+    
+    def test_mask_is_created(self):
+        """Test that a mask workspace is created if it doesn't already exist"""
+
+        uniquePrefix = "test_mic_"
+        maskWSName = uniquePrefix + "_mask"
+        # Ensure that the mask workspace doesn't already exist
+        assert maskWSName not in mtd
+
+        algo = ThisAlgo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", self.fakeRawData)
+        algo.setPropertyValue("MaskWorkspace", maskWSName)
+        algo.setProperty("Groupingworkspace", self.fakeGroupingWorkspace)
+        algo.setProperty("Ingredients", self.fakeIngredients.json())
+        algo.execute()
+        assert maskWSName in mtd
+
+    def test_existing_mask_is_used(self):
+        """Test that an existing mask workspace is not overwritten"""
+
+        algo = ThisAlgo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", self.fakeRawData)
+        algo.setProperty("MaskWorkspace", self.fakeMaskWorkspace)
+        algo.setProperty("Groupingworkspace", self.fakeGroupingWorkspace)
+        algo.setProperty("Ingredients", self.fakeIngredients.json())
+
+        assert self.fakeMaskWorkspace in mtd
+        # Using 'id' here doesn't work for some reason
+        #   so a title is given to the workspace instead.
+        mask = mtd[self.fakeMaskWorkspace]
+        maskTitle = "d1baefaf-d9b4-40db-8f4d-4249a3d3c11b"
+        mask.setTitle(maskTitle)
+
+        algo.execute()
+        assert self.fakeMaskWorkspace in mtd
+        mask = mtd[self.fakeMaskWorkspace]
+        assert mask.getTitle() == maskTitle
+
+    def test_none_are_masked(self):
+        """Test that no synthetic spectra are masked"""
+        # Success of this test validates the synthetic data used by the other tests.
+
+        algo = ThisAlgo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", self.fakeRawData)
+        algo.setProperty("MaskWorkspace", self.fakeMaskWorkspace)
+        algo.setProperty("Groupingworkspace", self.fakeGroupingWorkspace)
+        algo.setProperty("Ingredients", self.fakeIngredients.json())
+        assert self.fakeMaskWorkspace in mtd
+        mask = mtd[self.fakeMaskWorkspace]
+        assert mask.getNumberMasked() == 0
+
+        algo.execute()
+        assert mask.getNumberMasked() == 0
+
+    def countDetectorsForSpectra(self, inputWS: MatrixWorkspace, nss: Sequence[int]):
+        count = 0
+        for ns in nss:
+            count += len(inputWS.getSpectrum(ns).getDetectorIDs())
+        return count
+
+    def prepareSpectraToFail(self, inputWS: MatrixWorkspace, nss: Sequence[int]):
+        setSpectraToZero(inputWS, nss)
+
+    def test_failures_are_masked(self):
+        """Test that failing spectra are masked"""
+
+        algo = ThisAlgo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", self.fakeRawData)
+        algo.setProperty("MaskWorkspace", self.fakeMaskWorkspace)
+        algo.setProperty("Groupingworkspace", self.fakeGroupingWorkspace)
+        algo.setProperty("Ingredients", self.fakeIngredients.json())
+
+        maskWS = mtd[self.fakeMaskWorkspace]
+        assert maskWS.getNumberMasked() == 0
+        fakeRawData = mtd[self.fakeRawData]
+        # WARNING: Do _not_ zero the reference spectra:
+        #   in that case, the entire group corresponding to the reference will fail.
+        spectraToFail = (2, 5, 12)
+        self.prepareSpectraToFail(fakeRawData, spectraToFail)
+        # Verify that at least some spectra have been modified.
+        assert self.countDetectorsForSpectra(fakeRawData, spectraToFail) > 0
+
+        algo.execute()
+        assert maskWS.getNumberMasked() == self.countDetectorsForSpectra(fakeRawData, spectraToFail)
+        for ns in spectraToFail:
+            dets = fakeRawData.getSpectrum(ns).getDetectorIDs()
+            for det in dets:
+                assert maskWS.isMasked(det)
+
+    def test_masks_stay_masked(self):
+        """Test that incoming masked spectra are still masked at output"""
+
+        algo = ThisAlgo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", self.fakeRawData)
+        algo.setProperty("MaskWorkspace", self.fakeMaskWorkspace)
+        algo.setProperty("Groupingworkspace", self.fakeGroupingWorkspace)
+        algo.setProperty("Ingredients", self.fakeIngredients.json())
+
+        maskWS = mtd[self.fakeMaskWorkspace]
+        assert maskWS.getNumberMasked() == 0
+
+        fakeRawData = mtd[self.fakeRawData]
+        spectraToMask = (1, 4, 6, 7)
+        maskSpectra(maskWS, fakeRawData, spectraToMask)
+        # Verify that at least some detectors have been masked.
+        assert self.countDetectorsForSpectra(fakeRawData, spectraToMask) > 0
+
+        algo.execute()
+        assert maskWS.getNumberMasked() == self.countDetectorsForSpectra(fakeRawData, spectraToMask)
+        for ns in spectraToMask:
+            dets = fakeRawData.getSpectrum(ns).getDetectorIDs()
+            for det in dets:
+                assert maskWS.isMasked(det)
+
+    def test_masks_are_combined(self):
+        """Test that masks for failing spectra are combined with any input mask"""
+
+        algo = ThisAlgo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", self.fakeRawData)
+        algo.setProperty("MaskWorkspace", self.fakeMaskWorkspace)
+        algo.setProperty("Groupingworkspace", self.fakeGroupingWorkspace)
+        algo.setProperty("Ingredients", self.fakeIngredients.json())
+
+        maskWS = mtd[self.fakeMaskWorkspace]
+        assert maskWS.getNumberMasked() == 0
+
+        fakeRawData = mtd[self.fakeRawData]
+        # WARNING: see note at 'test_failures_are_masked'
+        spectraToFail = (2, 5, 12)
+        self.prepareSpectraToFail(fakeRawData, spectraToFail)
+        # Verify that at least some spectra have been modified.
+        assert self.countDetectorsForSpectra(fakeRawData, spectraToFail) > 0
+        # WARNING: do not overlap with the _failed_ spectra, unless the assertion count is corrected
+        spectraToMask = (1, 4, 6, 7)
+        maskSpectra(maskWS, fakeRawData, spectraToMask)
+        # Verify that at least some detectors have been masked.
+        assert self.countDetectorsForSpectra(fakeRawData, spectraToMask) > 0
+
+        algo.execute()
+        assert maskWS.getNumberMasked() == self.countDetectorsForSpectra(
+            fakeRawData, spectraToFail
+        ) + self.countDetectorsForSpectra(fakeRawData, spectraToMask)
+        for ns in spectraToFail:
+            dets = fakeRawData.getSpectrum(ns).getDetectorIDs()
+            for det in dets:
+                assert maskWS.isMasked(det)
+        for ns in spectraToMask:
+            dets = fakeRawData.getSpectrum(ns).getDetectorIDs()
+            for det in dets:
+                assert maskWS.isMasked(det)
 
 
 # this at teardown removes the loggers, eliminating logger error printouts
@@ -271,6 +349,7 @@ def clear_loggers():  # noqa: PT004
     """Remove handlers from all loggers"""
     import logging
 
+    yield  # teardown follows: ...
     loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
     for logger in loggers:
         handlers = getattr(logger, "handlers", [])

--- a/tests/unit/backend/recipe/algorithm/test_PixelDiffractionCalibration.py
+++ b/tests/unit/backend/recipe/algorithm/test_PixelDiffractionCalibration.py
@@ -1,17 +1,14 @@
-from typing import Any, Dict, List, Tuple
-from collections.abc import Sequence
 import json
-
 import unittest
-import pytest
-
+from collections.abc import Sequence
 from itertools import permutations
-import numpy as np
+from typing import Any, Dict, List, Tuple
 
+import numpy as np
+import pytest
 from mantid.api import MatrixWorkspace
 from mantid.dataobjects import MaskWorkspace
 from mantid.simpleapi import mtd
-
 from snapred.backend.dao.DetectorPeak import DetectorPeak
 from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients
@@ -19,19 +16,14 @@ from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients
 # needed to make mocked ingredients
 from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.dao.state.PixelGroup import PixelGroup
-from snapred.meta.Config import Resource
 
 # the algorithm to test
 from snapred.backend.recipe.algorithm.PixelDiffractionCalibration import (
     PixelDiffractionCalibration as ThisAlgo,  # noqa: E402
 )
-
-from util.helpers import (
-  deleteWorkspaceNoThrow,
-  setSpectraToZero,
-  maskSpectra
-)
+from snapred.meta.Config import Resource
 from util.diffraction_calibration_synthetic_data import SyntheticData
+from util.helpers import deleteWorkspaceNoThrow, maskSpectra, setSpectraToZero
 
 
 class TestPixelDiffractionCalibration(unittest.TestCase):
@@ -184,7 +176,7 @@ class TestPixelDiffractionCalibration(unittest.TestCase):
         for N_group in range(1, 5):
             for gids in permutations(dids, N_group):
                 assert algo.getRefID(gids) in gids
-    
+
     def test_mask_is_created(self):
         """Test that a mask workspace is created if it doesn't already exist"""
 

--- a/tests/unit/backend/recipe/test_DiffractionCalibrationRecipe.py
+++ b/tests/unit/backend/recipe/test_DiffractionCalibrationRecipe.py
@@ -1,6 +1,6 @@
-from typing import List
 import json
 import unittest
+from typing import List
 from unittest import mock
 
 import pytest

--- a/tests/unit/backend/recipe/test_DiffractionCalibrationRecipe.py
+++ b/tests/unit/backend/recipe/test_DiffractionCalibrationRecipe.py
@@ -1,22 +1,12 @@
+from typing import List
 import json
 import unittest
-from typing import List
 from unittest import mock
 
 import pytest
 from mantid.api import PythonAlgorithm
 from mantid.kernel import Direction
-from mantid.simpleapi import (
-    ConvertUnits,
-    CreateSampleWorkspace,
-    CreateWorkspace,
-    DeleteWorkspace,
-    LoadDetectorsGroupingFile,
-    LoadInstrument,
-    Rebin,
-    RebinRagged,
-    mtd,
-)
+from mantid.simpleapi import mtd
 from snapred.backend.dao.DetectorPeak import DetectorPeak
 from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients as TheseIngredients
@@ -24,81 +14,40 @@ from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.dao.state.PixelGroup import PixelGroup
 from snapred.backend.recipe.DiffractionCalibrationRecipe import DiffractionCalibrationRecipe as Recipe
 from snapred.meta.Config import Config, Resource
+from util.diffraction_calibration_synthetic_data import SyntheticData
+from util.helpers import deleteWorkspaceNoThrow
 
 ThisRecipe: str = "snapred.backend.recipe.DiffractionCalibrationRecipe"
 PixelCalAlgo: str = ThisRecipe + ".PixelDiffractionCalibration"
 GroupCalAlgo: str = ThisRecipe + ".GroupDiffractionCalibration"
 
 
-class TestDiffractionCalibtationRecipe(unittest.TestCase):
+class TestDiffractionCalibrationRecipe(unittest.TestCase):
     def setUp(self):
-        self.fakeRunNumber = "555"
-        fakeRunConfig = RunConfig(
-            runNumber=str(self.fakeRunNumber),
-            IPTS="",
-        )
-
-        fakePixelGroup = PixelGroup.parse_raw(Resource.read("/inputs/diffcal/fakePixelGroup.json"))
-        fakePixelGroup.focusGroup.definition = Resource.getPath("inputs/testInstrument/fakeSNAPFocGroup_Natural.xml")
-
-        peakList = [
-            DetectorPeak.parse_obj({"position": {"value": 2, "minimum": 1, "maximum": 3}}),
-            DetectorPeak.parse_obj({"position": {"value": 5, "minimum": 4, "maximum": 6}}),
-        ]
-
-        self.fakeIngredients = TheseIngredients(
-            runConfig=fakeRunConfig,
-            groupedPeakLists=[
-                GroupPeakList(groupID=3, peaks=peakList, maxfwhm=0.01),
-                GroupPeakList(groupID=7, peaks=peakList, maxfwhm=0.02),
-                GroupPeakList(groupID=2, peaks=peakList, maxfwhm=0.02),
-                GroupPeakList(groupID=11, peaks=peakList, maxfwhm=0.02),
-            ],
-            convergenceThreshold=0.5,
-            calPath=Resource.getPath("outputs/calibration/"),
-            pixelGroup=fakePixelGroup,
-        )
+        self.syntheticInputs = SyntheticData()
+        self.fakeIngredients = self.syntheticInputs.ingredients
 
         self.fakeRawData = "_test_diffcal_rx"
-        CreateWorkspace(
-            OutputWorkspace=self.fakeRawData,
-            DataX=[1, 2, 3, 4, 5, 6] * 16,
-            DataY=[2, 11, 2, 2, 11, 2] * 16,
-            UnitX="TOF",
-            NSpec=16,
-        )
-        Rebin(
-            InputWorkspace=self.fakeRawData,
-            Params=(1, -0.001, 6),
-            BinningMode="Logarithmic",
-            OutputWorkspace=self.fakeRawData,
-        )
-        LoadInstrument(
-            Workspace=self.fakeRawData,
-            Filename=Resource.getPath("inputs/testInstrument/fakeSNAPLite.xml"),
-            RewriteSpectraMap=True,
-        )
         self.fakeGroupingWorkspace = "_test_diffcal_rx_grouping"
-        LoadDetectorsGroupingFile(
-            InputFile=Resource.getPath("inputs/testInstrument/fakeSNAPFocGroup_Natural.xml"),
-            InputWorkspace=self.fakeRawData,
-            OutputWorkspace=self.fakeGroupingWorkspace,
-        )
+        self.fakeOutputWorkspace = "_test_diffcal_rx_output"
+        self.fakeTableWorkspace = "_test_diffcal_rx_table"
+        self.fakeMaskWorkspace = "_test_diffcal_rx_mask"
+        self.syntheticInputs.generateWorkspaces(self.fakeRawData, self.fakeGroupingWorkspace, self.fakeMaskWorkspace)
 
         self.groceryList = {
             "inputWorkspace": self.fakeRawData,
             "groupingWorkspace": self.fakeGroupingWorkspace,
+            "outputWorkspace": self.fakeOutputWorkspace,
+            "calibrationTable": self.fakeTableWorkspace,
+            "maskWorkspace": self.fakeMaskWorkspace,
         }
         self.recipe = Recipe()
 
     def tearDown(self) -> None:
         workspaces = mtd.getObjectNames()
         # remove all workspaces
-        for workspace in workspaces:
-            try:
-                DeleteWorkspace(workspace)
-            except ValueError:
-                print(f"Workspace {workspace} doesn't exist!")
+        for ws in workspaces:
+            deleteWorkspaceNoThrow(ws)
         return super().tearDown
 
     def test_chop_ingredients(self):
@@ -108,6 +57,7 @@ class TestDiffractionCalibtationRecipe(unittest.TestCase):
         self.recipe.unbagGroceries(self.groceryList)
         assert self.recipe.rawInput == self.fakeRawData
         assert self.recipe.groupingWS == self.fakeGroupingWorkspace
+        assert self.recipe.maskWS == self.fakeMaskWorkspace
 
     @mock.patch(PixelCalAlgo)
     @mock.patch(GroupCalAlgo)
@@ -122,6 +72,7 @@ class TestDiffractionCalibtationRecipe(unittest.TestCase):
         assert result["steps"] == [{"medianOffset": x} for x in [4, 2, 1, 0.5]]
         assert result["calibrationTable"] == "passed"
         assert result["outputWorkspace"] == "passed"
+        assert result["maskWorkspace"] == "passed"
 
     @mock.patch(PixelCalAlgo)
     def test_execute_unsuccessful_pixel_cal(self, mockPixelCalAlgo):
@@ -167,75 +118,27 @@ class TestDiffractionCalibtationRecipe(unittest.TestCase):
                 self.recipe.executeRecipe(self.fakeIngredients, self.groceryList)
             assert str(e.value).split("\n")[0] == f"passed {i}"
 
-    def makeFakeNeutronData(self, rawWS, groupingWS):
-        """Will cause algorithm to execute with sample data, instead of loading from file"""
-
-        TOFMin = self.fakeIngredients.pixelGroup.timeOfFlight.minimum
-        TOFMax = self.fakeIngredients.pixelGroup.timeOfFlight.maximum
-
-        # prepare with test data
-        CreateSampleWorkspace(
-            OutputWorkspace=rawWS,
-            Function="Powder Diffraction",
-            Xmin=0.2,
-            Xmax=5,
-            BinWidth=0.001,
-            XUnit="dSpacing",
-            NumBanks=4,  # must produce same number of pixels as fake instrument
-            BankPixelWidth=2,  # each bank has 4 pixels, 4 banks, 16 total
-        )
-        LoadInstrument(
-            Workspace=rawWS,
-            Filename=Resource.getPath("inputs/testInstrument/fakeSNAP.xml"),
-            RewriteSpectraMap=True,
-        )
-        LoadDetectorsGroupingFile(
-            InputFile=Resource.getPath("inputs/testInstrument/fakeSNAPFocGroup_Natural.xml"),
-            InputWorkspace=rawWS,
-            OutputWorkspace=groupingWS,
-        )
-        dMin = self.fakeIngredients.pixelGroup.dMin()
-        dMax = self.fakeIngredients.pixelGroup.dMax()
-        dBin = self.fakeIngredients.pixelGroup.dBin()
-        focWS = mtd[groupingWS]
-        allXmins = [0] * 16
-        allXmaxs = [0] * 16
-        allDelta = [0] * 16
-        for i, gid in enumerate(focWS.getGroupIDs()):
-            for detid in focWS.getDetectorIDsOfGroup(int(gid)):
-                allXmins[detid] = dMin[i]
-                allXmaxs[detid] = dMax[i]
-                allDelta[detid] = dBin[i]
-        RebinRagged(
-            InputWorkspace=rawWS,
-            OutputWorkspace=rawWS,
-            XMin=allXmins,
-            XMax=allXmaxs,
-            Delta=allDelta,
-        )
-        ConvertUnits(
-            InputWorkspace=rawWS,
-            OutputWorkspace=rawWS,
-            Target="TOF",
-        )
-        Rebin(
-            InputWorkspace=rawWS,
-            OutputWorkspace=rawWS,
-            Params=(TOFMin, -0.001, TOFMax),
-            BinningMode="Logarithmic",
-        )
-
     def test_execute_with_algos(self):
+        # create sample data
+        from datetime import date
+
         rawWS = "_test_diffcal_rx_data"
         groupingWS = "_test_diffcal_grouping"
-        self.makeFakeNeutronData(rawWS, groupingWS)
+        maskWS = "_test_diffcal_mask"
+        self.syntheticInputs.generateWorkspaces(rawWS, groupingWS, maskWS)
+
         self.groceryList["inputWorkspace"] = rawWS
         self.groceryList["groupingWorkspace"] = groupingWS
+        self.groceryList["maskWorkspace"] = maskWS
         try:
             res = self.recipe.executeRecipe(self.fakeIngredients, self.groceryList)
         except ValueError:
             print(res)
         assert res["result"]
+
+        assert res["maskWorkspace"]
+        mask = mtd[res["maskWorkspace"]]
+        assert mask.getNumberMasked() == 0
         assert res["steps"][-1]["medianOffset"] <= self.fakeIngredients.convergenceThreshold
 
     @mock.patch(PixelCalAlgo)
@@ -251,6 +154,7 @@ class TestDiffractionCalibtationRecipe(unittest.TestCase):
         assert result["steps"] == [{"medianOffset": 11 - i} for i in range(maxIterations)]
         assert result["calibrationTable"] == "fake"
         assert result["outputWorkspace"] == "fake"
+        assert result["maskWorkspace"] == "fake"
         # change the config then run again
         maxIterations = 7
         mockAlgo.getPropertyValue.side_effect = [f'{{"medianOffset": {11-i}}}' for i in range(10)]
@@ -260,6 +164,7 @@ class TestDiffractionCalibtationRecipe(unittest.TestCase):
         assert result["steps"] == [{"medianOffset": 11 - i} for i in range(maxIterations)]
         assert result["calibrationTable"] == "fake"
         assert result["outputWorkspace"] == "fake"
+        assert result["maskWorkspace"] == "fake"
 
     @mock.patch(PixelCalAlgo)
     @mock.patch(GroupCalAlgo)
@@ -273,6 +178,7 @@ class TestDiffractionCalibtationRecipe(unittest.TestCase):
         assert result["steps"] == [{"medianOffset": i} for i in [2, 1]]
         assert result["calibrationTable"] == "fake"
         assert result["outputWorkspace"] == "fake"
+        assert result["maskWorkspace"] == "fake"
 
 
 # this at teardown removes the loggers, eliminating logger error printouts
@@ -282,6 +188,7 @@ def clear_loggers():  # noqa: PT004
     """Remove handlers from all loggers"""
     import logging
 
+    yield  # ... teardown follows:
     loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
     for logger in loggers:
         handlers = getattr(logger, "handlers", [])

--- a/tests/util/diffraction_calibration_synthetic_data.py
+++ b/tests/util/diffraction_calibration_synthetic_data.py
@@ -135,7 +135,8 @@ class SyntheticData(object):
     def _fakePowderDiffractionPeakList(
         tofMin: float, tofMax: float, dMin: float, dMax: float, scale: float
     ) -> Tuple[List[Tuple[float, float, float]], str]:
-        """Duplicate the `CreateSampleWorkspace` 'Powder Diffraction' predefined function, but in d-spacing instead of TOF units.
+        """Duplicate the `CreateSampleWorkspace` 'Powder Diffraction' predefined function,
+             but in d-spacing instead of TOF units.
         -- returns (List[Peak(centre, sigma, height)], <background function string>)
         """
         # 'mantid/Framework/Algorithms/src/CreateSampleWorkspace.cpp': lines 85-94:

--- a/tests/util/diffraction_calibration_synthetic_data.py
+++ b/tests/util/diffraction_calibration_synthetic_data.py
@@ -60,7 +60,7 @@ class SyntheticData(object):
     SNAPInstrumentFilePath = str(Path(mantid.__file__).parent / "instrument" / "SNAP_Definition.xml")
     SNAPLiteInstrumentFilePath = Resource.getPath("inputs/pixel_grouping/SNAPLite_Definition.xml")
 
-    def __init__(self, workspaceType: str='Histogram', scale: float=1000.0):
+    def __init__(self, workspaceType: str = "Histogram", scale: float = 1000.0):
         fakeRunNumber = "555"
         self.fakeRunConfig = RunConfig(
             runNumber=str(fakeRunNumber),
@@ -73,14 +73,14 @@ class SyntheticData(object):
         self.fakeFocusGroup.definition = SyntheticData.fakeGroupingFilePath
 
         self.fakePixelGroup = PixelGroup.parse_raw(SyntheticData.fakePixelGroupPath)
-        
+
         # Place all peaks within the _minimum_ d-space range of any pixel group.
         dMin = max(self.fakePixelGroup.dMin())
         dMax = min(self.fakePixelGroup.dMax())
 
         # Overall _magnitude_ scale factor:
         self.scale = scale
-        
+
         self.workspaceType = workspaceType
 
         # TOF-domain used to convert from the original `CreateSampleWorkspace` 'Powder Diffraction' predefined function:

--- a/tests/util/diffraction_calibration_synthetic_data.py
+++ b/tests/util/diffraction_calibration_synthetic_data.py
@@ -1,0 +1,305 @@
+# @file: tests/util/diffraction_calibration_synthetic_data.py:
+#
+# Preparation of synthetic data for the following unit-test classes:
+#   * TestPixelDiffractionCalibration
+#   * TestGroupDiffractionCalibration
+#   * TestDiffractionCalibrationRecipe
+#
+
+import secrets
+from collections import namedtuple
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import mantid
+import numpy as np
+from mantid.api import ITableWorkspace, MatrixWorkspace
+from mantid.dataobjects import GroupingWorkspace, MaskWorkspace
+from mantid.simpleapi import (
+    ConvertUnits,
+    CreateSampleWorkspace,
+    LoadDetectorsGroupingFile,
+    LoadInstrument,
+    Rebin,
+    RebinRagged,
+    ScaleX,
+    mtd,
+)
+from snapred.backend.dao.DetectorPeak import DetectorPeak
+from snapred.backend.dao.GroupPeakList import GroupPeakList
+from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients
+from snapred.backend.dao.RunConfig import RunConfig
+from snapred.backend.dao.state.FocusGroup import FocusGroup
+from snapred.backend.dao.state.InstrumentState import InstrumentState
+from snapred.backend.dao.state.PixelGroup import PixelGroup
+from snapred.meta.Config import Resource
+from util.helpers import *
+
+Peak = namedtuple("Peak", "centre sigma height")
+
+
+def random_seed(bits: int) -> int:
+    # Generate a random seed of 'bits' length.
+    return secrets.randbits(bits)
+
+
+class SyntheticData(object):
+    """_Fixed_ implementation of synthetic data to be used for all diffraction-calibration tests."""
+
+    RANDOM_SEED = 311379324803478887040360489933500222827
+
+    # MOCK instruments and configuration files:
+    fakeInstrumentFilePath = Resource.getPath("inputs/testInstrument/fakeSNAP.xml")
+    fakeGroupingFilePath = Resource.getPath("inputs/testInstrument/fakeSNAPFocGroup_Natural.xml")
+    fakeInstrumentStatePath = Resource.read("inputs/diffcal/fakeInstrumentState.json")
+    fakeFocusGroupPath = Resource.read("inputs/diffcal/fakeFocusGroup.json")
+    fakePixelGroupPath = Resource.read("inputs/diffcal/fakePixelGroup.json")
+
+    # REAL instruments and configuration files:
+    SNAPInstrumentFilePath = str(Path(mantid.__file__).parent / "instrument" / "SNAP_Definition.xml")
+    SNAPLiteInstrumentFilePath = Resource.getPath("inputs/pixel_grouping/SNAPLite_Definition.xml")
+
+    def __init__(self, workspaceType: str='Histogram', scale: float=1000.0):
+        fakeRunNumber = "555"
+        self.fakeRunConfig = RunConfig(
+            runNumber=str(fakeRunNumber),
+            IPTS="",
+        )
+
+        self.fakeInstrumentState = InstrumentState.parse_raw(SyntheticData.fakeInstrumentStatePath)
+
+        self.fakeFocusGroup = FocusGroup.parse_raw(SyntheticData.fakeFocusGroupPath)
+        self.fakeFocusGroup.definition = SyntheticData.fakeGroupingFilePath
+
+        self.fakePixelGroup = PixelGroup.parse_raw(SyntheticData.fakePixelGroupPath)
+        
+        # Place all peaks within the _minimum_ d-space range of any pixel group.
+        dMin = max(self.fakePixelGroup.dMin())
+        dMax = min(self.fakePixelGroup.dMax())
+
+        # Overall _magnitude_ scale factor:
+        self.scale = scale
+        
+        self.workspaceType = workspaceType
+
+        # TOF-domain used to convert from the original `CreateSampleWorkspace` 'Powder Diffraction' predefined function:
+        #   In general, <particle bounds>: TOF-domain converted to d-spacing may be a larger interval than <pixel group>: d-spacing domain.
+        #   For the purposes of this initialization this doesn't matter, but these values should not be used elsewhere without keeping this in mind.
+        TOFMin = self.fakePixelGroup.timeOfFlight.minimum
+        TOFMax = self.fakePixelGroup.timeOfFlight.maximum
+        self.peaks, self.background_function = SyntheticData._fakePowderDiffractionPeakList(
+            TOFMin, TOFMax, dMin, dMax, self.scale
+        )
+
+        peakList = [
+            DetectorPeak.parse_obj(
+                {
+                    "position": {
+                        "value": p.centre,
+                        "minimum": p.centre - SyntheticData.fwhmFromSigma(p.sigma) / 2.0,
+                        "maximum": p.centre + SyntheticData.fwhmFromSigma(p.sigma) / 2.0,
+                    }
+                }
+            )
+            for p in self.peaks
+        ]
+
+        # For testing purposes: every pixel group will use the same peak list;
+        #   in spite of the offset shifts applied previously: these are still the correct _target_ peak locations.
+        peakLists: Dict[int, List[DetectorPeak]] = {2: peakList, 3: peakList, 7: peakList, 11: peakList}
+        maxFWHM = SyntheticData.fwhmFromSigma(max([p.sigma for p in self.peaks]))
+
+        self.ingredients = DiffractionCalibrationIngredients(
+            runConfig=self.fakeRunConfig,
+            focusGroup=self.fakeFocusGroup,
+            instrumentState=self.fakeInstrumentState,
+            groupedPeakLists=[
+                GroupPeakList(groupID=key, peaks=peakLists[key], maxfwhm=maxFWHM) for key in peakLists.keys()
+            ],
+            convergenceThreshold=0.5,
+            calPath=Resource.getPath("outputs/calibration/"),
+            maxOffset=100.0,  # bins: '100.0' seems to work
+            pixelGroup=self.fakePixelGroup,
+        )
+
+    @staticmethod
+    def random_seed(bits: int) -> int:
+        # Generate a random seed of 'bits' length.
+        return secrets.randbits(bits)
+
+    @staticmethod
+    def fwhmFromSigma(sigma: float) -> float:
+        return 2.0 * np.sqrt(2.0 * np.log(2.0)) * sigma
+
+    @staticmethod
+    def _fakePowderDiffractionPeakList(
+        tofMin: float, tofMax: float, dMin: float, dMax: float, scale: float
+    ) -> Tuple[List[Tuple[float, float, float]], str]:
+        """Duplicate the `CreateSampleWorkspace` 'Powder Diffraction' predefined function, but in d-spacing instead of TOF units.
+        -- returns (List[Peak(centre, sigma, height)], <background function string>)
+        """
+        # 'mantid/Framework/Algorithms/src/CreateSampleWorkspace.cpp': lines 85-94:
+        """
+          m_preDefinedFunctionmap.emplace("Powder Diffraction", "name= LinearBackground,A0=0.0850208,A1=-4.89583e-06;"
+                                                            "name=Gaussian,Height=0.584528,PeakCentre=$PC1$,Sigma=14.3772;"
+                                                            "name=Gaussian,Height=1.33361,PeakCentre=$PC2$,Sigma=15.2516;"
+                                                            "name=Gaussian,Height=1.74691,PeakCentre=$PC3$,Sigma=15.8395;"
+                                                            "name=Gaussian,Height=0.950388,PeakCentre=$PC4$,Sigma=19.8408;"
+                                                            "name=Gaussian,Height=1.92185,PeakCentre=$PC5$,Sigma=18.0844;"
+                                                            "name=Gaussian,Height=3.64069,PeakCentre=$PC6$,Sigma=19.2404;"
+                                                            "name=Gaussian,Height=2.8998,PeakCentre=$PC7$,Sigma=21.1127;"
+                                                            "name=Gaussian,Height=2.05237,PeakCentre=$PC8$,Sigma=21.9932;"
+                                                            "name=Gaussian,Height=8.40976,PeakCentre=$PC9$,Sigma=25.2751;");
+        """
+        # In practice: due to some type of rebinning issue in `PDCalibration`:
+        #   it was found necessary to apply an additional magnitude scale factor to the generated data.
+        # TODO: track down the reason for this and create an associated DEFECT.
+
+        centres = np.arange(dMin, dMax, 0.1 * (dMax - dMin))
+        dspDomain = dMax - dMin
+        tofDomain = tofMax - tofMin
+        peaks = [
+            Peak(centres[1], 14.3772 * dspDomain / tofDomain, scale * 0.584528),
+            Peak(centres[2], 15.2516 * dspDomain / tofDomain, scale * 1.33361),
+            Peak(centres[3], 15.8395 * dspDomain / tofDomain, scale * 1.74691),
+            Peak(centres[4], 19.8408 * dspDomain / tofDomain, scale * 0.950388),
+            Peak(centres[5], 18.0844 * dspDomain / tofDomain, scale * 1.92185),
+            Peak(centres[6], 19.2404 * dspDomain / tofDomain, scale * 3.64069),
+            Peak(centres[7], 21.1127 * dspDomain / tofDomain, scale * 2.8998),
+            Peak(centres[8], 21.9932 * dspDomain / tofDomain, scale * 2.05237),
+            Peak(centres[9], 25.2751 * dspDomain / tofDomain, scale * 8.40976),
+        ]
+        background = f"name= LinearBackground,A0={scale * 0.0850208},A1={scale * -4.89583e-06 * dspDomain / tofDomain};"
+        return peaks, background
+
+    def generateWorkspaces(self, rawWS: str, groupingWS: str, maskWS: str) -> None:
+        """Generate initialized workspace data:
+        -- rawWS: an input workspace in TOF units;
+        -- groupingWS: the associated grouping workspace;
+        -- maskWS: a compatible mask workspace
+        """
+        # IMPORTANT: why does this method exist as a public method, rather than just immediately generating these workspaces in the '__init__'?
+        #   In order to avoid collisions in the Analysis Data Service during _parallel_ test runs, especially when input workspaces
+        #     are modified: unique workspace names must be used.
+        #   This means that best practice is to generate (or clone) workspace data at point-of-use for each test method.
+        #   Either a per-test setup method can be used (with unique names), or a per-class setup method can be used, with cloning
+        #     to new workspaces with unique names.
+
+        # Notes:
+        #   * The design idea behind this data initialization is to start with _perfectly_ calibrated data,
+        #       and then work backwards.  In d-spacing, spectra from such data will have zero relative offsets (between pixels).
+        #   * A random normal distribution (with a known seed) is used to modify the starting data, with the offset shifts limited to
+        #       physically meaningful values.
+        #   * The actual modification used corresponds precisely to the d-space to TOF scaling (using DIFC).  This is more
+        #       physically relevant than just shifting the data by the offsets.
+        #       (However, as random offset shifts are used, this is probably a fine point.)
+        #   * Note that for many of the diffraction-calibration processing steps, units are in BINs, and not in d-spacing or TOF.
+        #   * Diffraction-calibration methods expect logarithmically binned input data in TOF units;
+        #   * Mathematically: since TOF is largely a scale-factor (DIFC) conversion from d-spacing,
+        #       properly logarithmically-binned d-spacing data, converted to TOF, will automatically have the proper TOF binning;
+        #   * Regardless, any rebinning must use the fact that for converted data,
+        #       the appropriate bin size for logarithmic binning will be _exactly_ the _same_
+        #       for both d-spacing and converted-to-TOF units.  If this requirement is not satisfied _rigorously_,
+        #       the following rebinning artifacts can be induced:
+        #         - artificial piecewise-linear smoothing (or interpolation) of the data;
+        #         - rebinning aliasing (and associated oscillation) in the calibration convergence loop;
+        #         - data rescaling issues: i.e. data magnitudes are much smaller (or larger) than expected.
+
+        TOFMin = self.ingredients.pixelGroup.timeOfFlight.minimum
+        TOFMax = self.ingredients.pixelGroup.timeOfFlight.maximum
+        dMin = self.ingredients.pixelGroup.dMin()
+        dMax = self.ingredients.pixelGroup.dMax()
+        dBin = self.ingredients.pixelGroup.dBin()
+        overallDMin = min(dMin)
+        overallDMax = max(dMax)
+
+        dBin_abs = max([abs(d) for d in dBin])
+        nominalBinCount = int((overallDMax - overallDMin) / dBin_abs)
+
+        functionString = self.background_function
+        for p in self.peaks:
+            functionString += f"name=Gaussian, PeakCentre={p.centre}, Height={p.height}, Sigma={p.sigma};"
+
+        # Create the input workspace 'rawWS':
+        CreateSampleWorkspace(
+            OutputWorkspace=rawWS,
+            WorkspaceType=self.workspaceType,
+            Function="User Defined",
+            UserDefinedFunction=functionString,
+            Xmin=overallDMin,
+            Xmax=overallDMax,
+            BinWidth=dBin_abs,
+            XUnit="dSpacing",
+            NumBanks=4,  # must produce same number of pixels as fake instrument
+            BankPixelWidth=2,  # each bank has 4 pixels, 4 banks, 16 total
+        )
+
+        LoadInstrument(
+            Workspace=rawWS,
+            Filename=self.fakeInstrumentFilePath,
+            RewriteSpectraMap=True,
+        )
+
+        # Load the grouping workspace 'groupingWS':
+        LoadDetectorsGroupingFile(
+            InputFile=self.fakeGroupingFilePath,
+            InputWorkspace=rawWS,
+            OutputWorkspace=groupingWS,
+        )
+
+        focWS = mtd[groupingWS]
+        detectors = focWS.detectorInfo()
+        allXmins = [0] * 16
+        allXmaxs = [0] * 16
+        allDelta = [0] * 16
+        for i, gid in enumerate(focWS.getGroupIDs()):
+            for detid in focWS.getDetectorIDsOfGroup(int(gid)):
+                det_index = detectors.indexOf(int(detid))
+                allXmins[det_index] = dMin[i]
+                allXmaxs[det_index] = dMax[i]
+                allDelta[det_index] = dBin[i]
+        RebinRagged(
+            InputWorkspace=rawWS,
+            OutputWorkspace=rawWS,
+            XMin=allXmins,
+            XMax=allXmaxs,
+            Delta=allDelta,
+        )
+
+        # Shift the spectra so that they have differing offsets
+        _ws = mtd[rawWS]
+        shiftSigma = 10.0  # bins
+        binOffsetShifts = np.random.default_rng(SyntheticData.RANDOM_SEED).normal(
+            loc=0.0, scale=shiftSigma, size=_ws.getNumberHistograms()
+        )
+        for ns in range(_ws.getNumberHistograms()):
+            bin_width = abs(allDelta[ns])
+            offset = binOffsetShifts[ns] * (dBin_abs / bin_width)  # retain normal distribution
+            factor = np.power(1.0 + bin_width, offset)
+            ScaleX(
+                InputWorkspace=rawWS,
+                OutputWorkspace=rawWS,
+                IndexMin=ns,
+                IndexMax=ns,
+                Factor=factor,
+                Operation="Multiply",
+            )
+
+        # Convert to non-ragged workspace:
+        Rebin(
+            InputWorkspace=rawWS,
+            OutputWorkspace=rawWS,
+            Params=(overallDMin, dBin_abs, overallDMax),
+            BinningMode="Logarithmic",
+        )
+
+        # Convert to TOF units (binning is already correct):
+        ConvertUnits(
+            InputWorkspace=rawWS,
+            OutputWorkspace=rawWS,
+            Target="TOF",
+        )
+
+        # Create the mask workspace 'maskWS':
+        createCompatibleMask(maskWS, rawWS, self.fakeInstrumentFilePath)

--- a/tests/util/helpers.py
+++ b/tests/util/helpers.py
@@ -40,15 +40,11 @@ def createCompatibleMask(maskWSName: str, templateWSName: str, instrumentFilePat
     )
     if mask.getInstrument().getNumberDetectors(True) != templateWS.getInstrument().getNumberDetectors(True):
         raise RuntimeError(
-            f'Instrument file resource "{instrumentFilePath}" does not describe the template workspace'
-            "s instrument"
+            f'Instrument file resource "{instrumentFilePath}" does not describe the template workspace' "s instrument"
         )
     # Copy any configurable instrument parameters from the template workspace.
-    CopyInstrumentParameters(
-        InputWorkspace=templateWSName,
-        OutputWorkspace=maskWSName
-    )
-    
+    CopyInstrumentParameters(InputWorkspace=templateWSName, OutputWorkspace=maskWSName)
+
     # Rebuild the spectra map "by hand" to exclude detectors which are monitors.
     info = mask.detectorInfo()
     ids = info.detectorIDs()
@@ -71,7 +67,7 @@ def createCompatibleMask(maskWSName: str, templateWSName: str, instrumentFilePat
 
 def setSpectraToZero(inputWS: MatrixWorkspace, nss: Sequence[int]):
     # Zero out all spectra in the list of spectra
-    if not 'EventWorkspace' in inputWS.id():
+    if "EventWorkspace" not in inputWS.id():
         for ns in nss:
             # allow "ragged" case
             zs = np.zeros_like(inputWS.readY(ns))
@@ -79,7 +75,8 @@ def setSpectraToZero(inputWS: MatrixWorkspace, nss: Sequence[int]):
     else:
         for ns in nss:
             inputWS.getSpectrum(ns).clear(False)
-    
+
+
 def maskSpectra(maskWS: MaskWorkspace, inputWS: MatrixWorkspace, nss: Sequence[int]):
     # Set mask flags for all detectors contributing to each spectrum in the list of spectra
     for ns in nss:
@@ -87,12 +84,13 @@ def maskSpectra(maskWS: MaskWorkspace, inputWS: MatrixWorkspace, nss: Sequence[i
         for det in dets:
             maskWS.setValue(det, True)
 
+
 def setGroupSpectraToZero(ws: MatrixWorkspace, groupingWS: GroupingWorkspace, gids: Sequence[int]):
     # Zero out all spectra contributing to each group in the list of groups
     detInfo = ws.detectorInfo()
     for gid in gids:
         dets = groupingWS.getDetectorIDsOfGroup(gid)
-        if not 'EventWorkspace' in ws.id():
+        if "EventWorkspace" not in ws.id():
             for det in dets:
                 ns = detInfo.indexOf(int(det))
                 # allow "ragged" case
@@ -102,6 +100,7 @@ def setGroupSpectraToZero(ws: MatrixWorkspace, groupingWS: GroupingWorkspace, gi
             for det in dets:
                 ns = detInfo.indexOf(int(det))
                 ws.getSpectrum(ns).clear(False)
+
 
 def maskGroups(maskWS: MaskWorkspace, groupingWS: GroupingWorkspace, gs: Sequence[int]):
     # Set mask flags for all detectors contributing to each group in the list of groups
@@ -139,7 +138,7 @@ def mutableWorkspaceClones(
 def deleteWorkspaceNoThrow(wsName: str):
     try:
         DeleteWorkspace(wsName)
-    except: # noqa: E722
+    except:  # noqa: E722
         pass
 
 

--- a/tests/util/helpers.py
+++ b/tests/util/helpers.py
@@ -1,0 +1,151 @@
+# @file: tests/util/helpers.py:
+#
+# Helper utility methods to be used by unit tests and CIS tests.
+#
+
+# *** DEBUG ***
+import pdb
+
+import unittest
+from collections.abc import Sequence
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+import pytest
+from mantid.api import ITableWorkspace, MatrixWorkspace
+from mantid.dataobjects import GroupingWorkspace, MaskWorkspace
+from mantid.simpleapi import (
+    ExtractMask,
+    LoadInstrument,
+    CopyInstrumentParameters,
+    WorkspaceFactory,
+    DeleteWorkspace,
+    ScaleX,
+    mtd,
+)
+from snapred.meta.Config import Resource
+
+
+def createCompatibleMask(maskWSName: str, templateWSName: str, instrumentFilePath: str) -> MaskWorkspace:
+    """
+    Create a `MaskWorkspace` compatible with a template workspace and instrument
+      (At present, due to limitations in the Mantid python API, the instrumentFilePath is necessary.)
+    """
+    templateWS = mtd[templateWSName]
+    inst = templateWS.getInstrument()
+    # Exclude pixels which are monitors:
+    mask = WorkspaceFactory.create("SpecialWorkspace2D", NVectors=inst.getNumberDetectors(True), XLength=1, YLength=1)
+    mtd[maskWSName] = mask
+    LoadInstrument(
+        Workspace=maskWSName,
+        Filename=instrumentFilePath,
+        RewriteSpectraMap=False,
+    )
+    if mask.getInstrument().getNumberDetectors(True) != templateWS.getInstrument().getNumberDetectors(True):
+        raise RuntimeError(
+            f'Instrument file resource "{instrumentFileResourceName}" does not describe the template workspace'
+            "s instrument"
+        )
+    # Copy any configurable instrument parameters from the template workspace.
+    CopyInstrumentParameters(
+        InputWorkspace=templateWSName,
+        OutputWorkspace=maskWSName
+    )
+    
+    # Rebuild the spectra map "by hand" to exclude detectors which are monitors.
+    info = mask.detectorInfo()
+    ids = info.detectorIDs()
+    wi = 0 # Warning: <detector info>.indexOf(id) != <workspace index of detectors excluding monitors>
+    for id in ids:
+        if info.isMonitor(info.indexOf(int(id))):
+            continue
+        s = mask.getSpectrum(wi)
+        s.setSpectrumNo(wi)
+        s.setDetectorID(int(id))
+        wi += 1
+    
+    # Convert workspace to a MaskWorkspace instance.
+    ExtractMask(InputWorkspace=maskWSName, OutputWorkspace=maskWSName)
+    assert isinstance(mtd[maskWSName], MaskWorkspace)
+    return mask
+
+
+def setSpectraToZero(inputWS: MatrixWorkspace, nss: Sequence[int]):
+    # Zero out all spectra in the list of spectra
+    if not 'EventWorkspace' in inputWS.id():
+        for ns in nss:
+            # allow "ragged" case
+            zs = np.zeros_like(inputWS.readY(ns))
+            inputWS.setY(ns, zs)
+    else:
+        for ns in nss:
+            inputWS.getSpectrum(ns).clear(False)
+    
+def maskSpectra(maskWS: MaskWorkspace, inputWS: MatrixWorkspace, nss: Sequence[int]):
+    # Set mask flags for all detectors contributing to each spectrum in the list of spectra
+    for ns in nss:
+        dets = inputWS.getSpectrum(ns).getDetectorIDs()
+        for det in dets:
+            maskWS.setValue(det, True)
+
+def setGroupSpectraToZero(ws: MatrixWorkspace, groupingWS: GroupingWorkspace, gids: Sequence[int]):
+    # Zero out all spectra contributing to each group in the list of groups
+    detInfo = ws.detectorInfo()
+    for gid in gids:
+        dets = groupingWS.getDetectorIDsOfGroup(gid)
+        if not 'EventWorkspace' in ws.id():
+            for det in dets:
+                ns = detInfo.indexOf(int(det))
+                # allow "ragged" case
+                zs = np.zeros_like(ws.readY(ns))
+                ws.setY(ns, zs)
+        else:
+            for det in dets:
+                ns = detInfo.indexOf(int(det))
+                ws.getSpectrum(ns).clear(False)
+            
+def maskGroups(maskWS: MaskWorkspace, groupingWS: GroupingWorkspace, gs: Sequence[int]):
+    # Set mask flags for all detectors contributing to each group in the list of groups
+    for gid in gs:
+        dets = groupingWS.getDetectorIDsOfGroup(gid)
+        for det in dets:
+            maskWS.setValue(int(det), True)
+
+
+def mutableWorkspaceClones(
+    sourceWorkspaceNames: Sequence[str], uniquePrefix: str, name_only: bool = False
+) -> Tuple[Any]:
+    """
+    Clone workspaces so that they can be modified by simultaneously running tests.
+    Each cloned workspace will have a name: <unique prefix> + <original workspace name>
+    """
+    from mantid.simpleapi import mtd
+
+    wss = []
+    ws_names = []
+    for name in sourceWorkspaceNames:
+        if name not in mtd:
+            raise RuntimeError(f'workspace "{name}" is not in the ADS')
+        if not name_only:
+            clone = mtd[name].clone()
+            clone_name = uniquePrefix + name
+            mtd[clone_name] = clone
+            wss.append(clone)
+        else:
+            clone_name = uniquePrefix + name
+            ws_names.append(clone_name)
+    return tuple(wss) if not name_only else tuple(ws_names)
+
+
+def deleteWorkspaceNoThrow(wsName: str):
+    try:
+        DeleteWorkspace(wsName)
+    except:
+        pass
+
+
+def nameOfRunningTestMethod(testCaseInstance: unittest.TestCase):
+    # Call anywhere in the unit test (or its 'setUp') as 'nameOfRunningTestMethod(self)': return the _name_ of the running test method
+    id_: str = testCaseInstance.id()
+    id_ = id_[id_.rfind(".") + 1 :]
+    return id_

--- a/tests/util/helpers.py
+++ b/tests/util/helpers.py
@@ -5,7 +5,6 @@
 
 # *** DEBUG ***
 import pdb
-
 import unittest
 from collections.abc import Sequence
 from typing import Any, Dict, List, Tuple
@@ -15,12 +14,12 @@ import pytest
 from mantid.api import ITableWorkspace, MatrixWorkspace
 from mantid.dataobjects import GroupingWorkspace, MaskWorkspace
 from mantid.simpleapi import (
+    CopyInstrumentParameters,
+    DeleteWorkspace,
     ExtractMask,
     LoadInstrument,
-    CopyInstrumentParameters,
-    WorkspaceFactory,
-    DeleteWorkspace,
     ScaleX,
+    WorkspaceFactory,
     mtd,
 )
 from snapred.meta.Config import Resource
@@ -47,15 +46,12 @@ def createCompatibleMask(maskWSName: str, templateWSName: str, instrumentFilePat
             "s instrument"
         )
     # Copy any configurable instrument parameters from the template workspace.
-    CopyInstrumentParameters(
-        InputWorkspace=templateWSName,
-        OutputWorkspace=maskWSName
-    )
-    
+    CopyInstrumentParameters(InputWorkspace=templateWSName, OutputWorkspace=maskWSName)
+
     # Rebuild the spectra map "by hand" to exclude detectors which are monitors.
     info = mask.detectorInfo()
     ids = info.detectorIDs()
-    wi = 0 # Warning: <detector info>.indexOf(id) != <workspace index of detectors excluding monitors>
+    wi = 0  # Warning: <detector info>.indexOf(id) != <workspace index of detectors excluding monitors>
     for id in ids:
         if info.isMonitor(info.indexOf(int(id))):
             continue
@@ -63,7 +59,7 @@ def createCompatibleMask(maskWSName: str, templateWSName: str, instrumentFilePat
         s.setSpectrumNo(wi)
         s.setDetectorID(int(id))
         wi += 1
-    
+
     # Convert workspace to a MaskWorkspace instance.
     ExtractMask(InputWorkspace=maskWSName, OutputWorkspace=maskWSName)
     assert isinstance(mtd[maskWSName], MaskWorkspace)
@@ -72,7 +68,7 @@ def createCompatibleMask(maskWSName: str, templateWSName: str, instrumentFilePat
 
 def setSpectraToZero(inputWS: MatrixWorkspace, nss: Sequence[int]):
     # Zero out all spectra in the list of spectra
-    if not 'EventWorkspace' in inputWS.id():
+    if "EventWorkspace" not in inputWS.id():
         for ns in nss:
             # allow "ragged" case
             zs = np.zeros_like(inputWS.readY(ns))
@@ -80,7 +76,8 @@ def setSpectraToZero(inputWS: MatrixWorkspace, nss: Sequence[int]):
     else:
         for ns in nss:
             inputWS.getSpectrum(ns).clear(False)
-    
+
+
 def maskSpectra(maskWS: MaskWorkspace, inputWS: MatrixWorkspace, nss: Sequence[int]):
     # Set mask flags for all detectors contributing to each spectrum in the list of spectra
     for ns in nss:
@@ -88,12 +85,13 @@ def maskSpectra(maskWS: MaskWorkspace, inputWS: MatrixWorkspace, nss: Sequence[i
         for det in dets:
             maskWS.setValue(det, True)
 
+
 def setGroupSpectraToZero(ws: MatrixWorkspace, groupingWS: GroupingWorkspace, gids: Sequence[int]):
     # Zero out all spectra contributing to each group in the list of groups
     detInfo = ws.detectorInfo()
     for gid in gids:
         dets = groupingWS.getDetectorIDsOfGroup(gid)
-        if not 'EventWorkspace' in ws.id():
+        if "EventWorkspace" not in ws.id():
             for det in dets:
                 ns = detInfo.indexOf(int(det))
                 # allow "ragged" case
@@ -103,7 +101,8 @@ def setGroupSpectraToZero(ws: MatrixWorkspace, groupingWS: GroupingWorkspace, gi
             for det in dets:
                 ns = detInfo.indexOf(int(det))
                 ws.getSpectrum(ns).clear(False)
-            
+
+
 def maskGroups(maskWS: MaskWorkspace, groupingWS: GroupingWorkspace, gs: Sequence[int]):
     # Set mask flags for all detectors contributing to each group in the list of groups
     for gid in gs:


### PR DESCRIPTION
### Any comments that anyone left at the previous [PR#165](https://github.com/neutrons/SNAPRed/pull/165) for this story will be addressed here.  Thanks in advance for your patience!

## Description of work

During the diffraction-calibration process, masking information is accumulated for failing pixels.  Failing pixels are identified both during the offset-computation stage, and also during the diffraction-focussing optimization stage.  All of this masking information must be combined. 

## Explanation of work

Most of the implementation changes required to combine pixel masking information were in the _Mantid_ codebase, and have already been successfully merged. With respect to the _SNAPRed_ codebase, the present commit includes the following changes:

* Definition of 'MaskWorkspace' as an _optional_ `Output` parameter of both `PixelDiffractionCalibration` and `GroupDiffractionCalibration`.  As documented, the present `Output` parameter definition covers the use case of applying information from a specified workspace that already exists.
* Proper treatment of the 'MaskWorkspace' parameter in the `DiffractionCalibrationRecipe`: -- support for an _mandatory_ 'MaskWorkspace' `Output` parameter; if the workspace already exists, its masking information will be applied;  Note that this parameter _must_ be initialized in order to properly pass masking information between the diffraction-calibration processing stages; -- passing of the 'MaskWorkspace' parameter between the `PixelDiffractionCalibration` and `GroupDiffractionCalibration` processing steps;
* Generation of the default 'OutputWorkspace' and 'MaskWorkspace' names in the `GroceryList` using the new `WorkspaceNameGenerator` system.
* Implementation of a new system for generating synthetic data to be used for the diffraction-calibration tests.  Note that many of the previous versions of the tests, when masking information was examined after execution, were failing for almost every pixel.  This new synthetic data system can be generalized (although it has not yet been generalized) to allow _automatic_ use with almost any instrument and its associated grouping definitions.
* Synthetic-data preparation classes and routines and associated test-helper routines are now located at `tests/util` in the SNAPRed codebase.  **Please let me know if you think there's a better location for these routines.**
* **Additional notes:  I was not quite sure how to deal with the possibility of an _incoming_ 'MaskWorkspace' parameter in `DiffractionCalibrationRequest`, and it is also possible that the FetchGroceries system needs additional modification to deal with such a parameter.  If required, at this point due to the extent of this current PR, all of this should be added to a _new_ story.**

## To test
A number of new _unit_ tests have been added at `test_PixelDiffractionCalibration`, and `test_GroupDiffractionCalibration`.  In addition, _existing_ unit tests have been modified so that _masking_ is verified where appropriate.  Note that the new synthetic-data preparation provides more-realistic data, that passes all of the execution tests without _any_ pixels failing -- this then allows pixels and groups to be _selectively_ failed, in order to test masking behavior.  Note: additional tests may be required to actually test the synthetic-data and test-helper methods -- at present, these are tested _implicitly_ in that the associated tests will fail if the methods do not work as required.


### CIS testing
A modified version of `new_diffcal_script.py` is at `diffcal_masking_script.py`: this script adds sections specifically to allow convenient setup for testing masking behavior.


## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#3464](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=3464)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
