### PR TITLE
fix the issue with lite mode output

### DIFF
--- a/src/snapred/backend/recipe/algorithm/DiffractionSpectrumWeightCalculator.py
+++ b/src/snapred/backend/recipe/algorithm/DiffractionSpectrumWeightCalculator.py
@@ -121,6 +121,8 @@ class DiffractionSpectrumWeightCalculator(PythonAlgorithm):
                 mask_indices = np.where(np.logical_and(x > peak.position.minimum, x < peak.position.maximum))
                 weights[mask_indices] = 0.0
             weight_ws.setY(index, weights)
+        
+        self.setProperty("WeightWorkspace", weight_ws)
 
         if isEventWorkspace:
             self.mantidSnapper.ConvertToEventWorkspace(

--- a/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
@@ -122,12 +122,6 @@ class LiteDataCreationAlgo(PythonAlgorithm):
                 Workspace=inputWorkspaceName,
             )
 
-        if self.getProperty("LiteDataMapWorkspace").isDefault:
-            self.mantidSnapper.WashDishes(
-                "Removing lite map workspace",
-                Workspace=groupingWorkspaceName,
-            )
-
         # iterate over spectra in grouped workspace, delete old ids and replace
         self.mantidSnapper.executeQueue()
         liteWksp = self.mantidSnapper.mtd[outputWorkspaceName]

--- a/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
@@ -136,6 +136,7 @@ class LiteDataCreationAlgo(PythonAlgorithm):
             el.clearDetectorIDs()
             el.addDetectorID(i)
         liteWksp.setComment(liteWksp.getComment() + "\nLite")
+        self.setProperty("OutputWorkspace", liteWksp)
 
 
 # Register algorithm with Mantid

--- a/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
@@ -88,7 +88,8 @@ class LiteDataCreationAlgo(PythonAlgorithm):
             # add the word "Lite" to the comments for good measure
             outWS = self.mantidSnapper.mtd[outputWorkspaceName]
             outWS.setComment(outWS.getComment() + "\nLite")
-            return
+            self.setProperty("OutputWorkspace", outWS)
+            return # NOTE EARLY
 
         # use group detector with specific grouping file to create lite data
         self.mantidSnapper.GroupDetectors(

--- a/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
@@ -112,6 +112,8 @@ class SmoothDataExcludingPeaksAlgo(PythonAlgorithm):
             # fill in the removed data using the spline function and original datapoints
             smoothing_results = tck(xMidpoints, extrapolate=False)
             outputWorkspace.setY(index, smoothing_results)
+            
+        self.setProperty("OutputWorkspace", outputWorkspace)
 
         self.mantidSnapper.WashDishes(
             "Cleaning up weight workspace...",

--- a/tests/unit/backend/recipe/algorithm/test_LiteDataCreationAlgo.py
+++ b/tests/unit/backend/recipe/algorithm/test_LiteDataCreationAlgo.py
@@ -372,6 +372,7 @@ def test_no_run_twice():
     )
     #
     liteDataCreationAlgo.mantidSnapper = mock.MagicMock()
+    liteDataCreationAlgo.setProperty = mock.MagicMock()
     liteDataCreationAlgo.setPropertyValue("InputWorkspace", inputWorkspace)
     assert liteDataCreationAlgo.execute()
     liteDataCreationAlgo.mantidSnapper.GroupDetectors.called_once()


### PR DESCRIPTION
## Description of work

This fixes a defect spotted with running the lite data algorithm through the `new_diffcal_script`

It also addresses some issues noted by Michael within normalization calibration.

It is unknown and probably unknowable how on earth we got this far into the process without noticing this.

## Explanation of work

For reasons known mystical and arcane, it is required to update the property with a pointer to the workspace in the ADS (the same pointer) at the end of the algorithm.  So we must set the thing back to itself, otherwise the mantid algorithm lifecycle will undo all of our work at the end of the algorithm.

Basically, any algorithm which uses

``` python
outputWS = self.mantidSnapper.mtd[self.getPropertyValue("OutputWorkspace")]
```
then edits `outputWS` using API function calls, must at some point perform
``` python
self.setProperty("OutputWorkspace", outputWS)
```

## To test

### Dev testing

<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing
``` python
from mantid.simpleapi import mtd

from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
from snapred.backend.data.GroceryService import GroceryService
from snapred.meta.Config import Config

#User input ###########################
badRunNumbers = ["57514", "58812"]  # known to have failed before
isLite = True
Config._config["cis_mode"] = False
LITE_DATA_RESOLUTION = 18432
#######################################

clerk = GroceryListItem.builder()
grocer = GroceryService()

for x in badRunNumbers:
    badList = clerk.neutron(x).lite().buildList()
    badWorkspace = grocer.fetchGroceryList(badList)[0]
    print(badWorkspace)
    assert mtd[badWorkspace].getNumberHistograms() == LITE_DATA_RESOLUTION
```

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#3553](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3553)
