### PR TITLE
dMin correct smoothing output

### DIFF
--- a/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
@@ -144,10 +144,10 @@ class SmoothDataExcludingPeaksAlgo(PythonAlgorithm):
                 smoothing_results = tck(xMidpoints, extrapolate=False)
                 outputWorkspace.setY(index, smoothing_results)
 
-                self.mantidSnapper.WashDishes(
-                    "Cleaning up weight workspace...",
-                    Workspace=self.weightWorkspaceName,
-                )
+            self.mantidSnapper.WashDishes(
+                "Cleaning up weight workspace...",
+                Workspace=self.weightWorkspaceName,
+            )
             self.mantidSnapper.executeQueue()
             self.setProperty("OutputWorkspace", outputWorkspace)
 

--- a/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
@@ -121,7 +121,11 @@ class SmoothDataExcludingPeaksAlgo(PythonAlgorithm):
 
         for index in range(numSpec):
             if np.all(weightWorkspace.readY(index) == 1):
-                smoothing_results = np.zeros_like(weightWorkspace.readY(index))
+                self.mantidSnapper.CloneWorkspace(
+                    "Cloning workspace for no peaks...",
+                    InputWorkspace=self.inputWorkspaceName,
+                    outputWorkspace=self.outputWorkspaceName,
+                )
             else:
                 x = inputWorkspace.readX(index)
                 y = inputWorkspace.readY(index)
@@ -138,14 +142,14 @@ class SmoothDataExcludingPeaksAlgo(PythonAlgorithm):
                 tck = make_smoothing_spline(weightXMidpoints, y, lam=self.lam)
                 # fill in the removed data using the spline function and original datapoints
                 smoothing_results = tck(xMidpoints, extrapolate=False)
-            outputWorkspace.setY(index, smoothing_results)
+                outputWorkspace.setY(index, smoothing_results)
 
-        self.mantidSnapper.WashDishes(
-            "Cleaning up weight workspace...",
-            Workspace=self.weightWorkspaceName,
-        )
-        self.mantidSnapper.executeQueue()
-        self.setProperty("OutputWorkspace", outputWorkspace)
+                self.mantidSnapper.WashDishes(
+                    "Cleaning up weight workspace...",
+                    Workspace=self.weightWorkspaceName,
+                )
+            self.mantidSnapper.executeQueue()
+            self.setProperty("OutputWorkspace", outputWorkspace)
 
 
 # Register algorithm with Mantid

--- a/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
@@ -126,6 +126,7 @@ class SmoothDataExcludingPeaksAlgo(PythonAlgorithm):
                     InputWorkspace=self.inputWorkspaceName,
                     outputWorkspace=self.outputWorkspaceName,
                 )
+                self.mantidSnapper.executeQueue()
             else:
                 x = inputWorkspace.readX(index)
                 y = inputWorkspace.readY(index)
@@ -144,12 +145,12 @@ class SmoothDataExcludingPeaksAlgo(PythonAlgorithm):
                 smoothing_results = tck(xMidpoints, extrapolate=False)
                 outputWorkspace.setY(index, smoothing_results)
 
-            self.mantidSnapper.WashDishes(
-                "Cleaning up weight workspace...",
-                Workspace=self.weightWorkspaceName,
-            )
-            self.mantidSnapper.executeQueue()
-            self.setProperty("OutputWorkspace", outputWorkspace)
+        self.mantidSnapper.WashDishes(
+            "Cleaning up weight workspace...",
+            Workspace=self.weightWorkspaceName,
+        )
+        self.mantidSnapper.executeQueue()
+        self.setProperty("OutputWorkspace", outputWorkspace)
 
 
 # Register algorithm with Mantid

--- a/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
@@ -120,23 +120,22 @@ class SmoothDataExcludingPeaksAlgo(PythonAlgorithm):
         numSpec = weightWorkspace.getNumberHistograms()
 
         for index in range(numSpec):
-            if np.any(weightWorkspace.readY(index) != 1):
-                x = inputWorkspace.readX(index)
-                y = inputWorkspace.readY(index)
+            x = inputWorkspace.readX(index)
+            y = inputWorkspace.readY(index)
 
-                weightX = weightWorkspace.readX(index)
-                weightY = weightWorkspace.readY(index)
+            weightX = weightWorkspace.readX(index)
+            weightY = weightWorkspace.readY(index)
 
-                weightXMidpoints = (weightX[:-1] + weightX[1:]) / 2
-                xMidpoints = (x[:-1] + x[1:]) / 2
+            weightXMidpoints = (weightX[:-1] + weightX[1:]) / 2
+            xMidpoints = (x[:-1] + x[1:]) / 2
 
-                weightXMidpoints = weightXMidpoints[weightY != 0]
-                y = y[weightY != 0]
-                # Generate spline with purged dataset
-                tck = make_smoothing_spline(weightXMidpoints, y, lam=self.lam)
-                # fill in the removed data using the spline function and original datapoints
-                smoothing_results = tck(xMidpoints, extrapolate=False)
-                outputWorkspace.setY(index, smoothing_results)
+            weightXMidpoints = weightXMidpoints[weightY != 0]
+            y = y[weightY != 0]
+            # Generate spline with purged dataset
+            tck = make_smoothing_spline(weightXMidpoints, y, lam=self.lam)
+            # fill in the removed data using the spline function and original datapoints
+            smoothing_results = tck(xMidpoints, extrapolate=False)
+            outputWorkspace.setY(index, smoothing_results)
 
         self.mantidSnapper.WashDishes(
             "Cleaning up weight workspace...",

--- a/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
@@ -120,14 +120,7 @@ class SmoothDataExcludingPeaksAlgo(PythonAlgorithm):
         numSpec = weightWorkspace.getNumberHistograms()
 
         for index in range(numSpec):
-            if np.all(weightWorkspace.readY(index) == 1):
-                self.mantidSnapper.CloneWorkspace(
-                    "Cloning workspace for no peaks...",
-                    InputWorkspace=self.inputWorkspaceName,
-                    outputWorkspace=self.outputWorkspaceName,
-                )
-                self.mantidSnapper.executeQueue()
-            else:
+            if np.any(weightWorkspace.readY(index) != 1):
                 x = inputWorkspace.readX(index)
                 y = inputWorkspace.readY(index)
 


### PR DESCRIPTION
## Description of work

Previous PR #222 had set spectra to flat lines at zero if there were no peaks in them.

@mguthriem said this was not the desired behavior.

This should fix the smoothing as required.

## Explanation of work

Removed the `if-elif` inside `SmoothDataExcludingPeaks` that skipped smoothing if no peaks were in the peak list.  Doing this skipped the important step of smoothing, using the smoothing-spline (which is not the same as a cubic spline and includes some not-node-fitting behavior).

## To test

### Dev testing

### CIS testing

## Link to EWM item
Created during Hackathon 2024/02/19
