### PR TITLE
Revert "diffraction calibration: xMin, xMax parameters"

### DIFF
--- a/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
@@ -230,9 +230,8 @@ class PixelDiffractionCalibration(PythonAlgorithm):
                 f"Calculate offset workspace {wsoff}",
                 InputWorkspace=wscc + f"_group{groupID}",
                 OutputWorkspace=wsoff,
-                # Scale the fitting ROI using the expected peak width (including a few possible peaks):
-                XMin=-(self.maxDSpaceShifts[groupID] / self.dBin) * 2.0,
-                XMax=(self.maxDSpaceShifts[groupID] / self.dBin) * 2.0,
+                XMin=-100,
+                XMax=100,
                 OffsetMode="Signed",
                 MaxOffset=self.maxOffset,
             )


### PR DESCRIPTION
Reverts neutrons/SNAPRed#191

This seems to be the cause of an error  when running the GUI, resulting in bounds of 0 on `GetDetectorOffsets`.

I'm still not entirely sure what the issue is.