### PR TITLE
TOF and dSpacing Units for GroupCalibrationWorkspace

### DIFF
--- a/src/snapred/backend/dao/ingredients/DiffractionCalibrationIngredients.py
+++ b/src/snapred/backend/dao/ingredients/DiffractionCalibrationIngredients.py
@@ -16,10 +16,3 @@ class DiffractionCalibrationIngredients(BaseModel):
     groupedPeakLists: List[GroupPeakList]
     convergenceThreshold: float
     maxOffset: float = Config["calibration.diffraction.maximumOffset"]
-    units: str = "TOF"
-
-    @validator("units")
-    def validatedSpacing(cls, v):
-        if v not in ["TOF", "dSpacing"]:
-            raise ValueError(f"dSpacing must be either 'TOF' or 'dSpacing', not '{v}'")
-        return v

--- a/src/snapred/backend/dao/ingredients/DiffractionCalibrationIngredients.py
+++ b/src/snapred/backend/dao/ingredients/DiffractionCalibrationIngredients.py
@@ -1,6 +1,6 @@
 from typing import Dict, List
 
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.RunConfig import RunConfig
@@ -16,3 +16,10 @@ class DiffractionCalibrationIngredients(BaseModel):
     groupedPeakLists: List[GroupPeakList]
     convergenceThreshold: float
     maxOffset: float = Config["calibration.diffraction.maximumOffset"]
+    units: str = "TOF"
+
+    @validator("units")
+    def validatedSpacing(cls, v):
+        if v not in ["TOF", "dSpacing"]:
+            raise ValueError(f"dSpacing must be either 'TOF' or 'dSpacing', not '{v}'")
+        return v

--- a/src/snapred/backend/dao/ingredients/DiffractionCalibrationIngredients.py
+++ b/src/snapred/backend/dao/ingredients/DiffractionCalibrationIngredients.py
@@ -1,6 +1,6 @@
 from typing import Dict, List
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel
 
 from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.RunConfig import RunConfig

--- a/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
@@ -317,18 +317,24 @@ class GroupDiffractionCalibration(PythonAlgorithm):
                 Target="TOF",
             )
 
-        # For inspection, save diffraction focused data before calculation
-        self.mantidSnapper.MakeDirtyDish(
-            "Save diffraction-focused TOF data",
-            InputWorkspace=outputWS if units == "TOF" else tmpWSdsp,
-            OutputWorkspace=tmpWStof,
-        )
+            # For inspection, save diffraction focused data before calculation
+            self.mantidSnapper.MakeDirtyDish(
+                "Save diffraction-focused TOF data",
+                InputWorkspace=outputWS if units == "TOF" else tmpWSdsp,
+                OutputWorkspace=tmpWStof,
+            )
 
-        # Delete diffraction-focused d-spacing data
-        self.mantidSnapper.WashDishes(
-            "Delete diffraction-focused d-spacing data",
-            Workspace=tmpWSdsp,
-        )
+            # Delete diffraction-focused d-spacing data
+            self.mantidSnapper.WashDishes(
+                "Delete diffraction-focused d-spacing data",
+                Workspace=tmpWSdsp,
+            )
+        else:
+            self.mantidSnapper.RenameWorkspace(
+                "",
+                InputWorkspace=tmpWSdsp,
+                OutputWorkspace=outputWS,
+            )
 
         # Execute queued Mantid algorithms
         self.mantidSnapper.executeQueue()

--- a/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
@@ -333,7 +333,6 @@ class GroupDiffractionCalibration(PythonAlgorithm):
 
         # Execute queued Mantid algorithms
         self.mantidSnapper.executeQueue()
-        breakpoint()
 
 
 # Register algorithm with Mantid

--- a/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
@@ -72,7 +72,6 @@ class GroupDiffractionCalibration(PythonAlgorithm):
         self.dMin = ingredients.pixelGroup.dMin()
         self.dMax = ingredients.pixelGroup.dMax()
         self.dBin = ingredients.pixelGroup.dBin()
-        self.units = ingredients.units
         pixelGroupIDs = ingredients.pixelGroup.groupIDs
 
         # from the pixel group, read the overall min/max TOF and binning

--- a/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
@@ -167,7 +167,7 @@ class GroupDiffractionCalibration(PythonAlgorithm):
 
         # process and diffraction focus the input data
         # must convert to d-spacing, diffraction focus, ragged rebin, then convert back to TOF
-        self.convertAndFocusAndReturn(self.wsTOF, self.outputWStof, "before", self.units)
+        self.convertAndFocusAndReturn(self.wsTOF, self.outputWStof, "before", "TOF")
 
     def PyExec(self) -> None:
         """
@@ -276,9 +276,9 @@ class GroupDiffractionCalibration(PythonAlgorithm):
             InstrumentWorkspace=self.wsTOF,
             CalibrationWorkspace=self.DIFCfinal,
         )
-        self.convertAndFocusAndReturn(self.wsTOF, self.outputWStof, "after", self.units)
+        self.convertAndFocusAndReturn(self.wsTOF, self.outputWStof, "after", "dSpacing")
 
-    def convertAndFocusAndReturn(self, inputWS: str, outputWS: str, note: str, units: str = "TOF"):
+    def convertAndFocusAndReturn(self, inputWS: str, outputWS: str, note: str, units: str):
         # Use workspace name generator
         tmpWStof = f"_TOF_{self.runNumber}_diffoc_{note}"
         tmpWSdsp = f"_DSP_{self.runNumber}_diffoc_{note}"
@@ -333,6 +333,7 @@ class GroupDiffractionCalibration(PythonAlgorithm):
 
         # Execute queued Mantid algorithms
         self.mantidSnapper.executeQueue()
+        breakpoint()
 
 
 # Register algorithm with Mantid

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -78,7 +78,7 @@ class _WorkspaceNameGenerator:
 
     def diffCalInput(self):
         return NameBuilder(
-            self._diffCalInputTemplate, self._diffCalInputTemplateKeys, self._delimiter, unit=self.Units.TOF
+            self._diffCalInputTemplate, self._diffCalInputTemplateKeys, self._delimiter, unit=self.Units.DSP
         )
 
     def diffCalTable(self):

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -78,7 +78,7 @@ class _WorkspaceNameGenerator:
 
     def diffCalInput(self):
         return NameBuilder(
-            self._diffCalInputTemplate, self._diffCalInputTemplateKeys, self._delimiter, unit=self.Units.DSP
+            self._diffCalInputTemplate, self._diffCalInputTemplateKeys, self._delimiter, unit=self.Units.TOF
         )
 
     def diffCalTable(self):
@@ -86,7 +86,7 @@ class _WorkspaceNameGenerator:
 
     def diffCalOutput(self):
         return NameBuilder(
-            self._diffCalOutputTemplate, self._diffCalOutputTemplateKeys, self._delimiter, unit=self.Units.TOF
+            self._diffCalOutputTemplate, self._diffCalOutputTemplateKeys, self._delimiter, unit=self.Units.DSP
         )
 
     def diffCalMask(self):

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -242,7 +242,7 @@ class TestGroceryService(unittest.TestCase):
     def test_diffcal_output_workspacename(self):
         # Test name generation for diffraction-calibration output workspace
         res = self.instance._createDiffcalOutputWorkspaceName(self.runNumber)
-        assert "tof" in res
+        assert "dsp" in res
         assert self.runNumber in res
         assert "diffoc" in res
 


### PR DESCRIPTION
## Description of work
This defect was relatively straight forward once the issue was understood. The work time for this task was longer than expected due to my lack in understanding of the Calibration Workflow.
<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work
This consisted largely of adding some branching logic and adding an addition parameter to `convertAndFocusReturn` method within `GroupDiffractionCalibration`. The arguments 
<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test
Please run Calibration Workflow twice. Steps to follow for practical testing:

1. Run Calibration Workflow w/ these inputs:
```python
Run Number: 46680
Convergence Threshold: 0.1
Peak Intensity Threshold: 0.0001
Bins Across Peak Width: 10
Sample: Diamond_001.json
Grouping File: column lite
```

2. Check the workspace list to ensure the proper units are retained

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#3819](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3819)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
