### PR TITLE
Added UI support for calibration quality assessment

### DIFF
--- a/src/snapred/backend/dao/request/CalibrationIndexRequest.py
+++ b/src/snapred/backend/dao/request/CalibrationIndexRequest.py
@@ -1,0 +1,15 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+from snapred.backend.dao.RunConfig import RunConfig
+from snapred.meta.Config import Config
+
+
+class CalibrationIndexRequest(BaseModel):
+    """
+    Request an index of all calibration records corresponding to
+    the instrument state associated with a given run
+    """
+
+    run: RunConfig

--- a/src/snapred/backend/dao/request/CalibrationLoadAssessmentRequest.py
+++ b/src/snapred/backend/dao/request/CalibrationLoadAssessmentRequest.py
@@ -1,0 +1,17 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+from snapred.backend.dao.RunConfig import RunConfig
+from snapred.meta.Config import Config
+
+
+class CalibrationLoadAssessmentRequest(BaseModel):
+    """
+    Request object to generate and load an assessment for a given calibration version
+    of the instrument state associated with a given run
+    """
+
+    runId: str
+    version: str
+    checkExistent: bool  # if true, do not generate assessment if it already exists

--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -99,8 +99,8 @@ class DataFactoryService:
     def getWorkspaceSingleUse(self, runId: str, useLiteMode: bool):
         return self.groceryService.fetchNeutronDataSingleUse(runId, useLiteMode)
 
-    def getCalibrationRecord(self, runId):
-        return self.lookupService.readCalibrationRecord(runId)
+    def getCalibrationRecord(self, runId, version: str = None):
+        return self.lookupService.readCalibrationRecord(runId, version)
 
     def getNormalizationRecord(self, runId):
         return self.lookupService.readNormalizationRecord(runId)

--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -1,3 +1,4 @@
+import os
 from pdb import run
 from typing import Dict
 
@@ -88,7 +89,7 @@ class DataFactoryService:
 
     def loadCalibrationDataWorkspace(self, runId, version, name):
         path = self.getCalibrationDataPath(runId, version)
-        return self.groceryService.fetchWorkspace(path, name)
+        return self.groceryService.fetchWorkspace(os.path.join(path, name) + ".nxs", name)
 
     def writeWorkspace(self, path, name):
         return self.groceryService.writeWorkspace(path, name)

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -110,7 +110,7 @@ class GroceryService:
         """
         saveAlgo = AlgorithmManager.create("SaveNexus")
         saveAlgo.setProperty("InputWorkspace", name)
-        saveAlgo.setProperty("Filename", path + name)
+        saveAlgo.setProperty("Filename", path)
         saveAlgo.execute()
 
     def writeGrouping(self, path: str, name: WorkspaceName):

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -120,7 +120,7 @@ class GroceryService:
         """
         saveAlgo = AlgorithmManager.create("SaveGroupingDefinition")
         saveAlgo.setProperty("GroupingWorkspace", name)
-        saveAlgo.setProperty("OutputFilename", path + name)
+        saveAlgo.setProperty("OutputFilename", os.path.join(path, name))
         saveAlgo.execute()
 
     def writeDiffCalTable(self, path: str, name: WorkspaceName, grouping: WorkspaceName = "", mask: WorkspaceName = ""):
@@ -131,7 +131,7 @@ class GroceryService:
         saveAlgo.setPropertyValue("CalibrationWorkspace", name)
         saveAlgo.setPropertyValue("GroupingWorkspace", grouping)
         saveAlgo.setPropertyValue("MaskWorkspace", mask)
-        saveAlgo.setPropertyValue("Filename", path + name)
+        saveAlgo.setPropertyValue("Filename", os.path.join(path, name))
         saveAlgo.execute()
 
     ## ACCESSING WORKSPACES

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -110,7 +110,8 @@ class GroceryService:
         """
         saveAlgo = AlgorithmManager.create("SaveNexus")
         saveAlgo.setProperty("InputWorkspace", name)
-        saveAlgo.setProperty("Filename", path)
+        saveAlgo.setProperty("Filename", os.path.join(path, name) + ".nxs")
+
         saveAlgo.execute()
 
     def writeGrouping(self, path: str, name: WorkspaceName):

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -519,18 +519,16 @@ class LocalDataService:
     def readCalibrationRecord(self, runId: str, version: str = None):
         stateId, _ = self._generateStateId(runId)
         recordPath: str = self.getCalibrationRecordPath(runId, "*")
-        # find the latest version
-        latestFile = ""
+        print(f"*****RECORD PATH: {recordPath}")
+        recordFile = ""
         if version:
-            latestFile = self._getFileOfVersion(recordPath, version)
+            recordFile = self._getFileOfVersion(recordPath, version)
         else:
-            latestFile = self._getLatestFile(recordPath)
-        # read the file
+            recordFile = self._getLatestFile(recordPath)
         record: CalibrationRecord = None
-        if latestFile:
-            logger.info(f"reading CalibrationRecord from {latestFile}")
-            record = parse_file_as(CalibrationRecord, latestFile)
-
+        if recordFile:
+            logger.info(f"reading CalibrationRecord from {recordFile}")
+            record = parse_file_as(CalibrationRecord, recordFile)
         return record
 
     def writeCalibrationRecord(self, record: CalibrationRecord, version: int = None):

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -517,13 +517,12 @@ class LocalDataService:
         return record
 
     def readCalibrationRecord(self, runId: str, version: str = None):
-        stateId, _ = self._generateStateId(runId)
-        recordPath: str = self.getCalibrationRecordPath(runId, "*")
-        print(f"*****RECORD PATH: {recordPath}")
-        recordFile = ""
+        recordFile: str = None
         if version:
-            recordFile = self._getFileOfVersion(recordPath, version)
+            recordPath: str = self.getCalibrationRecordPath(runId, version)
+            recordFile = self._getFileOfVersion(recordPath, int(version))
         else:
+            recordPath: str = self.getCalibrationRecordPath(runId, "*")
             recordFile = self._getLatestFile(recordPath)
         record: CalibrationRecord = None
         if recordFile:

--- a/src/snapred/backend/recipe/GenerateCalibrationMetricsWorkspaceRecipe.py
+++ b/src/snapred/backend/recipe/GenerateCalibrationMetricsWorkspaceRecipe.py
@@ -1,3 +1,7 @@
+from mantid.simpleapi import (
+    DeleteWorkspace,
+)
+
 from snapred.backend.dao.ingredients import CalibrationMetricsWorkspaceIngredients as Ingredients
 from snapred.backend.error.AlgorithmException import AlgorithmException
 from snapred.backend.log.logger import snapredLogger
@@ -7,6 +11,7 @@ from snapred.backend.recipe.GenericRecipe import (
     GenerateTableWorkspaceFromListOfDictRecipe,
 )
 from snapred.meta.decorators.Singleton import Singleton
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 from snapred.meta.redantic import list_to_raw
 
 logger = snapredLogger.getLogger(__name__)
@@ -21,32 +26,34 @@ class GenerateCalibrationMetricsWorkspaceRecipe:
         runId = ingredients.calibrationRecord.runNumber
 
         if ingredients.timestamp is not None:
-            logger.info(f"Executing recipe {__name__} for run: {runId} timestamp: {ingredients.timestamp}")
-            outputWS_stem = f"{runId}_calibrationMetrics_ts{ingredients.timestamp}"
+            calibVersionOrTimeStamp = "ts" + str(ingredients.timestamp)
+            logger.info(f"Executing recipe {__name__} for run: {runId} timestamp: {calibVersionOrTimeStamp}")
         else:
-            calibrationVersion = ingredients.calibrationRecord.version
-            logger.info(f"Executing recipe {__name__} for run: {runId} calibration version: {calibrationVersion}")
-            outputWS_stem = f"{runId}_calibrationMetrics_v{calibrationVersion}"
+            calibVersionOrTimeStamp = ingredients.calibrationRecord.version
+            logger.info(f"Executing recipe {__name__} for run: {runId} calibration version: {calibVersionOrTimeStamp}")
 
-        tableWS = outputWS_stem + "_table"
+        ws_table = wng.diffCalMetrics().runNumber(runId).version(calibVersionOrTimeStamp).metricName("table").build()
+
         try:
             # create a table workspace with all metrics
             GenerateTableWorkspaceFromListOfDictRecipe().executeRecipe(
                 ListOfDict=list_to_raw(ingredients.calibrationRecord.focusGroupCalibrationMetrics.calibrationMetric),
-                OutputWorkspace=tableWS,
+                OutputWorkspace=ws_table,
             )
 
             # convert the table workspace to 2 matrix workspaces: sigma vs. twoTheta and strain vs. twoTheta
             for metric in ["sigma", "strain"]:
+                ws_metric = (
+                    wng.diffCalMetrics().runNumber(runId).version(calibVersionOrTimeStamp).metricName(metric).build()
+                )
                 ConvertTableToMatrixWorkspaceRecipe().executeRecipe(
-                    InputWorkspace=tableWS,
+                    InputWorkspace=ws_table,
                     ColumnX="twoThetaAverage",
                     ColumnY=metric + "Average",
                     ColumnE=metric + "StandardDeviation",
-                    OutputWorkspace=outputWS_stem + "_" + metric,
+                    OutputWorkspace=ws_metric,
                 )
-
-            self.mantidSnapper.DeleteWorkspace(f"Deleting workspace {tableWS}", Workspace=tableWS)
+            DeleteWorkspace(Workspace=ws_table)
         except (RuntimeError, AlgorithmException) as e:
             errorString = str(e)
             raise Exception(errorString.split("\n")[0])

--- a/src/snapred/backend/recipe/GenerateCalibrationMetricsWorkspaceRecipe.py
+++ b/src/snapred/backend/recipe/GenerateCalibrationMetricsWorkspaceRecipe.py
@@ -29,7 +29,7 @@ class GenerateCalibrationMetricsWorkspaceRecipe:
             calibVersionOrTimeStamp = "ts" + str(ingredients.timestamp)
             logger.info(f"Executing recipe {__name__} for run: {runId} timestamp: {calibVersionOrTimeStamp}")
         else:
-            calibVersionOrTimeStamp = ingredients.calibrationRecord.version
+            calibVersionOrTimeStamp = "v" + str(ingredients.calibrationRecord.version)
             logger.info(f"Executing recipe {__name__} for run: {runId} calibration version: {calibVersionOrTimeStamp}")
 
         ws_table = wng.diffCalMetrics().runNumber(runId).version(calibVersionOrTimeStamp).metricName("table").build()

--- a/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
@@ -307,12 +307,12 @@ class GroupDiffractionCalibration(PythonAlgorithm):
         )
         # for inspection, save diffraction focused data before calculation
         self.mantidSnapper.MakeDirtyDish(
-            "save diffraction-focussed TOF data",
+            "Save diffraction-focused TOF data",
             InputWorkspace=outputWS,
             OutputWorkspace=tmpWStof,
         )
         self.mantidSnapper.WashDishes(
-            "save diffraction-focussed d-spacing data",
+            "Delete diffraction-focused d-spacing data",
             Workspace=tmpWSdsp,
         )
         self.mantidSnapper.executeQueue()

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -228,8 +228,10 @@ class CalibrationService(Service):
                         wkspaceExists = True
                         break
             if wkspaceExists:
-                errorTxt = f"Calibration assessment for Run {runId} Version {version} "
-                f"is already loaded: see workspace {ws_name}."
+                errorTxt = (
+                    f"Calibration assessment for Run {runId} Version {version} "
+                    f"is already loaded: see workspace {ws_name}."
+                )
                 logger.error(errorTxt)
                 raise ValueError(errorTxt)
 

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -195,7 +195,7 @@ class CalibrationService(Service):
         return calibrationIndex
 
     @FromString
-    def readQuality(self, request: CalibrationLoadAssessmentRequest):
+    def loadQualityAssessment(self, request: CalibrationLoadAssessmentRequest):
         runId = request.runId
         version = request.version
 

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -206,7 +206,7 @@ class CalibrationService(Service):
             logger.error(errorTxt)
             raise ValueError(errorTxt)
 
-        # check if any of the workspaces already exists
+        # check if any of the workspaces already exist
         if request.checkExistent:
             wkspaceExists = False
             for metricName in ["sigma", "strain"]:

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -4,7 +4,7 @@ from datetime import date
 from functools import lru_cache
 from typing import List, Tuple
 
-from pydantic import parse_raw_as
+from pydantic import parse_file_as, parse_raw_as
 
 from snapred.backend.dao import GroupPeakList, RunConfig
 from snapred.backend.dao.calibration import (
@@ -78,6 +78,7 @@ class CalibrationService(Service):
         self.registerPath("checkDataExists", self.fakeMethod)
         self.registerPath("assessment", self.assessQuality)
         self.registerPath("loadQualityAssessment", self.loadQualityAssessment)
+        self.registerPath("index", self.getCalibrationIndex)
         self.registerPath("retrievePixelGroupingParams", self.fakeMethod)
         self.registerPath("diffraction", self.diffractionCalibration)
         return

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -198,7 +198,6 @@ class CalibrationService(Service):
     def readQuality(self, request: CalibrationLoadAssessmentRequest):
         runId = request.runId
         version = request.version
-        print(f"*****readQuality: {runId} {version}")
 
         calibrationRecord = self.dataFactoryService.getCalibrationRecord(runId, version)
         if calibrationRecord is None:
@@ -217,13 +216,11 @@ class CalibrationService(Service):
                     .metricName(metricName)
                     .build()
                 )
-                print(f"*****CHECKING IF {ws_name} exists")
                 if self.dataFactoryService.workspaceDoesExist(ws_name):
                     wkspaceExists = True
                     break
             if not wkspaceExists:
                 for ws_name in calibrationRecord.workspaceNames:
-                    print(f"*****CHECKING IF {ws_name} exists")
                     if self.dataFactoryService.workspaceDoesExist(ws_name):
                         wkspaceExists = True
                         break

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -4,7 +4,7 @@ from datetime import date
 from functools import lru_cache
 from typing import List, Tuple
 
-from pydantic import parse_file_as, parse_raw_as
+from pydantic import parse_raw_as
 
 from snapred.backend.dao import GroupPeakList, RunConfig
 from snapred.backend.dao.calibration import (

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -77,7 +77,7 @@ class CalibrationService(Service):
         self.registerPath("hasState", self.hasState)
         self.registerPath("checkDataExists", self.fakeMethod)
         self.registerPath("assessment", self.assessQuality)
-        self.registerPath("quality", self.readQuality)
+        self.registerPath("loadQualityAssessment", self.loadQualityAssessment)
         self.registerPath("retrievePixelGroupingParams", self.fakeMethod)
         self.registerPath("diffraction", self.diffractionCalibration)
         return

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -44,6 +44,8 @@ class _WorkspaceNameGenerator:
     _diffCalOutputTemplateKeys = ["runNumber", "unit"]
     _diffCalMaskTemplate = Config[f"{_templateRoot}.diffCal.mask"]
     _diffCalMaskTemplateKeys = ["runNumber"]
+    _diffCalMetricTemplate = Config[f"{_templateRoot}.diffCal.metric"]
+    _diffCalMetricTemplateKeys = ["runNumber", "version", "metricName"]
 
     class Units:
         _templateRoot = "mantid.workspace.nameTemplate.units"
@@ -89,6 +91,9 @@ class _WorkspaceNameGenerator:
 
     def diffCalMask(self):
         return NameBuilder(self._diffCalMaskTemplate, self._diffCalMaskTemplateKeys, self._delimiter)
+
+    def diffCalMetrics(self):
+        return NameBuilder(self._diffCalMetricTemplate, self._diffCalMetricTemplateKeys, self._delimiter)
 
 
 WorkspaceNameGenerator = _WorkspaceNameGenerator()

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -96,6 +96,7 @@ mantid:
         table: "DIFC,{runNumber}"
         output: "{unit},{runNumber},diffoc"
         mask: "DIFC,{runNumber},mask"
+        metric: "{runNumber},{version},calibration_metrics,{metricName}"
       normCal:
         rawVandium: "{runNumber},{backgroundRunNumber},RVC"
         focusedRawVanadium: "{runNumber},{backgroundRunNumber},RVC,{groupingScheme}"

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -91,7 +91,7 @@ class SNAPRedGUI(QMainWindow):
 
     def changeEvent(self, event):
         if event.type() == event.WindowStateChange:
-            self.titleBar.presenter.windowStateChanged(self.windowState())
+            self.titleBar.presenter.windowStateChange(self.windowState())
 
     def resizeEvent(self, event):
         self.titleBar.presenter.resizeEvent(event)

--- a/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
+++ b/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
@@ -1,0 +1,53 @@
+from PyQt5.QtCore import QObject, Qt, pyqtSignal
+from PyQt5.QtWidgets import QLabel, QMessageBox, QVBoxLayout, QWidget
+
+from snapred.backend.api.InterfaceController import InterfaceController
+from snapred.backend.dao.request.CalibrationLoadAssessmentRequest import CalibrationLoadAssessmentRequest
+from snapred.backend.dao.SNAPRequest import SNAPRequest
+from snapred.backend.dao.SNAPResponse import SNAPResponse
+from snapred.ui.threading.worker_pool import WorkerPool
+
+
+class CalibrationAssessmentLoader(QObject):
+    worker_pool = WorkerPool()
+    interfaceController = InterfaceController()
+
+    assessmentLoaded = pyqtSignal(SNAPResponse)
+    """Emit when calibration assessment has been loaded.
+
+    :param SNAPResponse: The response from loading calibration assessment
+    """
+
+    def __init__(self, view):
+        super().__init__()
+        self.view = view
+
+    def handleLoadRequested(self):
+        if self.view.getCalibrationRecordCount() <= 1:
+            self.view.onLoadError("No calibration records available.")
+            return
+
+        if self.view.getSelectedCalibrationRecordIndex() == 0:
+            self.view.onLoadError("No calibration record selected.")
+            return
+
+        runId, version = self.view.getSelectedCalibrationRecordData()
+        print(f"*****handleLoadRequested: {runId} {version}")
+
+        payload = CalibrationLoadAssessmentRequest(runId=runId, version=version, checkExistent=True)
+        loadAssessmentRequest = SNAPRequest(path="/calibration/loadAssessment", payload=payload.json())
+
+        self.worker = self.worker_pool.createWorker(
+            target=self.interfaceController.executeRequest, args=(loadAssessmentRequest)
+        )
+        self.worker.result.connect(self.handleLoadAssessmentResult)
+        self.worker_pool.submitWorker(self.worker)
+
+    def handleLoadAssessmentResult(self, response: SNAPResponse):
+        print(f"*****handleLoadAssessmentResult response code: {response.code}; message:{response.message} ")
+        if response.code == 500:
+            self.view.onLoadError(response.message)
+
+    @property
+    def widget(self):
+        return self.view

--- a/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
+++ b/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
@@ -32,8 +32,6 @@ class CalibrationAssessmentLoader(QObject):
             return
 
         runId, version = self.view.getSelectedCalibrationRecordData()
-        print(f"*****handleLoadRequested: {runId} {version}")
-
         payload = CalibrationLoadAssessmentRequest(runId=runId, version=version, checkExistent=True)
         loadAssessmentRequest = SNAPRequest(path="/calibration/loadAssessment", payload=payload.json())
 
@@ -44,7 +42,6 @@ class CalibrationAssessmentLoader(QObject):
         self.worker_pool.submitWorker(self.worker)
 
     def handleLoadAssessmentResult(self, response: SNAPResponse):
-        print(f"*****handleLoadAssessmentResult response code: {response.code}; message:{response.message} ")
         if response.code == 500:
             self.view.onLoadError(response.message)
 

--- a/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
+++ b/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
@@ -33,7 +33,7 @@ class CalibrationAssessmentLoader(QObject):
 
         runId, version = self.view.getSelectedCalibrationRecordData()
         payload = CalibrationLoadAssessmentRequest(runId=runId, version=version, checkExistent=True)
-        loadAssessmentRequest = SNAPRequest(path="/calibration/loadAssessment", payload=payload.json())
+        loadAssessmentRequest = SNAPRequest(path="/calibration/loadQualityAssessment", payload=payload.json())
 
         self.worker = self.worker_pool.createWorker(
             target=self.interfaceController.executeRequest, args=(loadAssessmentRequest)

--- a/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
+++ b/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
@@ -32,9 +32,11 @@ class CalibrationAssessmentPresenter(QObject):
         payload = CalibrationLoadAssessmentRequest(runId=runId, version=version, checkExistent=True)
         loadAssessmentRequest = SNAPRequest(path="/calibration/loadQualityAssessment", payload=payload.json())
 
+        self.view.loadButton.setEnabled(False)
         self.worker = self.worker_pool.createWorker(
             target=self.interfaceController.executeRequest, args=(loadAssessmentRequest)
         )
+        self.worker.finished.connect(lambda: self.view.loadButton.setEnabled(True))
         self.worker.result.connect(self.handleLoadAssessmentResult)
         self.worker_pool.submitWorker(self.worker)
 
@@ -59,3 +61,7 @@ class CalibrationAssessmentPresenter(QObject):
             self.view.onError(response.message)
         else:
             self.view.updateCalibrationRecordList(response.data)
+
+    @property
+    def widget(self):
+        return self.view

--- a/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
+++ b/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
@@ -2,33 +2,30 @@ from PyQt5.QtCore import QObject, Qt, pyqtSignal
 from PyQt5.QtWidgets import QLabel, QMessageBox, QVBoxLayout, QWidget
 
 from snapred.backend.api.InterfaceController import InterfaceController
-from snapred.backend.dao.request.CalibrationLoadAssessmentRequest import CalibrationLoadAssessmentRequest
-from snapred.backend.dao.SNAPRequest import SNAPRequest
+from snapred.backend.dao import RunConfig, SNAPRequest
+from snapred.backend.dao.request import (
+    CalibrationIndexRequest,
+    CalibrationLoadAssessmentRequest,
+)
 from snapred.backend.dao.SNAPResponse import SNAPResponse
 from snapred.ui.threading.worker_pool import WorkerPool
 
 
-class CalibrationAssessmentLoader(QObject):
+class CalibrationAssessmentPresenter(QObject):
     worker_pool = WorkerPool()
     interfaceController = InterfaceController()
-
-    assessmentLoaded = pyqtSignal(SNAPResponse)
-    """Emit when calibration assessment has been loaded.
-
-    :param SNAPResponse: The response from loading calibration assessment
-    """
 
     def __init__(self, view):
         super().__init__()
         self.view = view
 
-    def handleLoadRequested(self):
+    def loadSelectedCalibrationAssessment(self):
         if self.view.getCalibrationRecordCount() < 1:
-            self.view.onLoadError("No calibration records available.")
+            self.view.onError("No calibration records available.")
             return
 
         if self.view.getSelectedCalibrationRecordIndex() < 0:
-            self.view.onLoadError("No calibration record selected.")
+            self.view.onError("No calibration record selected.")
             return
 
         runId, version = self.view.getSelectedCalibrationRecordData()
@@ -43,8 +40,22 @@ class CalibrationAssessmentLoader(QObject):
 
     def handleLoadAssessmentResult(self, response: SNAPResponse):
         if response.code == 500:
-            self.view.onLoadError(response.message)
+            self.view.onError(response.message)
 
-    @property
-    def widget(self):
-        return self.view
+    def loadCalibrationIndex(self, runNumber: str):
+        payload = CalibrationIndexRequest(
+            run=RunConfig(runNumber=runNumber),
+        )
+        loadCalibrationIndexRequest = SNAPRequest(path="calibration/index", payload=payload.json())
+
+        self.worker = self.worker_pool.createWorker(
+            target=self.interfaceController.executeRequest, args=(loadCalibrationIndexRequest)
+        )
+        self.worker.result.connect(self.handleLoadCalibrationIndexResult)
+        self.worker_pool.submitWorker(self.worker)
+
+    def handleLoadCalibrationIndexResult(self, response: SNAPResponse):
+        if response.code == 500:
+            self.view.onError(response.message)
+        else:
+            self.view.updateCalibrationRecordList(response.data)

--- a/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
+++ b/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
@@ -23,11 +23,11 @@ class CalibrationAssessmentLoader(QObject):
         self.view = view
 
     def handleLoadRequested(self):
-        if self.view.getCalibrationRecordCount() <= 1:
+        if self.view.getCalibrationRecordCount() < 1:
             self.view.onLoadError("No calibration records available.")
             return
 
-        if self.view.getSelectedCalibrationRecordIndex() == 0:
+        if self.view.getSelectedCalibrationRecordIndex() < 0:
             self.view.onLoadError("No calibration record selected.")
             return
 

--- a/src/snapred/ui/view/CalibrationAssessmentView.py
+++ b/src/snapred/ui/view/CalibrationAssessmentView.py
@@ -4,19 +4,20 @@ from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QComboBox, QGridLayout, QLabel, QMessageBox, QPushButton, QWidget
 
 from snapred.backend.dao.calibration import CalibrationIndexEntry
-from snapred.ui.presenter.CalibrationAssessmentPresenter import CalibrationAssessmentLoader
+from snapred.ui.presenter.CalibrationAssessmentPresenter import CalibrationAssessmentPresenter
 from snapred.ui.widget.JsonFormList import JsonFormList
 from snapred.ui.widget.LabeledField import LabeledField
 
 
 class CalibrationAssessmentView(QWidget):
-    signalLoadError = pyqtSignal(str)
+    signalRunNumberUpdate = pyqtSignal(str)
+    signalError = pyqtSignal(str)
 
     def __init__(self, name, jsonSchemaMap, parent=None):
         super().__init__(parent)
         self._jsonFormList = JsonFormList(name, jsonSchemaMap, parent=parent)
 
-        self.calibrationAssessmentLoader = CalibrationAssessmentLoader(self)
+        self.presenter = CalibrationAssessmentPresenter(self)
 
         self.layout = QGridLayout()
         self.setLayout(self.layout)
@@ -30,19 +31,21 @@ class CalibrationAssessmentView(QWidget):
 
         self.loadButton = QPushButton("Load")
         self.loadButton.setEnabled(True)
-        self.loadButton.clicked.connect(self.calibrationAssessmentLoader.handleLoadRequested)
+        self.loadButton.clicked.connect(self.presenter.loadSelectedCalibrationAssessment)
 
         self.calibrationRecordDropdown = QComboBox()
         self.calibrationRecordDropdown.setEnabled(True)
         self.calibrationRecordDropdown.addItem("Select Calibration Record")
         self.calibrationRecordDropdown.model().item(0).setEnabled(False)
 
-        self.signalLoadError.connect(self._displayLoadError)
+        self.signalError.connect(self._displayError)
 
         self.layout.addWidget(self.interactionText, 0, 0)
         self.layout.addWidget(LabeledField("Calibration Record:", self.calibrationRecordDropdown, self), 1, 0)
         self.layout.addWidget(self.loadButton, 1, 1)
         self.layout.addWidget(self.placeHolder)
+
+        self.signalRunNumberUpdate.connect(self.presenter.loadCalibrationIndex)
 
     def updateCalibrationRecordList(self, calibrationIndex: List[CalibrationIndexEntry]):
         # reset the combo-box by removing all items except for the first, which is a label
@@ -64,13 +67,16 @@ class CalibrationAssessmentView(QWidget):
     def getSelectedCalibrationRecordData(self):
         return self.calibrationRecordDropdown.currentData()
 
-    def onLoadError(self, msg: str):
-        self.signalLoadError.emit(msg)
+    def onError(self, msg: str):
+        self.signalError.emit(msg)
 
-    def _displayLoadError(self, msg: str):
+    def _displayError(self, msg: str):
         msgBox = QMessageBox()
         msgBox.setWindowTitle("Error")
         msgBox.setIcon(QMessageBox.Critical)
         msgBox.setText(msg)
         msgBox.setFixedSize(500, 200)
         msgBox.exec()
+
+    def updateRunNumber(self, runNumber):
+        self.signalRunNumberUpdate.emit(runNumber)

--- a/src/snapred/ui/view/CalibrationAssessmentView.py
+++ b/src/snapred/ui/view/CalibrationAssessmentView.py
@@ -32,37 +32,36 @@ class CalibrationAssessmentView(QWidget):
         self.loadButton.setEnabled(True)
         self.loadButton.clicked.connect(self.calibrationAssessmentLoader.handleLoadRequested)
 
-        self.calibrationDropdown = QComboBox()
-        self.calibrationDropdown.setEnabled(True)
-        self.calibrationDropdown.addItem("Select Calibration Record")
-        self.calibrationDropdown.model().item(0).setEnabled(False)
+        self.calibrationRecordDropdown = QComboBox()
+        self.calibrationRecordDropdown.setEnabled(True)
+        self.calibrationRecordDropdown.addItem("Select Calibration Record")
+        self.calibrationRecordDropdown.model().item(0).setEnabled(False)
 
         self.signalLoadError.connect(self._displayLoadError)
 
         self.layout.addWidget(self.interactionText, 0, 0)
-        self.layout.addWidget(LabeledField("Calibration Record:", self.calibrationDropdown, self), 1, 0)
+        self.layout.addWidget(LabeledField("Calibration Record:", self.calibrationRecordDropdown, self), 1, 0)
         self.layout.addWidget(self.loadButton, 1, 1)
         self.layout.addWidget(self.placeHolder)
 
-    def updateCalibrationList(self, calibrationIndex: List[CalibrationIndexEntry]):
+    def updateCalibrationRecordList(self, calibrationIndex: List[CalibrationIndexEntry]):
         # reset the combo-box by removing all items except for the first, which is a label
-        for item in range(1, self.calibrationDropdown.count()):
-            self.calibrationDropdown.removeItem(item)
+        for item in range(1, self.calibrationRecordDropdown.count()):
+            self.calibrationRecordDropdown.removeItem(item)
         # populate the combo-box from the input calibration index entries
         for entry in calibrationIndex:
             name = f"Version: {entry.version}; Run: {entry.runNumber}"
-            self.calibrationDropdown.addItem(name, (entry.runNumber, entry.version))
-
-        self.calibrationDropdown.setCurrentIndex(0)
+            self.calibrationRecordDropdown.addItem(name, (entry.runNumber, entry.version))
+        self.calibrationRecordDropdown.setCurrentIndex(0)
 
     def getCalibrationRecordCount(self):
-        return self.calibrationDropdown.count() - 1  # the first item is a label
+        return self.calibrationRecordDropdown.count() - 1  # the first item is a label
 
     def getSelectedCalibrationRecordIndex(self):
-        return self.calibrationDropdown.currentIndex() - 1  # the first item (index 0) is a label
+        return self.calibrationRecordDropdown.currentIndex() - 1  # the first item (index 0) is a label
 
     def getSelectedCalibrationRecordData(self):
-        return self.calibrationDropdown.currentData()
+        return self.calibrationRecordDropdown.currentData()
 
     def onLoadError(self, msg: str):
         self.signalLoadError.emit(msg)

--- a/src/snapred/ui/view/CalibrationAssessmentView.py
+++ b/src/snapred/ui/view/CalibrationAssessmentView.py
@@ -61,7 +61,7 @@ class CalibrationAssessmentView(QWidget):
         return self.calibrationDropdown.count() - 1  # the first item is a label
 
     def getSelectedCalibrationRecordIndex(self):
-        return self.calibrationDropdown.currentIndex() - 1  # the first item is a label
+        return self.calibrationDropdown.currentIndex() - 1  # the first item (index 0) is a label
 
     def getSelectedCalibrationRecordData(self):
         return self.calibrationDropdown.currentData()

--- a/src/snapred/ui/view/CalibrationAssessmentView.py
+++ b/src/snapred/ui/view/CalibrationAssessmentView.py
@@ -11,7 +11,6 @@ from snapred.ui.widget.LabeledField import LabeledField
 
 class CalibrationAssessmentView(QWidget):
     signalLoadError = pyqtSignal(str)
-    # signalLoadSuccess = pyqtSignal()
 
     def __init__(self, name, jsonSchemaMap, parent=None):
         super().__init__(parent)
@@ -39,7 +38,6 @@ class CalibrationAssessmentView(QWidget):
         self.calibrationDropdown.model().item(0).setEnabled(False)
 
         self.signalLoadError.connect(self._displayLoadError)
-        # self.signalLoadSuccess.connect(self._updateOnLoadSuccess)
 
         self.layout.addWidget(self.interactionText, 0, 0)
         self.layout.addWidget(LabeledField("Calibration Record:", self.calibrationDropdown, self), 1, 0)
@@ -47,7 +45,7 @@ class CalibrationAssessmentView(QWidget):
         self.layout.addWidget(self.placeHolder)
 
     def updateCalibrationList(self, calibrationIndex: List[CalibrationIndexEntry]):
-        # reset the combo-box by removing all items except for the first
+        # reset the combo-box by removing all items except for the first, which is a label
         for item in range(1, self.calibrationDropdown.count()):
             self.calibrationDropdown.removeItem(item)
         # populate the combo-box from the input calibration index entries
@@ -76,10 +74,3 @@ class CalibrationAssessmentView(QWidget):
         msgBox.setText(msg)
         msgBox.setFixedSize(500, 200)
         msgBox.exec()
-
-    # def onLoadSuccess(self):
-    #     self.signalLoadSuccess.emit()
-
-    # def _updateOnLoadSuccess(self):
-    #     index = self.calibrationDropdown.currentIndex()
-    #     self.calibrationDropdown.model().item(index).setEnabled(False)

--- a/src/snapred/ui/view/CalibrationAssessmentView.py
+++ b/src/snapred/ui/view/CalibrationAssessmentView.py
@@ -58,10 +58,10 @@ class CalibrationAssessmentView(QWidget):
         self.calibrationDropdown.setCurrentIndex(0)
 
     def getCalibrationRecordCount(self):
-        return self.calibrationDropdown.count()
+        return self.calibrationDropdown.count() - 1  # the first item is a label
 
     def getSelectedCalibrationRecordIndex(self):
-        return self.calibrationDropdown.currentIndex()
+        return self.calibrationDropdown.currentIndex() - 1  # the first item is a label
 
     def getSelectedCalibrationRecordData(self):
         return self.calibrationDropdown.currentData()

--- a/src/snapred/ui/view/CalibrationAssessmentView.py
+++ b/src/snapred/ui/view/CalibrationAssessmentView.py
@@ -37,7 +37,6 @@ class CalibrationAssessmentView(QWidget):
         self.calibrationDropdown.setEnabled(True)
         self.calibrationDropdown.addItem("Select Calibration Record")
         self.calibrationDropdown.model().item(0).setEnabled(False)
-        self.signalCalibrationRecordUpdate.connect(self._updateCalibrationRecord)
 
         self.signalLoadError.connect(self._displayLoadError)
         # self.signalLoadSuccess.connect(self._updateOnLoadSuccess)

--- a/src/snapred/ui/view/CalibrationAssessmentView.py
+++ b/src/snapred/ui/view/CalibrationAssessmentView.py
@@ -48,10 +48,11 @@ class CalibrationAssessmentView(QWidget):
         # reset the combo-box by removing all items except for the first, which is a label
         for item in range(1, self.calibrationRecordDropdown.count()):
             self.calibrationRecordDropdown.removeItem(item)
-        # populate the combo-box from the input calibration index entries
-        for entry in calibrationIndex:
-            name = f"Version: {entry.version}; Run: {entry.runNumber}"
-            self.calibrationRecordDropdown.addItem(name, (entry.runNumber, entry.version))
+        if calibrationIndex:
+            # populate the combo-box from the input calibration index entries
+            for entry in calibrationIndex:
+                name = f"Version: {entry.version}; Run: {entry.runNumber}"
+                self.calibrationRecordDropdown.addItem(name, (entry.runNumber, entry.version))
         self.calibrationRecordDropdown.setCurrentIndex(0)
 
     def getCalibrationRecordCount(self):

--- a/src/snapred/ui/view/CalibrationAssessmentView.py
+++ b/src/snapred/ui/view/CalibrationAssessmentView.py
@@ -1,48 +1,86 @@
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtWidgets import QComboBox, QGridLayout, QLabel, QLineEdit, QWidget
+from typing import List, Tuple
 
+from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtWidgets import QComboBox, QGridLayout, QLabel, QMessageBox, QPushButton, QWidget
+
+from snapred.backend.dao.calibration import CalibrationIndexEntry
+from snapred.ui.presenter.CalibrationAssessmentPresenter import CalibrationAssessmentLoader
 from snapred.ui.widget.JsonFormList import JsonFormList
 from snapred.ui.widget.LabeledField import LabeledField
 
 
 class CalibrationAssessmentView(QWidget):
-    signalRunNumberUpdate = pyqtSignal(str)
-    signalSampleUpdate = pyqtSignal(int)
+    signalLoadError = pyqtSignal(str)
+    # signalLoadSuccess = pyqtSignal()
 
-    def __init__(self, name, jsonSchemaMap, samples=[], parent=None):
+    def __init__(self, name, jsonSchemaMap, parent=None):
         super().__init__(parent)
         self._jsonFormList = JsonFormList(name, jsonSchemaMap, parent=parent)
+
+        self.calibrationAssessmentLoader = CalibrationAssessmentLoader(self)
 
         self.layout = QGridLayout()
         self.setLayout(self.layout)
 
-        self.interactionText = QLabel("Calibration Complete! Would you like to assess the calibration now?")
+        self.interactionText = QLabel(
+            "Calibration Complete! Please examine the calibration assessment workspaces. "
+            "You can also load and examine previous calibration assessments for the same "
+            "instrument state, if available."
+        )
+        self.placeHolder = QLabel("")
 
-        self.fieldRunNumber = LabeledField("Run Number :", self._jsonFormList.getField("run.runNumber"), self)
-        self.fieldRunNumber.setEnabled(False)
-        self.signalRunNumberUpdate.connect(self._updateRunNumber)
+        self.loadButton = QPushButton("Load")
+        self.loadButton.setEnabled(True)
+        self.loadButton.clicked.connect(self.calibrationAssessmentLoader.handleLoadRequested)
 
-        self.sampleDropdown = QComboBox()
-        self.sampleDropdown.setEnabled(False)
-        self.sampleDropdown.addItem("Select Sample")
-        self.sampleDropdown.addItems(samples)
-        self.sampleDropdown.model().item(0).setEnabled(False)
-        self.signalSampleUpdate.connect(self._updateSample)
+        self.calibrationDropdown = QComboBox()
+        self.calibrationDropdown.setEnabled(True)
+        self.calibrationDropdown.addItem("Select Calibration Record")
+        self.calibrationDropdown.model().item(0).setEnabled(False)
+        self.signalCalibrationRecordUpdate.connect(self._updateCalibrationRecord)
 
-        self.layout.addWidget(self.interactionText)
-        self.layout.addWidget(self.fieldRunNumber)
-        self.layout.addWidget(LabeledField("Sample :", self.sampleDropdown, self))
+        self.signalLoadError.connect(self._displayLoadError)
+        # self.signalLoadSuccess.connect(self._updateOnLoadSuccess)
 
-    # This signal boilerplate mumbo jumbo is necessary because worker threads cant update the gui directly
-    # So we have to send a signal to the main thread to update the gui, else we get an unhelpful segfault
-    def _updateRunNumber(self, runNumber):
-        self.fieldRunNumber.setText(runNumber)
+        self.layout.addWidget(self.interactionText, 0, 0)
+        self.layout.addWidget(LabeledField("Calibration Record:", self.calibrationDropdown, self), 1, 0)
+        self.layout.addWidget(self.loadButton, 1, 1)
+        self.layout.addWidget(self.placeHolder)
 
-    def updateRunNumber(self, runNumber):
-        self.signalRunNumberUpdate.emit(runNumber)
+    def updateCalibrationList(self, calibrationIndex: List[CalibrationIndexEntry]):
+        # reset the combo-box by removing all items except for the first
+        for item in range(1, self.calibrationDropdown.count()):
+            self.calibrationDropdown.removeItem(item)
+        # populate the combo-box from the input calibration index entries
+        for entry in calibrationIndex:
+            name = f"Version: {entry.version}; Run: {entry.runNumber}"
+            self.calibrationDropdown.addItem(name, (entry.runNumber, entry.version))
 
-    def _updateSample(self, sampleIndex):
-        self.sampleDropdown.setCurrentIndex(sampleIndex)
+        self.calibrationDropdown.setCurrentIndex(0)
 
-    def updateSample(self, sampleIndex):
-        self.signalSampleUpdate.emit(sampleIndex)
+    def getCalibrationRecordCount(self):
+        return self.calibrationDropdown.count()
+
+    def getSelectedCalibrationRecordIndex(self):
+        return self.calibrationDropdown.currentIndex()
+
+    def getSelectedCalibrationRecordData(self):
+        return self.calibrationDropdown.currentData()
+
+    def onLoadError(self, msg: str):
+        self.signalLoadError.emit(msg)
+
+    def _displayLoadError(self, msg: str):
+        msgBox = QMessageBox()
+        msgBox.setWindowTitle("Error")
+        msgBox.setIcon(QMessageBox.Critical)
+        msgBox.setText(msg)
+        msgBox.setFixedSize(500, 200)
+        msgBox.exec()
+
+    # def onLoadSuccess(self):
+    #     self.signalLoadSuccess.emit()
+
+    # def _updateOnLoadSuccess(self):
+    #     index = self.calibrationDropdown.currentIndex()
+    #     self.calibrationDropdown.model().item(index).setEnabled(False)

--- a/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
+++ b/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
@@ -8,7 +8,6 @@ from snapred.backend.dao.calibration import CalibrationIndexEntry, CalibrationRe
 from snapred.backend.dao.request import (
     CalibrationAssessmentRequest,
     CalibrationExportRequest,
-    CalibrationIndexRequest,
     DiffractionCalibrationRequest,
 )
 from snapred.backend.dao.SNAPResponse import SNAPResponse
@@ -84,8 +83,8 @@ class DiffractionCalibrationCreationWorkflow:
             return SNAPResponse(code=500, message=f"Missing Fields!{e}")
 
         self.runNumber = view.getFieldText("runNumber")
-
         self._saveCalibrationView.updateRunNumber(self.runNumber)
+
         self.focusGroupPath = view.groupingFileDropdown.currentText()
         self.useLiteMode = view.litemodeToggle.field.getState()
         self.calibrantSamplePath = view.sampleDropdown.currentText()
@@ -117,12 +116,7 @@ class DiffractionCalibrationCreationWorkflow:
         response = self.interfaceController.executeRequest(request)
         self.responses.append(response)
 
-        payload = CalibrationIndexRequest(
-            run=RunConfig(runNumber=self.runNumber),
-        )
-        request = SNAPRequest(path="calibration/index", payload=payload.json())
-        response = self.interfaceController.executeRequest(request)
-        self._calibrationAssessmentView.updateCalibrationRecordList(response.data)
+        self._calibrationAssessmentView.updateRunNumber(self.runNumber)
 
         return response
 

--- a/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
+++ b/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
@@ -122,7 +122,6 @@ class DiffractionCalibrationCreationWorkflow:
         )
         request = SNAPRequest(path="calibration/index", payload=payload.json())
         response = self.interfaceController.executeRequest(request)
-        self.responses.append(response)
         self._calibrationAssessmentView.updateCalibrationRecordList(response.data)
 
         return response

--- a/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
+++ b/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
@@ -122,7 +122,6 @@ class DiffractionCalibrationCreationWorkflow:
         request = SNAPRequest(path="calibration/index", payload=payload.json())
         response = self.interfaceController.executeRequest(request)
         self.responses.append(response)
-
         self._calibrationAssessmentView.updateCalibrationList(response.data)
 
         return response

--- a/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
+++ b/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
@@ -31,6 +31,7 @@ class DiffractionCalibrationCreationWorkflow:
         self.requests = []
         self.responses = []
         self.interfaceController = InterfaceController()
+
         request = SNAPRequest(path="api/parameters", payload="calibration/assessment")
         self.assessmentSchema = self.interfaceController.executeRequest(request).data
         # for each key, read string and convert to json
@@ -122,7 +123,7 @@ class DiffractionCalibrationCreationWorkflow:
         request = SNAPRequest(path="calibration/index", payload=payload.json())
         response = self.interfaceController.executeRequest(request)
         self.responses.append(response)
-        self._calibrationAssessmentView.updateCalibrationList(response.data)
+        self._calibrationAssessmentView.updateCalibrationRecordList(response.data)
 
         return response
 

--- a/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
+++ b/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
@@ -121,12 +121,13 @@ class DiffractionCalibrationCreationWorkflow:
         return response
 
     def _assessCalibration(self, workflowPresenter):  # noqa: ARG002
-        return self.responses[-1]
+        return self.responses[-1]  # [-1]: response from CalibrationAssessmentRequest for the calibration in progress
 
     def _saveCalibration(self, workflowPresenter):
         view = workflowPresenter.widget.tabView
         # pull fields from view for calibration save
-        calibrationRecord = self.responses[-1].data
+        calibrationRecord = self.responses[-1].data  # [-1]: response from CalibrationAssessmentRequest
+        # [-2]: response from DiffractionCalibrationRequest
         calibrationRecord.workspaceNames.append(self.responses[-2].data["calibrationTable"])
         calibrationIndexEntry = CalibrationIndexEntry(
             runNumber=view.fieldRunNumber.get(),

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -95,6 +95,7 @@ mantid:
           table: "_DIFC,{runNumber}"
           output: "_{unit},{runNumber},diffoc"
           mask: "_DIFC,{runNumber},mask"
+          metric: "{runNumber},{version},calibration_metrics,{metricName}"
         units:
           dSpacing: dsp
           timeOfFlight: tof

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -126,3 +126,10 @@ with mock.patch.dict(
         actual = dataExportService.getCalibrationDataPath(mock.Mock(), mock.Mock())
 
         assert actual == "expected"
+
+    def test_getCalibrationRecord():
+        dataExportService = DataFactoryService()
+        dataExportService.lookupService.readCalibrationRecord = mock.Mock(return_value="expected")
+        actual = dataExportService.getCalibrationRecord(mock.Mock(), mock.Mock())
+
+        assert actual == "expected"

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -266,7 +266,6 @@ class TestGroceryService(unittest.TestCase):
         with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmppath:
             self.instance.writeWorkspace(os.path.join(tmppath, name), name)
             assert os.path.exists(os.path.join(tmppath, name))
-        assert not os.path.exists(os.path.join(tmppath, name))
 
     def test_writeGrouping(self):
         path = Resource.getPath("outputs")

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -266,6 +266,7 @@ class TestGroceryService(unittest.TestCase):
         with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmppath:
             self.instance.writeWorkspace(os.path.join(tmppath, name), name)
             assert os.path.exists(os.path.join(tmppath, name))
+        assert not os.path.exists(os.path.join(tmppath, name))
 
     def test_writeGrouping(self):
         path = Resource.getPath("outputs")
@@ -277,8 +278,8 @@ class TestGroceryService(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmppath:
             self.instance.writeGrouping(tmppath, name)
-            assert os.path.exists(tmppath + name)
-        assert not os.path.exists(tmppath + name)
+            assert os.path.exists(os.path.join(tmppath, name))
+        assert not os.path.exists(os.path.join(tmppath, name))
 
     def test_writeDiffCalTable(self):
         path = Resource.getPath("outputs")
@@ -286,8 +287,8 @@ class TestGroceryService(unittest.TestCase):
         self.create_dumb_diffcal(name)
         with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmppath:
             self.instance.writeDiffCalTable(tmppath, name)
-            assert os.path.exists(tmppath + name)
-        assert not os.path.exists(tmppath + name)
+            assert os.path.exists(os.path.join(tmppath, name))
+        assert not os.path.exists(os.path.join(tmppath, name))
 
     ## TESTS OF ACCESS METHODS
 

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -264,9 +264,9 @@ class TestGroceryService(unittest.TestCase):
         name = "test_write_workspace"
         self.create_dumb_workspace(name)
         with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmppath:
-            self.instance.writeWorkspace(tmppath, name)
-            assert os.path.exists(tmppath + name)
-        assert not os.path.exists(tmppath + name)
+            self.instance.writeWorkspace(os.path.join(tmppath, name), name)
+            assert os.path.exists(os.path.join(tmppath, name))
+        assert not os.path.exists(os.path.join(tmppath, name))
 
     def test_writeGrouping(self):
         path = Resource.getPath("outputs")

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -548,6 +548,23 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualRecord.runNumber == "57514"
         assert actualRecord == testCalibrationRecord
 
+    def test_readWriteCalibrationRecord_with_version():
+        with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tempdir:
+            localDataService = LocalDataService()
+            localDataService.instrumentConfig = mock.Mock()
+            localDataService._generateStateId = mock.Mock()
+            localDataService._generateStateId.return_value = ("123", "456")
+            localDataService._readReductionParameters = mock.Mock()
+            localDataService._constructCalibrationStatePath = mock.Mock()
+            localDataService._constructCalibrationStatePath.return_value = f"{tempdir}/"
+            localDataService.groceryService = mock.Mock()
+            localDataService.writeCalibrationRecord(
+                CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord.json"))
+            )
+            actualRecord = localDataService.readCalibrationRecord("57514", "1")
+        assert actualRecord.runNumber == "57514"
+        assert actualRecord.version == 1
+
     def test_readWriteCalibrationRecord():
         testCalibrationRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord.json"))
         with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tempdir:

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -237,6 +237,9 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             mockRequest = MagicMock(runId=runId, version=version, checkExistent=False)
             self.instance.readQuality(mockRequest)
             with pytest.raises(ValueError) as excinfo:  # noqa: PT011
+                self.instance.readQuality(MagicMock(runId=runId, version=version, checkExistent=True))
+            assert "is already loaded" in str(excinfo.value)
+            with pytest.raises(ValueError) as excinfo:  # noqa: PT011
                 self.instance.readQuality(MagicMock(runId="57514", version="7", checkExistent=True))
             assert "is already loaded" in str(excinfo.value)
 

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -267,7 +267,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
                 ws_name = (
                     wng.diffCalMetrics()
                     .runNumber(calibRecord.runNumber)
-                    .version(calibRecord.version)
+                    .version("v" + str(calibRecord.version))
                     .metricName(metric)
                     .build()
                 )

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -77,6 +77,14 @@ with mock.patch.dict(
         res = calibrationService.load(mock.Mock())
         assert res == calibrationService.dataFactoryService.getCalibrationRecord.return_value
 
+    def test_getCalibrationIndex():
+        calibrationService = CalibrationService()
+        calibrationService.dataFactoryService.getCalibrationIndex = mock.Mock(
+            return_value=CalibrationIndexEntry(runNumber="1", comments="", author="")
+        )
+        calibrationService.getCalibrationIndex(MagicMock(run=MagicMock(runNumber="123")))
+        assert calibrationService.dataFactoryService.getCalibrationIndex.called
+
 
 from snapred.backend.service.CalibrationService import CalibrationService  # noqa: F811
 

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -237,7 +237,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             mockRequest = MagicMock(runId=runId, version=version, checkExistent=False)
             self.instance.readQuality(mockRequest)
             with pytest.raises(ValueError) as excinfo:  # noqa: PT011
-                self.instance.readQuality(MagicMock(runId=runId, version=version, checkExistent=True))
+                self.instance.readQuality(MagicMock(runId="57514", version="7", checkExistent=True))
             assert "is already loaded" in str(excinfo.value)
 
     def test_readQuality(self):

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -196,16 +196,16 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             ws_name = wng.diffCalMetrics().runNumber("57514").version("ts123").metricName(metric).build()
             assert self.instance.dataFactoryService.workspaceDoesExist(ws_name)
 
-    def test_readQuality_no_calibration_record_exception(self):
+    def test_load_quality_assessment_no_calibration_record_exception(self):
         self.instance.dataFactoryService.getCalibrationRecord = MagicMock(return_value=None)
         mockRequest = MagicMock(runId=MagicMock(), version=MagicMock(), checkExistent=False)
         with pytest.raises(ValueError) as excinfo:  # noqa: PT011
-            self.instance.readQuality(mockRequest)
+            self.instance.loadQualityAssessment(mockRequest)
         assert str(mockRequest.runId) in str(excinfo.value)
         assert str(mockRequest.version) in str(excinfo.value)
 
     @patch(thisService + "CalibrationMetricsWorkspaceIngredients", return_value=MagicMock())
-    def test_readQuality_no_calibration_metrics_exception(
+    def test_load_quality_assessment_no_calibration_metrics_exception(
         self,
         mockCalibrationMetricsWorkspaceIngredients,
     ):
@@ -213,10 +213,10 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         calibRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord.json"))
         self.instance.dataFactoryService.getCalibrationRecord = MagicMock(return_value=calibRecord)
         with pytest.raises(Exception) as excinfo:  # noqa: PT011
-            self.instance.readQuality(mockRequest)
+            self.instance.loadQualityAssessment(mockRequest)
         assert "The input table is empty" in str(excinfo.value)
 
-    def test_readQuality_check_existent(self):
+    def test_load_quality_assessment_check_existent(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             calibRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord.json"))
             self.instance.dataFactoryService.getCalibrationRecord = MagicMock(return_value=calibRecord)
@@ -235,15 +235,15 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             runId = MagicMock()
             version = MagicMock()
             mockRequest = MagicMock(runId=runId, version=version, checkExistent=False)
-            self.instance.readQuality(mockRequest)
+            self.instance.loadQualityAssessment(mockRequest)
             with pytest.raises(ValueError) as excinfo:  # noqa: PT011
-                self.instance.readQuality(MagicMock(runId=runId, version=version, checkExistent=True))
+                self.instance.loadQualityAssessment(MagicMock(runId=runId, version=version, checkExistent=True))
             assert "is already loaded" in str(excinfo.value)
             with pytest.raises(ValueError) as excinfo:  # noqa: PT011
-                self.instance.readQuality(MagicMock(runId="57514", version="7", checkExistent=True))
+                self.instance.loadQualityAssessment(MagicMock(runId="57514", version="7", checkExistent=True))
             assert "is already loaded" in str(excinfo.value)
 
-    def test_readQuality(self):
+    def test_load_quality_assessment(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             calibRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord.json"))
             self.instance.dataFactoryService.getCalibrationRecord = MagicMock(return_value=calibRecord)
@@ -260,7 +260,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
 
             # Call the method to test. Use a mocked run and a mocked version
             mockRequest = MagicMock(runId=MagicMock(), version=MagicMock(), checkExistent=False)
-            self.instance.readQuality(mockRequest)
+            self.instance.loadQualityAssessment(mockRequest)
 
             # Assert the expected calibration metric workspaces have been generated
             for metric in ["sigma", "strain"]:

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -11,6 +11,7 @@ from mantid.simpleapi import (
     CreateWorkspace,
     mtd,
 )
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 
 # Mock out of scope modules before importing DataExportService
 
@@ -191,31 +192,51 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         assert record == CalibrationRecord.return_value
 
         # Assert expected calibration metric workspaces have been generated
-        ws_name_stem = "57514_calibrationMetrics_ts123"
         for metric in ["sigma", "strain"]:
-            assert self.instance.dataFactoryService.workspaceDoesExist(ws_name_stem + "_" + metric)
+            ws_name = wng.diffCalMetrics().runNumber("57514").version("ts123").metricName(metric).build()
+            assert self.instance.dataFactoryService.workspaceDoesExist(ws_name)
 
     def test_readQuality_no_calibration_record_exception(self):
         self.instance.dataFactoryService.getCalibrationRecord = MagicMock(return_value=None)
-        run = MagicMock()
-        version = MagicMock()
+        mockRequest = MagicMock(runId=MagicMock(), version=MagicMock(), checkExistent=False)
         with pytest.raises(ValueError) as excinfo:  # noqa: PT011
-            self.instance.readQuality(run, version)
-        assert str(run) in str(excinfo.value)
-        assert str(version) in str(excinfo.value)
+            self.instance.readQuality(mockRequest)
+        assert str(mockRequest.runId) in str(excinfo.value)
+        assert str(mockRequest.version) in str(excinfo.value)
 
     @patch(thisService + "CalibrationMetricsWorkspaceIngredients", return_value=MagicMock())
     def test_readQuality_no_calibration_metrics_exception(
         self,
         mockCalibrationMetricsWorkspaceIngredients,
     ):
-        run = MagicMock()
-        version = MagicMock()
+        mockRequest = MagicMock(runId=MagicMock(), version=MagicMock(), checkExistent=False)
         calibRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord.json"))
         self.instance.dataFactoryService.getCalibrationRecord = MagicMock(return_value=calibRecord)
         with pytest.raises(Exception) as excinfo:  # noqa: PT011
-            self.instance.readQuality(run, version)
+            self.instance.readQuality(mockRequest)
         assert "The input table is empty" in str(excinfo.value)
+
+    def test_readQuality_check_existent(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            calibRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord.json"))
+            self.instance.dataFactoryService.getCalibrationRecord = MagicMock(return_value=calibRecord)
+
+            # Under a mocked calibration data path, create fake "persistent" workspace files
+            self.instance.dataFactoryService.getCalibrationDataPath = MagicMock(return_value=tmpdir)
+            for ws_name in calibRecord.workspaceNames:
+                CreateWorkspace(
+                    OutputWorkspace=ws_name,
+                    DataX=1,
+                    DataY=1,
+                )
+                self.instance.dataFactoryService.writeWorkspace(os.path.join(tmpdir, ws_name + ".nxs"), ws_name)
+
+            # Call the method to test. Use a mocked run and a mocked version
+            mockRequest = MagicMock(runId=MagicMock(), version=MagicMock(), checkExistent=False)
+            self.instance.readQuality(mockRequest)
+            with pytest.raises(ValueError) as excinfo:  # noqa: PT011
+                self.instance.readQuality(MagicMock(runId=MagicMock(), version=MagicMock(), checkExistent=True))
+            assert "is already loaded" in str(excinfo.value)
 
     def test_readQuality(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -233,13 +254,18 @@ class TestCalibrationServiceMethods(unittest.TestCase):
                 self.instance.dataFactoryService.writeWorkspace(os.path.join(tmpdir, ws_name + ".nxs"), ws_name)
 
             # Call the method to test. Use a mocked run and a mocked version
-            run = MagicMock()
-            version = MagicMock()
-            self.instance.readQuality(run, version)
+            mockRequest = MagicMock(runId=MagicMock(), version=MagicMock(), checkExistent=False)
+            self.instance.readQuality(mockRequest)
 
             # Assert the expected calibration metric workspaces have been generated
-            ws_name_stem = f"{calibRecord.runNumber}_calibrationMetrics_v{calibRecord.version}"
-            for ws_name in [ws_name_stem + "_sigma", ws_name_stem + "_strain"]:
+            for metric in ["sigma", "strain"]:
+                ws_name = (
+                    wng.diffCalMetrics()
+                    .runNumber(calibRecord.runNumber)
+                    .version(calibRecord.version)
+                    .metricName(metric)
+                    .build()
+                )
                 assert self.instance.dataFactoryService.workspaceDoesExist(ws_name)
 
             # Assert the "persistent" workspaces have been loaded

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -232,10 +232,12 @@ class TestCalibrationServiceMethods(unittest.TestCase):
                 self.instance.dataFactoryService.writeWorkspace(os.path.join(tmpdir, ws_name + ".nxs"), ws_name)
 
             # Call the method to test. Use a mocked run and a mocked version
-            mockRequest = MagicMock(runId=MagicMock(), version=MagicMock(), checkExistent=False)
+            runId = MagicMock()
+            version = MagicMock()
+            mockRequest = MagicMock(runId=runId, version=version, checkExistent=False)
             self.instance.readQuality(mockRequest)
             with pytest.raises(ValueError) as excinfo:  # noqa: PT011
-                self.instance.readQuality(MagicMock(runId=MagicMock(), version=MagicMock(), checkExistent=True))
+                self.instance.readQuality(MagicMock(runId=runId, version=version, checkExistent=True))
             assert "is already loaded" in str(excinfo.value)
 
     def test_readQuality(self):

--- a/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
+++ b/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
@@ -18,3 +18,10 @@ def testDiffCalInputNames():
 
 def testDiffCalTableName():
     assert "_difc_123" == wng.diffCalTable().runNumber(123).build()
+
+
+def testDiffCalMetricsName():
+    assert (
+        "123_1_calibration_metrics_strain"
+        == wng.diffCalMetrics().runNumber(123).version(1).metricName("strain").build()
+    )

--- a/tests/unit/ui/presenter/test_CalibrationAssessmentPresenter.py
+++ b/tests/unit/ui/presenter/test_CalibrationAssessmentPresenter.py
@@ -39,3 +39,25 @@ def test_handleLoad(calibrationAssessmentLoader):
 
         worker_pool.createWorker.assert_called_once_with(target=interfaceController.executeRequest, args=(request))
         worker_pool.submitWorker.assert_called_once()
+
+
+def test_handleLoad_no_records_available(calibrationAssessmentLoader):
+    view = calibrationAssessmentLoader.view
+    view.getCalibrationRecordCount = MagicMock(return_value=0)
+
+    calibrationAssessmentLoader.handleLoadRequested()
+
+    view.getCalibrationRecordCount.assert_called_once()
+    view.onLoadError.assert_called_once_with("No calibration records available.")
+
+
+def test_handleLoad_no_record_selected(calibrationAssessmentLoader):
+    view = calibrationAssessmentLoader.view
+    view.getCalibrationRecordCount = MagicMock(return_value=1)
+    view.getSelectedCalibrationRecordIndex = MagicMock(return_value=-1)
+
+    calibrationAssessmentLoader.handleLoadRequested()
+
+    view.getCalibrationRecordCount.assert_called_once()
+    view.getSelectedCalibrationRecordIndex.assert_called_once()
+    view.onLoadError.assert_called_once_with("No calibration record selected.")

--- a/tests/unit/ui/presenter/test_CalibrationAssessmentPresenter.py
+++ b/tests/unit/ui/presenter/test_CalibrationAssessmentPresenter.py
@@ -14,10 +14,10 @@ def calibrationAssessmentLoader():
     return CalibrationAssessmentLoader(view=view)
 
 
-def test_handleLoadButtonClicked(calibrationAssessmentLoader):
+def test_handleLoad(calibrationAssessmentLoader):
     view = calibrationAssessmentLoader.view
-    view.getCalibrationRecordCount = MagicMock(return_value=2)
-    view.getSelectedCalibrationRecordIndex = MagicMock(return_value=1)
+    view.getCalibrationRecordCount = MagicMock(return_value=1)
+    view.getSelectedCalibrationRecordIndex = MagicMock(return_value=0)
     view.getSelectedCalibrationRecordData = MagicMock(return_value=("12345", "1"))
 
     with patch.object(calibrationAssessmentLoader, "worker_pool") as worker_pool, patch.object(

--- a/tests/unit/ui/presenter/test_CalibrationAssessmentPresenter.py
+++ b/tests/unit/ui/presenter/test_CalibrationAssessmentPresenter.py
@@ -23,7 +23,7 @@ def test_load_record(calibrationAssessmentPresenter):
     with patch.object(calibrationAssessmentPresenter, "worker_pool") as worker_pool, patch.object(
         calibrationAssessmentPresenter, "interfaceController"
     ) as interfaceController:
-        calibrationAssessmentPresenter.handleLoadRequested()
+        calibrationAssessmentPresenter.loadSelectedCalibrationAssessment()
 
         view.getCalibrationRecordCount.assert_called_once()
         view.getSelectedCalibrationRecordIndex.assert_called_once()
@@ -43,7 +43,7 @@ def test_load_record_with_no_records_available(calibrationAssessmentPresenter):
     view = calibrationAssessmentPresenter.view
     view.getCalibrationRecordCount = MagicMock(return_value=0)
 
-    calibrationAssessmentPresenter.handleLoadRequested()
+    calibrationAssessmentPresenter.loadSelectedCalibrationAssessment()
 
     view.getCalibrationRecordCount.assert_called_once()
     view.onError.assert_called_once_with("No calibration records available.")
@@ -54,7 +54,7 @@ def test_load_record_with_no_record_selected(calibrationAssessmentPresenter):
     view.getCalibrationRecordCount = MagicMock(return_value=1)
     view.getSelectedCalibrationRecordIndex = MagicMock(return_value=-1)
 
-    calibrationAssessmentPresenter.handleLoadRequested()
+    calibrationAssessmentPresenter.loadSelectedCalibrationAssessment()
 
     view.getCalibrationRecordCount.assert_called_once()
     view.getSelectedCalibrationRecordIndex.assert_called_once()

--- a/tests/unit/ui/presenter/test_CalibrationAssessmentPresenter.py
+++ b/tests/unit/ui/presenter/test_CalibrationAssessmentPresenter.py
@@ -23,20 +23,18 @@ def test_handleLoad(calibrationAssessmentLoader):
     with patch.object(calibrationAssessmentLoader, "worker_pool") as worker_pool, patch.object(
         calibrationAssessmentLoader, "interfaceController"
     ) as interfaceController:
-        payload = CalibrationLoadAssessmentRequest(
-            runId="12345",
-            version="1",
-            checkExistent=True,
-        )
-
-        request = SNAPRequest(path="/calibration/loadAssessment", payload=payload.json())
-
         calibrationAssessmentLoader.handleLoadRequested()
 
         view.getCalibrationRecordCount.assert_called_once()
         view.getSelectedCalibrationRecordIndex.assert_called_once()
         view.getSelectedCalibrationRecordData.assert_called_once()
 
+        payload = CalibrationLoadAssessmentRequest(
+            runId="12345",
+            version="1",
+            checkExistent=True,
+        )
+        request = SNAPRequest(path="/calibration/loadQualityAssessment", payload=payload.json())
         worker_pool.createWorker.assert_called_once_with(target=interfaceController.executeRequest, args=(request))
         worker_pool.submitWorker.assert_called_once()
 

--- a/tests/unit/ui/presenter/test_CalibrationAssessmentPresenter.py
+++ b/tests/unit/ui/presenter/test_CalibrationAssessmentPresenter.py
@@ -5,25 +5,25 @@ from PyQt5.QtWidgets import QMessageBox
 from snapred.backend.dao.request.CalibrationLoadAssessmentRequest import CalibrationLoadAssessmentRequest
 from snapred.backend.dao.SNAPRequest import SNAPRequest
 from snapred.backend.dao.SNAPResponse import SNAPResponse
-from snapred.ui.presenter.CalibrationAssessmentPresenter import CalibrationAssessmentLoader
+from snapred.ui.presenter.CalibrationAssessmentPresenter import CalibrationAssessmentPresenter
 
 
 @pytest.fixture()
-def calibrationAssessmentLoader():
+def calibrationAssessmentPresenter():
     view = MagicMock()
-    return CalibrationAssessmentLoader(view=view)
+    return CalibrationAssessmentPresenter(view=view)
 
 
-def test_handleLoad(calibrationAssessmentLoader):
-    view = calibrationAssessmentLoader.view
+def test_load_record(calibrationAssessmentPresenter):
+    view = calibrationAssessmentPresenter.view
     view.getCalibrationRecordCount = MagicMock(return_value=1)
     view.getSelectedCalibrationRecordIndex = MagicMock(return_value=0)
     view.getSelectedCalibrationRecordData = MagicMock(return_value=("12345", "1"))
 
-    with patch.object(calibrationAssessmentLoader, "worker_pool") as worker_pool, patch.object(
-        calibrationAssessmentLoader, "interfaceController"
+    with patch.object(calibrationAssessmentPresenter, "worker_pool") as worker_pool, patch.object(
+        calibrationAssessmentPresenter, "interfaceController"
     ) as interfaceController:
-        calibrationAssessmentLoader.handleLoadRequested()
+        calibrationAssessmentPresenter.handleLoadRequested()
 
         view.getCalibrationRecordCount.assert_called_once()
         view.getSelectedCalibrationRecordIndex.assert_called_once()
@@ -39,23 +39,23 @@ def test_handleLoad(calibrationAssessmentLoader):
         worker_pool.submitWorker.assert_called_once()
 
 
-def test_handleLoad_no_records_available(calibrationAssessmentLoader):
-    view = calibrationAssessmentLoader.view
+def test_load_record_with_no_records_available(calibrationAssessmentPresenter):
+    view = calibrationAssessmentPresenter.view
     view.getCalibrationRecordCount = MagicMock(return_value=0)
 
-    calibrationAssessmentLoader.handleLoadRequested()
+    calibrationAssessmentPresenter.handleLoadRequested()
 
     view.getCalibrationRecordCount.assert_called_once()
-    view.onLoadError.assert_called_once_with("No calibration records available.")
+    view.onError.assert_called_once_with("No calibration records available.")
 
 
-def test_handleLoad_no_record_selected(calibrationAssessmentLoader):
-    view = calibrationAssessmentLoader.view
+def test_load_record_with_no_record_selected(calibrationAssessmentPresenter):
+    view = calibrationAssessmentPresenter.view
     view.getCalibrationRecordCount = MagicMock(return_value=1)
     view.getSelectedCalibrationRecordIndex = MagicMock(return_value=-1)
 
-    calibrationAssessmentLoader.handleLoadRequested()
+    calibrationAssessmentPresenter.handleLoadRequested()
 
     view.getCalibrationRecordCount.assert_called_once()
     view.getSelectedCalibrationRecordIndex.assert_called_once()
-    view.onLoadError.assert_called_once_with("No calibration record selected.")
+    view.onError.assert_called_once_with("No calibration record selected.")

--- a/tests/unit/ui/view/test_CalibrationAssessmentView.py
+++ b/tests/unit/ui/view/test_CalibrationAssessmentView.py
@@ -1,0 +1,25 @@
+from unittest.mock import MagicMock, Mock, call, patch
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QComboBox, QMessageBox
+from snapred.backend.dao.calibration import CalibrationIndexEntry
+from snapred.ui.view.CalibrationAssessmentView import CalibrationAssessmentView
+
+
+def test_calibrationrecord_dropdown(qtbot):
+    view = CalibrationAssessmentView(name="Test", jsonSchemaMap=MagicMock())
+    assert view.getCalibrationRecordCount() == 0
+
+    # test filling in the dropdown
+    runNumber = "1234"
+    version = "1"
+    calibrationIndexEntries = [CalibrationIndexEntry(runNumber=runNumber, version=version, comments="", author="")]
+    view.updateCalibrationRecordList(calibrationIndexEntries)
+    assert view.getCalibrationRecordCount() == 1
+    assert view.getSelectedCalibrationRecordIndex() == -1
+
+    # test making a selection in the dropdown
+    qtbot.addWidget(view.calibrationRecordDropdown)
+    qtbot.keyClicks(view.calibrationRecordDropdown, "Version: 1; Run: 1234")
+    assert view.getSelectedCalibrationRecordIndex() == 0
+    assert view.getSelectedCalibrationRecordData() == (runNumber, version)

--- a/tests/unit/ui/view/test_CalibrationAssessmentView.py
+++ b/tests/unit/ui/view/test_CalibrationAssessmentView.py
@@ -23,3 +23,11 @@ def test_calibrationrecord_dropdown(qtbot):
     qtbot.keyClicks(view.calibrationRecordDropdown, "Version: 1; Run: 1234")
     assert view.getSelectedCalibrationRecordIndex() == 0
     assert view.getSelectedCalibrationRecordData() == (runNumber, version)
+
+
+def test_on_load_error(qtbot):
+    view = CalibrationAssessmentView(name="Test", jsonSchemaMap=MagicMock())
+    qtbot.addWidget(view.loadButton)
+    view.onLoadError = MagicMock()
+    view.loadButton.click()
+    view.onLoadError.assert_called_once()

--- a/tests/unit/ui/view/test_CalibrationAssessmentView.py
+++ b/tests/unit/ui/view/test_CalibrationAssessmentView.py
@@ -6,7 +6,7 @@ from snapred.backend.dao.calibration import CalibrationIndexEntry
 from snapred.ui.view.CalibrationAssessmentView import CalibrationAssessmentView
 
 
-def test_calibrationrecord_dropdown(qtbot):
+def test_calibration_record_dropdown(qtbot):
     view = CalibrationAssessmentView(name="Test", jsonSchemaMap=MagicMock())
     assert view.getCalibrationRecordCount() == 0
 
@@ -25,9 +25,9 @@ def test_calibrationrecord_dropdown(qtbot):
     assert view.getSelectedCalibrationRecordData() == (runNumber, version)
 
 
-def test_on_load_error(qtbot):
+def test_error_on_load_calibration_record(qtbot):
     view = CalibrationAssessmentView(name="Test", jsonSchemaMap=MagicMock())
     qtbot.addWidget(view.loadButton)
-    view.onLoadError = MagicMock()
+    view.onError = MagicMock()
     view.loadButton.click()
-    view.onLoadError.assert_called_once()
+    view.onError.assert_called_once()


### PR DESCRIPTION
## Description of defect
This work is split off from [PR#172](https://github.com/neutrons/SNAPRed/pull/172)
Calibration assessment is facilitated by examining calibration metrics. At the moment, the user can view only the assessment for the calibration in progress. However, they need to be able to examine any earlier calibration record corresponding to the current instrument state.

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work
### UI

- The "Assessing" tab of the Test Panel is completely re-designed.  Its new purpose is to allow loading of assessments for _previous_ calibrations of the same instrument state. That is achieved by using the backend functionality developed earlier - see [PR#172](https://github.com/neutrons/SNAPRed/pull/172). The assessment for the calibration _in progress_ is now generated _prior_ to displaying the "Assessing" tab. 
- Fixed a bug causing SNAPRed UI to crash when the main window is minimized.

### Backend

- The names of the calibration metrics workspaces are now generated using `WorkspaceNameGenerator`.
- `DataFactoryService` `getCalibrationRecord` method is extended to accept calibration version number.
- Fixed a bug in `GroceryService` `WriteWorkspace` method and associated unit test.
- Refactored `GroceryService` to use  `os.path.join`
- Fixed a bug in `DataFactoryService` `loadCalibrationDataWorkspace`

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing

Affected unit tests:
```
pytest -k test_getCalibrationRecord
pytest -k test_writeWorkspace
pytest -k test_writeGrouping
pytest -k test_writeDiffCalTable
pytest -k test_readWriteCalibrationRecord
pytest -k test_load_quality_assessment
pytest -k testDiffCalMetricsName
pytest -k test_load_record
pytest -k test_calibration_record_dropdown
pytest -k test_error_on_load_calibration_record
```
GUI testing

```
On analysis.sns.gov
From SNAPRed directory and environment
python -m snapred
Open "Test Panel" and enter:
Run Number: 46680
Convergence Threshold: 0.1
Peak Intensity Threshold: 0.0001
Bins Across Peak Width: 10
Sample: Diamond_001.json
Grouping File: column lite
Click Continue
When "Assessing" tab is shown, choose Version 2 and click Load
In the "Workspaces" box look for names with 5882
```


<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing

<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

Same as developer GUI testing.


<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#3281](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=3281)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
