### PR TITLE
In DiffCal, warn if too few peaks

### DIFF
--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -105,6 +105,9 @@ class CalibrationService(Service):
             nBinsAcrossPeakWidth=request.nBinsAcrossPeakWidth,
         )
         ingredients = self.sousChef.prepDiffractionCalibrationIngredients(farmFresh)
+        empties = [gpl for gpl in ingredients.groupedPeakLists if len(gpl.peaks) < 2]
+        if len(empties) > 0:
+            raise RuntimeError(f"Insufficient peaks for groups {[gpl.groupID for gpl in empties]}")
 
         # groceries
         self.groceryClerk.name("inputWorkspace").neutron(request.runNumber).useLiteMode(request.useLiteMode).add()

--- a/src/snapred/ui/workflow/WorkflowImplementer.py
+++ b/src/snapred/ui/workflow/WorkflowImplementer.py
@@ -64,7 +64,6 @@ class WorkflowImplementer:
         if result.code >= 300:
             raise RuntimeError(result.message)
 
-
     @property
     def widget(self):
         return self.workflow.presenter.widget

--- a/src/snapred/ui/workflow/WorkflowImplementer.py
+++ b/src/snapred/ui/workflow/WorkflowImplementer.py
@@ -48,6 +48,7 @@ class WorkflowImplementer:
     def request(self, path, payload=None):
         request = SNAPRequest(path=path, payload=payload)
         response = self.interfaceController.executeRequest(request)
+        self._handleComplications(response)
         self.requests.append(request)
         self.responses.append(response)
         return response
@@ -58,6 +59,11 @@ class WorkflowImplementer:
             return True
         except ValueError as e:
             return SNAPResponse(code=500, message=f"Missing Fields!{e}")
+
+    def _handleComplications(self, result):
+        if result.code >= 300:
+            raise RuntimeError(result.message)
+
 
     @property
     def widget(self):

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -297,7 +297,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
     ):
         self.instance.dataFactoryService.getCifFilePath = mock.Mock(return_value="bundt/cake.egg")
 
-        mockIngredients = mock.Mock(groupedPeakLists = [mock.Mock(peaks=["orange"], groupID="banana")])
+        mockIngredients = mock.Mock(groupedPeakLists=[mock.Mock(peaks=["orange"], groupID="banana")])
         self.instance.sousChef = mock.Mock(spec_set=SousChef)
         self.instance.sousChef.prepDiffractionCalibrationIngredients.return_value = mockIngredients
 
@@ -306,11 +306,10 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         self.instance.groceryService.fetchGroceryDict = mock.Mock(return_value={"grocery1": "orange"})
 
         # Call the method with the provided parameters
-        request = mock.Mock(calibrantSamplePath = "bundt/cake_egg.py")
+        request = mock.Mock(calibrantSamplePath="bundt/cake_egg.py")
         with pytest.raises(RuntimeError) as e:
             self.instance.diffractionCalibration(request)
         assert mockIngredients.groupedPeakLists[0].groupID in str(e.value)
-
 
     @patch(thisService + "FarmFreshIngredients", spec_set=FarmFreshIngredients)
     @patch(thisService + "DiffractionCalibrationRecipe", spec_set=DiffractionCalibrationRecipe)
@@ -321,7 +320,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
     ):
         self.instance.dataFactoryService.getCifFilePath = mock.Mock(return_value="bundt/cake.egg")
 
-        mockIngredients = mock.Mock(groupedPeakLists = [mock.Mock(peaks=["orange", "apple"], groupID="banana")])
+        mockIngredients = mock.Mock(groupedPeakLists=[mock.Mock(peaks=["orange", "apple"], groupID="banana")])
         self.instance.sousChef = mock.Mock(spec_set=SousChef)
         self.instance.sousChef.prepDiffractionCalibrationIngredients.return_value = mockIngredients
 
@@ -331,7 +330,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         self.instance.groceryService.fetchGroceryDict = mock.Mock(return_value={"grocery1": "orange"})
 
         # Call the method with the provided parameters
-        request = mock.Mock(calibrantSamplePath = "bundt/cake_egg.py")
+        request = mock.Mock(calibrantSamplePath="bundt/cake_egg.py")
         res = self.instance.diffractionCalibration(request)
 
         # Perform assertions to check the result and method calls


### PR DESCRIPTION
## Description of work

When running the diffcal process, if there are fewer than two peaks in any of the groups, then the workflow will terminate unexpectedly with a warning message box saying only that `NoneType` is not subscriptable.

The actual issue occurs because there are too few peaks, and either `PDCalibration` inside `GroupDiffractionCalibration`, or else `GetDetectorOffsets` inside `PixelDiffractionCalibration` has thrown an error.  The error is apparently handled but the issue never bubbles up to user.

This will check, within the `CalibrationService`, if there are sufficient peaks *before* any data is even loaded, so the user can know to change input parameters.

## Explanation of work

Required
1. raising an exception inside the `CalibrationService` after the ingredients are prepped, if they have too few peaks
2. adjusting the workflow implementer to re-raise errors so that the presenter will put the error inside a message box

## To test

### Dev testing

Run the GUI.  Use your favorite run number.  Set the peak threshold intensity to 1.  You should immediately receive an error.

Change the peak intensity threshold to 0.05.  IF you selected the correct crystal file, then everything should run to completion.

### CIS testing

This is an internal issue.  But the CIS can test by doing the above.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

There is no assiciated ticket, but this was noticed while testing for EWM 3819

[EWM#3819](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3819)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
