### PR TITLE
Refactor normalization output

### DIFF
--- a/src/snapred/backend/dao/normalization/NormalizationRecord.py
+++ b/src/snapred/backend/dao/normalization/NormalizationRecord.py
@@ -12,3 +12,4 @@ class NormalizationRecord(BaseModel):
     normalization: Normalization
     workspaceNames: Optional[List[str]]
     version: Optional[int]
+    dMin: float

--- a/src/snapred/backend/dao/normalization/NormalizationRecord.py
+++ b/src/snapred/backend/dao/normalization/NormalizationRecord.py
@@ -2,14 +2,14 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
-from snapred.backend.dao.normalization.Normalization import Normalization
+from snapred.backend.dao.calibration.Calibration import Calibration
 
 
 class NormalizationRecord(BaseModel):
     runNumber: str
     backgroundRunNumber: str
     smoothingParameter: float
-    normalization: Normalization
+    calibration: Calibration
     workspaceNames: List[str] = []
     version: Optional[int]
     dMin: float

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -233,7 +233,8 @@ class LocalDataService:
 
     def _constructNormalizationCalibrationStatePath(self, stateId):
         # TODO: Propagate pathlib through codebase
-        return f"{self.instrumentConfig.calibrationDirectory / 'Powder' / stateId / 'normalization'}/"
+        # return f"{self.instrumentConfig.calibrationDirectory / 'Powder' / stateId / 'normalization'}/"
+        return f"{self.instrumentConfig.calibrationDirectory}/Powder/{stateId}/normalization/"
 
     def readCalibrationIndex(self, runId: str):
         # Need to run this because of its side effect, TODO: Remove side effect
@@ -448,7 +449,7 @@ class LocalDataService:
         # because it's written to a separate file during 'writeNormalizationState'.
         # However, if it is going to be _nested_, this marks it with the correct version.
         # (For example, use pydantic Field(exclude=True) to _stop_ nesting it.)
-        record.normalization.version = version
+        record.calibration.version = version
 
         normalizationPath = self._constructNormalizationCalibrationDataPath(runNumber, version)
         # check if directory exists for runId

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -150,6 +150,7 @@ class NormalizationService(Service):
             backgroundRunNumber=request.backgroundRunNumber,
             smoothingParameter=request.smoothingParameter,
             normalization=normalization,
+            dMin=request.dMin,
         )
         return record
 
@@ -195,7 +196,7 @@ class NormalizationService(Service):
             useLiteMode=request.useLiteMode,
             focusGroup=request.focusGroup,
         )
-        ingredients = self.sousChef.prepPixelGroup(farmFresh)
+        ingredients = self.sousChef.prepPixelGroup(farmFresh, True)
         return FocusSpectraRecipe().executeRecipe(
             InputWorkspace=request.inputWorkspace,
             GroupingWorkspace=request.groupingWorkspace,

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -144,12 +144,12 @@ class NormalizationService(Service):
 
     @FromString
     def normalizationAssessment(self, request: NormalizationCalibrationRequest):
-        normalization = self.dataFactoryService.getNormalizationState(request.runNumber)
+        calibration = self.dataFactoryService.getCalibrationState(request.runNumber)
         record = NormalizationRecord(
             runNumber=request.runNumber,
             backgroundRunNumber=request.backgroundRunNumber,
             smoothingParameter=request.smoothingParameter,
-            normalization=normalization,
+            calibration=calibration,
             dMin=request.dMin,
         )
         return record
@@ -196,7 +196,7 @@ class NormalizationService(Service):
             useLiteMode=request.useLiteMode,
             focusGroup=request.focusGroup,
         )
-        ingredients = self.sousChef.prepPixelGroup(farmFresh, True)
+        ingredients = self.sousChef.prepPixelGroup(farmFresh)
         return FocusSpectraRecipe().executeRecipe(
             InputWorkspace=request.inputWorkspace,
             GroupingWorkspace=request.groupingWorkspace,

--- a/tests/resources/inputs/normalization/NormalizationRecord.json
+++ b/tests/resources/inputs/normalization/NormalizationRecord.json
@@ -2,7 +2,7 @@
     "runNumber": 57514,
     "backgroundRunNumber": 58813,
     "smoothingParameter": 0.5,
-    "normalization":{
+    "calibration":{
         "instrumentState": {
             "id": "ab8704b0bc2a2342",
             "peakTailCoefficient": 1.1,
@@ -76,5 +76,6 @@
         "fitted_strippedFocussedData_stripped_2",
         "57514_calibration_reduction_result"
       ],
-    "version": 7
+    "version": 7,
+    "dMin": 0.4
 }

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -435,8 +435,8 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
         localDataService._readReductionParameters = mock.Mock()
-        localDataService._constructCalibrationStatePath = mock.Mock()
-        localDataService._constructCalibrationStatePath.return_value = Resource.getPath("outputs")
+        localDataService._constructNormalizationCalibrationStatePath = mock.Mock()
+        localDataService._constructNormalizationCalibrationStatePath.return_value = Resource.getPath("outputs")
         expectedFilePath = Resource.getPath("outputs") + "NormalizationIndex.json"
         localDataService.writeNormalizationIndexEntry(
             NormalizationIndexEntry(
@@ -479,8 +479,8 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
         localDataService._readReductionParameters = mock.Mock()
-        localDataService._constructCalibrationStatePath = mock.Mock()
-        localDataService._constructCalibrationStatePath.return_value = Resource.getPath("outputs")
+        localDataService._constructNormalizationCalibrationStatePath = mock.Mock()
+        localDataService._constructNormalizationCalibrationStatePath.return_value = Resource.getPath("outputs")
         expectedFilePath = Resource.getPath("outputs") + "NormalizationIndex.json"
         localDataService.writeNormalizationIndexEntry(
             NormalizationIndexEntry(
@@ -567,8 +567,8 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
             localDataService._generateStateId = mock.Mock()
             localDataService._generateStateId.return_value = ("ab8704b0bc2a2342", None)
             localDataService._readReductionParameters = mock.Mock()
-            localDataService._constructCalibrationStatePath = mock.Mock()
-            localDataService._constructCalibrationStatePath.return_value = f"{tempdir}/"
+            localDataService._constructNormalizationCalibrationStatePath = mock.Mock()
+            localDataService._constructNormalizationCalibrationStatePath.return_value = f"{tempdir}/"
             localDataService.groceryService = mock.Mock()
             # WARNING: 'writeNormalizationRecord' modifies <incoming record>.version,
             # and <incoming record>.normalization.version.
@@ -577,12 +577,12 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
             localDataService.writeNormalizationRecord(testNormalizationRecord)
             actualRecord = localDataService.readNormalizationRecord("57514")
             assert actualRecord.version == 1
-            assert actualRecord.normalization.version == 1
+            assert actualRecord.calibration.version == 1
             # write: version == 2
             localDataService.writeNormalizationRecord(testNormalizationRecord)
             actualRecord = localDataService.readNormalizationRecord("57514")
             assert actualRecord.version == 2
-            assert actualRecord.normalization.version == 2
+            assert actualRecord.calibration.version == 2
         assert actualRecord.runNumber == "57514"
         assert actualRecord == testNormalizationRecord
 
@@ -596,8 +596,8 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
             localDataService._generateStateId = mock.Mock()
             localDataService._generateStateId.return_value = ("ab8704b0bc2a2342", None)
             localDataService._readReductionParameters = mock.Mock()
-            localDataService._constructCalibrationStatePath = mock.Mock()
-            localDataService._constructCalibrationStatePath.return_value = f"{tempdir}/"
+            localDataService._constructNormalizationCalibrationStatePath = mock.Mock()
+            localDataService._constructNormalizationCalibrationStatePath.return_value = f"{tempdir}/"
             localDataService.groceryService = mock.Mock()
             localDataService.writeNormalizationRecord(testNormalizationRecord)
             actualRecord = localDataService.readNormalizationRecord("57514")
@@ -617,8 +617,8 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         localDataService = LocalDataService()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
-        localDataService._constructCalibrationStatePath = mock.Mock()
-        localDataService._constructCalibrationStatePath.return_value = Resource.getPath("outputs/")
+        localDataService._constructNormalizationCalibrationStatePath = mock.Mock()
+        localDataService._constructNormalizationCalibrationStatePath.return_value = Resource.getPath("outputs/")
         actualPath = localDataService.getNormalizationRecordPath("57514", 1)
         assert actualPath == Resource.getPath("outputs") + "/v_1/NormalizationRecord.json"
 
@@ -799,14 +799,13 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
             localDataService = LocalDataService()
             localDataService._generateStateId = mock.Mock()
             localDataService._generateStateId.return_value = ("123", "456")
-            localDataService._constructCalibrationStatePath = mock.Mock()
-            localDataService._constructCalibrationStatePath.return_value = f"{tempdir}/"
+            localDataService._constructNormalizationCalibrationStatePath = mock.Mock()
+            localDataService._constructNormalizationCalibrationStatePath.return_value = f"{tempdir}/"
             localDataService._getCurrentNormalizationRecord = mock.Mock()
             localDataService._getCurrentNormalizationRecord.return_value = Normalization.construct({"name": "test"})
             with Resource.open("/inputs/normalization/NormalizationParameters.json", "r") as f:
                 normalization = Normalization.parse_raw(f.read())
             localDataService.writeNormalizationState("123", normalization)
-            print(os.listdir(tempdir + "/v_1/"))
             assert os.path.exists(tempdir + "/v_1/NormalizationParameters.json")
 
     def test_initializeState():

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -194,14 +194,14 @@ class TestNormalizationService(unittest.TestCase):
     ):
         mockNormalization = MagicMock()
         mockDataFactoryService = mockDataFactoryService.return_value
-        mockDataFactoryService.getNormalizationState.return_value = mockNormalization
+        mockDataFactoryService.getCalibrationState.return_value = mockNormalization
 
         self.instance = NormalizationService()
         self.instance.dataFactoryService.getNormalizationRecord = MagicMock(return_value=mockNormalizationRecord)
 
         result = self.instance.normalizationAssessment(self.request)
 
-        mockDataFactoryService.getNormalizationState.assert_called_once_with(self.request.runNumber)
+        mockDataFactoryService.getCalibrationState.assert_called_once_with(self.request.runNumber)
         expected_record_mockId = "mock_normalization_record"
         assert result.mockId == expected_record_mockId
 


### PR DESCRIPTION
## Description of work


This updates the output of the save step in the Normalization GUI.  dMin and SmoothingParameter now exist inside of NormalizationRecord, and NormalizationParameters is no longer created as it was redundant. The output is now also saved in it's own normalization folder. 
 ## Explanation of work


LocalDataService was updated so that Normalization uses it's own functions, as opposed to using the same functions that Diffraction Calibration does. Changes in here also make it so that the saved output are now under .../<stateId>/normalization/v_* . SousChef was updated to handle specific Normalization case.
## To test

### Dev testing



To test this, make sure to fix your environment on SNS first. For us non CIS people, copy /SNS/SNAP/shared/Calibration to your home drive, and update the application.yml file to point to your copy, specifically the instrument.home field. This gets around the permissions issue. On the SNAPRed gui, open the test panel and click on the Normalization Calibration tab. Click the Check Calibration Initialization button first. This can generate the required file to start the Normalization Process. For the fields:

Run Number: 58813
Background Run Number: 58813
Smoothing Parameter: 0.5
Sample: Silicon_NIST_640D_001
Grouping File: Any should work

Click continue and wait for calibration to finish. There might be a warning, just click OK on the box. On the Tweak Parameters tab, just click continue. On the saving tab, click continue and you should see no errors. The saved files should now appear under /Calibration/Powder/<stateId>/normalization/v_<#>. The files should now be 3 different nxs files and a NormalizationRecord.json file. In the record file, you should now see the dMin and the SmoothingParameter fields. 

### CIS testing

Do the dev test, but you shouldn't have to fix your env beforehand, assuming you have write permissions.



## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#3814](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3814)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
