### PR TITLE
Changed output name for corrected vanadium in normalization

### DIFF
--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -72,13 +72,7 @@ class NormalizationService(Service):
 
         outputWorkspace = wng.run().runNumber(request.runNumber).group(groupingScheme).auxilary("S+F-Vanadium").build()
         correctedVanadium = wng.rawVanadium().runNumber(request.runNumber).build()
-        smoothedOutput = (
-            wng.run()
-            .runNumber(request.runNumber)
-            .group(groupingScheme)
-            .auxilary(f"{request.smoothingParameter}-s_{request.dMin}-dmin")
-            .build()
-        )
+        smoothedOutput = wng.smoothedFocusedRawVanadium().runNumber(request.runNumber).group(groupingScheme).build()
 
         if (
             self.groceryService.workspaceDoesExist(outputWorkspace)
@@ -122,12 +116,12 @@ class NormalizationService(Service):
         )
         outputWorkspace = self.focusSpectra(requestFs)
         # clone output focussedVanadium
-        focussedVanadiumWs = "focussedCorrectedVanadium"
-        self.groceryService.getCloneOfWorkspace(outputWorkspace, focussedVanadiumWs)
+        focusedVanadiumWs = wng.focusedRawVanadium().runNumber(request.runNumber).group(groupingScheme).build()
+        self.groceryService.getCloneOfWorkspace(outputWorkspace, focusedVanadiumWs)
         # 3. smooth
 
         smoothRequest = SmoothDataExcludingPeaksRequest(
-            inputWorkspace=focussedVanadiumWs,
+            inputWorkspace=focusedVanadiumWs,
             outputWorkspace=smoothedOutput,
             calibrantSamplePath=request.calibrantSamplePath,
             focusGroup=request.focusGroup,
@@ -139,7 +133,7 @@ class NormalizationService(Service):
         outputWorkspace = self.smoothDataExcludingPeaks(smoothRequest)
 
         return NormalizationResponse(
-            correctedVanadium=correctedVanadiumWs, outputWorkspace=focussedVanadiumWs, smoothedOutput=outputWorkspace
+            correctedVanadium=correctedVanadiumWs, outputWorkspace=focusedVanadiumWs, smoothedOutput=outputWorkspace
         ).dict()
 
     @FromString

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -71,7 +71,7 @@ class NormalizationService(Service):
         ).fromPrev().add()
 
         outputWorkspace = wng.run().runNumber(request.runNumber).group(groupingScheme).auxilary("S+F-Vanadium").build()
-        correctedVanadium = wng.run().runNumber(request.runNumber).group("unfoc").auxilary("raw_van_corr").build()
+        correctedVanadium = wng.rawVanadium().runNumber(request.runNumber).build()
         smoothedOutput = (
             wng.run()
             .runNumber(request.runNumber)

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -71,7 +71,7 @@ class NormalizationService(Service):
         ).fromPrev().add()
 
         outputWorkspace = wng.run().runNumber(request.runNumber).group(groupingScheme).auxilary("S+F-Vanadium").build()
-        correctedVanadium = wng.run().runNumber(request.runNumber).group(groupingScheme).auxilary("C-Vanadium").build()
+        correctedVanadium = wng.run().runNumber(request.runNumber).group("unfoc").auxilary("raw_van_corr").build()
         smoothedOutput = (
             wng.run()
             .runNumber(request.runNumber)

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -48,6 +48,10 @@ class _WorkspaceNameGenerator:
     _diffCalMetricTemplateKeys = ["runNumber", "version", "metricName"]
     _rawVanadiumTemplate = Config[f"{_templateRoot}.normCal.rawVanadium"]
     _rawVanadiumTemplateKeys = ["unit", "group", "runNumber"]
+    _focusedRawVanadiumTemplate = Config[f"{_templateRoot}.normCal.focusedRawVanadium"]
+    _focusedRawVanadiumTemplateKeys = ["unit", "group", "runNumber"]
+    _smoothedFocusedRawVanadiumTemplate = Config[f"{_templateRoot}.normCal.smoothedFocusedRawVanadium"]
+    _smoothedFocusedRawVanadiumTemplateKeys = ["unit", "group", "runNumber"]
 
     class Units:
         _templateRoot = "mantid.workspace.nameTemplate.units"
@@ -104,6 +108,16 @@ class _WorkspaceNameGenerator:
             self._delimiter,
             unit=self.Units.TOF,
             group=self.Groups.UNFOC,
+        )
+
+    def focusedRawVanadium(self):
+        return NameBuilder(
+            self._focusedRawVanadiumTemplate, self._focusedRawVanadiumTemplateKeys, self._delimiter, unit=self.Units.DSP
+        )
+
+    def smoothedFocusedRawVanadium(self):
+        return NameBuilder(
+            self._focusedRawVanadiumTemplate, self._focusedRawVanadiumTemplateKeys, self._delimiter, unit=self.Units.DSP
         )
 
 

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -46,6 +46,8 @@ class _WorkspaceNameGenerator:
     _diffCalMaskTemplateKeys = ["runNumber"]
     _diffCalMetricTemplate = Config[f"{_templateRoot}.diffCal.metric"]
     _diffCalMetricTemplateKeys = ["runNumber", "version", "metricName"]
+    _rawVanadiumTemplate = Config[f"{_templateRoot}.normCal.rawVanadium"]
+    _rawVanadiumTemplateKeys = ["unit", "group", "runNumber"]
 
     class Units:
         _templateRoot = "mantid.workspace.nameTemplate.units"
@@ -94,6 +96,15 @@ class _WorkspaceNameGenerator:
 
     def diffCalMetrics(self):
         return NameBuilder(self._diffCalMetricTemplate, self._diffCalMetricTemplateKeys, self._delimiter)
+
+    def rawVanadium(self):
+        return NameBuilder(
+            self._rawVanadiumTemplate,
+            self._rawVanadiumTemplateKeys,
+            self._delimiter,
+            unit=self.Units.TOF,
+            group=self.Groups.UNFOC,
+        )
 
 
 WorkspaceNameGenerator = _WorkspaceNameGenerator()

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -117,7 +117,10 @@ class _WorkspaceNameGenerator:
 
     def smoothedFocusedRawVanadium(self):
         return NameBuilder(
-            self._focusedRawVanadiumTemplate, self._focusedRawVanadiumTemplateKeys, self._delimiter, unit=self.Units.DSP
+            self._smoothedFocusedRawVanadiumTemplate,
+            self._smoothedFocusedRawVanadiumTemplateKeys,
+            self._delimiter,
+            unit=self.Units.DSP,
         )
 
 

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -99,8 +99,8 @@ mantid:
         metric: "{runNumber},{version},calibration_metrics,{metricName}"
       normCal:
         rawVanadium: "{unit},{group},{runNumber},raw_van_corr"
-        focusedRawVanadium: "{runNumber},{backgroundRunNumber},RVC,{groupingScheme}"
-        smoothedFocusedRawVanadium: "{runNumber},{backgroundRunNumber},RVC,{groupingScheme},{smoothingParameter}"
+        focusedRawVanadium: "{unit},{group},{runNumber},raw_van_corr"
+        smoothedFocusedRawVanadium: "{unit},{group},{runNumber},fitted_van_cor"
       units:
         dSpacing: DSP
         timeOfFlight: TOF

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -98,7 +98,7 @@ mantid:
         mask: "DIFC,{runNumber},mask"
         metric: "{runNumber},{version},calibration_metrics,{metricName}"
       normCal:
-        rawVandium: "{runNumber},{backgroundRunNumber},RVC"
+        rawVanadium: "{unit},{group},{runNumber},raw_van_corr"
         focusedRawVanadium: "{runNumber},{backgroundRunNumber},RVC,{groupingScheme}"
         smoothedFocusedRawVanadium: "{runNumber},{backgroundRunNumber},RVC,{groupingScheme},{smoothingParameter}"
       units:

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -96,6 +96,10 @@ mantid:
           output: "_{unit},{runNumber},diffoc"
           mask: "_DIFC,{runNumber},mask"
           metric: "{runNumber},{version},calibration_metrics,{metricName}"
+        normCal:
+          rawVanadium: "{unit},{group},{runNumber},raw_van_corr"
+          focusedRawVanadium: "{runNumber},{backgroundRunNumber},RVC,{groupingScheme}"
+          smoothedFocusedRawVanadium: "{runNumber},{backgroundRunNumber},RVC,{groupingScheme},{smoothingParameter}"
         units:
           dSpacing: dsp
           timeOfFlight: tof

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -98,8 +98,8 @@ mantid:
           metric: "{runNumber},{version},calibration_metrics,{metricName}"
         normCal:
           rawVanadium: "{unit},{group},{runNumber},raw_van_corr"
-          focusedRawVanadium: "{runNumber},{backgroundRunNumber},RVC,{groupingScheme}"
-          smoothedFocusedRawVanadium: "{runNumber},{backgroundRunNumber},RVC,{groupingScheme},{smoothingParameter}"
+          focusedRawVanadium: "{unit},{group},{runNumber},raw_van_corr"
+          smoothedFocusedRawVanadium: "{unit},{group},{runNumber},fitted_van_cor"
         units:
           dSpacing: dsp
           timeOfFlight: tof

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -245,7 +245,7 @@ class TestNormalizationService(unittest.TestCase):
         self.instance = NormalizationService()
         result = self.instance.normalization(self.request)
         assert result == {
-            "correctedVanadium": f"tof_{self.request.focusGroup.name}_12345_c-vanadium",
+            "correctedVanadium": "tof_unfoc_12345_raw_van_corr",
             "outputWorkspace": f"tof_{self.request.focusGroup.name}_12345_s+f-vanadium",
             "smoothedOutput": f"tof_{self.request.focusGroup.name}_12345_0.5-s_{self.request.dMin}-dmin",
         }

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -247,5 +247,5 @@ class TestNormalizationService(unittest.TestCase):
         assert result == {
             "correctedVanadium": "tof_unfoc_12345_raw_van_corr",
             "outputWorkspace": f"tof_{self.request.focusGroup.name}_12345_s+f-vanadium",
-            "smoothedOutput": f"tof_{self.request.focusGroup.name}_12345_0.5-s_{self.request.dMin}-dmin",
+            "smoothedOutput": "dsp_apple_12345_raw_van_corr",
         }

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -247,5 +247,5 @@ class TestNormalizationService(unittest.TestCase):
         assert result == {
             "correctedVanadium": "tof_unfoc_12345_raw_van_corr",
             "outputWorkspace": f"tof_{self.request.focusGroup.name}_12345_s+f-vanadium",
-            "smoothedOutput": "dsp_apple_12345_raw_van_corr",
+            "smoothedOutput": "dsp_apple_12345_fitted_van_cor",
         }


### PR DESCRIPTION
## Description of work

This changes the output name for the raw corrected vanadium file when performing a normalization calibration.

## Explanation of work

How the name in the service was being created got updated.

## To test

### Dev testing

To test this, make sure to fix your environment on SNS first. For us non CIS people, copy /SNS/SNAP/shared/Calibration to your home drive, and update the application.yml file to point to your copy, specifically the instrument.home field. This gets around the permissions issue. On the SNAPRed gui, open the test panel and click on the Normalization Calibration tab. Click the Check Calibration Initialization button first. This can generate the required file to start the Normalization Process. For the fields:

Run Number: 58813
Background Run Number: 58813
Smoothing Parameter: 0.5
Sample: Silicon_NIST_640D_001
Grouping File: Any should work

Click continue and wait for calibration to finish. There might be a warning, just click OK on the box. On the Tweak Parameters tab, just click continue. On the saving tab, click continue and you should see no errors. The saved files should now appear under /Calibration/Powder//normalization/v_<#>. The files should now be 3 different nxs files and a NormalizationRecord.json file. You should now see a file that shows as tof_unfoc_58813_raw_van_corr.nxs

### CIS testing

Do the dev test, but you shouldn't have to fix your env beforehand, assuming you have write permissions.


## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#3986](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3986)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
