### PR TITLE
allows workspace list to stretch

### DIFF
--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -6,6 +6,7 @@ from qtpy.QtWidgets import (
     QApplication,
     QMainWindow,
     QPushButton,
+    QSizePolicy,
     QSplitter,
     QStatusBar,
     QVBoxLayout,

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -4,9 +4,12 @@ from mantidqt.widgets.algorithmprogress import AlgorithmProgressWidget
 from qtpy.QtCore import Qt, QTimer
 from qtpy.QtWidgets import (
     QApplication,
+    QGridLayout,
     QHBoxLayout,
+    QLayout,
     QMainWindow,
     QPushButton,
+    QSizePolicy,
     QSplitter,
     QStatusBar,
     QVBoxLayout,
@@ -41,13 +44,9 @@ class SNAPRedGUI(QMainWindow):
         # myiv.show_view()
 
         # import pdb; pdb.set_trace()
-        workspaceWidgetWrapper = QWidget()
-        workspaceWidgetWrapperLayout = QHBoxLayout()
         workspaceWidget = WorkspaceWidget(self)
-        workspaceWidgetWrapper.setObjectName("workspaceTreeWidget")
-        workspaceWidgetWrapperLayout.addWidget(workspaceWidget, alignment=Qt.AlignCenter)
-        workspaceWidgetWrapper.setLayout(workspaceWidgetWrapperLayout)
-        splitter.addWidget(workspaceWidgetWrapper)
+        splitter.addWidget(workspaceWidget)
+
         splitter.addWidget(AlgorithmProgressWidget())
 
         centralWidget = QWidget()

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -4,12 +4,8 @@ from mantidqt.widgets.algorithmprogress import AlgorithmProgressWidget
 from qtpy.QtCore import Qt, QTimer
 from qtpy.QtWidgets import (
     QApplication,
-    QGridLayout,
-    QHBoxLayout,
-    QLayout,
     QMainWindow,
     QPushButton,
-    QSizePolicy,
     QSplitter,
     QStatusBar,
     QVBoxLayout,


### PR DESCRIPTION
## Description of work
Lets the workspace list stretch left and all over, however the buttons move a little and dont looks as stylish when stretched.  
Function over Form I suppose.


## To test

Open the gui and stretch the window
