### PR TITLE
Fix plot views in normalization calibration

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,6 +63,7 @@ with mock.patch("builtins.__import__", side_effect=import_mock):
         "mantid.plots.plotfunctions",
         "mantid.plots.datafunctions",
         "mantid.plots.utility",
+        "workbench.plotting",
         "workbench.plugins.workspacewidget",
     ]
 

--- a/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
+++ b/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
@@ -41,7 +41,7 @@ class SpecifyNormalizationCalibrationView(QWidget):
         self.signalBackgroundRunNumberUpdate.connect(self._updateBackgroundRunNumber)
 
         # create the graph elements
-        self.figure = plt.figure(figsize=(50, 50))
+        self.figure = plt.figure(constrained_layout=True)
         self.canvas = MantidFigureCanvas(self.figure)
         self.navigationBar = WorkbenchNavigationToolbar(self.canvas, self)
 
@@ -172,7 +172,9 @@ class SpecifyNormalizationCalibrationView(QWidget):
             ax.set_title(f"Group ID: {i + 1}")
             ax.set_xlabel("d-Spacing (Å)")
             ax.set_ylabel("Intensity")
-        plt.tight_layout()
+
+        # resize window and redraw
+        self.setMinimumHeight(self.size().height() + int(self.figure.get_size_inches()[1]*self.figure.dpi))
         self.canvas.draw()
 
     def _optimizeRowsAndCols(self, numGraphs):

--- a/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
+++ b/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
@@ -5,8 +5,7 @@ from mantid.simpleapi import mtd
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QComboBox, QGridLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton, QSlider, QWidget
-
-# from workbench.plotting.figuremanager import MantidFigureCanvas
+from workbench.plotting.figuremanager import MantidFigureCanvas
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
 
 from snapred.meta.Config import Config
@@ -53,7 +52,7 @@ class SpecifyNormalizationCalibrationView(QWidget):
         )
 
         self.figure = fig
-        self.canvas = FigureCanvas(self.figure)
+        self.canvas = MantidFigureCanvas(self.figure)
         self.navigationBar = WorkbenchNavigationToolbar(self.canvas, self)
 
         self.sampleDropDown = QComboBox()

--- a/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
+++ b/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 from mantid.simpleapi import mtd
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QComboBox, QGridLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton, QSlider, QWidget
-from workbench.plotting.figuremanager import MantidFigureCanvas, FigureManagerWorkbench
+from workbench.plotting.figuremanager import FigureManagerWorkbench, MantidFigureCanvas
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
 
 from snapred.meta.Config import Config
@@ -179,7 +179,6 @@ class SpecifyNormalizationCalibrationView(QWidget):
         self.layout.addWidget(self.canvas, 1, 0, 1, -1)
 
     def _updateGraphsOption1(self):
-    
         # get the updated workspaces and optimal graph grid
         focusedWorkspace = mtd[self.focusWorkspace]
         smoothedWorkspace = mtd[self.smoothedWorkspace]

--- a/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
+++ b/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
@@ -174,7 +174,7 @@ class SpecifyNormalizationCalibrationView(QWidget):
             ax.set_ylabel("Intensity")
 
         # resize window and redraw
-        self.setMinimumHeight(self.size().height() + int(self.figure.get_size_inches()[1]*self.figure.dpi))
+        self.setMinimumHeight(self.size().height() + int(self.figure.get_size_inches()[1] * self.figure.dpi))
         self.canvas.draw()
 
     def _optimizeRowsAndCols(self, numGraphs):

--- a/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
+++ b/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
@@ -104,16 +104,16 @@ class SpecifyNormalizationCalibrationView(QWidget):
         smoothingLayout.addWidget(self.smoothingLineEdit)
         smoothingLayout.addWidget(self.fielddMin)
 
-        # self.layout.addWidget(self.navigationBar, 0,0)
-        self.layout.addWidget(self.canvas, 0, 0, 1, -1)
-        self.layout.addWidget(self.fieldRunNumber, 1, 0)
-        self.layout.addWidget(self.fieldBackgroundRunNumber, 1, 1)
-        self.layout.addLayout(smoothingLayout, 2, 0)
-        self.layout.addWidget(LabeledField("Sample :", self.sampleDropDown, self), 3, 0)
-        self.layout.addWidget(LabeledField("Grouping File :", self.groupingDropDown, self), 3, 1)
-        self.layout.addWidget(self.recalculationButton, 4, 0, 1, 2)
+        self.layout.addWidget(self.navigationBar, 0, 0)
+        self.layout.addWidget(self.canvas, 1, 0, 1, -1)
+        self.layout.addWidget(self.fieldRunNumber, 2, 0)
+        self.layout.addWidget(self.fieldBackgroundRunNumber, 2, 1)
+        self.layout.addLayout(smoothingLayout, 3, 0)
+        self.layout.addWidget(LabeledField("Sample :", self.sampleDropDown, self), 4, 0)
+        self.layout.addWidget(LabeledField("Grouping File :", self.groupingDropDown, self), 4, 1)
+        self.layout.addWidget(self.recalculationButton, 5, 0, 1, 2)
 
-        self.layout.setRowStretch(0, 3)
+        self.layout.setRowStretch(1, 3)
         # self.layout.setRowStretch(1, 1)
 
         self.signalUpdateRecalculationButton.connect(self.setEnableRecalculateButton)
@@ -149,10 +149,6 @@ class SpecifyNormalizationCalibrationView(QWidget):
         except:  # noqa: E722
             raise Exception("Must be a numerical value.")
 
-    def resizeEvent(self, event):
-        self._updateGraphs()
-        super().resizeEvent(event)
-
     def emitValueChange(self):
         index = self.groupingDropDown.currentIndex()
         v = self.smoothingSlider.value() / 100.0
@@ -175,15 +171,8 @@ class SpecifyNormalizationCalibrationView(QWidget):
         smoothedWorkspace = mtd[self.smoothedWorkspace]
         numGraphs = focusedWorkspace.getNumberHistograms()
 
-        fig, axes = plt.subplots(
-            figsize=(50,50),
-            nrows=1,
-            ncols=numGraphs,
-            subplot_kw={"projection": "mantid"},
-        )
-        self.figure = fig
-
-        for i, ax in enumerate(axes):
+        for i in range(numGraphs):
+            ax = self.figure.add_subplot(1, numGraphs, i + 1, projection='mantid')
             ax.plot(focusedWorkspace, wkspIndex=i, label="Focused Data", normalize_by_bin_width=True)
             ax.plot(smoothedWorkspace, wkspIndex=i, label="Smoothed Data", normalize_by_bin_width=True, linestyle="--")
             ax.legend()
@@ -191,9 +180,7 @@ class SpecifyNormalizationCalibrationView(QWidget):
             ax.set_xlabel("d-Spacing (Å)")
             ax.set_ylabel("Intensity")
 
-        self.canvas.figure = self.figure
         self.canvas.draw()
-        self.layout.addWidget(self.canvas, 0, 0, 1, -1)
 
     def setEnableRecalculateButton(self, enable):
         self.recalculationButton.setEnabled(enable)

--- a/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
+++ b/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
@@ -18,7 +18,6 @@ class SpecifyNormalizationCalibrationView(QWidget):
     signalBackgroundRunNumberUpdate = pyqtSignal(str)
     signalValueChanged = pyqtSignal(int, float, float)
     signalUpdateRecalculationButton = pyqtSignal(bool)
-    # signalUpdateGraphs = pyqtSignal(bool)
 
     def __init__(self, name, jsonSchemaMap, samples=[], groups=[], parent=None):
         super().__init__(parent)
@@ -30,11 +29,6 @@ class SpecifyNormalizationCalibrationView(QWidget):
         self.layout = QGridLayout()
         self.setLayout(self.layout)
 
-        # create the graph elements
-        self.figure = plt.figure()
-        self.canvas = MantidFigureCanvas(self.figure)
-        self.navigationBar = WorkbenchNavigationToolbar(self.canvas, self)
-
         # create the run number fields
         self.fieldRunNumber = LabeledField("Run Number :", self._jsonFormList.getField("run.runNumber"), self)
         self.fieldRunNumber.setEnabled(False)
@@ -45,6 +39,11 @@ class SpecifyNormalizationCalibrationView(QWidget):
         )
         self.fieldBackgroundRunNumber.setEnabled(False)
         self.signalBackgroundRunNumberUpdate.connect(self._updateBackgroundRunNumber)
+
+        # create the graph elements
+        self.figure = plt.figure()
+        self.canvas = MantidFigureCanvas(self.figure)
+        self.navigationBar = WorkbenchNavigationToolbar(self.canvas, self)
 
         # create the other specification elements
         self.sampleDropDown = QComboBox()
@@ -155,20 +154,6 @@ class SpecifyNormalizationCalibrationView(QWidget):
         )
         self._updateGraphs()
 
-    def _optimizeRowsAndCols(self, numGraphs):
-        # Get best size for layout
-        sqrtSize = int(numGraphs**0.5)
-        if sqrtSize == numGraphs**0.5:
-            rowSize = sqrtSize
-            colSize = sqrtSize
-        elif numGraphs <= ((sqrtSize + 1) * sqrtSize):
-            rowSize = sqrtSize
-            colSize = sqrtSize + 1
-        else:
-            rowSize = sqrtSize + 1
-            colSize = sqrtSize + 1
-        return rowSize, colSize
-
     def _updateGraphs(self):
         # get the updated workspaces and optimal graph grid
         focusedWorkspace = mtd[self.focusWorkspace]
@@ -187,6 +172,20 @@ class SpecifyNormalizationCalibrationView(QWidget):
             ax.set_xlabel("d-Spacing (Å)")
             ax.set_ylabel("Intensity")
         self.canvas.draw()
+
+    def _optimizeRowsAndCols(self, numGraphs):
+        # Get best size for layout
+        sqrtSize = int(numGraphs**0.5)
+        if sqrtSize == numGraphs**0.5:
+            rowSize = sqrtSize
+            colSize = sqrtSize
+        elif numGraphs <= ((sqrtSize + 1) * sqrtSize):
+            rowSize = sqrtSize
+            colSize = sqrtSize + 1
+        else:
+            rowSize = sqrtSize + 1
+            colSize = sqrtSize + 1
+        return rowSize, colSize
 
     def setEnableRecalculateButton(self, enable):
         self.recalculationButton.setEnabled(enable)

--- a/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
+++ b/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
@@ -5,7 +5,8 @@ from mantid.simpleapi import mtd
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QComboBox, QGridLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton, QSlider, QWidget
-from workbench.plotting.figuremanager import MantidFigureCanvas
+
+# from workbench.plotting.figuremanager import MantidFigureCanvas
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
 
 from snapred.meta.Config import Config
@@ -52,7 +53,7 @@ class SpecifyNormalizationCalibrationView(QWidget):
         )
 
         self.figure = fig
-        self.canvas = MantidFigureCanvas(self.figure)
+        self.canvas = FigureCanvas(self.figure)
         self.navigationBar = WorkbenchNavigationToolbar(self.canvas, self)
 
         self.sampleDropDown = QComboBox()

--- a/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
+++ b/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
@@ -1,5 +1,4 @@
 import math
-
 import unittest.mock as mock
 
 import matplotlib.pyplot as plt
@@ -8,9 +7,9 @@ from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QComboBox, QGridLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton, QSlider, QWidget
 from workbench.plotting.figuremanager import MantidFigureCanvas
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
+
 # from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 # from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
-
 from snapred.meta.Config import Config
 from snapred.ui.widget.JsonFormList import JsonFormList
 from snapred.ui.widget.LabeledField import LabeledField
@@ -47,9 +46,9 @@ class SpecifyNormalizationCalibrationView(QWidget):
         self.signalBackgroundRunNumberUpdate.connect(self._updateBackgroundRunNumber)
 
         fig, ax = plt.subplots(
-            figsize=(10, 6.5258), 
-            nrows = 3,
-            ncols = 3,
+            figsize=(10, 6.5258),
+            nrows=3,
+            ncols=3,
             subplot_kw={"projection": "mantid"},
         )
 
@@ -168,8 +167,8 @@ class SpecifyNormalizationCalibrationView(QWidget):
 
     def _optimizeRowsAndCols(self, numGraphs):
         # Get best size for layout
-        sqrtSize = int( numGraphs ** 0.5 )
-        if sqrtSize == numGraphs ** 0.5:
+        sqrtSize = int(numGraphs**0.5)
+        if sqrtSize == numGraphs**0.5:
             rowSize = sqrtSize
             colSize = sqrtSize
         elif numGraphs <= ((sqrtSize + 1) * sqrtSize):
@@ -240,7 +239,6 @@ class SpecifyNormalizationCalibrationView(QWidget):
         # self.layout.addWidget(self.canvas, 1, 0, 1, -1)
 
         self.canvas.draw()
-
 
     def setEnableRecalculateButton(self, enable):
         self.recalculationButton.setEnabled(enable)

--- a/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
+++ b/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
@@ -172,7 +172,7 @@ class SpecifyNormalizationCalibrationView(QWidget):
         numGraphs = focusedWorkspace.getNumberHistograms()
 
         for i in range(numGraphs):
-            ax = self.figure.add_subplot(1, numGraphs, i + 1, projection='mantid')
+            ax = self.figure.add_subplot(1, numGraphs, i + 1, projection="mantid")
             ax.plot(focusedWorkspace, wkspIndex=i, label="Focused Data", normalize_by_bin_width=True)
             ax.plot(smoothedWorkspace, wkspIndex=i, label="Smoothed Data", normalize_by_bin_width=True, linestyle="--")
             ax.legend()

--- a/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
+++ b/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
@@ -15,14 +15,10 @@ from snapred.ui.widget.LabeledField import LabeledField
 
 class SpecifyNormalizationCalibrationView(QWidget):
     signalRunNumberUpdate = pyqtSignal(str)
-    signalGroupingUpdate = pyqtSignal(int)
     signalBackgroundRunNumberUpdate = pyqtSignal(str)
-    signalCalibrantUpdate = pyqtSignal(int)
-    signalUpdateSmoothingParameter = pyqtSignal(float)
     signalValueChanged = pyqtSignal(int, float, float)
-    signalWorkspacesUpdate = pyqtSignal(str, str)
     signalUpdateRecalculationButton = pyqtSignal(bool)
-    signalUpdateGraphs = pyqtSignal(bool)
+    # signalUpdateGraphs = pyqtSignal(bool)
 
     def __init__(self, name, jsonSchemaMap, samples=[], groups=[], parent=None):
         super().__init__(parent)
@@ -34,6 +30,12 @@ class SpecifyNormalizationCalibrationView(QWidget):
         self.layout = QGridLayout()
         self.setLayout(self.layout)
 
+        # create the graph elements
+        self.figure = plt.figure()
+        self.canvas = MantidFigureCanvas(self.figure)
+        self.navigationBar = WorkbenchNavigationToolbar(self.canvas, self)
+
+        # create the run number fields
         self.fieldRunNumber = LabeledField("Run Number :", self._jsonFormList.getField("run.runNumber"), self)
         self.fieldRunNumber.setEnabled(False)
         self.signalRunNumberUpdate.connect(self._updateRunNumber)
@@ -44,6 +46,7 @@ class SpecifyNormalizationCalibrationView(QWidget):
         self.fieldBackgroundRunNumber.setEnabled(False)
         self.signalBackgroundRunNumberUpdate.connect(self._updateBackgroundRunNumber)
 
+        # create the other specification elements
         self.sampleDropDown = QComboBox()
         self.sampleDropDown.setEnabled(False)
         self.sampleDropDown.addItems(samples)
@@ -92,6 +95,9 @@ class SpecifyNormalizationCalibrationView(QWidget):
         smoothingLayout.addWidget(self.smoothingLineEdit)
         smoothingLayout.addWidget(self.fielddMin)
 
+        # add all elements to the grid layout
+        self.layout.addWidget(self.navigationBar, 0, 0)
+        self.layout.addWidget(self.canvas, 1, 0, 1, -1)
         self.layout.addWidget(self.fieldRunNumber, 2, 0)
         self.layout.addWidget(self.fieldBackgroundRunNumber, 2, 1)
         self.layout.addLayout(smoothingLayout, 3, 0)
@@ -102,7 +108,6 @@ class SpecifyNormalizationCalibrationView(QWidget):
         self.layout.setRowStretch(1, 3)
 
         self.signalUpdateRecalculationButton.connect(self.setEnableRecalculateButton)
-        self.signalUpdateGraphs.connect(self.updateGraphs)
 
     def _updateRunNumber(self, runNumber):
         self.fieldRunNumber.setText(runNumber)
@@ -165,20 +170,6 @@ class SpecifyNormalizationCalibrationView(QWidget):
         return rowSize, colSize
 
     def _updateGraphs(self):
-        self.signalUpdateGraphs.emit(True)
-
-    def updateGraphs(self, _):
-        self.initFigure()
-        self._updateGraphsOption1()
-
-    def initFigure(self):
-        self.figure = plt.figure()
-        self.canvas = MantidFigureCanvas(self.figure)
-        self.navigationBar = WorkbenchNavigationToolbar(self.canvas, self)
-        self.layout.addWidget(self.navigationBar, 0, 0)
-        self.layout.addWidget(self.canvas, 1, 0, 1, -1)
-
-    def _updateGraphsOption1(self):
         # get the updated workspaces and optimal graph grid
         focusedWorkspace = mtd[self.focusWorkspace]
         smoothedWorkspace = mtd[self.smoothedWorkspace]

--- a/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
+++ b/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
@@ -170,9 +170,11 @@ class SpecifyNormalizationCalibrationView(QWidget):
         focusedWorkspace = mtd[self.focusWorkspace]
         smoothedWorkspace = mtd[self.smoothedWorkspace]
         numGraphs = focusedWorkspace.getNumberHistograms()
+        ncols = 3
+        nrows = int(numGraphs / ncols) + 1
 
         for i in range(numGraphs):
-            ax = self.figure.add_subplot(1, numGraphs, i + 1, projection="mantid")
+            ax = self.figure.add_subplot(nrows, ncols, i + 1, projection="mantid")
             ax.plot(focusedWorkspace, wkspIndex=i, label="Focused Data", normalize_by_bin_width=True)
             ax.plot(smoothedWorkspace, wkspIndex=i, label="Smoothed Data", normalize_by_bin_width=True, linestyle="--")
             ax.legend()

--- a/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
+++ b/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
@@ -41,7 +41,7 @@ class SpecifyNormalizationCalibrationView(QWidget):
         self.signalBackgroundRunNumberUpdate.connect(self._updateBackgroundRunNumber)
 
         # create the graph elements
-        self.figure = plt.figure()
+        self.figure = plt.figure(figsize=(50, 50))
         self.canvas = MantidFigureCanvas(self.figure)
         self.navigationBar = WorkbenchNavigationToolbar(self.canvas, self)
 
@@ -168,9 +168,11 @@ class SpecifyNormalizationCalibrationView(QWidget):
             ax.plot(focusedWorkspace, wkspIndex=i, label="Focused Data", normalize_by_bin_width=True)
             ax.plot(smoothedWorkspace, wkspIndex=i, label="Smoothed Data", normalize_by_bin_width=True, linestyle="--")
             ax.legend()
+            ax.tick_params(direction="in")
             ax.set_title(f"Group ID: {i + 1}")
             ax.set_xlabel("d-Spacing (Å)")
             ax.set_ylabel("Intensity")
+        plt.tight_layout()
         self.canvas.draw()
 
     def _optimizeRowsAndCols(self, numGraphs):


### PR DESCRIPTION
## Description of work

There were some visual issues present in the normalization graphs.

1. There was no navigation toolbar, which prevented zooming
2. Only the array of y-values was being plotted, so that the x-axis showed index instead of d-spacing
3. The graphs were not being normalized by binwidth, which is the mantid default
4. Extraneous errors were being logged into the workbench console.

Errors 1-3 were easily fixed, following work in PR #224.

Error 4 proved has related to
1. an older version of mantid
2. an `Axis` object being garbage-collected, while mantid workbench retained the object's event listener, triggering the errors.

## Explanation of work

Edited the normalization graph display view.

It will display a grid of graphs, and try to optimize the layout of the graphs based on the number of groups, trying to make things as square as possible.

The navigation toolbar works, but some of the workbench-specific features do not seem to work.  The navigation toolbar should probably be replaced with the standard matplot toolbar.

I needed to mock out the workbench.plotting module in the docs config in order for the docs to build.

## To test

### Dev testing

On analysis, pull this branch and launch workbench.  Open the SNAPRed interface.  Try running normalization with
- run number = 58813
- background run number = 58813 (just use the same one)
- smoothing = 0.5 (or literally anything)
- sample = any of the vanadiums
- grouping = Column

The graphs will be flat, but that isn't important.

Make sure the graphs are visible, labels don't overlap, the the size is reasonable.

On the navigation toolbar, click the zoom icon.  Try dragging a rectangle over one of the graphs: it should zoom in on the region selected.

Switch grouping from Column to All.  After a while, it should display a single graph.

Make sure no errors were logged in the console during this process.

### CIS testing

Do the same as above, but look at realistic data runs.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#3730](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3730)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
