### PR TITLE
Ewm3679 fix over binning data

### DIFF
--- a/src/snapred/backend/dao/CrystallographicInfo.py
+++ b/src/snapred/backend/dao/CrystallographicInfo.py
@@ -28,10 +28,10 @@ class CrystallographicInfo(BaseModel):
 
     def __init__(
         self,
-        hkl: List[Tuple[int, int, int]] = [],
-        dSpacing: List[float] = [],
-        fSquared: List[float] = [],
-        multiplicities: List[int] = [],
+        hkl: List[Tuple[int, int, int]] = None,
+        dSpacing: List[float] = None,
+        fSquared: List[float] = None,
+        multiplicities: List[int] = None,
         peaks=[],
     ):
         if peaks != []:

--- a/src/snapred/backend/dao/CrystallographicInfo.py
+++ b/src/snapred/backend/dao/CrystallographicInfo.py
@@ -28,10 +28,10 @@ class CrystallographicInfo(BaseModel):
 
     def __init__(
         self,
-        hkl: List[Tuple[int, int, int]] = None,
-        dSpacing: List[float] = None,
-        fSquared: List[float] = None,
-        multiplicities: List[int] = None,
+        hkl: List[Tuple[int, int, int]] = [],
+        dSpacing: List[float] = [],
+        fSquared: List[float] = [],
+        multiplicities: List[int] = [],
         peaks=[],
     ):
         if peaks != []:
@@ -41,7 +41,6 @@ class CrystallographicInfo(BaseModel):
             raise ValueError("Structure factors and hkl required to have same length")
         if len(multiplicities) != len(hkl):
             raise ValueError("Multiplicities and hkl required to have same length")
-
         if len(dSpacing) != len(hkl):
             raise ValueError("Spacings and hkl required to have same length")
         peaks = [

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -136,4 +136,4 @@ constants:
     rebinParams: [2000, -0.001, 14500]
 
   DetectorPeakPredictor:
-    fwhm: 2.35482004503 # used to convert gaussian to fwhm 2 * sqrt(2 * log_e(2))
+    fwhm: 1.17741002252 # used to convert gaussian to fwhm (2 * log_e(2))

--- a/tests/resources/inputs/SNAPInstPrm.json
+++ b/tests/resources/inputs/SNAPInstPrm.json
@@ -19,9 +19,9 @@
     "L1": 15.0,
     "L2": 0.5,
     "delToT": 0.002,
-    "delLoL": 6.452e-5,
-    "delThNoGuide": 6.667e-4,
-    "delThWithGuide": 3.200e-3,
+    "delLoL": 0.003226,
+    "delThNoGuide": 2.13e-3,
+    "delThWithGuide": 6.40e-3,
     "alpha": 0.1,
     "beta_0": 0.02,
     "beta_1": 0.05


### PR DESCRIPTION
## Description of work
The work of this story is:

1) modify the input parameters to `EstimateResolutionDiffraction` (stored in SNAPInstPrm.json) so that it returns 2σ (see below for values)
2) modify the parameter `fwhm` (stored in application.yml) - which is the factor that converts δd to a full width half max of the peak - by dividing it by 2.
3) Modify NBinsAcrossPeakWidth

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work
The changes are detailed here. Old values are struck through.

SNAPInstPrm.json

“delToT”: 0.002,
“delLoL”: 6.452e-5,0.003226
“delThNoGuide”: 6.667e-4, TODO: GET VALUE
“delThWithGuide”: 3.200e-3, 6.40e-3

Application.yml

nBinsAcrossPeakWidth: 10 6 (I think this is set in SNAPRed GUI, so no change needed) 

DetectorPeakPredictor:
    fwhm: 2.35482004503  1.17741002252# used to convert gaussian standard deviation to fwhm 2 * sqrt(2 * log_e(2))
<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test
Ensure all unit tests pass.

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#3679](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3679)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
