### PR TITLE
Add defaults to service to prevent error with no dMin

### DIFF
--- a/src/snapred/backend/service/CrystallographicInfoService.py
+++ b/src/snapred/backend/service/CrystallographicInfoService.py
@@ -2,13 +2,18 @@ from typing import Any, Dict
 
 from snapred.backend.recipe.CrystallographicInfoRecipe import CrystallographicInfoRecipe
 from snapred.backend.service.Service import Service
+from snapred.meta.Config import Config
 from snapred.meta.decorators.FromString import FromString
 from snapred.meta.decorators.Singleton import Singleton
 
 
 @Singleton
 class CrystallographicInfoService(Service):
+    D_MIN = Config["constants.CrystallographicInfo.dMin"]
+    D_MAX = Config["constants.CrystallographicInfo.dMax"]
+
     # register the service in ServiceFactory please!
+    # NEVER!
     def __init__(self):
         super().__init__()
         self.registerPath("", self.ingest)
@@ -19,11 +24,11 @@ class CrystallographicInfoService(Service):
         return "ingestion"
 
     @FromString
-    def ingest(self, cifPath: str, dMin: float) -> Dict[Any, Any]:
+    def ingest(self, cifPath: str, dMin: float = D_MIN, dMax: float = D_MAX) -> Dict[Any, Any]:
         data: Dict[Any, Any] = {}
         # TODO: collect runs by state then by calibration of state, execute sets of runs by calibration of thier state
         try:
-            data = CrystallographicInfoRecipe().executeRecipe(cifPath, dMin=dMin)
+            data = CrystallographicInfoRecipe().executeRecipe(cifPath, dMin=dMin, dMax=dMax)
         except:
             raise
         return data

--- a/tests/unit/backend/service/test_CrystallographicInfoService.py
+++ b/tests/unit/backend/service/test_CrystallographicInfoService.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from snapred.backend.service.CrystallographicInfoService import CrystallographicInfoService
+from snapred.meta.Config import Config
 
 
 @patch("snapred.backend.service.CrystallographicInfoService.CrystallographicInfoRecipe")
@@ -10,5 +11,5 @@ def test_CrystallographicInfoService(mockRecipe):
     assert service.name() == "ingestion"
 
     result = service.ingest("cifPath", 1.0)
-    mockRecipe.executeRecipe.assert_called_once_with("cifPath", dMin=1.0)
+    mockRecipe.executeRecipe.assert_called_once_with("cifPath", dMin=1.0, dMax=Config["constants.CrystallographicInfo.dMax"])
     assert result == mockRecipe.executeRecipe.return_value

--- a/tests/unit/backend/service/test_CrystallographicInfoService.py
+++ b/tests/unit/backend/service/test_CrystallographicInfoService.py
@@ -11,5 +11,7 @@ def test_CrystallographicInfoService(mockRecipe):
     assert service.name() == "ingestion"
 
     result = service.ingest("cifPath", 1.0)
-    mockRecipe.executeRecipe.assert_called_once_with("cifPath", dMin=1.0, dMax=Config["constants.CrystallographicInfo.dMax"])
+    mockRecipe.executeRecipe.assert_called_once_with(
+        "cifPath", dMin=1.0, dMax=Config["constants.CrystallographicInfo.dMax"]
+    )
     assert result == mockRecipe.executeRecipe.return_value


### PR DESCRIPTION
## Description of work

There was an uncaught error with a recent PR, and now the GUI fails due to not having a `dMin` value specified in the xtal service.

## Explanation of work

Added defaults.

## To test

### Dev testing

Run diffcal with run number 58813 (it's fast).

### CIS testing

N/A

## Link to EWM item
N/A