### PR TITLE
patch problems with xtal rx

### DIFF
--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -172,10 +172,12 @@ class NormalizationService(Service):
 
     @FromString
     def vanadiumCorrection(self, request: VanadiumCorrectionRequest):
+        cifPath = self.dataFactoryService.getCifFilePath(request.calibrantSamplePath.split("/")[-1].split(".")[0])
         farmFresh = FarmFreshIngredients(
             runNumber=request.runNumber,
             useLiteMode=request.useLiteMode,
             focusGroup=request.focusGroup,
+            cifPath=cifPath,
             calibrantSamplePath=request.calibrantSamplePath,
         )
         ingredients = self.sousChef.prepNormalizationIngredients(farmFresh)

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -101,6 +101,9 @@ class SousChef(Service):
             return Config["instrument.native.definition.file"]
 
     def prepCrystallographicInfo(self, ingredients: FarmFreshIngredients):
+        if not ingredients.cifPath:
+            samplePath = ingredients.calibrantSamplePath.split("/")[-1].split(".")[0]
+            ingredients.cifPath = self.dataFactoryService.getCifFilePath(samplePath)
         key = (ingredients.cifPath, ingredients.dBounds.minimum, ingredients.dBounds.maximum)
         if key not in self._xtalCache:
             self._xtalCache[key] = CrystallographicInfoService().ingest(*key)["crystalInfo"]

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -135,6 +135,7 @@ class TestNormalizationService(unittest.TestCase):
         )
         self.instance = NormalizationService()
         self.instance.sousChef.prepNormalizationIngredients = MagicMock()
+        self.instance.dataFactoryService = MagicMock()
 
         res = self.instance.vanadiumCorrection(mockRequest)
 

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -145,6 +145,25 @@ class TestSousChef(unittest.TestCase):
         assert not XtalService.called
         assert res == self.instance._xtalCache[key]
 
+    @mock.patch(thisService + "CrystallographicInfoService")
+    def test_prepXtalInfo_noCif(self, XtalService):
+        key = (self.ingredients.cifPath, self.ingredients.dBounds.minimum, self.ingredients.dBounds.maximum)
+        # ensure the cache is preped
+        self.instance._xtalCache[key] = mock.Mock()
+        # make ingredients with no CIF path
+        incompleteIngredients = FarmFreshIngredients.parse_obj(self.ingredients)
+        incompleteIngredients.cifPath = None
+
+        # mock out the data factory
+        self.instance.dataFactoryService = mock.Mock()
+        self.instance.dataFactoryService.getCifFilePath.return_value = self.ingredients.cifPath
+
+        res = self.instance.prepCrystallographicInfo(incompleteIngredients)
+
+        assert not XtalService.called
+        assert res == self.instance._xtalCache[key]
+        assert self.instance.dataFactoryService.getCifFilePath.called
+
     @mock.patch(thisService + "PeakIngredients")
     def test_prepPeakIngredients(self, PeakIngredients):
         self.instance.prepCrystallographicInfo = mock.Mock()


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

There was an apparent error inside `SousChef` when creating `NormalizationIngredients` from the `NormalizationService.vanaciumCorrection` method, where the `FarmFreshIngredients` did not have a CIF path.  This adds a safety check just before the xtal service is called, to ensure CIF path is present and to populate it from the calibrant sample path if it is now.

## Explanation of work

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing

<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing

<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

``` python
# replace with your test script below
```

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
