### PR TITLE
Patch ever-growing window heights

### DIFF
--- a/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
+++ b/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
@@ -106,6 +106,9 @@ class SpecifyNormalizationCalibrationView(QWidget):
 
         self.layout.setRowStretch(1, 3)
 
+        # store the initial layout without graphs
+        self.initialLayoutHeight = self.size().height()
+
         self.signalUpdateRecalculationButton.connect(self.setEnableRecalculateButton)
 
     def _updateRunNumber(self, runNumber):
@@ -174,7 +177,7 @@ class SpecifyNormalizationCalibrationView(QWidget):
             ax.set_ylabel("Intensity")
 
         # resize window and redraw
-        self.setMinimumHeight(self.size().height() + int(self.figure.get_size_inches()[1] * self.figure.dpi))
+        self.setMinimumHeight(self.initialLayoutHeight + int(self.figure.get_size_inches()[1] * self.figure.dpi))
         self.canvas.draw()
 
     def _optimizeRowsAndCols(self, numGraphs):


### PR DESCRIPTION
## Description of work

In PR #226 I foolishly coded the window heights to keep growing.  This led to unexpected view issues when Malcolm tried testing other functionality.

This fix will prevent the window from growing increasingly when the figures are populated.

## Explanation of work

I had previously used the window height, and added to it the figure height.  This changed the window height, so that the next time this was called the window got even larger, and larger, and larger.

This saves the initial window height and adds the figure height to that, so that the new window height remains pretty stable.

## To test

### Dev testing

In GUI run normalization calibration
- 58813
- 58813
- vanadium 001
- 0.5
- Column

Then try changing dMin, smoothing parameter, grouping, and verify that the window stays a reasonable height.


### CIS testing

<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

``` python
# replace with your test script below
```

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
