### PR TITLE
Centralized I/O for special workspaces

### DIFF
--- a/src/snapred/backend/dao/calibration/Calibration.py
+++ b/src/snapred/backend/dao/calibration/Calibration.py
@@ -6,7 +6,7 @@ from snapred.backend.dao.state import InstrumentState
 
 
 class Calibration(BaseModel):
-    """This is actually a group of parameters(mostly) used to peform a fitting.
+    """This is actually a group of parameters(mostly) used to perform a fitting.
     The contents of which are static.
     """
 

--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -81,13 +81,15 @@ class GroceryListItem(BaseModel):
                     # the Lite grouping scheme reduces native resolution to Lite mode
                     if v.get("useLiteMode"):
                         logger.warning(
-                            "the lite-mode flag must be False for the 'lite' grouping scheme -- this cannot be overridden"
+                            "the lite-mode flag must be False for the 'lite' grouping scheme" +
+                            " -- this cannot be overridden"
                         )                    
                     v["useLiteMode"] = False  # the lite data map only works on native data
                     
                     if v.get("runNumber") is not None:
                         logger.warning(
-                            "the run number must not be specified for 'lite' grouping scheme -- this cannot be overridden"
+                            "the run number must not be specified for 'lite' grouping scheme" +
+                            " -- this cannot be overridden"
                         )                    
                     # the Lite grouping scheme uses the unmodified native instrument
                     v["runNumber"] = cls.RESERVED_NATIVE_RUNID

--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -80,11 +80,15 @@ class GroceryListItem(BaseModel):
                 if v["groupingScheme"] == "Lite":
                     # the Lite grouping scheme reduces native resolution to Lite mode
                     if v.get("useLiteMode"):
-                        logger.warning("the lite-mode flag must be False for the 'lite' grouping scheme -- this cannot be overridden")                    
+                        logger.warning(
+                            "the lite-mode flag must be False for the 'lite' grouping scheme -- this cannot be overridden"
+                        )                    
                     v["useLiteMode"] = False  # the lite data map only works on native data
                     
                     if v.get("runNumber") is not None:
-                        logger.warning("the run number must not be specified for 'lite' grouping scheme -- this cannot be overridden")                    
+                        logger.warning(
+                            "the run number must not be specified for 'lite' grouping scheme -- this cannot be overridden"
+                        )                    
                     # the Lite grouping scheme uses the unmodified native instrument
                     v["runNumber"] = cls.RESERVED_NATIVE_RUNID
                 if v.get("runNumber") is None:

--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -1,29 +1,31 @@
-from typing import Literal, Optional, ClassVar
+from typing import ClassVar, Literal, Optional
 
 from pydantic import BaseModel, root_validator
 
-from snapred.meta.Config import Config
 from snapred.backend.log.logger import snapredLogger
+from snapred.meta.Config import Config
 
 logger = snapredLogger.getLogger(__name__)
+
 
 class GroceryListItem(BaseModel):
     """
     Holds necessary information for a single item in grocery list
     """
+
     # Reserved instrument-cache run-number values:
-    RESERVED_NATIVE_RUNID: ClassVar[str] = "000000" # unmodified _native_ instrument:
-                                                    #   from 'SNAP_Definition.xml'
-    RESERVED_LITE_RUNID: ClassVar[str] = "000001"   # unmodified _lite_ instrument  :
-                                                    #   from 'SNAPLite.xml' 
+    RESERVED_NATIVE_RUNID: ClassVar[str] = "000000"  # unmodified _native_ instrument:
+    #   from 'SNAP_Definition.xml'
+    RESERVED_LITE_RUNID: ClassVar[str] = "000001"  # unmodified _lite_ instrument  :
+    #   from 'SNAPLite.xml'
 
     workspaceType: Literal["neutron", "grouping", "diffcal", "diffcal_output", "diffcal_table", "diffcal_mask"]
     useLiteMode: bool  # indicates if data should be reduced to lite mode
-    
-    # optional loader:    
+
+    # optional loader:
     # -- "" tells FetchGroceries to choose the loader
     loader: Literal["", "LoadGroupingDefinition", "LoadNexus", "LoadEventNexus", "LoadNexusProcessed"] = ""
-    
+
     # the correct combinaton of the below must be set -- neutron and grouping require a runNumber,
     #   grouping additionally requires a groupingScheme
     runNumber: Optional[str]
@@ -42,10 +44,10 @@ class GroceryListItem(BaseModel):
     # if set to False, neutron data will not be loaded in a clean, cached way
     # this is faster and uses less memory, if you know you only need one copy
     keepItClean: bool = True
-    
+
     # name the property the workspace will be used for
     propertyName: Optional[str]
-    
+
     # flag to indicate if this is an _output_ workspace:
     # an output workspace will not be loaded,
     # it may or may not already exist in the ADS
@@ -81,16 +83,16 @@ class GroceryListItem(BaseModel):
                     # the Lite grouping scheme reduces native resolution to Lite mode
                     if v.get("useLiteMode"):
                         logger.warning(
-                            "the lite-mode flag must be False for the 'lite' grouping scheme" +
-                            " -- this cannot be overridden"
-                        )                    
+                            "the lite-mode flag must be False for the 'lite' grouping scheme"
+                            + " -- this cannot be overridden"
+                        )
                     v["useLiteMode"] = False  # the lite data map only works on native data
-                    
+
                     if v.get("runNumber") is not None:
                         logger.warning(
-                            "the run number must not be specified for 'lite' grouping scheme" +
-                            " -- this cannot be overridden"
-                        )                    
+                            "the run number must not be specified for 'lite' grouping scheme"
+                            + " -- this cannot be overridden"
+                        )
                     # the Lite grouping scheme uses the unmodified native instrument
                     v["runNumber"] = cls.RESERVED_NATIVE_RUNID
                 if v.get("runNumber") is None:

--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -71,7 +71,7 @@ class GroceryListItem(BaseModel):
                     raise ValueError("you must specify the grouping scheme to use")
                 if v["groupingScheme"] == "Lite":
                     # the Lite grouping scheme reduces native resolution to Lite mode
-                    v["useLiteMode"] = False  # the lite data map only works on native data                        
+                    v["useLiteMode"] = False  # the lite data map only works on native data
             case "diffcal":
                 if v.get("runNumber") is None:
                     raise ValueError("diffraction-calibration input table workspace requires a run number")
@@ -80,14 +80,18 @@ class GroceryListItem(BaseModel):
                 if v.get("runNumber") is None:
                     raise ValueError(f"diffraction-calibration {v['workspaceType']} requires a run number")
                 if v.get("isOutput") is False:
-                    raise ValueError(f"diffraction-calibration {v['workspaceType']} output specification is special-order only")
+                    raise ValueError(
+                        f"diffraction-calibration {v['workspaceType']} output specification is special-order only"
+                    )
                 if v.get("instrumentPropertySource") is not None:
                     raise ValueError("Loading diffcal-output data should not specify an instrument")
             case "diffcal_table" | "diffcal_mask":
                 if v.get("runNumber") is None:
                     raise ValueError(f"diffraction-calibration {v['workspaceType']} requires a run number")
                 if v.get("isOutput") is False:
-                    raise ValueError(f"diffraction-calibration {v['workspaceType']} output specification is special-order only")
+                    raise ValueError(
+                        f"diffraction-calibration {v['workspaceType']} output specification is special-order only"
+                    )
             case _:
                 raise ValueError(f"unrecognized 'workspaceType': '{v['workspaceType']}'")
         return v

--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -1,20 +1,29 @@
-from typing import Literal, Optional
+from typing import Literal, Optional, ClassVar
 
 from pydantic import BaseModel, root_validator
 
 from snapred.meta.Config import Config
+from snapred.backend.log.logger import snapredLogger
 
+logger = snapredLogger.getLogger(__name__)
 
 class GroceryListItem(BaseModel):
     """
     Holds necessary information for a single item in grocery list
     """
+    # Reserved instrument-cache run-number values:
+    RESERVED_NATIVE_RUNID: ClassVar[str] = "000000" # unmodified _native_ instrument:
+                                                    #   from 'SNAP_Definition.xml'
+    RESERVED_LITE_RUNID: ClassVar[str] = "000001"   # unmodified _lite_ instrument  :
+                                                    #   from 'SNAPLite.xml' 
 
     workspaceType: Literal["neutron", "grouping", "diffcal", "diffcal_output", "diffcal_table", "diffcal_mask"]
     useLiteMode: bool  # indicates if data should be reduced to lite mode
-    # optional loader:
+    
+    # optional loader:    
     # -- "" tells FetchGroceries to choose the loader
     loader: Literal["", "LoadGroupingDefinition", "LoadNexus", "LoadEventNexus", "LoadNexusProcessed"] = ""
+    
     # the correct combinaton of the below must be set -- neutron and grouping require a runNumber,
     #   grouping additionally requires a groupingScheme
     runNumber: Optional[str]
@@ -25,7 +34,7 @@ class GroceryListItem(BaseModel):
     #   require an instrument definition, these next two properties indicate
     #   which property defines the instrument source,
     #   and then what type of source it is.
-    # In general these properties should no longer be used, except to override
+    # Warning: in general these properties should no longer be used, except to override
     #   the automatic instrument-donor caching system.
     instrumentPropertySource: Optional[Literal["InstrumentName", "InstrumentFilename", "InstrumentDonor"]]
     instrumentSource: Optional[str]
@@ -33,8 +42,10 @@ class GroceryListItem(BaseModel):
     # if set to False, neutron data will not be loaded in a clean, cached way
     # this is faster and uses less memory, if you know you only need one copy
     keepItClean: bool = True
+    
     # name the property the workspace will be used for
     propertyName: Optional[str]
+    
     # flag to indicate if this is an _output_ workspace:
     # an output workspace will not be loaded,
     # it may or may not already exist in the ADS
@@ -64,14 +75,21 @@ class GroceryListItem(BaseModel):
                 if v.get("instrumentPropertySource") is not None:
                     raise ValueError("Loading neutron data should not specify an instrument")
             case "grouping":
-                if v.get("runNumber") is None:
-                    # A run number is required in order to cache instrument parameters
-                    raise ValueError("Loading a grouping scheme requires a run number")
                 if v.get("groupingScheme") is None:
                     raise ValueError("you must specify the grouping scheme to use")
                 if v["groupingScheme"] == "Lite":
                     # the Lite grouping scheme reduces native resolution to Lite mode
+                    if v.get("useLiteMode"):
+                        logger.warning("the lite-mode flag must be False for the 'lite' grouping scheme -- this cannot be overridden")                    
                     v["useLiteMode"] = False  # the lite data map only works on native data
+                    
+                    if v.get("runNumber") is not None:
+                        logger.warning("the run number must not be specified for 'lite' grouping scheme -- this cannot be overridden")                    
+                    # the Lite grouping scheme uses the unmodified native instrument
+                    v["runNumber"] = cls.RESERVED_NATIVE_RUNID
+                if v.get("runNumber") is None:
+                    # A run number is required in order to cache instrument parameters
+                    raise ValueError("Loading a grouping scheme requires a run number")
             case "diffcal":
                 if v.get("runNumber") is None:
                     raise ValueError("diffraction-calibration input table workspace requires a run number")

--- a/src/snapred/backend/data/DataExportService.py
+++ b/src/snapred/backend/data/DataExportService.py
@@ -7,8 +7,8 @@ from snapred.backend.dao.normalization.NormalizationIndexEntry import Normalizat
 from snapred.backend.dao.normalization.NormalizationRecord import NormalizationRecord
 from snapred.backend.dao.state.CalibrantSample.CalibrantSamples import CalibrantSamples
 from snapred.backend.data.LocalDataService import LocalDataService
-from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 from snapred.meta.decorators.Singleton import Singleton
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
 
 @Singleton

--- a/src/snapred/backend/data/DataExportService.py
+++ b/src/snapred/backend/data/DataExportService.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from snapred.backend.dao.calibration.Calibration import Calibration
 from snapred.backend.dao.calibration.CalibrationIndexEntry import CalibrationIndexEntry
 from snapred.backend.dao.calibration.CalibrationRecord import CalibrationRecord
@@ -5,18 +7,21 @@ from snapred.backend.dao.normalization.NormalizationIndexEntry import Normalizat
 from snapred.backend.dao.normalization.NormalizationRecord import NormalizationRecord
 from snapred.backend.dao.state.CalibrantSample.CalibrantSamples import CalibrantSamples
 from snapred.backend.data.LocalDataService import LocalDataService
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 from snapred.meta.decorators.Singleton import Singleton
 
 
 @Singleton
 class DataExportService:
-    dataService: "LocalDataService"  # Optional[LocalDataService]
+    dataService: "LocalDataService"
 
     def __init__(self, dataService: LocalDataService = None) -> None:
-        if dataService:
-            self.dataService = dataService
-        else:
-            self.dataService = LocalDataService()
+        self.dataService = self._defaultClass(dataService, LocalDataService)
+
+    def _defaultClass(self, val, clazz):
+        if val is None:
+            val = clazz()
+        return val
 
     def exportCalibrationIndexEntry(self, entry: CalibrationIndexEntry):
         self.dataService.writeCalibrationIndexEntry(entry)
@@ -24,10 +29,10 @@ class DataExportService:
     def exportCalibrationRecord(self, record: CalibrationRecord):
         return self.dataService.writeCalibrationRecord(record)
 
-    def exportCalibrationReductionResult(self, runId: str, workspaceName: str):
-        return self.dataService.writeCalibrationReductionResult(runId, workspaceName)
+    def exportCalibrationWorkspaces(self, record: CalibrationRecord):
+        return self.dataService.writeCalibrationWorkspaces(record)
 
-    def writeCalibrantSampleFile(self, entry: CalibrantSamples):
+    def exportCalibrantSampleFile(self, entry: CalibrantSamples):
         self.dataService.writeCalibrantSample(entry)
 
     def exportCalibrationState(self, runId: str, calibration: Calibration):
@@ -39,8 +44,20 @@ class DataExportService:
     def exportNormalizationRecord(self, record: NormalizationRecord):
         return self.dataService.writeNormalizationRecord(record)
 
+    def exportNormalizationWorkspaces(self, record: NormalizationRecord):
+        return self.dataService.writeNormalizationWorkspaces(record)
+
+    def exportWorkspace(self, path: Path, filename: Path, workspaceName: WorkspaceName):
+        """
+        Write a MatrixWorkspace (derived) workspace to disk in nexus format.
+        """
+        return self.dataService.writeWorkspace(path, filename, workspaceName)
+
     def initializeState(self, runId: str, name: str):
         return self.dataService.initializeState(runId, name)
 
-    def deleteWorkspace(self, workspaceName: str):
-        return self.dataService.deleteWorkspace(workspaceName)
+    def deleteWorkspace(self, name):
+        return self.groceryService.deleteWorkspace(name)
+
+    def deleteWorkspaceUnconditional(self, name):
+        return self.groceryService.deleteWorkspaceUnconditional(name)

--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -21,10 +21,10 @@ class DataFactoryService:
     cache: Dict[str, ReductionState] = {}
 
     def __init__(self, lookupService: LocalDataService = None, groceryService: GroceryService = None) -> None:
-        self.lookupService = self.defaultClass(lookupService, LocalDataService)
-        self.groceryService = self.defaultClass(groceryService, GroceryService)
+        self.lookupService = self._defaultClass(lookupService, LocalDataService)
+        self.groceryService = self._defaultClass(groceryService, GroceryService)
 
-    def defaultClass(self, val, clazz):
+    def _defaultClass(self, val, clazz):
         if val is None:
             val = clazz()
         return val
@@ -75,24 +75,12 @@ class DataFactoryService:
     def getWorkspaceForName(self, name):
         return self.groceryService.getWorkspaceForName(name)
 
-    def getClonedofWorkspace(self, name, copy):
+    def getCloneOfWorkspace(self, name, copy):
         return self.groceryService.getCloneOfWorkspace(name, copy)
 
-    def workspaceDoesExist(self, name):
-        return self.groceryService.workspaceDoesExist(name)
-
-    def deleteWorkspace(self, name):
-        return self.groceryService.deleteWorkspace(name)
-
-    def deleteWorkspaceUnconditional(self, name):
-        return self.groceryService.deleteWorkspaceUnconditional(name)
-
-    def loadCalibrationDataWorkspace(self, runId, version, name):
+    def getCalibrationDataWorkspace(self, runId, version, name):
         path = self.getCalibrationDataPath(runId, version)
         return self.groceryService.fetchWorkspace(os.path.join(path, name) + ".nxs", name)
-
-    def writeWorkspace(self, path, name):
-        return self.groceryService.writeWorkspace(path, name)
 
     def getWorkspaceCached(self, runId: str, useLiteMode: bool):
         return self.groceryService.fetchNeutronDataCached(runId, useLiteMode)
@@ -124,3 +112,12 @@ class DataFactoryService:
 
     def getCalibrationDataPath(self, runId: str, version: str):
         return self.lookupService._constructCalibrationDataPath(runId, version)
+
+    def workspaceDoesExist(self, name):
+        return self.groceryService.workspaceDoesExist(name)
+
+    def deleteWorkspace(self, name):
+        return self.groceryService.deleteWorkspace(name)
+
+    def deleteWorkspaceUnconditional(self, name):
+        return self.groceryService.deleteWorkspaceUnconditional(name)

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -1,14 +1,14 @@
+import json
 import os
 from functools import cache
-from typing import Any, Dict, List, Tuple
 from pathlib import Path
-import json
+from typing import Any, Dict, List, Tuple
 
 from mantid.api import AlgorithmManager, mtd
 
+from snapred.backend.dao.ingredients import GroceryListItem
 from snapred.backend.dao.state import DetectorState
 from snapred.backend.data.LocalDataService import LocalDataService
-from snapred.backend.dao.ingredients import GroceryListItem
 from snapred.backend.recipe.FetchGroceriesRecipe import FetchGroceriesRecipe
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Singleton import Singleton
@@ -24,6 +24,7 @@ class GroceryService:
     Yeah, I can get that for you.
     Just send me a list.
     """
+
     dataService: "LocalDataService"
 
     def __init__(self, dataService: LocalDataService = None):
@@ -163,7 +164,7 @@ class GroceryService:
     def _createGroupingWorkspaceName(self, groupingScheme: str, runId: str, useLiteMode: bool) -> WorkspaceName:
         # TODO: use WNG here!
         if groupingScheme == "Lite":
-            return f"lite_grouping_map"
+            return "lite_grouping_map"
         instr = "lite" if useLiteMode else "native"
         return f"{Config['grouping.workspacename.' + instr]}_{groupingScheme}_{runId}"
 

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -24,7 +24,6 @@ class GroceryService:
     Yeah, I can get that for you.
     Just send me a list.
     """
-
     dataService: "LocalDataService"
 
     def __init__(self, dataService: LocalDataService = None):
@@ -274,7 +273,9 @@ class GroceryService:
             loadEmptyInstrument.execute()
 
             # Initialize the instrument parameters
-            self._updateInstrumentParameters(runId, wsName)
+            # (Reserved IDs will use the unmodified instrument.)
+            if runId != GroceryListItem.RESERVED_NATIVE_RUNID and runId != GroceryListItem.RESERVED_LITE_RUNID:
+                self._updateInstrumentParameters(runId, wsName)
         self._loadedInstruments[key] = wsName
         return wsName
 
@@ -445,7 +446,7 @@ class GroceryService:
         return data
 
     def fetchLiteDataMap(self, runId: str) -> WorkspaceName:
-        item = GroceryListItem.builder().grouping(runId, "Lite").build()
+        item = GroceryListItem.builder().grouping("Lite").build()
         return self.fetchGroupingDefinition(item)["workspace"]
 
     def fetchGroupingDefinition(self, item: GroceryListItem) -> Dict[str, Any]:

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -494,8 +494,6 @@ class GroceryService:
         """
         
         runNumber, version, useLiteMode = item.runNumber, item.version, item.useLiteMode
-        key = self._key(runNumber, version)
-        path = self._getCalibrationDataPath(runNumber, version)
         tableWorkspaceName =  self._createDiffcalTableWorkspaceName(runNumber)
         maskWorkspaceName =  self._createDiffcalMaskWorkspaceName(runNumber)
 

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -1,12 +1,15 @@
 import os
 from functools import cache
 from typing import Any, Dict, List, Tuple
+from pathlib import Path
+import json
 
 from mantid.api import AlgorithmManager, mtd
 
+from snapred.backend.dao.state import DetectorState
 from snapred.backend.dao.ingredients import GroceryListItem
-from snapred.backend.recipe.algorithm.SaveGroupingDefinition import SaveGroupingDefinition
 from snapred.backend.recipe.FetchGroceriesRecipe import FetchGroceriesRecipe
+from snapred.backend.data.LocalDataService import LocalDataService
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Singleton import Singleton
 from snapred.meta.mantid.WorkspaceNameGenerator import NameBuilder, WorkspaceName
@@ -21,21 +24,42 @@ class GroceryService:
     Yeah, I can get that for you.
     Just send me a list.
     """
+    dataService: "LocalDataService"
 
-    def __init__(self):
+    def __init__(self, dataService: LocalDataService = None):
+        self.dataService = self._defaultClass(dataService, LocalDataService)
+        
+        # _loadedRuns caches a count of the number of copies made from the neutron-data workspace
+        #   corresponding to a given (runId, isLiteMode) key:
+        #   This count is:
+        #     None: if a workspace is not loaded;
+        #        0: if it is loaded, but no copies have been made;
+        #       >0: if any copies have been made, since loading
         self._loadedRuns: Dict[Tuple[str, bool], int] = {}
-        self._loadedGroupings: Dict[Tuple[str, bool], str] = {}
+        
+        # Cache maps to workspace names, for various purposes
+        self._loadedGroupings: Dict[Tuple[str, str, bool], str] = {}
+        self._loadedInstruments: Dict[Tuple[str, bool], str] = {}
+        
         self.grocer = FetchGroceriesRecipe()
 
-    def _key(self, using: str, useLiteMode: bool) -> Tuple[str, bool]:
+    def _defaultClass(self, val, clazz):
+        if val is None:
+            val = clazz()
+        return val
+
+    def _key(self, *tokens: Tuple[Any, ...]) -> Tuple[Any,...]:
         """
-        Creates keys used for accessing workspaces from the cache
+        Creates keys used for accessing workspaces from the various cache maps
         """
-        return (using, useLiteMode)
+        # Each token needs to be separately hashable, but beyond that,
+        #   enforcing key consistency over distinct cache maps seemed to be overkill.
+        return tokens
 
     def rebuildCache(self):
         self.rebuildNeutronCache()
         self.rebuildGroupingCache()
+        self.rebuildInstrumentCache()
 
     def rebuildNeutronCache(self):
         for loadedRun in self._loadedRuns.copy():
@@ -45,24 +69,64 @@ class GroceryService:
         for loadedGrouping in self._loadedGroupings.copy():
             self._updateGroupingCacheFromADS(loadedGrouping, self._loadedGroupings[loadedGrouping])
 
+    def rebuildInstrumentCache(self):
+        for loadedInstrument in self._loadedInstruments.copy():
+            self._updateInstrumentCacheFromADS(*loadedInstrument)
+
     def getCachedWorkspaces(self):
         """
         Returns a list of all workspaces cached in GroceryService
         """
-        cachedWorkspaces = []
-        cachedWorkspaces.extend(
+        cachedWorkspaces = set()
+        cachedWorkspaces.update(
             [self._createRawNeutronWorkspaceName(runId, useLiteMode) for runId, useLiteMode in self._loadedRuns.keys()]
         )
-        cachedWorkspaces.extend(self._loadedGroupings.values())
+        cachedWorkspaces.update(self._loadedGroupings.values())
+        cachedWorkspaces.update(self._loadedInstruments.values())
 
-        return cachedWorkspaces
+        return list(cachedWorkspaces)
 
+
+    def _updateNeutronCacheFromADS(self, runId: str, useLiteMode: bool):
+        """
+        If the workspace has been loaded, but is not represented in the cache
+        then update the cache to represent this condition
+        """
+        workspace = self._createRawNeutronWorkspaceName(runId, useLiteMode)
+        key = self._key(runId, useLiteMode)
+        if self.workspaceDoesExist(workspace) and self._loadedRuns.get(key) is None:
+            # 0 => loaded with no copies
+            self._loadedRuns[key] = 0
+        elif self._loadedRuns.get(key) is not None and not self.workspaceDoesExist(workspace):
+            del self._loadedRuns[key]
+
+    def _updateGroupingCacheFromADS(self, key, workspace):
+        """
+        Ensure cache consistency for a single grouping workspace.
+        """
+        if self.workspaceDoesExist(workspace) and self._loadedGroupings.get(key) is None:
+            self._loadedGroupings[key] = workspace
+        elif self._loadedGroupings.get(key) is not None and not self.workspaceDoesExist(workspace):
+            del self._loadedGroupings[key]
+
+    def _updateInstrumentCacheFromADS(self, runId: str, useLiteMode: bool):
+        """
+        Ensure cache consistency for a single instrument-donor workspace.
+        """
+        # The workspace name in the cache may be either a neutron data workspace or an empty-instrument workspace.
+        workspace = self._createRawNeutronWorkspaceName(runId, useLiteMode) 
+        key = self._key(runId, useLiteMode)
+        if self.workspaceDoesExist(workspace) and self._loadedInstruments.get(key) is None:
+            self._loadedInstruments[key] = workspace
+        elif self._loadedInstruments.get(key) is not None:
+            workspace = self._loadedInstruments.get(key)
+            if not self.workspaceDoesExist(workspace):
+                del self._loadedInstruments[key]
+      
     ## FILENAME METHODS
 
     def getIPTS(self, runNumber: str, instrumentName: str = Config["instrument.name"]) -> str:
-        from mantid.simpleapi import GetIPTS
-
-        ipts = GetIPTS(runNumber, instrumentName)
+        ipts = self.dataService.getIPTS(runNumber, instrumentName)
         return str(ipts)
 
     def _createNeutronFilename(self, runNumber: str, useLiteMode: bool) -> str:
@@ -78,7 +142,7 @@ class GroceryService:
         home = "instrument.calibration.powder.grouping.home"
         pre = "grouping.filename.prefix"
         ext = "grouping.filename." + instr + ".extension"
-        return Config[home] + "/" + Config[pre] + groupingScheme + Config[ext]
+        return f"{Config[home]}/{Config[pre]}{groupingScheme}{Config[ext]}"
 
     ## WORKSPACE NAME METHODS
 
@@ -88,70 +152,48 @@ class GroceryService:
             runNameBuilder.lite(wng.Lite.TRUE)
         return runNameBuilder
 
-    def _createNeutronWorkspaceName(self, runId: str, useLiteMode: bool) -> str:
+    def _createNeutronWorkspaceName(self, runId: str, useLiteMode: bool) -> WorkspaceName:
         return self._createNeutronWorkspaceNameBuilder(runId, useLiteMode).build()
 
-    def _createRawNeutronWorkspaceName(self, runId: str, useLiteMode: bool) -> str:
-        return self._createNeutronWorkspaceNameBuilder(runId, useLiteMode).auxilary("Raw").build()
+    def _createRawNeutronWorkspaceName(self, runId: str, useLiteMode: bool) -> WorkspaceName:
+        return self._createNeutronWorkspaceNameBuilder(runId, useLiteMode).auxiliary("Raw").build()
 
-    def _createCopyNeutronWorkspaceName(self, runId: str, useLiteMode: bool, numCopies: int) -> str:
-        return self._createNeutronWorkspaceNameBuilder(runId, useLiteMode).auxilary(f"Copy{numCopies}").build()
+    def _createCopyNeutronWorkspaceName(self, runId: str, useLiteMode: bool, numCopies: int) -> WorkspaceName:
+        return self._createNeutronWorkspaceNameBuilder(runId, useLiteMode).auxiliary(f"Copy{numCopies}").build()
 
-    def _createGroupingWorkspaceName(self, groupingScheme: str, useLiteMode: bool):
+    def _createGroupingWorkspaceName(self, groupingScheme: str, runId: str, useLiteMode: bool) -> WorkspaceName:
+        # TODO: use WNG here!
         if groupingScheme == "Lite":
-            return "lite_grouping_map"
+            return f"lite_grouping_map_{runId}"
         instr = "lite" if useLiteMode else "native"
-        return Config["grouping.workspacename." + instr] + groupingScheme
+        return f"{Config['grouping.workspacename.' + instr]}_{groupingScheme}_{runId}"
 
-    def _createDiffcalInputWorkspaceName(self, runId: str):
+    def _createDiffcalInputWorkspaceName(self, runId: str) -> WorkspaceName:
         return wng.diffCalInput().runNumber(runId).build()
 
-    def _createDiffcalOutputWorkspaceName(self, runId: str):
+    def _createDiffcalOutputWorkspaceName(self, runId: str) -> WorkspaceName:
         return wng.diffCalOutput().runNumber(runId).build()
 
-    def _createDiffcalTableWorkspaceName(self, runId: str):
+    def _createDiffcalOutputWorkspaceFilename(self, runId: str, version: str) -> str:
+        return str(Path(self._getCalibrationDataPath(runId, version)) / (self._createDiffcalOutputWorkspaceName(runId) + ".nxs"))
+
+    def _createDiffcalTableWorkspaceName(self, runId: str) -> WorkspaceName:
         return wng.diffCalTable().runNumber(runId).build()
 
-    def _createDiffcalMaskWorkspaceName(self, runId: str):
+    def _createDiffcalMaskWorkspaceName(self, runId: str) -> WorkspaceName:
         return wng.diffCalMask().runNumber(runId).build()
 
-    ## WRITING TO DISK
-
-    def writeWorkspace(self, path: str, name: WorkspaceName):
-        """
-        Writes a Mantid Workspace to disk.
-        """
-        saveAlgo = AlgorithmManager.create("SaveNexus")
-        saveAlgo.setProperty("InputWorkspace", name)
-        saveAlgo.setProperty("Filename", os.path.join(path, name) + ".nxs")
-
-        saveAlgo.execute()
-
-    def writeGrouping(self, path: str, name: WorkspaceName):
-        """
-        Writes a Mantid Workspace to disk.
-        """
-        saveAlgo = AlgorithmManager.create("SaveGroupingDefinition")
-        saveAlgo.setProperty("GroupingWorkspace", name)
-        saveAlgo.setProperty("OutputFilename", os.path.join(path, name))
-        saveAlgo.execute()
-
-    def writeDiffCalTable(self, path: str, name: WorkspaceName, grouping: WorkspaceName = "", mask: WorkspaceName = ""):
-        """
-        Writes a diffcal table from a Mantid TableWorkspace to disk.
-        """
-        saveAlgo = AlgorithmManager.create("SaveDiffCal")
-        saveAlgo.setPropertyValue("CalibrationWorkspace", name)
-        saveAlgo.setPropertyValue("GroupingWorkspace", grouping)
-        saveAlgo.setPropertyValue("MaskWorkspace", mask)
-        saveAlgo.setPropertyValue("Filename", os.path.join(path, name))
-        saveAlgo.execute()
+    def _createDiffcalTableFilename(self, runId: str, version: str) -> str:
+        return str(Path(self._getCalibrationDataPath(runId, version)) / (self._createDiffcalTableWorkspaceName(runId) + ".h5"))
 
     ## ACCESSING WORKSPACES
     """
     These methods are for acccessing Mantid's ADS at the service layer
     """
-
+    
+    def uniqueHiddenName(self):
+        return mtd.unique_hidden_name()
+        
     def workspaceDoesExist(self, name: WorkspaceName):
         return mtd.doesExist(name)
 
@@ -190,53 +232,108 @@ class GroceryService:
             ws = None
         return ws
 
-    def _updateNeutronCacheFromADS(self, runId: str, useLiteMode: bool):
-        """
-        If the workspace has been loaded, but is not represented in the cache
-        then update the cache to represent this condition
-        """
-        workspace = self._createRawNeutronWorkspaceName(runId, useLiteMode)
-        key = self._key(runId, useLiteMode)
-        # if the raw data has been loaded but not represent in cache
-        if self.workspaceDoesExist(workspace) and self._loadedRuns.get(key) is None:
-            self._loadedRuns[key] = 0
-        # if the raw data has not been loaded but the cache thinks it has
-        if self._loadedRuns.get(key) is not None and not self.workspaceDoesExist(workspace):
-            del self._loadedRuns[key]
-
-    def _updateGroupingCacheFromADS(self, key, workspace):
-        """
-        If the workspace has been loaded, but is not represented in the cache
-        then update the cache to represent this condition
-        """
-        if self.workspaceDoesExist(workspace) and self._loadedGroupings.get(key) is None:
-            self._loadedGroupings[key] = workspace
-        if self._loadedGroupings.get(key) is not None and not self.workspaceDoesExist(workspace):
-            del self._loadedGroupings[key]
-
     ## FETCH METHODS
     """
-    The fetch methods orchestrate finding datas files, loading them into workspaces,
+    The fetch methods orchestrate finding data files, loading them into workspaces,
     and preserving a cache to prevent re-loading the same data files.
     """
 
-    def fetchWorkspace(self, path: str, name: WorkspaceName, loader: str = "") -> WorkspaceName:
+    def _fetchInstrumentDonor(self, runId: str, useLiteMode: bool) -> WorkspaceName:
+        self._updateInstrumentCacheFromADS(runId, useLiteMode)
+        
+        key = self._key(runId, useLiteMode)
+        if self._loadedInstruments.get(key) is not None:
+            return self._loadedInstruments.get(key)
+        
+        wsName = None
+        self._updateNeutronCacheFromADS(runId, useLiteMode)
+        if self._loadedRuns.get(key) is not None:
+            # If possible, use a cached neutron-data workspace as an instrument donor
+            wsName = self._createRawNeutronWorkspaceName(runId, useLiteMode)
+        else:
+            # Otherwise, create an instrument donor.
+            #   Alternatively, depending on performance, loading the corresponding neutron-data workspace
+            #   could also be triggered here.
+
+            wsName = self.uniqueHiddenName()
+            
+            # Load the bare instrument:
+            instrumentFilename = Config["instrument.lite.definition.file"] if useLiteMode\
+                                     else Config["instrument.native.definition.file"]
+            loadEmptyInstrument = AlgorithmManager.create("LoadEmptyInstrument")
+            loadEmptyInstrument.setProperty("Filename", instrumentFilename)
+            loadEmptyInstrument.setProperty("OutputWorkspace", wsName)
+            loadEmptyInstrument.execute()
+            
+            # Initialize the instrument parameters
+            self._updateInstrumentParameters(runId, wsName)
+        self._loadedInstruments[key] = wsName
+        return wsName
+
+    def _updateInstrumentParameters(self, runNumber: str, wsName: str):
+        """
+        Update mutable instrument parameters
+        """
+        # Moved from `PixelGroupingParametersCalculationAlgorithm` for more general application here.
+        
+        detectorState: DetectorState = self._getDetectorState(runNumber)
+
+        # Add sample logs with detector "arc" and "lin" parameters to the workspace
+        # NOTE after adding the logs, it is necessary to update the instrument to
+        #  factor in these new parameters, or else calculations will be inconsistent.
+        #  This is done with a call to `ws->populateInstrumentParameters()` from within mantid.
+        #  This call only needs to happen with the last log
+        logsAdded = 0
+        for paramName in ("arc", "lin"):
+            for index in range(2):
+                addSampleLog = AlgorithmManager.create("AddSampleLog")
+                addSampleLog.setProperty("Workspace", wsName)
+                addSampleLog.setProperty("LogName", "det_" + paramName + str(index + 1))
+                addSampleLog.setProperty("LogText", str(getattr(detectorState, paramName)[index]))
+                addSampleLog.setProperty("LogType", "Number Series")
+                addSampleLog.setProperty("UpdateInstrumentParameters", (logsAdded >= 3))
+                addSampleLog.execute()
+                logsAdded += 1
+
+    def _getDetectorState(self, runNumber: str) -> DetectorState:
+        """
+        Get the `DetectorState` associated with a given run number
+        """
+        # This method is provided to facilitate workspace loading with a _complete_ instrument state
+        return self.dataService.readDetectorState(runNumber)
+
+    def _getCalibrationDataPath(self, runNumber: str, version: str) -> str:
+        return self.dataService._constructCalibrationDataPath(runNumber, version)
+            
+    def fetchWorkspace(self, filePath: str, name: WorkspaceName, loader: str = "") -> WorkspaceName:
         """
         Will fetch a workspace given a name and a path.
-        Returns the same workspace name, if the workspace exists or can be loaded.
+        inputs:
+        - "filePath": complete path to workspace file
+        - "name": workspace name
+        - "loader" -- (optional) the loader algorithm to use to load the data
+        outputs a dictionary with keys
+        - "result": true if everything ran correctly
+        - "loader": the loader that was used by the algorithm; use it next time
+        - "workspace": the name of the workspace created in the ADS
         """
+        data = None
         if self.workspaceDoesExist(name):
-            return name
+            data = {
+                "result": True,
+                "loader": "cached",
+                "workspace": name,
+            }
         else:
             try:
-                res = self.grocer.executeRecipe(path, name, loader)
+                data = self.grocer.executeRecipe(filePath, name, loader)
             except RuntimeError:
-                raise RuntimeError(f"Failed to load workspace {name} from {path}")
-            if res["result"] is True:
-                return res["workspace"]
-            else:
-                raise RuntimeError(f"Failed to load workspace {name} from {path}")
-
+                # Mantid's error message is not particularly useful, although it's logged in any case
+                data = {"result": False}
+            if not data["result"]: 
+                raise RuntimeError(f"unable to load workspace {name} from {filePath}")
+        return data
+        
     def fetchNeutronDataSingleUse(self, runId: str, useLiteMode: bool, loader: str = "") -> Dict[str, Any]:
         """
         Fetch a neutron data file, without copy-protection.
@@ -339,8 +436,8 @@ class GroceryService:
         self._loadedRuns[key] += 1
         return data
 
-    def fetchLiteDataMap(self) -> WorkspaceName:
-        item = GroceryListItem.builder().grouping("Lite").build()
+    def fetchLiteDataMap(self, runId: str) -> WorkspaceName:
+        item = GroceryListItem.builder().grouping(runId, "Lite").build()
         return self.fetchGroupingDefinition(item)["workspace"]
 
     def fetchGroupingDefinition(self, item: GroceryListItem) -> Dict[str, Any]:
@@ -353,15 +450,11 @@ class GroceryService:
         - "loader", either "LoadGroupingDefinition" or "cached"
         - "workspace", the name of the new grouping workspace in the ADS
         """
-        itemTuple = (item.groupingScheme, item.useLiteMode)
-        workspaceName = self._createGroupingWorkspaceName(*itemTuple)
-        filename = self._createGroupingFilename(*itemTuple)
-        groupingLoader = "LoadGroupingDefinition"
-        key = self._key(*itemTuple)
-
-        groupingIsLoaded = self._loadedGroupings.get(key) is not None and self.workspaceDoesExist(
-            self._loadedGroupings.get(key)
-        )
+        key = self._key(item.groupingScheme, item.runNumber, item.useLiteMode)
+        workspaceName = self._createGroupingWorkspaceName(item.groupingScheme, item.runNumber, item.useLiteMode)
+        
+        self._updateGroupingCacheFromADS(key, workspaceName)
+        groupingIsLoaded = self._loadedGroupings.get(key) is not None
 
         if groupingIsLoaded:
             data = {
@@ -370,19 +463,72 @@ class GroceryService:
                 "workspace": workspaceName,
             }
         else:
-            if self._loadedGroupings.get(key) is not None:
-                self.rebuildCache()
+            filename = self._createGroupingFilename(item.groupingScheme, item.useLiteMode)
+            groupingLoader = "LoadGroupingDefinition"
+            
+            # Unless overridden: use a cached workspace as the instrument donor.
+            instrumentPropertySource, instrumentSource = ("InstrumentDonor", self._fetchInstrumentDonor(item.runNumber, item.useLiteMode))\
+                if not item.instrumentPropertySource else (item.instrumentPropertySource, item.instrumentSource)
             data = self.grocer.executeRecipe(
                 filename=filename,
                 workspace=workspaceName,
                 loader=groupingLoader,
-                instrumentPropertySource=item.instrumentPropertySource,
-                instrumentSource=item.instrumentSource,
+                instrumentPropertySource=instrumentPropertySource,
+                instrumentSource=instrumentSource,
             )
             self._loadedGroupings[key] = data["workspace"]
 
         return data
 
+    def fetchCalibrationWorkspaces(self, item: GroceryListItem) -> Dict[str, Any]:
+        """
+        Fetch diffraction-calibration table and mask workspaces
+        inputs:
+        - item, a GroceryListItem
+        outputs a dictionary with
+        - "result", true if everything ran correctly
+        - "loader", either "LoadDiffractionCalibrationWorkspaces" or "cached"
+        - "workspace", the name of the new workspace in the ADS:
+          this defaults to the name of the calibration-table workspace, but the
+          mask workspace will be loaded as well
+        """
+        
+        runNumber, version, useLiteMode = item.runNumber, item.version, item.useLiteMode
+        key = self._key(runNumber, version)
+        path = self._getCalibrationDataPath(runNumber, version)
+        tableWorkspaceName =  self._createDiffcalTableWorkspaceName(runNumber)
+        maskWorkspaceName =  self._createDiffcalMaskWorkspaceName(runNumber)
+
+        if self.workspaceDoesExist(tableWorkspaceName):
+            data = {
+                "result": True,
+                "loader": "cached",
+                "workspace": tableWorkspaceName,
+            }
+        else:        
+            # table + mask are in the same hdf5 file:
+            filename = self._createDiffcalTableFilename(runNumber, version)
+
+            # Unless overridden: use a cached workspace as the instrument donor.
+            instrumentPropertySource, instrumentSource = ("InstrumentDonor", self._fetchInstrumentDonor(runNumber, useLiteMode))\
+                if not item.instrumentPropertySource else (item.instrumentPropertySource, item.instrumentSource)
+            data = self.grocer.executeRecipe(
+                filename=filename,
+                
+                # IMPORTANT: Both table and mask workspaces will be loaded,
+                #   however, the 'workspace' property needs to return 
+                #   a `MatrixWorkspace`-derived property, otherwise Mantid gets confused.
+                workspace=maskWorkspaceName,
+                
+                loader="LoadCalibrationWorkspaces",
+                instrumentPropertySource=instrumentPropertySource,
+                instrumentSource=instrumentSource,
+                loaderArgs=json.dumps({"CalibrationTable": tableWorkspaceName, "MaskWorkspace": maskWorkspaceName}),
+            )
+            data["workspace"] = tableWorkspaceName
+            
+        return data
+        
     def fetchGroceryList(self, groceryList: List[GroceryListItem]) -> List[WorkspaceName]:
         """
         inputs:
@@ -391,7 +537,6 @@ class GroceryService:
         - the names of the workspaces, in the same order as items in the grocery list
         """
         groceries = []
-        prev: WorkspaceName = ""
         for item in groceryList:
             match item.workspaceType:
                 # for neutron data stored in a nexus file
@@ -400,28 +545,36 @@ class GroceryService:
                         res = self.fetchNeutronDataCached(item.runNumber, item.useLiteMode, item.loader)
                     else:
                         res = self.fetchNeutronDataSingleUse(item.runNumber, item.useLiteMode, item.loader)
-                    # save the most recently-loaded neutron data as a possible instrument donor
-                    prev = res["workspace"]
                 # for grouping definitions
                 case "grouping":
-                    # this flag indicates to use most recently-loaded nexus data as the instrument donor
-                    if item.instrumentSource == "prev":
-                        item.instrumentPropertySource = "InstrumentDonor"
-                        item.instrumentSource = prev
                     res = self.fetchGroupingDefinition(item)
                 case "diffcal":
-                    res = {"result": True, "workspace": self._createDiffcalInputWorkspaceName(item.runNumber)}
+                    res = {"result": False, "workspace": self._createDiffcalInputWorkspaceName(item.runNumber)}
                     raise RuntimeError(
                         "not implemented: no path available to fetch diffcal "
                         + f"input table workspace: '{res['workspace']}'"
                     )
-                # for output (i.e. special-order) workspaces
+                # for diffraction-calibration workspaces
                 case "diffcal_output":
-                    res = {"result": True, "workspace": self._createDiffcalOutputWorkspaceName(item.runNumber)}
+                    diffcalOutputWorkspaceName = self._createDiffcalOutputWorkspaceName(item.runNumber)
+                    if item.isOutput:
+                        res = {"result": True, "workspace": diffcalOutputWorkspaceName}
+                    else:
+                        res = self.fetchWorkspace(self._createDiffcalOutputWorkspaceFilename(item.runNumber, item.version), diffcalOutputWorkspaceName)
                 case "diffcal_table":
-                    res = {"result": True, "workspace": self._createDiffcalTableWorkspaceName(item.runNumber)}
+                    tableWorkspaceName = self._createDiffcalTableWorkspaceName(item.runNumber)
+                    if item.isOutput:
+                        res = {"result": True, "workspace": tableWorkspaceName}
+                    else:
+                        res = self.fetchCalibrationWorkspaces(item)
+                        res["workspace"] = tableWorkspaceName
                 case "diffcal_mask":
-                    res = {"result": True, "workspace": self._createDiffcalMaskWorkspaceName(item.runNumber)}
+                    maskWorkspaceName = self._createDiffcalMaskWorkspaceName(item.runNumber)
+                    if item.isOutput:
+                        res = {"result": True, "workspace": self._createDiffcalMaskWorkspaceName(item.runNumber)}
+                    else:
+                        res = self.fetchCalibrationWorkspaces(item)
+                        res["workspace"] = maskWorkspaceName
                 case _:
                     raise RuntimeError(f"unrecognized 'workspaceType': '{item.workspaceType}'")
             # check that the fetch operation succeeded and if so append the workspace

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -163,7 +163,7 @@ class GroceryService:
     def _createGroupingWorkspaceName(self, groupingScheme: str, runId: str, useLiteMode: bool) -> WorkspaceName:
         # TODO: use WNG here!
         if groupingScheme == "Lite":
-            return f"lite_grouping_map_{runId}"
+            return f"lite_grouping_map"
         instr = "lite" if useLiteMode else "native"
         return f"{Config['grouping.workspacename.' + instr]}_{groupingScheme}_{runId}"
 

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -6,9 +6,13 @@ from errno import ENOENT as NOT_FOUND
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-import h5py
-from mantid.kernel import PhysicalConstants
 from pydantic import parse_file_as
+import h5py
+
+from mantid.kernel import PhysicalConstants
+from mantid.api import AlgorithmManager, ITableWorkspace
+from mantid.dataobjects import MaskWorkspace
+from mantid.simpleapi import GetIPTS, mtd
 
 from snapred.backend.dao import (
     GSASParameters,
@@ -31,13 +35,13 @@ from snapred.backend.dao.state import (
     NormalizationCalibrant,
 )
 from snapred.backend.dao.state.CalibrantSample import CalibrantSamples
-from snapred.backend.data.GroceryService import GroceryService
 from snapred.backend.error.StateValidationException import StateValidationException
+from snapred.backend.recipe.algorithm.SaveGroupingDefinition import SaveGroupingDefinition
 from snapred.backend.log.logger import snapredLogger
 from snapred.meta.Config import Config, Resource
 from snapred.meta.decorators.ExceptionHandler import ExceptionHandler
 from snapred.meta.decorators.Singleton import Singleton
-from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as WNG, WorkspaceName
 from snapred.meta.redantic import (
     write_model_list_pretty,
     write_model_pretty,
@@ -61,9 +65,9 @@ class LocalDataService:
     reductionParameterCache: Dict[str, Any] = {}
     iptsCache: Dict[str, Any] = {}
     stateIdCache: Dict[str, ObjectSHA] = {}
-    instrumentConfig: "InstrumentConfig"  # Optional[InstrumentConfig]
+    instrumentConfig: "InstrumentConfig"
     verifyPaths: bool = True
-    groceryService: GroceryService = GroceryService()
+
     # conversion factor from microsecond/Angstrom to meters
     CONVERSION_FACTOR = Config["constants.m2cm"] * PhysicalConstants.h / PhysicalConstants.NeutronMass
 
@@ -139,12 +143,22 @@ class LocalDataService:
             stateId=diffCalibration.instrumentState.id,
         )
 
+    def getIPTS(self, runNumber: str, instrumentName: str = Config["instrument.name"]) -> str:
+        ipts = GetIPTS(runNumber, instrumentName)
+        return str(ipts)
+
+    def workspaceIsInstance(self, wsName: str, wsType: Any) -> bool:
+        # Is the workspace an instance of the specified type.
+        if not mtd.doesExist(wsName):
+            return False
+        return isinstance(mtd[wsName], wsType)
+                 
     def readRunConfig(self, runId: str) -> RunConfig:
         return self._readRunConfig(runId)
 
     def _readRunConfig(self, runId: str) -> RunConfig:
-        # lookup IPST number
-        iptsPath = self.groceryService.getIPTS(runId)
+        # lookup path for IPTS number
+        iptsPath = self.getIPTS(runId)
 
         return RunConfig(
             IPTS=iptsPath,
@@ -171,7 +185,7 @@ class LocalDataService:
         if os.path.exists(fName):
             f = h5py.File(fName, "r")
         else:
-            raise FileNotFoundError("File {} does not exist".format(fName))
+            raise FileNotFoundError(f"PVFile '{fName}' does not exist")
         return f
 
     @ExceptionHandler(StateValidationException)
@@ -180,23 +194,17 @@ class LocalDataService:
             SHA = self.stateIdCache[runId]
             return SHA.hex, SHA.decodedKey
 
-        f = self._readPVFile(runId)
-
-        try:
-            det_arc1 = f.get("entry/DASlogs/det_arc1/value")[0]
-            det_arc2 = f.get("entry/DASlogs/det_arc2/value")[0]
-            wav = f.get("entry/DASlogs/BL3:Chop:Skf1:WavelengthUserReq/value")[0]
-            freq = f.get("entry/DASlogs/BL3:Det:TH:BL:Frequency/value")[0]
-            GuideIn = f.get("entry/DASlogs/BL3:Mot:OpticsPos:Pos/value")[0]
-        except:  # noqa: E722
-            raise ValueError("Could not find all required logs in file {}".format(self._constructPVFilePath(runId)))
-
+        detectorState = self.readDetectorState(runId)
         stateID = StateId(
-            vdet_arc1=det_arc1,
-            vdet_arc2=det_arc2,
-            WavelengthUserReq=wav,
-            Frequency=freq,
-            Pos=GuideIn,
+            vdet_arc1=detectorState.arc[0],
+            vdet_arc2=detectorState.arc[1],
+            WavelengthUserReq=detectorState.wav,
+            Frequency=detectorState.freq,
+            Pos=detectorState.guideStat,
+            # TODO: these should probably be added:
+            #   if they change with the runId, there will be a potential hash collision.
+            # det_lin1=detectorState.lin[0],
+            # det_lin2=detectorState.lin[1],
         )
         SHA = ObjectSHA.fromObject(stateID)
         self.stateIdCache[runId] = SHA
@@ -340,6 +348,8 @@ class LocalDataService:
             raise ValueError(f"No calibration data found for runId {runId}")
         return self._constructCalibrationDataPath(runId, version)
 
+
+
     def writeCalibrationIndexEntry(self, entry: CalibrationIndexEntry):
         stateId, _ = self._generateStateId(entry.runNumber)
         calibrationPath: str = self._constructCalibrationStatePath(stateId)
@@ -432,7 +442,7 @@ class LocalDataService:
 
         return record
 
-    def writeNormalizationRecord(self, record: NormalizationRecord, version: int = None):  # noqa: F821
+    def writeNormalizationRecord(self, record: NormalizationRecord, version: int = None) -> NormalizationRecord:  # noqa: F821
         """
         Persists a `NormalizationRecord` to either a new version folder, or overwrite a specific version.
         -- side effect: updates version numbers of incoming `NormalizationRecord` and its nested `Normalization`.
@@ -457,12 +467,21 @@ class LocalDataService:
             os.makedirs(normalizationPath)
         # append to record and write to file
         write_model_pretty(record, recordPath)
-
-        for workspace in record.workspaceNames:
-            self.groceryService.writeWorkspace(normalizationPath, workspace)
         logger.info(f"wrote NormalizationRecord: version: {version}")
         return record
 
+    def writeNormalizationWorkspaces(self, record: NormalizationRecord) -> NormalizationRecord:
+        """
+        Writes the workspaces associated with a `NormalizationRecord` to disk:
+        -- assumes that `writeNormalizationRecord` has already been called, and that the version folder exists
+        """
+        normalizationDataPath = Path(self._constructNormalizationCalibrationDataPath(record.runNumber, record.version))
+        for workspace in record.workspaceNames:
+            filename = Path(workspace + ".nxs")
+            self.writeWorkspace(normalizationDataPath, filename, workspace)
+        return record
+    
+    
     def readCalibrationRecord(self, runId: str, version: str = None):
         recordFile: str = None
         if version:
@@ -505,24 +524,34 @@ class LocalDataService:
         write_model_pretty(record, recordPath)
 
         self.writeCalibrationState(runNumber, record.calibrationFittingIngredients, version)
-        for workspace in record.workspaceNames:
-            self.groceryService.writeWorkspace(calibrationPath, workspace)
         logger.info(f"Wrote CalibrationRecord: version: {version}")
         return record
 
-    def writeCalibrationReductionResult(self, runId: str, workspaceName: WorkspaceName, dryrun: bool = False):
-        # use mantid to write workspace to file
-        stateId, _ = self._generateStateId(runId)
-        calibrationPath: str = self._constructCalibrationStatePath(stateId)
-        filenameFormat = f"{calibrationPath}{runId}/{workspaceName}" + "_v{}.nxs"
-        # find total number of files
-        foundFiles = self._findMatchingFileList(filenameFormat.format("*"), throws=False)
-        version = len(foundFiles) + 1
-
-        filename = filenameFormat.format(version)
-        if not dryrun:
-            self.groceryService.writeWorkspace(filename, workspaceName)
-        return filename
+    def writeCalibrationWorkspaces(self, record: CalibrationRecord):
+        """
+        Writes the workspaces associated with a `CalibrationRecord` to disk:
+        -- assumes that `writeCalibrationRecord` has already been called, and that the version folder exists
+        """
+        calibrationDataPath = Path(self._constructCalibrationDataPath(record.runNumber, record.version))
+        calibrationTable = None
+        maskWorkspace = None
+        for workspace in record.workspaceNames:
+            if self.workspaceIsInstance(workspace, ITableWorkspace):
+                calibrationTable = workspace
+                continue
+            if self.workspaceIsInstance(workspace, MaskWorkspace):
+                maskWorkspace = workspace
+                continue
+            workspaceFilename = Path(workspace + ".nxs")
+            self.writeWorkspace(calibrationDataPath, workspaceFilename, workspace)
+        if not calibrationTable:
+            logger.warning("the diffraction-calibration table is missing from the workspace list")
+        if not maskWorkspace:
+            logger.warning("the diffraction-calibration mask is missing from the workspace list")
+        if calibrationTable or maskWorkspace:
+            diffCalFilename = Path(WNG.diffCalTable().runNumber(record.runNumber).version(record.version).build() + ".h5") 
+            self.writeDiffCalWorkspaces(calibrationDataPath, diffCalFilename, tableWorkspaceName=calibrationTable, maskWorkspaceName=maskWorkspace)
+        return record
 
     def writeCalibrantSample(self, sample: CalibrantSamples):
         samplePath: str = Config["samples.home"]
@@ -649,20 +678,29 @@ class LocalDataService:
         if not os.path.exists(normalizationPath):
             os.makedirs(normalizationPath)
         write_model_pretty(normalization, normalizationParametersPath)
+    
+    def readDetectorState(self, runId: str) -> DetectorState:
+        detectorState = None
+        pvFile = self._readPVFile(runId)
+        try:
+            detectorState = DetectorState(
+                arc=[pvFile.get("entry/DASlogs/det_arc1/value")[0], pvFile.get("entry/DASlogs/det_arc2/value")[0]],
+                wav=pvFile.get("entry/DASlogs/BL3:Chop:Skf1:WavelengthUserReq/value")[0],
+                freq=pvFile.get("entry/DASlogs/BL3:Det:TH:BL:Frequency/value")[0],
+                guideStat=pvFile.get("entry/DASlogs/BL3:Mot:OpticsPos:Pos/value")[0],
+                lin=[pvFile.get("entry/DASlogs/det_lin1/value")[0], pvFile.get("entry/DASlogs/det_lin2/value")[0]],
+            )
+        except:  # noqa: E722
+            raise ValueError(f"Could not find all required logs in file '{self._constructPVFilePath(runId)}'")        
+        return detectorState
 
     @ExceptionHandler(StateValidationException)
     def initializeState(self, runId: str, name: str = None):
         stateId, _ = self._generateStateId(runId)
 
-        # pull pv data similar to how we generate stateId
-        pvFile = self._readPVFile(runId)
-        detectorState = DetectorState(
-            arc=[pvFile.get("entry/DASlogs/det_arc1/value")[0], pvFile.get("entry/DASlogs/det_arc2/value")[0]],
-            wav=pvFile.get("entry/DASlogs/BL3:Chop:Skf1:WavelengthUserReq/value")[0],
-            freq=pvFile.get("entry/DASlogs/BL3:Det:TH:BL:Frequency/value")[0],
-            guideStat=pvFile.get("entry/DASlogs/BL3:Mot:OpticsPos:Pos/value")[0],
-            lin=[pvFile.get("entry/DASlogs/det_lin1/value")[0], pvFile.get("entry/DASlogs/det_lin2/value")[0]],
-        )
+        # Read the detector state from the pv data file
+        detectorState = self.readDetectorState(runId)
+        
         # then read data from the common calibration state parameters stored at root of calibration directory
         instrumentConfig = self.readInstrumentConfig()
         # then pull static values specified by Malcolm from resources
@@ -782,3 +820,36 @@ class LocalDataService:
 
     def groupingSchemaFromPath(self, path: str) -> str:
         return path.split("/")[-1].split("_")[-1].split(".")[0]
+
+    ## WRITING WORKSPACES TO DISK
+
+    def writeWorkspace(self, path: Path, filename: Path, workspaceName: WorkspaceName):
+        """
+        Write a MatrixWorkspace (derived) workspace to disk in nexus format.
+        """
+        if filename.suffix != ".nxs":
+            raise RuntimeError(f"[writeWorkspace]: specify filename including '.nxs' extension, not {filename}")
+        saveAlgo = AlgorithmManager.create("SaveNexus")
+        saveAlgo.setProperty("InputWorkspace", workspaceName)
+        saveAlgo.setProperty("Filename", str(path / filename))
+        saveAlgo.execute()
+
+    def writeGroupingWorkspace(self, path: Path, filename: Path, workspaceName: WorkspaceName):
+        """
+        Write a grouping workspace to disk in Mantid 'SaveDiffCal' hdf-5 format.
+        """
+        self.writeDiffCalWorkspaces(path, filename, groupingWorkspaceName=workspaceName)
+
+    def writeDiffCalWorkspaces(self, path: Path, filename: Path, tableWorkspaceName: WorkspaceName = "", maskWorkspaceName: WorkspaceName = "", groupingWorkspaceName: WorkspaceName = ""):
+        """
+        Writes any or all of the calibration table, mask and grouping workspaces to disk:
+        -- up to three workspaces may be written to one 'SaveDiffCal' hdf-5 format file.
+        """
+        if filename.suffix != ".h5":
+            raise RuntimeError(f"[writeCalibrationWorkspaces]: specify filename including '.h5' extension, not {filename}")
+        saveAlgo = AlgorithmManager.create("SaveDiffCal")
+        saveAlgo.setPropertyValue("CalibrationWorkspace", tableWorkspaceName)
+        saveAlgo.setPropertyValue("MaskWorkspace", maskWorkspaceName)
+        saveAlgo.setPropertyValue("GroupingWorkspace", groupingWorkspaceName)
+        saveAlgo.setPropertyValue("Filename", str(path / filename))
+        saveAlgo.execute()

--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -20,10 +20,12 @@ class FetchGroceriesRecipe:
     def executeRecipe(
         self,
         filename: str,
-        workspace: str,
+        workspace: str = "",
         loader: str = "",
         instrumentPropertySource=None,
         instrumentSource="",
+        *,
+        loaderArgs: str = "",       
     ) -> Dict[str, Any]:
         """
         Wraps the fetch groceries algorithm
@@ -32,7 +34,8 @@ class FetchGroceriesRecipe:
         - workspace -- a string name for the workspace to load data into
         - loader -- the loading algorithm to use, if you think you already know
         - instrumentPropertySource -- (optional) the property to specify the instrument source
-        - instrumentSource -- (optional) the source of the instrument for grouping workspaces
+        - instrumentSource -- (optional) the source of the instrument for grouping and mask workspaces
+        - loaderArgs -- any required keyword arguments for the loader
         outputs a dictionary with keys
         - "result": true if everything ran correctly
         - "loader": the loader that was used by the algorithm, use it next time (is blank if loading skipped)
@@ -48,8 +51,9 @@ class FetchGroceriesRecipe:
         algo.setPropertyValue("Filename", filename)
         algo.setPropertyValue("OutputWorkspace", workspace)
         algo.setPropertyValue("LoaderType", loader)
+        algo.setPropertyValue("LoaderArgs", loaderArgs)
         if instrumentPropertySource is not None:
-            algo.setProperty(str(instrumentPropertySource), instrumentSource)
+            algo.setPropertyValue(str(instrumentPropertySource), instrumentSource)
         try:
             data["result"] = algo.execute()
             data["loader"] = algo.getPropertyValue("LoaderType")

--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -25,7 +25,7 @@ class FetchGroceriesRecipe:
         instrumentPropertySource=None,
         instrumentSource="",
         *,
-        loaderArgs: str = "",       
+        loaderArgs: str = "",
     ) -> Dict[str, Any]:
         """
         Wraps the fetch groceries algorithm

--- a/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
@@ -16,8 +16,8 @@ from mantid.kernel import (
 )
 
 from snapred.backend.log.logger import snapredLogger
-from snapred.backend.recipe.algorithm.LoadGroupingDefinition import LoadGroupingDefinition
 from snapred.backend.recipe.algorithm.LoadCalibrationWorkspaces import LoadCalibrationWorkspaces
+from snapred.backend.recipe.algorithm.LoadGroupingDefinition import LoadGroupingDefinition
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 
 logger = snapredLogger.getLogger(__name__)
@@ -51,12 +51,13 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
             "LoaderType",
             "",
             StringListValidator(
-                ["",
-                 "LoadGroupingDefinition",
-                 "LoadCalibrationWorkspaces",
-                 "LoadNexus",
-                 "LoadEventNexus",
-                 "LoadNexusProcessed",
+                [
+                    "",
+                    "LoadGroupingDefinition",
+                    "LoadCalibrationWorkspaces",
+                    "LoadNexus",
+                    "LoadEventNexus",
+                    "LoadNexusProcessed",
                 ]
             ),
             direction=Direction.InOut,
@@ -90,7 +91,9 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
         # cannot load a grouping workspace with a nexus loader
         issues: Dict[str, str] = {}
         loader = self.getPropertyValue("LoaderType")
-        if not loader in ["LoadCalibrationWorkspaces",]:
+        if loader not in [
+            "LoadCalibrationWorkspaces",
+        ]:
             if self.getProperty("OutputWorkspace").isDefault:
                 issues["OutputWorkspace"] = f"loader '{loader}' requires an 'OutputWorkspace' argument"
             if not self.getProperty("LoaderArgs").isDefault:
@@ -150,6 +153,7 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
         self.mantidSnapper.executeQueue()
         self.setPropertyValue("OutputWorkspace", outWS)
         self.setPropertyValue("LoaderType", str(loaderType))
+
 
 # Register algorithm with Mantid
 AlgorithmFactory.subscribe(FetchGroceriesAlgorithm)

--- a/src/snapred/backend/recipe/algorithm/LoadCalibrationWorkspaces.py
+++ b/src/snapred/backend/recipe/algorithm/LoadCalibrationWorkspaces.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from typing import Dict
 
 from mantid.api import (
-    mtd,
     AlgorithmFactory,
     FileAction,
     FileProperty,
@@ -11,6 +10,7 @@ from mantid.api import (
     MatrixWorkspaceProperty,
     PropertyMode,
     PythonAlgorithm,
+    mtd,
 )
 from mantid.dataobjects import MaskWorkspaceProperty
 from mantid.kernel import Direction
@@ -63,7 +63,7 @@ class LoadCalibrationWorkspaces(PythonAlgorithm):
             MaskWorkspaceProperty("MaskWorkspace", "", Direction.Output, PropertyMode.Mandatory),
             doc="Name of the output mask workspace",
         )
-        
+
         self.setRethrows(True)
         self.mantidSnapper = MantidSnapper(self, __name__)
 
@@ -116,6 +116,7 @@ class LoadCalibrationWorkspaces(PythonAlgorithm):
 
         self.setPropertyValue("CalibrationTable", self.calibrationTable)
         self.setPropertyValue("MaskWorkspace", self.maskWorkspace)
+
 
 # Register algorithm with Mantid
 AlgorithmFactory.subscribe(LoadCalibrationWorkspaces)

--- a/src/snapred/backend/recipe/algorithm/LoadCalibrationWorkspaces.py
+++ b/src/snapred/backend/recipe/algorithm/LoadCalibrationWorkspaces.py
@@ -1,0 +1,121 @@
+import pathlib
+from datetime import datetime
+from typing import Dict
+
+from mantid.api import (
+    mtd,
+    AlgorithmFactory,
+    FileAction,
+    FileProperty,
+    ITableWorkspaceProperty,
+    MatrixWorkspaceProperty,
+    PropertyMode,
+    PythonAlgorithm,
+)
+from mantid.dataobjects import MaskWorkspaceProperty
+from mantid.kernel import Direction
+
+from snapred.backend.log.logger import snapredLogger
+from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
+from snapred.meta.Config import Config
+
+logger = snapredLogger.getLogger(__name__)
+
+
+class LoadCalibrationWorkspaces(PythonAlgorithm):
+    """
+    This algorithm creates a table workspace and a mask workspace from a calibration-data hdf5 file.
+    inputs:
+
+        Filename: str -- path to the input HDF5 format file
+        InstrumentDonor: str -- name of the instrument donor workspace
+        CalibrationTable: str -- name of the output table workspace
+        MaskWorkspace: str -- name of the output mask workspace
+    """
+
+    def category(self):
+        return "SNAPRed Data Handling"
+
+    def PyInit(self) -> None:
+        # define supported file name extensions
+        self.supported_file_extensions = ["H5", "HD5", "HDF"]
+        self.all_extensions = self.supported_file_extensions
+
+        self.declareProperty(
+            FileProperty(
+                "Filename",
+                defaultValue="",
+                action=FileAction.Load,
+                extensions=self.all_extensions,
+                direction=Direction.Input,
+            ),
+            doc="Path to HDF5 format file to be loaded",
+        )
+        self.declareProperty(
+            MatrixWorkspaceProperty("InstrumentDonor", "", Direction.Input),
+            doc="Workspace to use as an instrument donor",
+        )
+        self.declareProperty(
+            ITableWorkspaceProperty("CalibrationTable", "", Direction.Output, PropertyMode.Mandatory),
+            doc="Name of the output table workspace",
+        )
+        self.declareProperty(
+            MaskWorkspaceProperty("MaskWorkspace", "", Direction.Output, PropertyMode.Mandatory),
+            doc="Name of the output mask workspace",
+        )
+        
+        self.setRethrows(True)
+        self.mantidSnapper = MantidSnapper(self, __name__)
+
+    def validateInputs(self) -> Dict[str, str]:
+        errors = {}
+
+        if self.getProperty("Filename").isDefault:
+            errors["Filename"] = "You must specify the HDF5 format filename to load"
+            return errors
+
+        filename = self.getPropertyValue("Filename")
+        extension = pathlib.Path(filename).suffix[1:].upper()
+        # TODO this validation SHOULD occur as part of property validation
+        if extension not in self.supported_file_extensions:
+            errors["Filename"] = f"File extension {extension} is not supported"
+
+        return errors
+
+    def chopIngredients(self, filePath: str):
+        pass
+
+    def unbagGroceries(self):
+        pass
+
+    def PyExec(self) -> None:
+        self.calibrationTable = self.getPropertyValue("CalibrationTable")
+        self.maskWorkspace = self.getPropertyValue("MaskWorkspace")
+
+        baseName = mtd.unique_hidden_name()
+        self.mantidSnapper.LoadDiffCal(
+            "Loading constants table and mask from calibration file...",
+            Filename=self.getPropertyValue("Filename"),
+            InputWorkspace=self.getPropertyValue("InstrumentDonor"),
+            MakeGroupingWorkspace=False,
+            MakeCalWorkspace=True,
+            MakeMaskWorkspace=True,
+            WorkspaceName=baseName,
+        )
+        self.mantidSnapper.RenameWorkspace(
+            "Renaming table workspace...",
+            InputWorkspace=baseName + "_cal",
+            OutputWorkspace=self.calibrationTable,
+        )
+        self.mantidSnapper.RenameWorkspace(
+            "Renaming mask workspace...",
+            InputWorkspace=baseName + "_mask",
+            OutputWorkspace=self.maskWorkspace,
+        )
+        self.mantidSnapper.executeQueue()
+
+        self.setPropertyValue("CalibrationTable", self.calibrationTable)
+        self.setPropertyValue("MaskWorkspace", self.maskWorkspace)
+
+# Register algorithm with Mantid
+AlgorithmFactory.subscribe(LoadCalibrationWorkspaces)

--- a/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
@@ -87,7 +87,7 @@ class LoadGroupingDefinition(PythonAlgorithm):
         groupingFileExt = pathlib.Path(groupingFilename).suffix[1:].upper()
         # TODO this validation SHOULD occur as part of property validation
         if groupingFileExt not in self.all_extensions:
-            errors["GroupingFilename"] = f"Grouping file extension {groupingFileExt} not supported"
+            errors["GroupingFilename"] = f"Grouping file extension {groupingFileExt} is not supported"
 
         if groupingFileExt not in self.supported_xml_file_extensions:
             if not self.getProperty("InstrumentDonor").isDefault:

--- a/src/snapred/backend/recipe/algorithm/ReductionAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/ReductionAlgorithm.py
@@ -9,7 +9,7 @@ from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 
 #######################################################
 # ATTENTION: Could be replaced by alignAndFocusPowder #
-# please confirm that attenutation correction before  #
+# please confirm that attenuation correction before  #
 # and after is equivalent                             #
 #######################################################
 class ReductionAlgorithm(PythonAlgorithm):

--- a/src/snapred/backend/service/CalibrantSampleService.py
+++ b/src/snapred/backend/service/CalibrantSampleService.py
@@ -22,6 +22,6 @@ class CalibrantSampleService(Service):
     @FromString
     def save_sample(self, calibrantSample: CalibrantSamples):
         try:
-            self.dataExportService.writeCalibrantSampleFile(calibrantSample)
+            self.dataExportService.exportCalibrantSampleFile(calibrantSample)
         except:
             raise

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -111,7 +111,7 @@ class CalibrationService(Service):
 
         # groceries
         self.groceryClerk.name("inputWorkspace").neutron(request.runNumber).useLiteMode(request.useLiteMode).add()
-        self.groceryClerk.name("groupingWorkspace").grouping(request.runNumber, request.focusGroup.name).useLiteMode(
+        self.groceryClerk.name("groupingWorkspace").fromRun(request.runNumber).grouping(request.focusGroup.name).useLiteMode(
             request.useLiteMode
         ).add()
         self.groceryClerk.specialOrder().name("outputWorkspace").diffcal_output(request.runNumber).useLiteMode(

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -60,7 +60,7 @@ class CalibrationService(Service):
     def __init__(self):
         super().__init__()
         self.dataFactoryService = DataFactoryService()
-        self.dataExportService = DataExportService()
+        self.dataExportService = DataExportService()        
         self.groceryService = GroceryService()
         self.groceryClerk = GroceryListItem.builder()
         self.sousChef = SousChef()
@@ -111,9 +111,9 @@ class CalibrationService(Service):
 
         # groceries
         self.groceryClerk.name("inputWorkspace").neutron(request.runNumber).useLiteMode(request.useLiteMode).add()
-        self.groceryClerk.name("groupingWorkspace").grouping(request.focusGroup.name).useLiteMode(
+        self.groceryClerk.name("groupingWorkspace").grouping(request.runNumber, request.focusGroup.name).useLiteMode(
             request.useLiteMode
-        ).fromPrev().add()
+        ).add()
         self.groceryClerk.specialOrder().name("outputWorkspace").diffcal_output(request.runNumber).useLiteMode(
             request.useLiteMode
         ).add()
@@ -134,6 +134,7 @@ class CalibrationService(Service):
         entry = request.calibrationIndexEntry
         calibrationRecord = request.calibrationRecord
         calibrationRecord = self.dataExportService.exportCalibrationRecord(calibrationRecord)
+        calibrationRecord = self.dataExportService.exportCalibrationWorkspaces(calibrationRecord)
         entry.version = calibrationRecord.version
         self.saveCalibrationToIndex(entry)
 
@@ -238,7 +239,7 @@ class CalibrationService(Service):
 
         # load persistent workspaces
         for ws_name in calibrationRecord.workspaceNames:
-            self.dataFactoryService.loadCalibrationDataWorkspace(
+            self.dataFactoryService.getCalibrationDataWorkspace(
                 calibrationRecord.runNumber, calibrationRecord.version, ws_name
             )
 

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -111,9 +111,9 @@ class CalibrationService(Service):
 
         # groceries
         self.groceryClerk.name("inputWorkspace").neutron(request.runNumber).useLiteMode(request.useLiteMode).add()
-        self.groceryClerk.name("groupingWorkspace").fromRun(request.runNumber).grouping(request.focusGroup.name).useLiteMode(
-            request.useLiteMode
-        ).add()
+        self.groceryClerk.name("groupingWorkspace").fromRun(request.runNumber).grouping(
+            request.focusGroup.name
+        ).useLiteMode(request.useLiteMode).add()
         self.groceryClerk.specialOrder().name("outputWorkspace").diffcal_output(request.runNumber).useLiteMode(
             request.useLiteMode
         ).add()

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -60,7 +60,7 @@ class CalibrationService(Service):
     def __init__(self):
         super().__init__()
         self.dataFactoryService = DataFactoryService()
-        self.dataExportService = DataExportService()        
+        self.dataExportService = DataExportService()
         self.groceryService = GroceryService()
         self.groceryClerk = GroceryListItem.builder()
         self.sousChef = SousChef()

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -67,11 +67,11 @@ class NormalizationService(Service):
         self.groceryClerk.name("backgroundWorkspace").neutron(request.backgroundRunNumber).useLiteMode(
             request.useLiteMode
         ).add()
-        self.groceryClerk.name("groupingWorkspace").grouping(groupingScheme).useLiteMode(
+        self.groceryClerk.name("groupingWorkspace").grouping(request.runNumber, groupingScheme).useLiteMode(
             request.useLiteMode
-        ).fromPrev().add()
+        ).add()
 
-        outputWorkspace = wng.run().runNumber(request.runNumber).group(groupingScheme).auxilary("S+F-Vanadium").build()
+        outputWorkspace = wng.run().runNumber(request.runNumber).group(groupingScheme).auxiliary("S+F-Vanadium").build()
         correctedVanadium = wng.rawVanadium().runNumber(request.runNumber).build()
         smoothedOutput = wng.smoothedFocusedRawVanadium().runNumber(request.runNumber).group(groupingScheme).build()
 
@@ -157,6 +157,7 @@ class NormalizationService(Service):
         entry = request.normalizationIndexEntry
         normalizationRecord = request.normalizationRecord
         normalizationRecord = self.dataExportService.exportNormalizationRecord(normalizationRecord)
+        normalizationRecord = self.dataExportService.exportNormalizationWorkspaces(normalizationRecord)
         entry.version = normalizationRecord.version
         self.saveNormalizationToIndex(entry)
 

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -67,7 +67,7 @@ class NormalizationService(Service):
         self.groceryClerk.name("backgroundWorkspace").neutron(request.backgroundRunNumber).useLiteMode(
             request.useLiteMode
         ).add()
-        self.groceryClerk.name("groupingWorkspace").grouping(request.runNumber, groupingScheme).useLiteMode(
+        self.groceryClerk.name("groupingWorkspace").fromRun(request.runNumber).grouping(groupingScheme).useLiteMode(
             request.useLiteMode
         ).add()
 

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -79,7 +79,7 @@ class SousChef(Service):
                 nBinsAcrossPeakWidth=ingredients.nBinsAcrossPeakWidth,
             )
             getGrouping = (
-                self.groceryClerk.grouping(ingredients.focusGroup.name)
+                self.groceryClerk.grouping(ingredients.runNumber, ingredients.focusGroup.name)
                 .useLiteMode(ingredients.useLiteMode)
                 .source(InstrumentFilename=self._getInstrumentDefinitionFilename(ingredients.useLiteMode))
                 .buildList()

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -79,7 +79,7 @@ class SousChef(Service):
                 nBinsAcrossPeakWidth=ingredients.nBinsAcrossPeakWidth,
             )
             getGrouping = (
-                self.groceryClerk.grouping(ingredients.runNumber, ingredients.focusGroup.name)
+                self.groceryClerk.fromRun(ingredients.runNumber).grouping(ingredients.focusGroup.name)
                 .useLiteMode(ingredients.useLiteMode)
                 .source(InstrumentFilename=self._getInstrumentDefinitionFilename(ingredients.useLiteMode))
                 .buildList()

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -79,7 +79,8 @@ class SousChef(Service):
                 nBinsAcrossPeakWidth=ingredients.nBinsAcrossPeakWidth,
             )
             getGrouping = (
-                self.groceryClerk.fromRun(ingredients.runNumber).grouping(ingredients.focusGroup.name)
+                self.groceryClerk.fromRun(ingredients.runNumber)
+                .grouping(ingredients.focusGroup.name)
                 .useLiteMode(ingredients.useLiteMode)
                 .source(InstrumentFilename=self._getInstrumentDefinitionFilename(ingredients.useLiteMode))
                 .buildList()

--- a/src/snapred/meta/builder/GroceryListBuilder.py
+++ b/src/snapred/meta/builder/GroceryListBuilder.py
@@ -18,8 +18,9 @@ class GroceryListBuilder:
         self._tokens["runNumber"] = runId
         return self
 
-    def grouping(self, groupingScheme: str):
+    def grouping(self, runId: str, groupingScheme: str):
         self._tokens["workspaceType"] = "grouping"
+        self._tokens["runNumber"] = runId
         self._tokens["groupingScheme"] = groupingScheme
         return self
 
@@ -60,19 +61,15 @@ class GroceryListBuilder:
         return self
 
     def source(self, **kwarg):
+        # This setter is retained primarily to allow overriding the
+        #   automatic instrument-donor caching system.
         if len(kwarg.keys()) > 1:
             raise RuntimeError("You can only specify one instrument source")
         else:
             self._hasInstrumentSource = True
-            propuhdy, source = list(kwarg.items())[0]
-            self._tokens["instrumentPropertySource"] = propuhdy
-            self._tokens["instrumentSource"] = source
-        return self
-
-    def fromPrev(self):
-        self._hasInstrumentSource = True
-        self._tokens["instrumentPropertySource"] = "InstrumentDonor"
-        self._tokens["instrumentSource"] = "prev"
+            instrumentPropertySource, instrumentSource = list(kwarg.items())[0]
+            self._tokens["instrumentPropertySource"] = instrumentPropertySource
+            self._tokens["instrumentSource"] = instrumentSource
         return self
 
     def name(self, name: str):
@@ -88,10 +85,6 @@ class GroceryListBuilder:
         return self
 
     def build(self) -> GroceryListItem:
-        # if no instrument source set, use the instrument filename
-        if self._tokens["workspaceType"] == "grouping" and not self._hasInstrumentSource:
-            self._tokens["instrumentPropertySource"] = "InstrumentFilename"
-            self._tokens["instrumentSource"] = str(Config["instrument.native.definition.file"])
         # create the grocery item list, and return
         return GroceryListItem(**self._tokens)
 

--- a/src/snapred/meta/builder/GroceryListBuilder.py
+++ b/src/snapred/meta/builder/GroceryListBuilder.py
@@ -5,6 +5,7 @@ from snapred.meta.Config import Config
 
 
 class GroceryListBuilder:
+    
     def __init__(
         self,
     ):
@@ -18,12 +19,15 @@ class GroceryListBuilder:
         self._tokens["runNumber"] = runId
         return self
 
-    def grouping(self, runId: str, groupingScheme: str):
+    def grouping(self, groupingScheme: str):
         self._tokens["workspaceType"] = "grouping"
-        self._tokens["runNumber"] = runId
         self._tokens["groupingScheme"] = groupingScheme
         return self
-
+    
+    def fromRun(self, runId: str):
+        self._tokens["runNumber"] = runId
+        return self
+    
     def specialOrder(self):
         self._tokens["isOutput"] = True
         return self
@@ -90,8 +94,8 @@ class GroceryListBuilder:
 
     def add(self):
         self._list.append(self.build())
-        self._hasInstrumentSource = False
         self._tokens = {}
+        self._hasInstrumentSource = False
 
     def buildList(self) -> List[GroceryListItem]:
         if self._tokens != {}:

--- a/src/snapred/meta/builder/GroceryListBuilder.py
+++ b/src/snapred/meta/builder/GroceryListBuilder.py
@@ -5,7 +5,6 @@ from snapred.meta.Config import Config
 
 
 class GroceryListBuilder:
-    
     def __init__(
         self,
     ):
@@ -23,11 +22,11 @@ class GroceryListBuilder:
         self._tokens["workspaceType"] = "grouping"
         self._tokens["groupingScheme"] = groupingScheme
         return self
-    
+
     def fromRun(self, runId: str):
         self._tokens["runNumber"] = runId
         return self
-    
+
     def specialOrder(self):
         self._tokens["isOutput"] = True
         return self

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -35,15 +35,15 @@ class _WorkspaceNameGenerator:
     _templateRoot = "mantid.workspace.nameTemplate"
     _delimiter = Config[f"{_templateRoot}.delimiter"]
     _runTemplate = Config[f"{_templateRoot}.run"]
-    _runTemplateKeys = ["runNumber", "auxilary", "lite", "unit", "group"]
+    _runTemplateKeys = ["runNumber", "auxiliary", "lite", "unit", "group"]
     _diffCalInputTemplate = Config[f"{_templateRoot}.diffCal.input"]
     _diffCalInputTemplateKeys = ["runNumber", "unit"]
     _diffCalTableTemplate = Config[f"{_templateRoot}.diffCal.table"]
-    _diffCalTableTemplateKeys = ["runNumber"]
+    _diffCalTableTemplateKeys = ["runNumber", "version"]
     _diffCalOutputTemplate = Config[f"{_templateRoot}.diffCal.output"]
-    _diffCalOutputTemplateKeys = ["runNumber", "unit"]
+    _diffCalOutputTemplateKeys = ["runNumber", "version", "unit"]
     _diffCalMaskTemplate = Config[f"{_templateRoot}.diffCal.mask"]
-    _diffCalMaskTemplateKeys = ["runNumber"]
+    _diffCalMaskTemplateKeys = ["runNumber", "version"]
     _diffCalMetricTemplate = Config[f"{_templateRoot}.diffCal.metric"]
     _diffCalMetricTemplateKeys = ["runNumber", "version", "metricName"]
     _rawVanadiumTemplate = Config[f"{_templateRoot}.normCal.rawVanadium"]
@@ -76,7 +76,7 @@ class _WorkspaceNameGenerator:
             self._runTemplate,
             self._runTemplateKeys,
             self._delimiter,
-            auxilary="",
+            auxiliary="",
             unit=self.Units.TOF,
             group=self.Groups.ALL,
             lite=self.Lite.FALSE,
@@ -88,18 +88,24 @@ class _WorkspaceNameGenerator:
         )
 
     def diffCalTable(self):
-        return NameBuilder(self._diffCalTableTemplate, self._diffCalTableTemplateKeys, self._delimiter)
+        return NameBuilder(
+            self._diffCalTableTemplate, self._diffCalTableTemplateKeys, self._delimiter, version=""
+        )
 
     def diffCalOutput(self):
         return NameBuilder(
-            self._diffCalOutputTemplate, self._diffCalOutputTemplateKeys, self._delimiter, unit=self.Units.DSP
+            self._diffCalOutputTemplate, self._diffCalOutputTemplateKeys, self._delimiter, unit=self.Units.TOF, version=""
         )
 
     def diffCalMask(self):
-        return NameBuilder(self._diffCalMaskTemplate, self._diffCalMaskTemplateKeys, self._delimiter)
+        return NameBuilder(
+            self._diffCalMaskTemplate, self._diffCalMaskTemplateKeys, self._delimiter, version=""
+        )
 
     def diffCalMetrics(self):
-        return NameBuilder(self._diffCalMetricTemplate, self._diffCalMetricTemplateKeys, self._delimiter)
+        return NameBuilder(
+            self._diffCalMetricTemplate, self._diffCalMetricTemplateKeys, self._delimiter, version=""
+        )
 
     def rawVanadium(self):
         return NameBuilder(

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -88,24 +88,22 @@ class _WorkspaceNameGenerator:
         )
 
     def diffCalTable(self):
-        return NameBuilder(
-            self._diffCalTableTemplate, self._diffCalTableTemplateKeys, self._delimiter, version=""
-        )
+        return NameBuilder(self._diffCalTableTemplate, self._diffCalTableTemplateKeys, self._delimiter, version="")
 
     def diffCalOutput(self):
         return NameBuilder(
-            self._diffCalOutputTemplate, self._diffCalOutputTemplateKeys, self._delimiter, unit=self.Units.TOF, version=""
+            self._diffCalOutputTemplate,
+            self._diffCalOutputTemplateKeys,
+            self._delimiter,
+            unit=self.Units.TOF,
+            version="",
         )
 
     def diffCalMask(self):
-        return NameBuilder(
-            self._diffCalMaskTemplate, self._diffCalMaskTemplateKeys, self._delimiter, version=""
-        )
+        return NameBuilder(self._diffCalMaskTemplate, self._diffCalMaskTemplateKeys, self._delimiter, version="")
 
     def diffCalMetrics(self):
-        return NameBuilder(
-            self._diffCalMetricTemplate, self._diffCalMetricTemplateKeys, self._delimiter, version=""
-        )
+        return NameBuilder(self._diffCalMetricTemplate, self._diffCalMetricTemplateKeys, self._delimiter, version="")
 
     def rawVanadium(self):
         return NameBuilder(

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -85,12 +85,12 @@ mantid:
   workspace:
     nameTemplate:
       delimiter: "_"
-      run: "{unit},{group},{lite},{runNumber},{auxilary}"
+      run: "{unit},{group},{lite},{runNumber},{auxiliary}"
       diffCal:
         input: "{unit},{runNumber},raw"
-        table: "DIFC,{runNumber}"
-        output: "{unit},{runNumber},diffoc"
-        mask: "DIFC,{runNumber},mask"
+        table: "DIFC,{runNumber},{version}"
+        output: "{unit},{runNumber},{version},diffoc"
+        mask: "DIFC,{runNumber},{version},mask"
         metric: "{runNumber},{version},calibration_metrics,{metricName}"
       normCal:
         rawVanadium: "{unit},{group},{runNumber},raw_van_corr"

--- a/tests/cis_tests/detector_peak_script.py
+++ b/tests/cis_tests/detector_peak_script.py
@@ -75,7 +75,7 @@ for group in peakList:
 
 clerk = GroceryListItem.builder()
 clerk.neutron(runNumber).useLiteMode(isLite).add()
-clerk.grouping(groupingScheme).useLiteMode(isLite).fromPrev().add()
+clerk.grouping(runNumber, groupingScheme).useLiteMode(isLite).add()
 groceries = GroceryService().fetchGroceryList(clerk.buildList())
 
 ConvertUnits(

--- a/tests/cis_tests/detector_peak_script.py
+++ b/tests/cis_tests/detector_peak_script.py
@@ -75,7 +75,7 @@ for group in peakList:
 
 clerk = GroceryListItem.builder()
 clerk.neutron(runNumber).useLiteMode(isLite).add()
-clerk.grouping(runNumber, groupingScheme).useLiteMode(isLite).add()
+clerk.fromRun(runNumber).grouping(groupingScheme).useLiteMode(isLite).add()
 groceries = GroceryService().fetchGroceryList(clerk.buildList())
 
 ConvertUnits(

--- a/tests/cis_tests/diffcal_masking_script.py
+++ b/tests/cis_tests/diffcal_masking_script.py
@@ -136,7 +136,7 @@ ingredients = DiffractionCalibrationIngredients(
 
 clerk = GroceryListItem.builder()
 clerk.neutron(runNumber).useLiteMode(isLite).add()
-clerk.grouping(groupingScheme).useLiteMode(isLite).add()
+clerk.grouping(runNumber, groupingScheme).useLiteMode(isLite).add()
 groceries = GroceryService().fetchGroceryList(clerk.buildList())
 
 ### OPTIONAL: CREATE AN INPUT MASK, IF REQUIRED FOR TESTING. ##########
@@ -233,7 +233,7 @@ except:
 
 clerk = GroceryListItem.builder()
 clerk.name("inputWorkspace").neutron(runNumber).useLiteMode(isLite).add()
-clerk.name("groupingWorkspace").grouping(groupingScheme).useLiteMode(isLite).fromPrev().add()
+clerk.name("groupingWorkspace").grouping(runNumber, groupingScheme).useLiteMode(isLite).add()
 
 groceries = GroceryService().fetchGroceryDict(
     groceryDict=clerk.buildDict(),

--- a/tests/cis_tests/diffcal_masking_script.py
+++ b/tests/cis_tests/diffcal_masking_script.py
@@ -136,7 +136,7 @@ ingredients = DiffractionCalibrationIngredients(
 
 clerk = GroceryListItem.builder()
 clerk.neutron(runNumber).useLiteMode(isLite).add()
-clerk.grouping(runNumber, groupingScheme).useLiteMode(isLite).add()
+clerk.fromRun(runNumber).grouping(groupingScheme).useLiteMode(isLite).add()
 groceries = GroceryService().fetchGroceryList(clerk.buildList())
 
 ### OPTIONAL: CREATE AN INPUT MASK, IF REQUIRED FOR TESTING. ##########
@@ -233,7 +233,7 @@ except:
 
 clerk = GroceryListItem.builder()
 clerk.name("inputWorkspace").neutron(runNumber).useLiteMode(isLite).add()
-clerk.name("groupingWorkspace").grouping(runNumber, groupingScheme).useLiteMode(isLite).add()
+clerk.name("groupingWorkspace").fromRun(runNumber).grouping(groupingScheme).useLiteMode(isLite).add()
 
 groceries = GroceryService().fetchGroceryDict(
     groceryDict=clerk.buildDict(),

--- a/tests/cis_tests/new_diffcal_script.py
+++ b/tests/cis_tests/new_diffcal_script.py
@@ -54,7 +54,7 @@ ingredients = SousChef().prepDiffractionCalibrationIngredients(farmFresh)
 
 clerk = GroceryListItem.builder()
 clerk.neutron(runNumber).useLiteMode(isLite).add()
-clerk.grouping(runNumber, groupingScheme).useLiteMode(isLite).add()
+clerk.fromRun(runNumber).grouping(groupingScheme).useLiteMode(isLite).add()
 groceries = GroceryService().fetchGroceryList(clerk.buildList())
 
 ### RUN PIXEL CALIBRATION ##########
@@ -102,7 +102,7 @@ assert False
 
 clerk = GroceryListItem.builder()
 clerk.name("inputWorkspace").neutron(runNumber).useLiteMode(isLite).add()
-clerk.name("groupingWorkspace").grouping(runNumber, groupingScheme).useLiteMode(isLite).add()
+clerk.name("groupingWorkspace").fromRun(runNumber).grouping(groupingScheme).useLiteMode(isLite).add()
 
 groceries = GroceryService().fetchGroceryDict(
     groceryDict=clerk.buildDict(),

--- a/tests/cis_tests/new_diffcal_script.py
+++ b/tests/cis_tests/new_diffcal_script.py
@@ -54,7 +54,7 @@ ingredients = SousChef().prepDiffractionCalibrationIngredients(farmFresh)
 
 clerk = GroceryListItem.builder()
 clerk.neutron(runNumber).useLiteMode(isLite).add()
-clerk.grouping(groupingScheme).useLiteMode(isLite).add()
+clerk.grouping(runNumber, groupingScheme).useLiteMode(isLite).add()
 groceries = GroceryService().fetchGroceryList(clerk.buildList())
 
 ### RUN PIXEL CALIBRATION ##########
@@ -102,7 +102,7 @@ assert False
 
 clerk = GroceryListItem.builder()
 clerk.name("inputWorkspace").neutron(runNumber).useLiteMode(isLite).add()
-clerk.name("groupingWorkspace").grouping(groupingScheme).useLiteMode(isLite).fromPrev().add()
+clerk.name("groupingWorkspace").grouping(runNumber, groupingScheme).useLiteMode(isLite).add()
 
 groceries = GroceryService().fetchGroceryDict(
     groceryDict=clerk.buildDict(),

--- a/tests/cis_tests/normalization_calibration_script.py
+++ b/tests/cis_tests/normalization_calibration_script.py
@@ -63,7 +63,7 @@ ingredients = SousChef().getNormalizationIngredients(farmFresh)
 clerk = GroceryListItem.builder()
 clerk.name("inputWorkspace").neutron(runNumber).useLiteMode(isLite).add()
 clerk.name("backgroundWorkspace").neutron(backgroundRunNumber).useLiteMode(isLite).add()
-clerk.name("groupingWorkspace").grouping(runNumber, groupingScheme).useLiteMode(isLite).add()
+clerk.name("groupingWorkspace").fromRun(runNumber).grouping(groupingScheme).useLiteMode(isLite).add()
 groceries = GroceryService().fetchGroceryList(clerk.buildList())
 
 CNA = CalibrationNormalizationAlgo()

--- a/tests/cis_tests/normalization_calibration_script.py
+++ b/tests/cis_tests/normalization_calibration_script.py
@@ -63,7 +63,7 @@ ingredients = SousChef().getNormalizationIngredients(farmFresh)
 clerk = GroceryListItem.builder()
 clerk.name("inputWorkspace").neutron(runNumber).useLiteMode(isLite).add()
 clerk.name("backgroundWorkspace").neutron(backgroundRunNumber).useLiteMode(isLite).add()
-clerk.name("groupingWorkspace").grouping(groupingScheme).useLiteMode(isLite).fromPrev().add()
+clerk.name("groupingWorkspace").grouping(runNumber, groupingScheme).useLiteMode(isLite).add()
 groceries = GroceryService().fetchGroceryList(clerk.buildList())
 
 CNA = CalibrationNormalizationAlgo()

--- a/tests/cis_tests/raw_vanadium_proto.py
+++ b/tests/cis_tests/raw_vanadium_proto.py
@@ -64,7 +64,7 @@ ingredients.reductionState.stateConfig.tofMax = TOFBinParams[2]
 clerk = GroceryListItem.builder()
 clerk.neutron(VRun).useLiteMode(liteMode).add()
 clerk.neutron(VBRun).useLiteMode(liteMode).add()
-clerk.grouping(VRun, groupingScheme).useLiteMode(liteMode).add()
+clerk.fromRun(VRun).grouping(groupingScheme).useLiteMode(liteMode).add()
 groceries = GroceryService().fetchGroceryList(clerk.buildList())
 
 # CREATE MATERIAL ########################################################

--- a/tests/cis_tests/raw_vanadium_proto.py
+++ b/tests/cis_tests/raw_vanadium_proto.py
@@ -64,7 +64,7 @@ ingredients.reductionState.stateConfig.tofMax = TOFBinParams[2]
 clerk = GroceryListItem.builder()
 clerk.neutron(VRun).useLiteMode(liteMode).add()
 clerk.neutron(VBRun).useLiteMode(liteMode).add()
-clerk.grouping(groupingScheme).useLiteMode(liteMode).add()
+clerk.grouping(VRun, groupingScheme).useLiteMode(liteMode).add()
 groceries = GroceryService().fetchGroceryList(clerk.buildList())
 
 # CREATE MATERIAL ########################################################

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -89,12 +89,12 @@ mantid:
     workspace:
       nameTemplate:
         delimiter: "_"
-        run: "{unit},{group},{lite},{runNumber},{auxilary}"
+        run: "{unit},{group},{lite},{runNumber},{auxiliary}"
         diffCal:
           input: "_{unit},{runNumber},raw"
-          table: "_DIFC,{runNumber}"
-          output: "_{unit},{runNumber},diffoc"
-          mask: "_DIFC,{runNumber},mask"
+          table: "_DIFC,{runNumber},{version}"
+          output: "_{unit},{runNumber},{version},diffoc"
+          mask: "_DIFC,{runNumber},{version},mask"
           metric: "{runNumber},{version},calibration_metrics,{metricName}"
         normCal:
           rawVanadium: "{unit},{group},{runNumber},raw_van_corr"

--- a/tests/resources/inputs/calibration/CalibrationRecord.json
+++ b/tests/resources/inputs/calibration/CalibrationRecord.json
@@ -628,7 +628,8 @@
       "fitted_strippedFocussedData_stripped_0",
       "fitted_strippedFocussedData_stripped_1",
       "fitted_strippedFocussedData_stripped_2",
-      "57514_calibration_reduction_result"
+      "_difc_57514",
+      "_difc_57514_mask"
     ],
     "version": 7
   }

--- a/tests/resources/inputs/normalization/NormalizationRecord.json
+++ b/tests/resources/inputs/normalization/NormalizationRecord.json
@@ -73,8 +73,7 @@
     "workspaceNames": [
         "fitted_strippedFocussedData_stripped_0",
         "fitted_strippedFocussedData_stripped_1",
-        "fitted_strippedFocussedData_stripped_2",
-        "57514_calibration_reduction_result"
+        "fitted_strippedFocussedData_stripped_2"
       ],
     "version": 7,
     "dMin": 0.4

--- a/tests/resources/inputs/testInstrument/fakeSNAP.xml
+++ b/tests/resources/inputs/testInstrument/fakeSNAP.xml
@@ -36,12 +36,44 @@
   -->
 
   <!--DETECTORS-->
-  <component type="Column1">
-    <location x="-2.0+value" z="-5.0+value"/>
+  <component type="East">
+    <location >
+      <parameter name="roty">
+        <logfile id="det_arc2" eq="180.0+value"/>
+      </parameter>
+      <parameter name="r-position">
+        <logfile id="det_lin2" eq="0.5+value" />
+      </parameter>
+      <parameter name="t-position">
+        <logfile id="det_arc2" />
+      </parameter>
+    </location>
   </component>
-  <component type="Column2">
-    <location x="+2.0+value" z="-5.0+value"/>
+  <component type="West">
+    <location >
+      <parameter name="roty">
+        <logfile id="det_arc1" eq="180.0+value"/>
+      </parameter>
+      <parameter name="r-position">
+        <logfile id="det_lin1" eq="0.5+value" />
+      </parameter>
+      <parameter name="t-position">
+        <logfile id="det_arc1" />
+      </parameter>
+    </location>
   </component>
+
+  <type name="East">
+    <component type="Column1">
+      <location x="-2.0+value" z="-5.0+value"/>
+    </component>
+  </type>
+  <type name="West">
+    <component type="Column2">
+      <location x="+2.0+value" z="-5.0+value"/>
+    </component>
+  </type>
+  
 
   <type name="Column1">
     <component type="panel" idstart="0" idfillbyfirst="x" idstepbyrow="2" >

--- a/tests/resources/inputs/testInstrument/fakeSNAP.xml
+++ b/tests/resources/inputs/testInstrument/fakeSNAP.xml
@@ -73,7 +73,7 @@
       <location x="+2.0+value" z="-5.0+value"/>
     </component>
   </type>
-  
+
 
   <type name="Column1">
     <component type="panel" idstart="0" idfillbyfirst="x" idstepbyrow="2" >

--- a/tests/resources/inputs/testInstrument/fakeSNAPLite.xml
+++ b/tests/resources/inputs/testInstrument/fakeSNAPLite.xml
@@ -73,7 +73,7 @@
       <location x="+2.0+value" z="-5.0+value"/>
     </component>
   </type>
-  
+
   <type name="Column1">/
     <component type="pixel" idlist="column1-id-list">
       <location name="pixel1">

--- a/tests/resources/inputs/testInstrument/fakeSNAPLite.xml
+++ b/tests/resources/inputs/testInstrument/fakeSNAPLite.xml
@@ -36,13 +36,44 @@
   -->
 
   <!--DETECTORS-->
-  <component type="Column1">
-    <location x="-2.0+value" z="-5.0+value"/>
+  <component type="East">
+    <location >
+      <parameter name="roty">
+        <logfile id="det_arc2" eq="180.0+value"/>
+      </parameter>
+      <parameter name="r-position">
+        <logfile id="det_lin2" eq="0.5+value" />
+      </parameter>
+      <parameter name="t-position">
+        <logfile id="det_arc2" />
+      </parameter>
+    </location>
   </component>
-  <component type="Column2">
-    <location x="+2.0+value" z="-5.0+value"/>
+  <component type="West">
+    <location >
+      <parameter name="roty">
+        <logfile id="det_arc1" eq="180.0+value"/>
+      </parameter>
+      <parameter name="r-position">
+        <logfile id="det_lin1" eq="0.5+value" />
+      </parameter>
+      <parameter name="t-position">
+        <logfile id="det_arc1" />
+      </parameter>
+    </location>
   </component>
 
+  <type name="East">
+    <component type="Column1">
+      <location x="-2.0+value" z="-5.0+value"/>
+    </component>
+  </type>
+  <type name="West">
+    <component type="Column2">
+      <location x="+2.0+value" z="-5.0+value"/>
+    </component>
+  </type>
+  
   <type name="Column1">/
     <component type="pixel" idlist="column1-id-list">
       <location name="pixel1">

--- a/tests/unit/backend/dao/test_GroceryListBuilder.py
+++ b/tests/unit/backend/dao/test_GroceryListBuilder.py
@@ -97,7 +97,9 @@ class TestGroceryListBuilder(unittest.TestCase):
         assert item.workspaceType == "grouping"
 
         for useLite in [True, False]:
-            item = GroceryListBuilder().fromRun(self.runNumber).grouping(self.groupingScheme).useLiteMode(useLite).build()
+            item = (
+                GroceryListBuilder().fromRun(self.runNumber).grouping(self.groupingScheme).useLiteMode(useLite).build()
+            )
             assert item.groupingScheme == self.groupingScheme
             assert item.useLiteMode == useLite
             assert item.workspaceType == "grouping"
@@ -153,12 +155,12 @@ class TestGroceryListBuilder(unittest.TestCase):
     def test_nexus_with_instrument(self):
         with pytest.raises(ValueError) as e:
             GroceryListBuilder().neutron(self.runNumber).native().source(InstrumentName="SNAP").build()
-        assert "should not specify an instrument" in str(e.value)        
+        assert "should not specify an instrument" in str(e.value)
 
     def test_diffcal_output_with_instrument(self):
         with pytest.raises(ValueError) as e:
             GroceryListBuilder().diffcal_output(self.runNumber).native().source(InstrumentName="SNAP").build()
-        assert "should not specify an instrument" in str(e.value)        
+        assert "should not specify an instrument" in str(e.value)
 
     def test_nexus_clean_and_dirty(self):
         item = GroceryListBuilder().neutron(self.runNumber).native().clean().build()

--- a/tests/unit/backend/dao/test_GroceryListBuilder.py
+++ b/tests/unit/backend/dao/test_GroceryListBuilder.py
@@ -141,12 +141,12 @@ class TestGroceryListBuilder(unittest.TestCase):
 
     def test_nexus_with_instrument(self):
         with pytest.raises(ValueError) as e:
-            item = GroceryListBuilder().neutron(self.runNumber).native().source(InstrumentName="SNAP").build()
+            GroceryListBuilder().neutron(self.runNumber).native().source(InstrumentName="SNAP").build()
         assert "should not specify an instrument" in str(e.value)        
 
     def test_diffcal_output_with_instrument(self):
         with pytest.raises(ValueError) as e:
-            item = GroceryListBuilder().diffcal_output(self.runNumber).native().source(InstrumentName="SNAP").build()
+            GroceryListBuilder().diffcal_output(self.runNumber).native().source(InstrumentName="SNAP").build()
         assert "should not specify an instrument" in str(e.value)        
 
     def test_nexus_clean_and_dirty(self):
@@ -184,8 +184,8 @@ class TestGroceryListBuilder(unittest.TestCase):
         assert groceryList[2].workspaceType == "grouping"
         assert groceryList[2].groupingScheme == self.groupingScheme
         assert groceryList[2].useLiteMode is False
-        assert groceryList[2].instrumentPropertySource == None
-        assert groceryList[2].instrumentSource == None
+        assert groceryList[2].instrumentPropertySource is None
+        assert groceryList[2].instrumentSource is None
 
     def test_build_list_hanging(self):
         builder = GroceryListBuilder()

--- a/tests/unit/backend/dao/test_GroceryListBuilder.py
+++ b/tests/unit/backend/dao/test_GroceryListBuilder.py
@@ -123,13 +123,21 @@ class TestGroceryListBuilder(unittest.TestCase):
         assert item.instrumentPropertySource == "InstrumentFilename"
         assert item.instrumentSource == self.instrumentFilename
 
-        item = GroceryListBuilder().grouping(self.runNumber, self.groupingScheme).native().source(InstrumentName="SNAP").build()
+        item = (
+            GroceryListBuilder()
+            .grouping(self.runNumber, self.groupingScheme)
+            .native()
+            .source(InstrumentName="SNAP")
+            .build()
+        )
         assert item.instrumentPropertySource == "InstrumentName"
         assert item.instrumentSource == "SNAP"
 
     def test_fail_bad_property_source(self):
         with pytest.raises(ValidationError):
-            GroceryListBuilder().grouping(self.runNumber, self.groupingScheme).native().source(MyBestFriend="trust me").build()
+            GroceryListBuilder().grouping(self.runNumber, self.groupingScheme).native().source(
+                MyBestFriend="trust me"
+            ).build()
 
     def test_fail_two_sources(self):
         with pytest.raises(RuntimeError) as e:
@@ -165,7 +173,9 @@ class TestGroceryListBuilder(unittest.TestCase):
     def test_build_list(self):
         builder = GroceryListBuilder()
         builder.neutron(self.runNumber).native().add()
-        builder.grouping(self.runNumber, self.groupingScheme).native().source(InstrumentDonor=self.instrumentDonor).add()
+        builder.grouping(self.runNumber, self.groupingScheme).native().source(
+            InstrumentDonor=self.instrumentDonor
+        ).add()
         builder.grouping(self.runNumber, self.groupingScheme).native().add()
         groceryList = builder.buildList()
         # test the list built correctly
@@ -210,7 +220,9 @@ class TestGroceryListBuilder(unittest.TestCase):
         # make the list with out any property names
         builder = GroceryListBuilder()
         builder.neutron(self.runNumber).native().add()
-        builder.grouping(self.runNumber, self.groupingScheme).native().source(InstrumentDonor=self.instrumentDonor).add()
+        builder.grouping(self.runNumber, self.groupingScheme).native().source(
+            InstrumentDonor=self.instrumentDonor
+        ).add()
         builder.grouping(self.runNumber, self.groupingScheme).native().add()
         groceryDict = builder.buildDict()
         # test the dictionary has nothing in it

--- a/tests/unit/backend/dao/test_GroceryListBuilder.py
+++ b/tests/unit/backend/dao/test_GroceryListBuilder.py
@@ -86,18 +86,18 @@ class TestGroceryListBuilder(unittest.TestCase):
         assert item.propertyName == propertyName
 
     def test_grouping_native_lite(self):
-        item = GroceryListBuilder().grouping(self.runNumber, self.groupingScheme).native().build()
+        item = GroceryListBuilder().fromRun(self.runNumber).grouping(self.groupingScheme).native().build()
         assert item.groupingScheme == self.groupingScheme
         assert item.useLiteMode is False
         assert item.workspaceType == "grouping"
 
-        item = GroceryListBuilder().grouping(self.runNumber, self.groupingScheme).lite().build()
+        item = GroceryListBuilder().fromRun(self.runNumber).grouping(self.groupingScheme).lite().build()
         assert item.groupingScheme == self.groupingScheme
         assert item.useLiteMode is True
         assert item.workspaceType == "grouping"
 
         for useLite in [True, False]:
-            item = GroceryListBuilder().grouping(self.runNumber, self.groupingScheme).useLiteMode(useLite).build()
+            item = GroceryListBuilder().fromRun(self.runNumber).grouping(self.groupingScheme).useLiteMode(useLite).build()
             assert item.groupingScheme == self.groupingScheme
             assert item.useLiteMode == useLite
             assert item.workspaceType == "grouping"
@@ -105,7 +105,8 @@ class TestGroceryListBuilder(unittest.TestCase):
     def test_grouping_with_source(self):
         item = (
             GroceryListBuilder()
-            .grouping(self.runNumber, self.groupingScheme)
+            .fromRun(self.runNumber)
+            .grouping(self.groupingScheme)
             .native()
             .source(InstrumentDonor=self.instrumentDonor)
             .build()
@@ -115,7 +116,8 @@ class TestGroceryListBuilder(unittest.TestCase):
 
         item = (
             GroceryListBuilder()
-            .grouping(self.runNumber, self.groupingScheme)
+            .fromRun(self.runNumber)
+            .grouping(self.groupingScheme)
             .native()
             .source(InstrumentFilename=self.instrumentFilename)
             .build()
@@ -125,7 +127,8 @@ class TestGroceryListBuilder(unittest.TestCase):
 
         item = (
             GroceryListBuilder()
-            .grouping(self.runNumber, self.groupingScheme)
+            .fromRun(self.runNumber)
+            .grouping(self.groupingScheme)
             .native()
             .source(InstrumentName="SNAP")
             .build()
@@ -135,13 +138,13 @@ class TestGroceryListBuilder(unittest.TestCase):
 
     def test_fail_bad_property_source(self):
         with pytest.raises(ValidationError):
-            GroceryListBuilder().grouping(self.runNumber, self.groupingScheme).native().source(
+            GroceryListBuilder().fromRun(self.runNumber).grouping(self.groupingScheme).native().source(
                 MyBestFriend="trust me"
             ).build()
 
     def test_fail_two_sources(self):
         with pytest.raises(RuntimeError) as e:
-            GroceryListBuilder().grouping(self.runNumber, self.groupingScheme).native().source(
+            GroceryListBuilder().fromRun(self.runNumber).grouping(self.groupingScheme).native().source(
                 MyBestFriend="trust me",
                 SusyFromClass="i heard it too",
             ).build()
@@ -173,10 +176,10 @@ class TestGroceryListBuilder(unittest.TestCase):
     def test_build_list(self):
         builder = GroceryListBuilder()
         builder.neutron(self.runNumber).native().add()
-        builder.grouping(self.runNumber, self.groupingScheme).native().source(
+        builder.fromRun(self.runNumber).grouping(self.groupingScheme).native().source(
             InstrumentDonor=self.instrumentDonor
         ).add()
-        builder.grouping(self.runNumber, self.groupingScheme).native().add()
+        builder.fromRun(self.runNumber).grouping(self.groupingScheme).native().add()
         groceryList = builder.buildList()
         # test the list built correctly
         assert len(groceryList) == 3
@@ -184,13 +187,13 @@ class TestGroceryListBuilder(unittest.TestCase):
         assert groceryList[0].workspaceType == "neutron"
         assert groceryList[0].runNumber == self.runNumber
         assert groceryList[0].useLiteMode is False
-        # second item is native grouping froma donor
+        # second item is native grouping from a specified donor
         assert groceryList[1].workspaceType == "grouping"
         assert groceryList[1].groupingScheme == self.groupingScheme
         assert groceryList[1].useLiteMode is False
         assert groceryList[1].instrumentPropertySource == "InstrumentDonor"
         assert groceryList[1].instrumentSource == self.instrumentDonor
-        # third item is native grouping from prev
+        # third item is native grouping with instrument from the cache
         assert groceryList[2].workspaceType == "grouping"
         assert groceryList[2].groupingScheme == self.groupingScheme
         assert groceryList[2].useLiteMode is False
@@ -220,10 +223,10 @@ class TestGroceryListBuilder(unittest.TestCase):
         # make the list with out any property names
         builder = GroceryListBuilder()
         builder.neutron(self.runNumber).native().add()
-        builder.grouping(self.runNumber, self.groupingScheme).native().source(
+        builder.fromRun(self.runNumber).grouping(self.groupingScheme).native().source(
             InstrumentDonor=self.instrumentDonor
         ).add()
-        builder.grouping(self.runNumber, self.groupingScheme).native().add()
+        builder.fromRun(self.runNumber).grouping(self.groupingScheme).native().add()
         groceryDict = builder.buildDict()
         # test the dictionary has nothing in it
         assert len(groceryDict) == 0

--- a/tests/unit/backend/dao/test_GroceryListItem.py
+++ b/tests/unit/backend/dao/test_GroceryListItem.py
@@ -13,6 +13,7 @@ from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
 from snapred.meta.builder.GroceryListBuilder import GroceryListBuilder
 from snapred.meta.Config import Resource
 
+
 class TestGroceryListItem(unittest.TestCase):
     # we only need this workspace made once for entire test suite
     @classmethod

--- a/tests/unit/backend/dao/test_GroceryListItem.py
+++ b/tests/unit/backend/dao/test_GroceryListItem.py
@@ -13,7 +13,6 @@ from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
 from snapred.meta.builder.GroceryListBuilder import GroceryListBuilder
 from snapred.meta.Config import Resource
 
-
 class TestGroceryListItem(unittest.TestCase):
     # we only need this workspace made once for entire test suite
     @classmethod

--- a/tests/unit/backend/dao/test_GroceryListItem.py
+++ b/tests/unit/backend/dao/test_GroceryListItem.py
@@ -52,6 +52,7 @@ class TestGroceryListItem(unittest.TestCase):
         try:
             GroceryListItem(
                 workspaceType="grouping",
+                runNumber=self.runNumber,
                 useLiteMode=True,
                 groupingScheme="Column",
                 instrumentPropertySource="InstrumentDonor",
@@ -68,11 +69,23 @@ class TestGroceryListItem(unittest.TestCase):
             )
             assert "you must set the run config" in e.msg()
 
+    def test_grouping_needs_runNumber(self):
+        # test needs runNumber
+        with pytest.raises(ValueError) as e:
+            GroceryListItem(
+                workspaceType="grouping",
+                groupingScheme="Column",
+                instrumentPropertySource="InstrumentDonor",
+                instrumentSource=self.instrumentDonor,
+            )
+            assert "run number" in e.msg()
+
     def test_grouping_needs_useLiteMode(self):
         # test needs useLiteMode
         with pytest.raises(ValueError) as e:
             GroceryListItem(
                 workspaceType="grouping",
+                runNumber=self.runNumber,
                 groupingScheme="Column",
                 instrumentPropertySource="InstrumentDonor",
                 instrumentSource=self.instrumentDonor,
@@ -84,33 +97,36 @@ class TestGroceryListItem(unittest.TestCase):
         with pytest.raises(ValueError) as e:
             GroceryListItem(
                 workspaceType="grouping",
+                runNumber=self.runNumber,
                 useLiteMode=True,
                 instrumentPropertySource="InstrumentDonor",
                 instrumentSource=self.instrumentDonor,
             )
             assert "grouping scheme" in e.msg()
 
-    def test_grouping_needs_propertySource(self):
-        # test needs instrument property source
+    def test_neutron_with_instrument(self):
+        # workspaceType "neutron" should not specify an instrument
         with pytest.raises(ValueError) as e:
             GroceryListItem(
-                workspaceType="grouping",
+                workspaceType="neutron",
+                runNumber=self.runNumber,
                 useLiteMode=True,
-                groupingScheme="Column",
+                instrumentPropertySource="InstrumentDonor",
                 instrumentSource=self.instrumentDonor,
             )
-            assert "instrument source" in e.msg()
+            assert "should not specify an instrument" in e.msg()
 
-    def test_grouping_needs_instrumentSource(self):
-        # test needs instrument source
+    def test_grouping_incomplete_instrumentSource(self):
+        # workspaceType "grouping" needs a complete instrument source
         with pytest.raises(ValueError) as e:
             GroceryListItem(
                 workspaceType="grouping",
+                runNumber=self.runNumber,
                 useLiteMode=True,
                 groupingScheme="Column",
                 instrumentPropertySource="InstrumentDonor",
             )
-            assert "instrument source" in e.msg()
+            assert "if 'instrumentPropertySource' is specified then 'instrumentSource' must be specified" in e.msg()
 
     def test_builder(self):
         builder = GroceryListItem.builder()

--- a/tests/unit/backend/data/test_DataExportService.py
+++ b/tests/unit/backend/data/test_DataExportService.py
@@ -1,3 +1,5 @@
+
+import pytest
 import unittest.mock as mock
 
 # Mock out of scope modules before importing DataExportService
@@ -29,12 +31,12 @@ with mock.patch.dict(
         dataExportService.exportCalibrationRecord(mock.Mock())
         assert dataExportService.dataService.writeCalibrationRecord.called
 
-    def test_exportCalibrationReductionResult():
+    def test_exportCalibrationWorkspaces():
         dataExportService = DataExportService()
-        dataExportService.dataService.writeCalibrationReductionResult = mock.Mock()
-        dataExportService.dataService.writeCalibrationReductionResult.return_value = "expected"
-        dataExportService.exportCalibrationReductionResult(mock.Mock(), mock.Mock())
-        assert dataExportService.dataService.writeCalibrationReductionResult.called
+        dataExportService.dataService.writeCalibrationWorkspaces = mock.Mock()
+        dataExportService.dataService.writeCalibrationWorkspaces.return_value = "expected"
+        dataExportService.exportCalibrationWorkspaces(mock.Mock())
+        assert dataExportService.dataService.writeCalibrationWorkspaces.called
 
     def test_exportCalibrationState():
         dataExportService = DataExportService()
@@ -65,3 +67,24 @@ with mock.patch.dict(
         dataExportService.dataService.writeNormalizationRecord.return_value = "expected"
         dataExportService.exportNormalizationRecord(mock.Mock())
         assert dataExportService.dataService.writeNormalizationRecord.called
+
+    def test_exportNormalizationWorkspaces():
+        dataExportService = DataExportService()
+        dataExportService.dataService.writeNormalizationWorkspaces = mock.Mock()
+        dataExportService.dataService.writeNormalizationWorkspaces.return_value = "expected"
+        dataExportService.exportNormalizationWorkspaces(mock.Mock())
+        assert dataExportService.dataService.writeNormalizationWorkspaces.called
+
+# this at teardown removes the loggers, eliminating logger error printouts
+# see https://github.com/pytest-dev/pytest/issues/5502#issuecomment-647157873
+@pytest.fixture(autouse=True)
+def clear_loggers():  # noqa: PT004
+    """Remove handlers from all loggers"""
+    import logging
+
+    yield  # ... teardown follows:
+    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
+    for logger in loggers:
+        handlers = getattr(logger, "handlers", [])
+        for handler in handlers:
+            logger.removeHandler(handler)

--- a/tests/unit/backend/data/test_DataExportService.py
+++ b/tests/unit/backend/data/test_DataExportService.py
@@ -1,6 +1,6 @@
+import unittest.mock as mock
 
 import pytest
-import unittest.mock as mock
 
 # Mock out of scope modules before importing DataExportService
 # mock.patch("snapred.backend.data"] = mock.Mock()
@@ -74,6 +74,7 @@ with mock.patch.dict(
         dataExportService.dataService.writeNormalizationWorkspaces.return_value = "expected"
         dataExportService.exportNormalizationWorkspaces(mock.Mock())
         assert dataExportService.dataService.writeNormalizationWorkspaces.called
+
 
 # this at teardown removes the loggers, eliminating logger error printouts
 # see https://github.com/pytest-dev/pytest/issues/5502#issuecomment-647157873

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -987,7 +987,7 @@ class TestGroceryService(unittest.TestCase):
     @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
     def test_fetch_grocery_list_diffcal_output_cached(self, mockCalibrationDataPath):
         # Test of workspace type "diffcal_output" as `Input` argument in the `GroceryList`:
-        #   workspace already in ADS        
+        #   workspace already in ADS
         mockCalibrationDataPath.return_value = "/does/not/exist"
         groceryList = GroceryListItem.builder().native().diffcal_output(self.runNumber1).buildList()
         diffCalOutputName = wng.diffCalOutput().runNumber(self.runNumber1).build()
@@ -1025,7 +1025,7 @@ class TestGroceryService(unittest.TestCase):
     @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
     def test_fetch_grocery_list_diffcal_table_cached(self, mockCalibrationDataPath):
         # Test of workspace type "diffcal_table" as `Input` argument in the `GroceryList`:
-        #   workspace already in ADS        
+        #   workspace already in ADS
         mockCalibrationDataPath.return_value = "/does/not/exist"
         groceryList = GroceryListItem.builder().native().diffcal_table(self.runNumber1).buildList()
         diffCalTableName = wng.diffCalTable().runNumber(self.runNumber1).build()
@@ -1089,7 +1089,7 @@ class TestGroceryService(unittest.TestCase):
     @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
     def test_fetch_grocery_list_diffcal_mask_cached(self, mockCalibrationDataPath):
         # Test of workspace type "diffcal_mask" as `Input` argument in the `GroceryList`:
-        #   workspace already in ADS        
+        #   workspace already in ADS
         mockCalibrationDataPath.return_value = "/does/not/exist"
         groceryList = GroceryListItem.builder().native().diffcal_mask(self.runNumber1).buildList()
         diffCalMaskName = wng.diffCalMask().runNumber(self.runNumber1).build()
@@ -1160,11 +1160,17 @@ class TestGroceryService(unittest.TestCase):
 
         clerk = GroceryListItem.builder()
         clerk.native().neutron(self.runNumber).add()
-        clerk.native().fromRun(self.runNumber).grouping(self.groupingScheme).source(InstrumentDonor=cleanWorkspace).add()
+        clerk.native().fromRun(self.runNumber).grouping(self.groupingScheme).source(
+            InstrumentDonor=cleanWorkspace
+        ).add()
         groceryList = clerk.buildList()
 
         groupItemWithSource = (
-            clerk.native().fromRun(self.runNumber).grouping(self.groupingScheme).source(InstrumentDonor=cleanWorkspace).build()
+            clerk.native()
+            .fromRun(self.runNumber)
+            .grouping(self.groupingScheme)
+            .source(InstrumentDonor=cleanWorkspace)
+            .build()
         )
 
         res = self.instance.fetchGroceryList(groceryList)
@@ -1229,13 +1235,15 @@ class TestGroceryService(unittest.TestCase):
     @mock.patch.object(GroceryService, "_createRawNeutronWorkspaceName")
     @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
     @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
-    def test_fetch_instrument_donor_neutron_data(self,
-        mockUpdateInstrumentCacheFromADS, # noqa: ARG002
-        mockUpdateNeutronCacheFromADS, # noqa: ARG002
-        mockCreateRawNeutronWorkspaceName
+    def test_fetch_instrument_donor_neutron_data(
+        self,
+        mockUpdateInstrumentCacheFromADS,  # noqa: ARG002
+        mockUpdateNeutronCacheFromADS,  # noqa: ARG002
+        mockCreateRawNeutronWorkspaceName,
+    ):
+        with mock.patch.dict(self.instance._loadedRuns, {(self.runNumber, self.useLiteMode): 0}), mock.patch.dict(
+            self.instance._loadedInstruments, {}
         ):
-        with mock.patch.dict(self.instance._loadedRuns, {(self.runNumber, self.useLiteMode): 0}),\
-            mock.patch.dict(self.instance._loadedInstruments, {}):
             mockCreateRawNeutronWorkspaceName.return_value = self.sampleWS
             testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode)
             assert testWS == self.sampleWS
@@ -1243,39 +1251,43 @@ class TestGroceryService(unittest.TestCase):
     @mock.patch.object(GroceryService, "_createRawNeutronWorkspaceName")
     @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
     @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
-    def test_fetch_instrument_donor_neutron_data_is_cached(self,
-        mockUpdateInstrumentCacheFromADS, # noqa: ARG002
-        mockUpdateNeutronCacheFromADS, # noqa: ARG002
-        mockCreateRawNeutronWorkspaceName
-        ):
-        with mock.patch.dict(self.instance._loadedRuns, {(self.runNumber, self.useLiteMode): 0}),\
-            mock.patch.dict(self.instance._loadedInstruments, {}) as mockLoadedInstruments:
+    def test_fetch_instrument_donor_neutron_data_is_cached(
+        self,
+        mockUpdateInstrumentCacheFromADS,  # noqa: ARG002
+        mockUpdateNeutronCacheFromADS,  # noqa: ARG002
+        mockCreateRawNeutronWorkspaceName,
+    ):
+        with mock.patch.dict(self.instance._loadedRuns, {(self.runNumber, self.useLiteMode): 0}), mock.patch.dict(
+            self.instance._loadedInstruments, {}
+        ) as mockLoadedInstruments:
             mockCreateRawNeutronWorkspaceName.return_value = self.sampleWS
-            testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode) # noqa: F841
+            testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode)  # noqa: F841
             assert mockLoadedInstruments == {(self.runNumber, self.useLiteMode): self.sampleWS}
 
     @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
     @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
-    def test_fetch_instrument_donor_cached(self,
-        mockUpdateInstrumentCacheFromADS, # noqa: ARG002
-        mockUpdateNeutronCacheFromADS # noqa: ARG002
+    def test_fetch_instrument_donor_cached(
+        self,
+        mockUpdateInstrumentCacheFromADS,  # noqa: ARG002
+        mockUpdateNeutronCacheFromADS,  # noqa: ARG002
+    ):
+        with mock.patch.dict(self.instance._loadedRuns, {}), mock.patch.dict(
+            self.instance._loadedInstruments, {(self.runNumber, self.useLiteMode): self.sampleWS}
         ):
-        with mock.patch.dict(self.instance._loadedRuns, {}),\
-            mock.patch.dict(self.instance._loadedInstruments, {(self.runNumber, self.useLiteMode): self.sampleWS}):
             testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode)
             assert testWS == self.sampleWS
 
     @mock.patch.object(GroceryService, "_getDetectorState")
     @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
     @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
-    def test_fetch_instrument_donor_empty_instrument(self,
-        mockUpdateInstrumentCacheFromADS, # noqa: ARG002
-        mockUpdateNeutronCacheFromADS, # noqa: ARG002
-        mockGetDetectorState
-        ):
+    def test_fetch_instrument_donor_empty_instrument(
+        self,
+        mockUpdateInstrumentCacheFromADS,  # noqa: ARG002
+        mockUpdateNeutronCacheFromADS,  # noqa: ARG002
+        mockGetDetectorState,
+    ):
         mockGetDetectorState.return_value = self.detectorState2
-        with mock.patch.dict(self.instance._loadedRuns, {}),\
-            mock.patch.dict(self.instance._loadedInstruments, {}):
+        with mock.patch.dict(self.instance._loadedRuns, {}), mock.patch.dict(self.instance._loadedInstruments, {}):
             testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode)
             assert mtd.doesExist(testWS)
             assert not testWS == self.sampleWS
@@ -1292,14 +1304,16 @@ class TestGroceryService(unittest.TestCase):
     @mock.patch.object(GroceryService, "_getDetectorState")
     @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
     @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
-    def test_fetch_instrument_donor_empty_instrument_is_cached(self,
-        mockUpdateInstrumentCacheFromADS, # noqa: ARG002
-        mockUpdateNeutronCacheFromADS, # noqa: ARG002
-        mockGetDetectorState
-        ):
+    def test_fetch_instrument_donor_empty_instrument_is_cached(
+        self,
+        mockUpdateInstrumentCacheFromADS,  # noqa: ARG002
+        mockUpdateNeutronCacheFromADS,  # noqa: ARG002
+        mockGetDetectorState,
+    ):
         mockGetDetectorState.return_value = self.detectorState2
-        with mock.patch.dict(self.instance._loadedRuns, {}),\
-            mock.patch.dict(self.instance._loadedInstruments, {}) as mockLoadedInstruments:
+        with mock.patch.dict(self.instance._loadedRuns, {}), mock.patch.dict(
+            self.instance._loadedInstruments, {}
+        ) as mockLoadedInstruments:
             testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode)
             assert mockLoadedInstruments == {(self.runNumber, self.useLiteMode): testWS}
 

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -285,7 +285,7 @@ class TestGroceryService(unittest.TestCase):
     def test_diffcal_output_workspacename(self):
         # Test name generation for diffraction-calibration focussed-data workspace
         res = self.instance._createDiffcalOutputWorkspaceName(self.runNumber)
-        assert "dsp" in res
+        assert "tof" in res
         assert self.runNumber in res
         assert "diffoc" in res
 
@@ -989,22 +989,20 @@ class TestGroceryService(unittest.TestCase):
     def test_fetch_grocery_list_diffcal_output_cached(self, mockCalibrationDataPath):
         # Test of workspace type "diffcal_output" as `Input` argument in the `GroceryList`:
         #   workspace already in ADS        
-        path = Resource.getPath("outputs")
-        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpPath:
-            mockCalibrationDataPath.return_value = "/does/not/exist"
-            groceryList = GroceryListItem.builder().native().diffcal_output(self.runNumber1).buildList()
-            diffCalOutputName = wng.diffCalOutput().runNumber(self.runNumber1).build()
-            CloneWorkspace(
-                InputWorkspace=self.sampleWS,
-                OutputWorkspace=diffCalOutputName,
-            )
-            assert mtd.doesExist(diffCalOutputName)
-            testTitle = "I'm a little teapot"
-            mtd[diffCalOutputName].setTitle(testTitle)
-            items = self.instance.fetchGroceryList(groceryList)
-            assert items[0] == diffCalOutputName
-            assert mtd.doesExist(diffCalOutputName)
-            assert mtd[diffCalOutputName].getTitle() == testTitle
+        mockCalibrationDataPath.return_value = "/does/not/exist"
+        groceryList = GroceryListItem.builder().native().diffcal_output(self.runNumber1).buildList()
+        diffCalOutputName = wng.diffCalOutput().runNumber(self.runNumber1).build()
+        CloneWorkspace(
+            InputWorkspace=self.sampleWS,
+            OutputWorkspace=diffCalOutputName,
+        )
+        assert mtd.doesExist(diffCalOutputName)
+        testTitle = "I'm a little teapot"
+        mtd[diffCalOutputName].setTitle(testTitle)
+        items = self.instance.fetchGroceryList(groceryList)
+        assert items[0] == diffCalOutputName
+        assert mtd.doesExist(diffCalOutputName)
+        assert mtd[diffCalOutputName].getTitle() == testTitle
 
     @mock.patch.object(GroceryService, "_fetchInstrumentDonor")
     @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
@@ -1029,22 +1027,20 @@ class TestGroceryService(unittest.TestCase):
     def test_fetch_grocery_list_diffcal_table_cached(self, mockCalibrationDataPath):
         # Test of workspace type "diffcal_table" as `Input` argument in the `GroceryList`:
         #   workspace already in ADS        
-        path = Resource.getPath("outputs")
-        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpPath:
-            mockCalibrationDataPath.return_value = "/does/not/exist"
-            groceryList = GroceryListItem.builder().native().diffcal_table(self.runNumber1).buildList()
-            diffCalTableName = wng.diffCalTable().runNumber(self.runNumber1).build()
-            CloneWorkspace(
-                InputWorkspace=self.sampleTableWS,
-                OutputWorkspace=diffCalTableName,
-            )
-            assert mtd.doesExist(diffCalTableName)
-            testTitle = "I'm a little teapot"
-            mtd[diffCalTableName].setTitle(testTitle)
-            items = self.instance.fetchGroceryList(groceryList)
-            assert items[0] == diffCalTableName
-            assert mtd.doesExist(diffCalTableName)
-            assert mtd[diffCalTableName].getTitle() == testTitle
+        mockCalibrationDataPath.return_value = "/does/not/exist"
+        groceryList = GroceryListItem.builder().native().diffcal_table(self.runNumber1).buildList()
+        diffCalTableName = wng.diffCalTable().runNumber(self.runNumber1).build()
+        CloneWorkspace(
+            InputWorkspace=self.sampleTableWS,
+            OutputWorkspace=diffCalTableName,
+        )
+        assert mtd.doesExist(diffCalTableName)
+        testTitle = "I'm a little teapot"
+        mtd[diffCalTableName].setTitle(testTitle)
+        items = self.instance.fetchGroceryList(groceryList)
+        assert items[0] == diffCalTableName
+        assert mtd.doesExist(diffCalTableName)
+        assert mtd[diffCalTableName].getTitle() == testTitle
 
     @mock.patch.object(GroceryService, "_fetchInstrumentDonor")
     @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
@@ -1095,31 +1091,29 @@ class TestGroceryService(unittest.TestCase):
     def test_fetch_grocery_list_diffcal_mask_cached(self, mockCalibrationDataPath):
         # Test of workspace type "diffcal_mask" as `Input` argument in the `GroceryList`:
         #   workspace already in ADS        
-        path = Resource.getPath("outputs")
-        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpPath:
-            mockCalibrationDataPath.return_value = "/does/not/exist"
-            groceryList = GroceryListItem.builder().native().diffcal_mask(self.runNumber1).buildList()
-            diffCalMaskName = wng.diffCalMask().runNumber(self.runNumber1).build()
-            CloneWorkspace(
-                InputWorkspace=self.sampleMaskWS,
-                OutputWorkspace=diffCalMaskName,
-            )
-            assert mtd.doesExist(diffCalMaskName)
-            testTitle = "I'm a little teapot"
-            mtd[diffCalMaskName].setTitle(testTitle)
+        mockCalibrationDataPath.return_value = "/does/not/exist"
+        groceryList = GroceryListItem.builder().native().diffcal_mask(self.runNumber1).buildList()
+        diffCalMaskName = wng.diffCalMask().runNumber(self.runNumber1).build()
+        CloneWorkspace(
+            InputWorkspace=self.sampleMaskWS,
+            OutputWorkspace=diffCalMaskName,
+        )
+        assert mtd.doesExist(diffCalMaskName)
+        testTitle = "I'm a little teapot"
+        mtd[diffCalMaskName].setTitle(testTitle)
 
-            # Reloading is triggered based on whether or not the corresponding table workspace is in the ADS.
-            diffCalTableName = wng.diffCalTable().runNumber(self.runNumber1).build()
-            CloneWorkspace(
-                InputWorkspace=self.sampleTableWS,
-                OutputWorkspace=diffCalTableName,
-            )
-            assert mtd.doesExist(diffCalTableName)
+        # Reloading is triggered based on whether or not the corresponding table workspace is in the ADS.
+        diffCalTableName = wng.diffCalTable().runNumber(self.runNumber1).build()
+        CloneWorkspace(
+            InputWorkspace=self.sampleTableWS,
+            OutputWorkspace=diffCalTableName,
+        )
+        assert mtd.doesExist(diffCalTableName)
 
-            items = self.instance.fetchGroceryList(groceryList)
-            assert items[0] == diffCalMaskName
-            assert mtd.doesExist(diffCalMaskName)
-            assert mtd[diffCalMaskName].getTitle() == testTitle
+        items = self.instance.fetchGroceryList(groceryList)
+        assert items[0] == diffCalMaskName
+        assert mtd.doesExist(diffCalMaskName)
+        assert mtd[diffCalMaskName].getTitle() == testTitle
 
     @mock.patch.object(GroceryService, "_fetchInstrumentDonor")
     @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
@@ -1223,7 +1217,8 @@ class TestGroceryService(unittest.TestCase):
     @mock.patch.object(GroceryService, "_createRawNeutronWorkspaceName")
     @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
     @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
-    def test_fetch_instrument_donor_neutron_data(self, mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS, mockCreateRawNeutronWorkspaceName):
+    def test_fetch_instrument_donor_neutron_data(self, # noqa: ARG002
+        mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS, mockCreateRawNeutronWorkspaceName):
         with mock.patch.dict(self.instance._loadedRuns, {(self.runNumber, self.useLiteMode): 0}) as mockLoadedRuns,\
             mock.patch.dict(self.instance._loadedInstruments, {}) as mockLoadedInstruments:
             mockCreateRawNeutronWorkspaceName.return_value = self.sampleWS
@@ -1233,28 +1228,31 @@ class TestGroceryService(unittest.TestCase):
     @mock.patch.object(GroceryService, "_createRawNeutronWorkspaceName")
     @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
     @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
-    def test_fetch_instrument_donor_neutron_data_is_cached(self, mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS, mockCreateRawNeutronWorkspaceName):
-        with mock.patch.dict(self.instance._loadedRuns, {(self.runNumber, self.useLiteMode): 0}) as mockLoadedRuns,\
+    def test_fetch_instrument_donor_neutron_data_is_cached(self, # noqa: ARG002
+        mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS, mockCreateRawNeutronWorkspaceName):
+        with mock.patch.dict(self.instance._loadedRuns, {(self.runNumber, self.useLiteMode): 0}),\
             mock.patch.dict(self.instance._loadedInstruments, {}) as mockLoadedInstruments:
             mockCreateRawNeutronWorkspaceName.return_value = self.sampleWS
-            testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode)
+            testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode) # noqa: F841
             assert mockLoadedInstruments == {(self.runNumber, self.useLiteMode): self.sampleWS}
 
     @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
     @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
-    def test_fetch_instrument_donor_cached(self, mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS):
-        with mock.patch.dict(self.instance._loadedRuns, {}) as mockLoadedRuns,\
-            mock.patch.dict(self.instance._loadedInstruments, {(self.runNumber, self.useLiteMode): self.sampleWS}) as mockLoadedInstruments:
+    def test_fetch_instrument_donor_cached(self, # noqa: ARG002
+        mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS):
+        with mock.patch.dict(self.instance._loadedRuns, {}),\
+            mock.patch.dict(self.instance._loadedInstruments, {(self.runNumber, self.useLiteMode): self.sampleWS}):
             testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode)
             assert testWS == self.sampleWS
             
     @mock.patch.object(GroceryService, "_getDetectorState")
     @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
     @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
-    def test_fetch_instrument_donor_empty_instrument(self, mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS, mockGetDetectorState):
+    def test_fetch_instrument_donor_empty_instrument(self, # noqa: ARG002
+        mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS, mockGetDetectorState):
         mockGetDetectorState.return_value = self.detectorState2
-        with mock.patch.dict(self.instance._loadedRuns, {}) as mockLoadedRuns,\
-            mock.patch.dict(self.instance._loadedInstruments, {}) as mockLoadedInstruments:
+        with mock.patch.dict(self.instance._loadedRuns, {}),\
+            mock.patch.dict(self.instance._loadedInstruments, {}):
             testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode)
             assert mtd.doesExist(testWS)
             assert not testWS == self.sampleWS
@@ -1271,9 +1269,10 @@ class TestGroceryService(unittest.TestCase):
     @mock.patch.object(GroceryService, "_getDetectorState")
     @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
     @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
-    def test_fetch_instrument_donor_empty_instrument_is_cached(self, mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS, mockGetDetectorState):
+    def test_fetch_instrument_donor_empty_instrument_is_cached(self, # noqa: ARG002
+        mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS, mockGetDetectorState):
         mockGetDetectorState.return_value = self.detectorState2
-        with mock.patch.dict(self.instance._loadedRuns, {}) as mockLoadedRuns,\
+        with mock.patch.dict(self.instance._loadedRuns, {}),\
             mock.patch.dict(self.instance._loadedInstruments, {}) as mockLoadedInstruments:
             testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode)
             assert mockLoadedInstruments == {(self.runNumber, self.useLiteMode): testWS}
@@ -1290,7 +1289,8 @@ class TestGroceryService(unittest.TestCase):
     def test_update_instrument_cache_from_ADS_cache_del(self, mockCreateRawNeutronWorkspaceName):
         testWSName = "not_any_workspace"
         mockCreateRawNeutronWorkspaceName.return_value = testWSName
-        with mock.patch.dict(self.instance._loadedInstruments, {(self.runNumber, self.useLiteMode): testWSName}) as mockLoadedInstruments:
+        with mock.patch.dict(self.instance._loadedInstruments, {(self.runNumber, self.useLiteMode): testWSName})\
+            as mockLoadedInstruments:
             self.instance._updateInstrumentCacheFromADS(self.runNumber, self.useLiteMode)
             assert mockLoadedInstruments == {}
     
@@ -1299,13 +1299,6 @@ class TestGroceryService(unittest.TestCase):
         mockReadDetectorState.return_value = self.detectorState1
         detectorState = self.instance._getDetectorState(self.runNumber)
         assert detectorState == self.detectorState1
- 
-    @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
-    def test_get_detector_state(self, mockConstructCalibrationDataPath):
-        testPath = "some/path/that/may_not_exist/"
-        mockConstructCalibrationDataPath.return_value = testPath
-        calibrationDataPath = self.instance._getCalibrationDataPath(self.runNumber, self.version)
-        assert calibrationDataPath == testPath
 
     @mock.patch(ThisService + "mtd")
     def test_unique_hidden_name(self, mockADS):

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -986,23 +986,21 @@ class TestGroceryService(unittest.TestCase):
     @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
     def test_fetch_grocery_list_diffcal_output_cached(self, mockCalibrationDataPath):
         # Test of workspace type "diffcal_output" as `Input` argument in the `GroceryList`:
-        #   workspace already in ADS
-        path = Resource.getPath("outputs")
-        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpPath:
-            mockCalibrationDataPath.return_value = "/does/not/exist"
-            groceryList = GroceryListItem.builder().native().diffcal_output(self.runNumber1).buildList()
-            diffCalOutputName = wng.diffCalOutput().runNumber(self.runNumber1).build()
-            CloneWorkspace(
-                InputWorkspace=self.sampleWS,
-                OutputWorkspace=diffCalOutputName,
-            )
-            assert mtd.doesExist(diffCalOutputName)
-            testTitle = "I'm a little teapot"
-            mtd[diffCalOutputName].setTitle(testTitle)
-            items = self.instance.fetchGroceryList(groceryList)
-            assert items[0] == diffCalOutputName
-            assert mtd.doesExist(diffCalOutputName)
-            assert mtd[diffCalOutputName].getTitle() == testTitle
+        #   workspace already in ADS        
+        mockCalibrationDataPath.return_value = "/does/not/exist"
+        groceryList = GroceryListItem.builder().native().diffcal_output(self.runNumber1).buildList()
+        diffCalOutputName = wng.diffCalOutput().runNumber(self.runNumber1).build()
+        CloneWorkspace(
+            InputWorkspace=self.sampleWS,
+            OutputWorkspace=diffCalOutputName,
+        )
+        assert mtd.doesExist(diffCalOutputName)
+        testTitle = "I'm a little teapot"
+        mtd[diffCalOutputName].setTitle(testTitle)
+        items = self.instance.fetchGroceryList(groceryList)
+        assert items[0] == diffCalOutputName
+        assert mtd.doesExist(diffCalOutputName)
+        assert mtd[diffCalOutputName].getTitle() == testTitle
 
     @mock.patch.object(GroceryService, "_fetchInstrumentDonor")
     @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
@@ -1026,23 +1024,21 @@ class TestGroceryService(unittest.TestCase):
     @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
     def test_fetch_grocery_list_diffcal_table_cached(self, mockCalibrationDataPath):
         # Test of workspace type "diffcal_table" as `Input` argument in the `GroceryList`:
-        #   workspace already in ADS
-        path = Resource.getPath("outputs")
-        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpPath:
-            mockCalibrationDataPath.return_value = "/does/not/exist"
-            groceryList = GroceryListItem.builder().native().diffcal_table(self.runNumber1).buildList()
-            diffCalTableName = wng.diffCalTable().runNumber(self.runNumber1).build()
-            CloneWorkspace(
-                InputWorkspace=self.sampleTableWS,
-                OutputWorkspace=diffCalTableName,
-            )
-            assert mtd.doesExist(diffCalTableName)
-            testTitle = "I'm a little teapot"
-            mtd[diffCalTableName].setTitle(testTitle)
-            items = self.instance.fetchGroceryList(groceryList)
-            assert items[0] == diffCalTableName
-            assert mtd.doesExist(diffCalTableName)
-            assert mtd[diffCalTableName].getTitle() == testTitle
+        #   workspace already in ADS        
+        mockCalibrationDataPath.return_value = "/does/not/exist"
+        groceryList = GroceryListItem.builder().native().diffcal_table(self.runNumber1).buildList()
+        diffCalTableName = wng.diffCalTable().runNumber(self.runNumber1).build()
+        CloneWorkspace(
+            InputWorkspace=self.sampleTableWS,
+            OutputWorkspace=diffCalTableName,
+        )
+        assert mtd.doesExist(diffCalTableName)
+        testTitle = "I'm a little teapot"
+        mtd[diffCalTableName].setTitle(testTitle)
+        items = self.instance.fetchGroceryList(groceryList)
+        assert items[0] == diffCalTableName
+        assert mtd.doesExist(diffCalTableName)
+        assert mtd[diffCalTableName].getTitle() == testTitle
 
     @mock.patch.object(GroceryService, "_fetchInstrumentDonor")
     @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
@@ -1092,19 +1088,17 @@ class TestGroceryService(unittest.TestCase):
     @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
     def test_fetch_grocery_list_diffcal_mask_cached(self, mockCalibrationDataPath):
         # Test of workspace type "diffcal_mask" as `Input` argument in the `GroceryList`:
-        #   workspace already in ADS
-        path = Resource.getPath("outputs")
-        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpPath:
-            mockCalibrationDataPath.return_value = "/does/not/exist"
-            groceryList = GroceryListItem.builder().native().diffcal_mask(self.runNumber1).buildList()
-            diffCalMaskName = wng.diffCalMask().runNumber(self.runNumber1).build()
-            CloneWorkspace(
-                InputWorkspace=self.sampleMaskWS,
-                OutputWorkspace=diffCalMaskName,
-            )
-            assert mtd.doesExist(diffCalMaskName)
-            testTitle = "I'm a little teapot"
-            mtd[diffCalMaskName].setTitle(testTitle)
+        #   workspace already in ADS        
+        mockCalibrationDataPath.return_value = "/does/not/exist"
+        groceryList = GroceryListItem.builder().native().diffcal_mask(self.runNumber1).buildList()
+        diffCalMaskName = wng.diffCalMask().runNumber(self.runNumber1).build()
+        CloneWorkspace(
+            InputWorkspace=self.sampleMaskWS,
+            OutputWorkspace=diffCalMaskName,
+        )
+        assert mtd.doesExist(diffCalMaskName)
+        testTitle = "I'm a little teapot"
+        mtd[diffCalMaskName].setTitle(testTitle)
 
         # Reloading is triggered based on whether or not the corresponding table workspace is in the ADS.
         diffCalTableName = wng.diffCalTable().runNumber(self.runNumber1).build()
@@ -1234,12 +1228,13 @@ class TestGroceryService(unittest.TestCase):
     @mock.patch.object(GroceryService, "_createRawNeutronWorkspaceName")
     @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
     @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
-    def test_fetch_instrument_donor_neutron_data(
-        self, mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS, mockCreateRawNeutronWorkspaceName
-    ):
-        with mock.patch.dict(
-            self.instance._loadedRuns, {(self.runNumber, self.useLiteMode): 0}
-        ) as mockLoadedRuns, mock.patch.dict(self.instance._loadedInstruments, {}) as mockLoadedInstruments:
+    def test_fetch_instrument_donor_neutron_data(self,
+        mockUpdateInstrumentCacheFromADS, # noqa: ARG002
+        mockUpdateNeutronCacheFromADS, # noqa: ARG002
+        mockCreateRawNeutronWorkspaceName
+        ):
+        with mock.patch.dict(self.instance._loadedRuns, {(self.runNumber, self.useLiteMode): 0}),\
+            mock.patch.dict(self.instance._loadedInstruments, {}):
             mockCreateRawNeutronWorkspaceName.return_value = self.sampleWS
             testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode)
             assert testWS == self.sampleWS
@@ -1247,31 +1242,36 @@ class TestGroceryService(unittest.TestCase):
     @mock.patch.object(GroceryService, "_createRawNeutronWorkspaceName")
     @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
     @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
-    def test_fetch_instrument_donor_neutron_data_is_cached(
-        self, mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS, mockCreateRawNeutronWorkspaceName
-    ):
-        with mock.patch.dict(
-            self.instance._loadedRuns, {(self.runNumber, self.useLiteMode): 0}
-        ) as mockLoadedRuns, mock.patch.dict(self.instance._loadedInstruments, {}) as mockLoadedInstruments:
+    def test_fetch_instrument_donor_neutron_data_is_cached(self,
+        mockUpdateInstrumentCacheFromADS, # noqa: ARG002
+        mockUpdateNeutronCacheFromADS, # noqa: ARG002
+        mockCreateRawNeutronWorkspaceName
+        ):
+        with mock.patch.dict(self.instance._loadedRuns, {(self.runNumber, self.useLiteMode): 0}),\
+            mock.patch.dict(self.instance._loadedInstruments, {}) as mockLoadedInstruments:
             mockCreateRawNeutronWorkspaceName.return_value = self.sampleWS
             testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode) # noqa: F841
             assert mockLoadedInstruments == {(self.runNumber, self.useLiteMode): self.sampleWS}
 
     @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
     @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
-    def test_fetch_instrument_donor_cached(self, mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS):
-        with mock.patch.dict(self.instance._loadedRuns, {}) as mockLoadedRuns, mock.patch.dict(
-            self.instance._loadedInstruments, {(self.runNumber, self.useLiteMode): self.sampleWS}
-        ) as mockLoadedInstruments:
+    def test_fetch_instrument_donor_cached(self,
+        mockUpdateInstrumentCacheFromADS, # noqa: ARG002
+        mockUpdateNeutronCacheFromADS # noqa: ARG002
+        ):
+        with mock.patch.dict(self.instance._loadedRuns, {}),\
+            mock.patch.dict(self.instance._loadedInstruments, {(self.runNumber, self.useLiteMode): self.sampleWS}):
             testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode)
             assert testWS == self.sampleWS
 
     @mock.patch.object(GroceryService, "_getDetectorState")
     @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
     @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
-    def test_fetch_instrument_donor_empty_instrument(
-        self, mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS, mockGetDetectorState
-    ):
+    def test_fetch_instrument_donor_empty_instrument(self,
+        mockUpdateInstrumentCacheFromADS, # noqa: ARG002
+        mockUpdateNeutronCacheFromADS, # noqa: ARG002
+        mockGetDetectorState
+        ):
         mockGetDetectorState.return_value = self.detectorState2
         with mock.patch.dict(self.instance._loadedRuns, {}) as mockLoadedRuns, mock.patch.dict(
             self.instance._loadedInstruments, {}
@@ -1292,9 +1292,11 @@ class TestGroceryService(unittest.TestCase):
     @mock.patch.object(GroceryService, "_getDetectorState")
     @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
     @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
-    def test_fetch_instrument_donor_empty_instrument_is_cached(
-        self, mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS, mockGetDetectorState
-    ):
+    def test_fetch_instrument_donor_empty_instrument_is_cached(self,
+        mockUpdateInstrumentCacheFromADS, # noqa: ARG002
+        mockUpdateNeutronCacheFromADS, # noqa: ARG002
+        mockGetDetectorState
+        ):
         mockGetDetectorState.return_value = self.detectorState2
         with mock.patch.dict(self.instance._loadedRuns, {}) as mockLoadedRuns, mock.patch.dict(
             self.instance._loadedInstruments, {}

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -270,7 +270,7 @@ class TestGroceryService(unittest.TestCase):
     def test_litedatamap_workspacename(self):
         """Test the creation of name for Lite data map"""
         res = self.instance._createGroupingWorkspaceName("Lite", self.runNumber, True)
-        assert res == f"lite_grouping_map_{self.runNumber}"
+        assert res == "lite_grouping_map"
 
     def test_diffcal_input_workspacename(self):
         # Test name generation for diffraction-calibration input workspace

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -99,7 +99,8 @@ class TestGroceryService(unittest.TestCase):
         self.instance = GroceryService()
         self.groupingItem = (
             GroceryListItem.builder()
-            .grouping(self.runNumber, self.groupingScheme)
+            .fromRun(self.runNumber)
+            .grouping(self.groupingScheme)
             .native()
             .source(InstrumentDonor=self.sampleWS)
             .build()
@@ -889,7 +890,7 @@ class TestGroceryService(unittest.TestCase):
         mockGroceryList.builder.return_value.grouping.return_value.build.return_value = mockLiteMapGroceryItem
 
         # call once and load
-        testItem = ("Lite", self.runNumber, False)
+        testItem = ("Lite", GroceryListItem.RESERVED_NATIVE_RUNID, False)
         groupingWorkspaceName = self.instance._createGroupingWorkspaceName(*testItem)
         groupKey = self.instance._key(*testItem)
 
@@ -904,7 +905,7 @@ class TestGroceryService(unittest.TestCase):
         clerk = GroceryListItem.builder()
         clerk.native().neutron(self.runNumber).add()
         clerk.native().neutron(self.runNumber).dirty().add()
-        clerk.native().grouping(self.runNumber, self.groupingScheme).source(InstrumentDonor=self.sampleWS).add()
+        clerk.native().fromRun(self.runNumber).grouping(self.groupingScheme).source(InstrumentDonor=self.sampleWS).add()
         groceryList = clerk.buildList()
 
         # expected workspaces
@@ -1159,11 +1160,11 @@ class TestGroceryService(unittest.TestCase):
 
         clerk = GroceryListItem.builder()
         clerk.native().neutron(self.runNumber).add()
-        clerk.native().grouping(self.runNumber, self.groupingScheme).source(InstrumentDonor=cleanWorkspace).add()
+        clerk.native().fromRun(self.runNumber).grouping(self.groupingScheme).source(InstrumentDonor=cleanWorkspace).add()
         groceryList = clerk.buildList()
 
         groupItemWithSource = (
-            clerk.native().grouping(self.runNumber, self.groupingScheme).source(InstrumentDonor=cleanWorkspace).build()
+            clerk.native().fromRun(self.runNumber).grouping(self.groupingScheme).source(InstrumentDonor=cleanWorkspace).build()
         )
 
         res = self.instance.fetchGroceryList(groceryList)
@@ -1345,7 +1346,7 @@ class TestGroceryService(unittest.TestCase):
     def test_fetch_grocery_dict(self, mockFetchList):
         clerk = GroceryListItem.builder()
         clerk.native().neutron(self.runNumber).name("InputWorkspace").add()
-        clerk.native().grouping(self.runNumber, self.groupingScheme).name("GroupingWorkspace").add()
+        clerk.native().fromRun(self.runNumber).grouping(self.groupingScheme).name("GroupingWorkspace").add()
         groceryDict = clerk.buildDict()
 
         # expected workspaces
@@ -1362,7 +1363,7 @@ class TestGroceryService(unittest.TestCase):
     def test_fetch_grocery_dict_with_kwargs(self, mockFetchList):
         clerk = GroceryListItem.builder()
         clerk.native().neutron(self.runNumber).name("InputWorkspace").add()
-        clerk.native().grouping(self.runNumber, self.groupingScheme).name("GroupingWorkspace").add()
+        clerk.native().fromRun(self.runNumber).grouping(self.groupingScheme).name("GroupingWorkspace").add()
         groceryDict = clerk.buildDict()
 
         # expected workspaces

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -1,25 +1,44 @@
 # ruff: noqa: E722, PT011, PT012
 
 import os
+import shutil
+from pathlib import Path
+from typing import Tuple, Dict
 import tempfile
+
 import unittest
 from curses import raw
 from unittest import mock
-
 import pytest
+
+from util.helpers import createCompatibleDiffCalTable, createCompatibleMask
+from util.kernel_helpers import tupleFromV3D, tupleFromQuat
+from util.instrument_helpers import mapFromSampleLogs
+
 from mantid.simpleapi import (
     CompareWorkspaces,
     CreateEmptyTableWorkspace,
+    LoadEmptyInstrument,
+    CreateLogPropertyTable,
+    SaveParameterFile,
+    LoadParameterFile,
     CreateGroupingWorkspace,
     CreateWorkspace,
+    CloneWorkspace,
     DeleteWorkspace,
     LoadInstrument,
+    ExtractMask,
     SaveNexusProcessed,
+    SaveDiffCal,
     mtd,
 )
+from mantid.kernel import Quat, V3D
+
 from pydantic import ValidationError
+from snapred.backend.dao.state import DetectorState
 from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
 from snapred.backend.data.GroceryService import GroceryService
+from snapred.backend.data.LocalDataService import LocalDataService
 from snapred.meta.Config import Config, Resource
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 
@@ -34,37 +53,57 @@ class TestGroceryService(unittest.TestCase):
         This is created at the start of this test suite, then deleted at the end.
         """
         cls.runNumber = "555"
-        cls.filepath = Resource.getPath(f"inputs/test_{cls.runNumber}_groceryservice.nxs")
-        cls.instrumentFilepath = Resource.getPath("inputs/testInstrument/fakeSNAP.xml")
+        cls.version = "1"
+        cls.runNumber1 = "556"
+        cls.useLiteMode = False
+        cls.version = None
+        cls.sampleWSFilePath = Resource.getPath(f"inputs/test_{cls.runNumber}_groceryservice.nxs")
+        
+        cls.instrumentFilePath = Resource.getPath("inputs/testInstrument/fakeSNAP.xml")
+        Config["instrument"]["native"]["definition"]["file"] = cls.instrumentFilePath
+        
+        cls.instrumentLiteFilePath = Resource.getPath("inputs/testInstrument/fakeSNAPLite.xml")
+        Config["instrument"]["lite"]["definition"]["file"] = cls.instrumentLiteFilePath
+        
         cls.fetchedWSname = "_fetched_grocery"
         cls.groupingScheme = "Native"
         # create some sample data
         cls.sampleWS = "_grocery_to_fetch"
-        cls.exclude = [cls.sampleWS, cls.fetchedWSname]
-        CreateWorkspace(
+
+        LoadEmptyInstrument(
+            Filename=cls.instrumentFilePath,
             OutputWorkspace=cls.sampleWS,
-            DataX=[1] * 16,
-            DataY=[1] * 16,
-            NSpec=16,
-        )
-        # load an instrument into sample data
-        LoadInstrument(
-            Workspace=cls.sampleWS,
-            Filename=cls.instrumentFilepath,
-            InstrumentName="fakeSNAP",
-            RewriteSpectraMap=True,
         )
         SaveNexusProcessed(
             InputWorkspace=cls.sampleWS,
-            Filename=cls.filepath,
+            Filename=cls.sampleWSFilePath,
         )
-        assert os.path.exists(cls.filepath)
+        assert os.path.exists(cls.sampleWSFilePath)
+        
+        cls.detectorState1 = DetectorState(arc=(1.0, 2.0), wav=3.0, freq=4.0, guideStat=1, lin=(5.0, 6.0))
+        cls.detectorState2 = DetectorState(arc=(7.0, 8.0), wav=9.0, freq=10.0, guideStat=2, lin=(11.0, 12.0))
+        
+        cls.sampleDiffCalFilePath =  Resource.getPath(f"inputs/test_diffcal_{cls.runNumber}_groceryservice.h5")
+        cls.sampleTableWS = "_table_grocery_to_fetch"
+        createCompatibleDiffCalTable(cls.sampleTableWS, cls.sampleWS)
+        cls.sampleMaskWS = "_mask_grocery_to_fetch"
+        createCompatibleMask(cls.sampleMaskWS, cls.sampleWS, cls.instrumentFilePath)
+        
+        SaveDiffCal(
+            CalibrationWorkspace=cls.sampleTableWS,
+            MaskWorkspace=cls.sampleMaskWS,
+            Filename=cls.sampleDiffCalFilePath,
+        )
+        assert os.path.exists(cls.sampleDiffCalFilePath)
 
+        cls.exclude = [cls.sampleWS, cls.fetchedWSname, cls.sampleTableWS, cls.sampleMaskWS]
+            
+ 
     def setUp(self):
         self.instance = GroceryService()
         self.groupingItem = (
             GroceryListItem.builder()
-            .grouping(self.groupingScheme)
+            .grouping(self.runNumber, self.groupingScheme)
             .native()
             .source(InstrumentDonor=self.sampleWS)
             .build()
@@ -74,7 +113,7 @@ class TestGroceryService(unittest.TestCase):
     def clearoutWorkspaces(self) -> None:
         """Delete the workspaces created by loading"""
         for ws in mtd.getObjectNames():
-            if ws != self.sampleWS:
+            if ws not in (self.sampleWS, self.sampleTableWS, self.sampleMaskWS):
                 DeleteWorkspace(ws)
 
     def tearDown(self):
@@ -91,24 +130,21 @@ class TestGroceryService(unittest.TestCase):
         """
         for ws in mtd.getObjectNames():
             DeleteWorkspace(ws)
-        os.remove(cls.filepath)
+        os.remove(cls.sampleWSFilePath)
+        os.remove(cls.sampleDiffCalFilePath)
         return super().tearDownClass()
 
-    def create_dumb_workspace(self, wsname):
+    @classmethod
+    def create_dumb_workspace(cls, wsName):
         CreateWorkspace(
-            OutputWorkspace=wsname,
+            OutputWorkspace=wsName,
             DataX=[1],
             DataY=[1],
         )
 
-    def create_dumb_diffcal(self, wsname):
-        ws = CreateEmptyTableWorkspace(OutputWorkspace=wsname)
-        ws.addColumn(type="int", name="detid", plottype=6)
-        ws.addRow({"detid": 0})
-
     ## TESTS OF FILENAME METHODS
 
-    @mock.patch("mantid.simpleapi.GetIPTS")
+    @mock.patch.object(LocalDataService, "getIPTS")
     def test_getIPTS(self, mockGetIPTS):
         mockGetIPTS.return_value = "here/"
         res = self.instance.getIPTS(self.runNumber)
@@ -126,6 +162,7 @@ class TestGroceryService(unittest.TestCase):
 
     def test_key_neutron(self):
         """ensure the key is a unique identifier for run number and lite mode"""
+        # This tests both <neutron data> and <instrument donor> key tuples.
         runId1 = "555"
         runId2 = "556"
         lite = True
@@ -143,24 +180,30 @@ class TestGroceryService(unittest.TestCase):
 
     def test_key_grouping(self):
         """ensure the key is a unique identifier for run number and lite mode"""
+        runId1 = "2462"
         grouping1 = "555"
+        runId2 = "2463"
         grouping2 = "556"
+        
         lite = True
         native = False
         # two keys with different groupings are different
-        assert self.instance._key(grouping1, lite) != self.instance._key(grouping2, lite)
+        assert self.instance._key(grouping1, runId1, lite) != self.instance._key(grouping2, runId1, lite)
         # two keys with same grouping but different resolution are different
-        assert self.instance._key(grouping1, lite) != self.instance._key(grouping1, native)
+        assert self.instance._key(grouping1, runId1, lite) != self.instance._key(grouping1, runId1, native)
+        # two keys with same grouping but different runNumber are different
+        assert self.instance._key(grouping1, runId1, lite) != self.instance._key(grouping1, runId2, native)
         # two keys with different grouping  and resolution are different
-        assert self.instance._key(grouping1, lite) != self.instance._key(grouping2, native)
-        assert self.instance._key(grouping1, native) != self.instance._key(grouping2, lite)
+        assert self.instance._key(grouping1, runId1, lite) != self.instance._key(grouping2, runId1, native)
+        assert self.instance._key(grouping1, runId1, native) != self.instance._key(grouping2, runId1, lite)
         # it is shaped like itself
-        assert self.instance._key(grouping1, lite) == self.instance._key(grouping1, lite)
-        assert self.instance._key(grouping1, native) == self.instance._key(grouping1, native)
+        assert self.instance._key(grouping1, runId1, lite) == self.instance._key(grouping1, runId1, lite)
+        assert self.instance._key(grouping1, runId1, native) == self.instance._key(grouping1, runId1, native)
 
-    @mock.patch("mantid.simpleapi.GetIPTS", mock.Mock(return_value="nowhere/"))
-    def test_nexus_filename(self):
+    @mock.patch.object(LocalDataService, "getIPTS")
+    def test_nexus_filename(self, mockGetIPTS):
         """Test the creation of the nexus filename"""
+        mockGetIPTS.return_value = "nowhere/"
         res = self.instance._createNeutronFilename(self.runNumber, False)
         assert "nowhere" in res
         assert Config["nexus.native.prefix"] in res
@@ -220,78 +263,54 @@ class TestGroceryService(unittest.TestCase):
         """Test the creation of a grouping workspace name"""
         uniqueGroupingScheme = "Fruitcake"
         self.groupingItem.groupingScheme = uniqueGroupingScheme
-        res = self.instance._createGroupingWorkspaceName(uniqueGroupingScheme, False)
+        res = self.instance._createGroupingWorkspaceName(uniqueGroupingScheme, self.runNumber, False)
         assert uniqueGroupingScheme in res
         assert "lite" not in res.lower()
-        res = self.instance._createGroupingWorkspaceName(uniqueGroupingScheme, True)
+        res = self.instance._createGroupingWorkspaceName(uniqueGroupingScheme, self.runNumber, True)
         assert uniqueGroupingScheme in res
         assert "lite" in res.lower()
 
     def test_litedatamap_workspacename(self):
         """Test the creation of name for Lite data map"""
-        res = self.instance._createGroupingWorkspaceName("Lite", True)
-        assert res == "lite_grouping_map"
+        res = self.instance._createGroupingWorkspaceName("Lite", self.runNumber, True)
+        assert res == f"lite_grouping_map_{self.runNumber}"
 
     def test_diffcal_input_workspacename(self):
-        # Test name generation for diffraction-calibration focussed-data workspace
+        # Test name generation for diffraction-calibration input workspace
         res = self.instance._createDiffcalInputWorkspaceName(self.runNumber)
         assert "tof" in res
         assert self.runNumber in res
         assert "raw" in res
 
     def test_diffcal_output_workspacename(self):
-        # Test name generation for diffraction-calibration output workspace
+        # Test name generation for diffraction-calibration focussed-data workspace
         res = self.instance._createDiffcalOutputWorkspaceName(self.runNumber)
         assert "dsp" in res
         assert self.runNumber in res
         assert "diffoc" in res
 
     def test_diffcal_table_workspacename(self):
-        # Test name generation for diffraction-calibration output workspace
+        # Test name generation for diffraction-calibration output table
         res = self.instance._createDiffcalTableWorkspaceName(self.runNumber)
         assert "difc" in res
         assert self.runNumber in res
 
     def test_diffcal_mask_workspacename(self):
-        # Test name generation for diffraction-calibration output workspace
+        # Test name generation for diffraction-calibration output mask
         res = self.instance._createDiffcalMaskWorkspaceName(self.runNumber)
         assert "difc" in res
         assert self.runNumber in res
         assert "mask" in res
 
-    ## TESTS OF WRITING METHODS
-
-    def test_writeWorkspace(self):
-        path = Resource.getPath("outputs")
-        name = "test_write_workspace"
-        self.create_dumb_workspace(name)
-        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmppath:
-            self.instance.writeWorkspace(os.path.join(tmppath, name), name)
-            assert os.path.exists(os.path.join(tmppath, name))
-        assert not os.path.exists(os.path.join(tmppath, name))
-
-    def test_writeGrouping(self):
-        path = Resource.getPath("outputs")
-        name = "test_write_grouping.hdf"
-        CreateGroupingWorkspace(
-            OutputWorkspace=name,
-            CustomGroupingString="1",
-            InstrumentFilename=Resource.getPath("inputs/testInstrument/fakeSNAP.xml"),
-        )
-        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmppath:
-            self.instance.writeGrouping(tmppath, name)
-            assert os.path.exists(os.path.join(tmppath, name))
-        assert not os.path.exists(os.path.join(tmppath, name))
-
-    def test_writeDiffCalTable(self):
-        path = Resource.getPath("outputs")
-        name = "test_write_diffcal"
-        self.create_dumb_diffcal(name)
-        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmppath:
-            self.instance.writeDiffCalTable(tmppath, name)
-            assert os.path.exists(os.path.join(tmppath, name))
-        assert not os.path.exists(os.path.join(tmppath, name))
-
+    @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
+    def test_diffcal_table_filename(self, mockConstructCalibrationDataPath):
+        # Test name generation for diffraction-calibration table filename
+        mockConstructCalibrationDataPath.return_value = "nowhere/"
+        res = self.instance._createDiffcalTableFilename(self.runNumber, self.version)
+        assert "difc" in res
+        assert self.runNumber in res
+        assert ".h5" in res
+        
     ## TESTS OF ACCESS METHODS
 
     def test_workspaceDoesExist_false(self):
@@ -312,7 +331,7 @@ class TestGroceryService(unittest.TestCase):
         assert mtd.doesExist(wsname)
         assert self.instance.getWorkspaceForName(wsname)
 
-    def test_getWorkspaceForName_unexists(self):
+    def test_getWorkspaceForName_does_not_exist(self):
         wsname = "_test_ws_"
         assert not mtd.doesExist(wsname)
         assert not self.instance.getWorkspaceForName(wsname)
@@ -391,10 +410,11 @@ class TestGroceryService(unittest.TestCase):
 
     def test_updateGroupingCacheFromADS_noop(self):
         """ws is not in cache and not in ADS"""
-        groupingScheme = "555"
+        groupingScheme = "column"
+        runId = "555"
         useLiteMode = True
         wsname = "_test_ws_"
-        key = (groupingScheme, useLiteMode)
+        key = self.instance._key(groupingScheme, runId, useLiteMode)
         self.instance._createGroupingWorkspaceName = mock.Mock(return_value=wsname)
         assert self.instance._loadedGroupings == {}
         assert not mtd.doesExist(wsname)
@@ -405,10 +425,11 @@ class TestGroceryService(unittest.TestCase):
 
     def test_updateGroupingCacheFromADS_both(self):
         """ws is in cache and in ADS"""
-        groupingScheme = "555"
+        groupingScheme = "column"
+        runId = "555"
         useLiteMode = True
         wsname = "_test_ws_"
-        key = (groupingScheme, useLiteMode)
+        key = self.instance._key(groupingScheme, runId, useLiteMode)
         self.instance._createGroupingWorkspaceName = mock.Mock(return_value=wsname)
         self.instance._loadedGroupings[key] = wsname
         self.create_dumb_workspace(wsname)
@@ -419,10 +440,11 @@ class TestGroceryService(unittest.TestCase):
 
     def test_updateGroupingCacheFromADS_cache_no_ADS(self):
         """ws is in cache but not ADS"""
-        groupingScheme = "555"
+        groupingScheme = "column"
+        runId = "555"
         useLiteMode = True
         wsname = "_test_ws_"
-        key = (groupingScheme, useLiteMode)
+        key = self.instance._key(groupingScheme, runId, useLiteMode)
         self.instance._createGroupingWorkspaceName = mock.Mock(return_value=wsname)
         self.instance._loadedGroupings[key] = wsname
         assert not mtd.doesExist(wsname)
@@ -432,10 +454,11 @@ class TestGroceryService(unittest.TestCase):
 
     def test_updateGroupingCacheFromADS_ADS_no_cache(self):
         """ws is in ADS and not in cache"""
-        groupingScheme = "555"
+        groupingScheme = "column"
+        runId = "555"
         useLiteMode = True
         wsname = "_test_ws_"
-        key = (groupingScheme, useLiteMode)
+        key = self.instance._key(groupingScheme, runId, useLiteMode)
         self.instance._createGroupingWorkspaceName = mock.Mock(return_value=wsname)
         self.create_dumb_workspace(wsname)
         assert self.instance._loadedGroupings == {}
@@ -444,15 +467,59 @@ class TestGroceryService(unittest.TestCase):
         assert self.instance._createGroupingWorkspaceName.called_once_with(groupingScheme, wsname)
         assert self.instance._loadedGroupings == {key: wsname}
 
-    def test_rebuildGroupingCache(self):
-        """Test the correct behavior of the rebuildGroupingCache method"""
-        groupingScheme = "555"
-        useLiteMode = True
+    @mock.patch.object(GroceryService, "_createRawNeutronWorkspaceName")
+    def test_updateInstrumentCacheFromADS_noop(self, mockNeutronWorkspaceName):
+        """ws is not in cache and not in ADS"""
         wsname = "_test_ws_"
-        key = (groupingScheme, useLiteMode)
-        self.instance._loadedGroupings[key] = wsname
-        self.instance.rebuildGroupingCache()
+        mockNeutronWorkspaceName.return_value = wsname
+        runId = "555"
+        useLiteMode = True
+        assert self.instance._loadedInstruments == {}
+        assert not mtd.doesExist(wsname)
+        self.instance._updateInstrumentCacheFromADS(runId, useLiteMode)
+        assert self.instance._loadedInstruments == {}
+        assert not mtd.doesExist(wsname)
+
+    @mock.patch.object(GroceryService, "_createRawNeutronWorkspaceName")
+    def test_updateInstrumentCacheFromADS_both(self, mockNeutronWorkspaceName):
+        """ws is in cache and in ADS"""
+        wsname = "_test_ws_"
+        mockNeutronWorkspaceName.return_value = wsname
+        runId = "555"
+        useLiteMode = True
+        key = self.instance._key(runId, useLiteMode)
+        self.instance._loadedInstruments[key] = wsname
+        self.create_dumb_workspace(wsname)
+        assert mtd.doesExist(wsname)
+        self.instance._updateInstrumentCacheFromADS(runId, useLiteMode)
+        assert self.instance._loadedInstruments == {key: wsname}
+
+    @mock.patch.object(GroceryService, "_createRawNeutronWorkspaceName")
+    def test_updateInstrumentCacheFromADS_cache_no_ADS(self, mockNeutronWorkspaceName):
+        """ws is in cache but not ADS"""
+        wsname = "_test_ws_"
+        mockNeutronWorkspaceName.return_value = wsname
+        runId = "555"
+        useLiteMode = True
+        key = self.instance._key(runId, useLiteMode)
+        self.instance._loadedInstruments[key] = wsname
+        assert not mtd.doesExist(wsname)
+        self.instance._updateInstrumentCacheFromADS(runId, useLiteMode)
+        assert self.instance._loadedInstruments == {}
+
+    @mock.patch.object(GroceryService, "_createRawNeutronWorkspaceName")
+    def test_updateInstrumentCacheFromADS_ADS_no_cache(self, mockNeutronWorkspaceName):
+        """ws is in ADS and not in cache"""
+        wsname = "_test_ws_"
+        mockNeutronWorkspaceName.return_value = wsname
+        runId = "555"
+        useLiteMode = True
+        key = self.instance._key(runId, useLiteMode)
+        self.create_dumb_workspace(wsname)
         assert self.instance._loadedGroupings == {}
+        assert mtd.doesExist(wsname)
+        self.instance._updateInstrumentCacheFromADS(runId, useLiteMode)
+        assert self.instance._loadedInstruments == {key: wsname}
 
     def test_rebuildNeutronCache(self):
         """Test the correct behavior of the rebuildNeutronCache method"""
@@ -463,17 +530,45 @@ class TestGroceryService(unittest.TestCase):
         self.instance.rebuildNeutronCache()
         assert self.instance._loadedRuns == {}
 
-    def test_rebuildCache(self):
-        """Test the correct behavior of the rebuildCache method"""
+    def test_rebuildGroupingCache(self):
+        """Test the correct behavior of the rebuildGroupingCache method"""
+        groupingScheme = "column"
         runId = "555"
         useLiteMode = True
         wsname = "_test_ws_"
+        key = self.instance._key(groupingScheme, runId, useLiteMode)
+        self.instance._loadedGroupings[key] = wsname
+        self.instance.rebuildGroupingCache()
+        assert self.instance._loadedGroupings == {}
+
+    @mock.patch.object(GroceryService, "_createRawNeutronWorkspaceName")
+    def test_rebuildInstrumentCache(self, mockNeutronWorkspaceName):
+        """Test the correct behavior of the rebuildInstrumentCache method"""
+        wsname = "_test_ws_"
+        mockNeutronWorkspaceName.return_value = wsname
+        runId = "555"
+        useLiteMode = True
+        key = self.instance._key(runId, useLiteMode)
+        self.instance._loadedInstruments[key] = wsname
+        self.instance.rebuildInstrumentCache()
+        assert self.instance._loadedInstruments == {}
+        
+    @mock.patch.object(GroceryService, "_createRawNeutronWorkspaceName")
+    def test_rebuildCache(self, mockNeutronWorkspaceName):
+        """Test the correct behavior of the rebuildCache method"""
+        wsname = "_test_ws_"
+        mockNeutronWorkspaceName.return_value = wsname
+        groupingScheme = "column"
+        runId = "555"
+        useLiteMode = True
         key = (runId, useLiteMode)
         self.instance._loadedRuns[key] = 1
-        self.instance._loadedGroupings[key] = wsname
+        self.instance._loadedGroupings[self.instance._key(groupingScheme, runId, useLiteMode)] = wsname
+        self.instance._loadedInstruments[key] = wsname
         self.instance.rebuildCache()
         assert self.instance._loadedRuns == {}
         assert self.instance._loadedGroupings == {}
+        assert self.instance._loadedInstruments == {}
 
     ## TEST CLEANUP METHODS
 
@@ -506,32 +601,40 @@ class TestGroceryService(unittest.TestCase):
 
     ## TEST FETCH METHODS
 
-    def test_fetch(self):
-        """Test the correct behavior of the fetch method"""
+    def test_fetchWorkspace(self):
+        """Test the correct behavior of the fetchWorkspace method"""
         self.clearoutWorkspaces()
-        res = self.instance.fetchWorkspace(self.filepath, self.fetchedWSname, "")
-        assert res == self.fetchedWSname
+        res = self.instance.fetchWorkspace(self.sampleWSFilePath, self.fetchedWSname, loader="")
+        assert res == {
+                "result": True,
+                "loader": "LoadNexusProcessed",
+                "workspace": self.fetchedWSname,
+            }
         assert CompareWorkspaces(
             Workspace1=self.sampleWS,
-            Workspace2=res,
+            Workspace2=res["workspace"],
         )
 
         # make sure it won't load same workspace name again
         self.instance.grocer.executeRecipe = mock.Mock(return_value="bad")
         assert mtd.doesExist(self.fetchedWSname)
-        res = self.instance.fetchWorkspace(self.filepath, self.fetchedWSname, "")
-        assert res == self.fetchedWSname
+        res = self.instance.fetchWorkspace(self.sampleWSFilePath, self.fetchedWSname, loader="")
+        assert res == {
+                "result": True,
+                "loader": "cached",
+                "workspace": self.fetchedWSname,
+            }
         assert self.instance.grocer.executeRecipe.not_called
         assert CompareWorkspaces(
             Workspace1=self.sampleWS,
-            Workspace2=res,
+            Workspace2=res["workspace"],
         )
 
     def test_fetch_failed(self):
         # this is some file that it can't load
         mockFilename = Resource.getPath("inputs/crystalInfo/fake_file.cif")
         with pytest.raises(RuntimeError) as e:
-            self.instance.fetchWorkspace(mockFilename, self.fetchedWSname, "")
+            self.instance.fetchWorkspace(mockFilename, self.fetchedWSname, loader="")
         assert self.fetchedWSname in str(e.value)
         assert mockFilename in str(e.value)
 
@@ -539,16 +642,16 @@ class TestGroceryService(unittest.TestCase):
         # this is some file that it can't load
         self.instance.grocer.executeRecipe = mock.Mock(return_value={"result": False})
         with pytest.raises(RuntimeError) as e:
-            self.instance.fetchWorkspace(self.filepath, self.fetchedWSname, "")
+            self.instance.fetchWorkspace(self.sampleWSFilePath, self.fetchedWSname, loader="")
         assert self.fetchedWSname in str(e.value)
-        assert self.filepath in str(e.value)
+        assert self.sampleWSFilePath in str(e.value)
 
     @mock.patch.object(GroceryService, "convertToLiteMode")
     @mock.patch.object(GroceryService, "_createNeutronFilename")
     def test_fetch_dirty_nexus_native(self, mockFilename, mockMakeLite):
         """Test the correct behavior when fetching raw nexus data"""
         # patch the filename function to point to the test file
-        mockFilename.return_value = self.filepath
+        mockFilename.return_value = self.sampleWSFilePath
 
         # easier calls
         testItem = (self.runNumber, False)
@@ -634,7 +737,7 @@ class TestGroceryService(unittest.TestCase):
         assert mockFilename.return_value in str(e.value)
 
         # mock filename to point at test file
-        mockFilename.return_value = self.filepath
+        mockFilename.return_value = self.sampleWSFilePath
 
         # run with nothing loaded -- it will find the file and load it
         res = self.instance.fetchNeutronDataCached(*testItem)
@@ -704,8 +807,8 @@ class TestGroceryService(unittest.TestCase):
         mockFilename.side_effect = [
             fakeFilename,  # called in the assert below
             fakeFilename,  # called at beginning of function looking for Lite file
-            self.filepath,  # called inside elif when looking for Native file
-            self.filepath,  # called inside the block when making the filename variable
+            self.sampleWSFilePath,  # called inside elif when looking for Native file
+            self.sampleWSFilePath,  # called inside the block when making the filename variable
         ]
         assert not os.path.isfile(self.instance._createNeutronFilename(*testItem))
 
@@ -722,7 +825,7 @@ class TestGroceryService(unittest.TestCase):
         assert self.instance.convertToLiteMode.called_once
 
         # clear out the Lite workspaces from ADS and the cache
-        mockFilename.side_effect = [fakeFilename, self.filepath]
+        mockFilename.side_effect = [fakeFilename, self.sampleWSFilePath]
         for ws in [workspaceNameLiteRaw, workspaceNameLiteCopy1]:
             DeleteWorkspace(ws)
             assert not mtd.doesExist(ws)
@@ -746,7 +849,7 @@ class TestGroceryService(unittest.TestCase):
     @mock.patch.object(GroceryService, "_createGroupingFilename")
     def test_fetch_grouping(self, mockFilename):
         mockFilename.return_value = Resource.getPath("inputs/testInstrument/fakeSNAPFocGroup_Natural.xml")
-        testItem = (self.groupingItem.groupingScheme, self.groupingItem.useLiteMode)
+        testItem = (self.groupingItem.groupingScheme, self.runNumber, self.groupingItem.useLiteMode)
 
         # call once and load
         groupingWorkspaceName = self.instance._createGroupingWorkspaceName(*testItem)
@@ -772,25 +875,27 @@ class TestGroceryService(unittest.TestCase):
             self.instance.fetchGroupingDefinition(self.groupingItem)
 
     @mock.patch("snapred.backend.data.GroceryService.GroceryListItem")
+    @mock.patch.object(GroceryService, "_fetchInstrumentDonor")
     @mock.patch.object(GroceryService, "_createGroupingWorkspaceName")
     @mock.patch.object(GroceryService, "_createGroupingFilename")
-    def test_fetch_lite_data_map(self, mockFilename, mockWSName, mockGroceryList):
+    def test_fetch_lite_data_map(self, mockFilename, mockWSName, mockFetchInstrumentDonor, mockGroceryList):
         """
         This is a special case of the fetch grouping method.
         """
         mockFilename.return_value = Resource.getPath("inputs/testInstrument/fakeSNAPLiteGroupMap.xml")
         mockWSName.return_value = "lite_map"
+        mockFetchInstrumentDonor.return_value = self.sampleWS
         # have to subvert the validation methods in grocerylistitem
-        mockLiteMapGroceryItem = GroceryListItem(workspaceType="grouping", groupingScheme="Lite")
-        mockLiteMapGroceryItem.instrumentSource = self.instrumentFilepath
+        mockLiteMapGroceryItem = GroceryListItem(workspaceType="grouping", runNumber=self.runNumber, groupingScheme="Lite")
+        mockLiteMapGroceryItem.instrumentSource = self.instrumentFilePath
         mockGroceryList.builder.return_value.grouping.return_value.build.return_value = mockLiteMapGroceryItem
 
         # call once and load
-        testItem = ("Lite", False)
+        testItem = ("Lite", self.runNumber, False)
         groupingWorkspaceName = self.instance._createGroupingWorkspaceName(*testItem)
         groupKey = self.instance._key(*testItem)
 
-        res = self.instance.fetchLiteDataMap()
+        res = self.instance.fetchLiteDataMap(self.runNumber)
         assert res == groupingWorkspaceName
         assert self.instance._loadedGroupings == {groupKey: groupingWorkspaceName}
 
@@ -801,7 +906,7 @@ class TestGroceryService(unittest.TestCase):
         clerk = GroceryListItem.builder()
         clerk.native().neutron(self.runNumber).add()
         clerk.native().neutron(self.runNumber).dirty().add()
-        clerk.native().grouping(self.groupingScheme).source(InstrumentDonor=self.sampleWS).add()
+        clerk.native().grouping(self.runNumber, self.groupingScheme).source(InstrumentDonor=self.sampleWS).add()
         groceryList = clerk.buildList()
 
         # expected workspaces
@@ -839,21 +944,208 @@ class TestGroceryService(unittest.TestCase):
         ):
             self.instance.fetchGroceryList(groceryList)
 
-    def test_fetch_grocery_list_diffcal_output(self):
-        groceryList = GroceryListItem.builder().native().diffcal_output(self.runNumber).buildList()
+    @mock.patch.object(GroceryService, "_getDetectorState")
+    def test_fetch_grocery_list_specialOrder_diffcal_output(self, mockDetectorState):
+        # Test of workspace type "diffcal_output" as `Output` (i.e. "specialOrder") argument in the `GroceryList`
+        mockDetectorState.return_value = self.detectorState1
+        groceryList = GroceryListItem.builder().specialOrder().native().diffcal_output(self.runNumber).buildList()
         items = self.instance.fetchGroceryList(groceryList)
         assert items[0] == wng.diffCalOutput().runNumber(self.runNumber).build()
 
-    def test_fetch_grocery_list_diffcal_table(self):
-        groceryList = GroceryListItem.builder().native().diffcal_table(self.runNumber).buildList()
+    @mock.patch.object(GroceryService, "_getDetectorState")
+    def test_fetch_grocery_list_specialOrder_diffcal_table(self, mockDetectorState):
+        # Test of workspace type "diffcal_table" as `Output` (i.e. "specialOrder") argument in the `GroceryList`
+        mockDetectorState.return_value = self.detectorState1
+        groceryList = GroceryListItem.builder().specialOrder().native().diffcal_table(self.runNumber).buildList()
         items = self.instance.fetchGroceryList(groceryList)
         assert items[0] == wng.diffCalTable().runNumber(self.runNumber).build()
 
-    def test_fetch_grocery_list_diffcal_mask(self):
-        groceryList = GroceryListItem.builder().native().diffcal_mask(self.runNumber).buildList()
+    @mock.patch.object(GroceryService, "_getDetectorState")
+    def test_fetch_grocery_list_specialOrder_diffcal_mask(self, mockDetectorState):
+        # Test of workspace type "diffcal_mask" as `Output` (i.e. "specialOrder") argument in the `GroceryList`
+        mockDetectorState.return_value = self.detectorState1
+        groceryList = GroceryListItem.builder().specialOrder().native().diffcal_mask(self.runNumber).buildList()
         items = self.instance.fetchGroceryList(groceryList)
         assert items[0] == wng.diffCalMask().runNumber(self.runNumber).build()
 
+    @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
+    def test_fetch_grocery_list_diffcal_output(self, mockCalibrationDataPath):
+        # Test of workspace type "diffcal_output" as `Input` argument in the `GroceryList`        
+        path = Resource.getPath("outputs")
+        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpPath:
+            mockCalibrationDataPath.return_value = tmpPath
+            groceryList = GroceryListItem.builder().native().diffcal_output(self.runNumber1).buildList()
+            diffCalOutputName = wng.diffCalOutput().runNumber(self.runNumber1).build()
+            diffCalOutputFilename = diffCalOutputName + ".nxs"
+            shutil.copy2(self.sampleWSFilePath, Path(tmpPath) / diffCalOutputFilename)
+            assert (Path(tmpPath) / diffCalOutputFilename).exists()
+            
+            assert not mtd.doesExist(diffCalOutputName)
+            items = self.instance.fetchGroceryList(groceryList)
+            assert items[0] == diffCalOutputName
+            assert mtd.doesExist(diffCalOutputName)
+
+    @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
+    def test_fetch_grocery_list_diffcal_output_cached(self, mockCalibrationDataPath):
+        # Test of workspace type "diffcal_output" as `Input` argument in the `GroceryList`:
+        #   workspace already in ADS        
+        path = Resource.getPath("outputs")
+        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpPath:
+            mockCalibrationDataPath.return_value = "/does/not/exist"
+            groceryList = GroceryListItem.builder().native().diffcal_output(self.runNumber1).buildList()
+            diffCalOutputName = wng.diffCalOutput().runNumber(self.runNumber1).build()
+            CloneWorkspace(
+                InputWorkspace=self.sampleWS,
+                OutputWorkspace=diffCalOutputName,
+            )
+            assert mtd.doesExist(diffCalOutputName)
+            testTitle = "I'm a little teapot"
+            mtd[diffCalOutputName].setTitle(testTitle)
+            items = self.instance.fetchGroceryList(groceryList)
+            assert items[0] == diffCalOutputName
+            assert mtd.doesExist(diffCalOutputName)
+            assert mtd[diffCalOutputName].getTitle() == testTitle
+
+    @mock.patch.object(GroceryService, "_fetchInstrumentDonor")
+    @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
+    def test_fetch_grocery_list_diffcal_table(self, mockCalibrationDataPath, mockFetchInstrumentDonor):
+        # Test of workspace type "diffcal_table" as `Input` argument in the `GroceryList`        
+        path = Resource.getPath("outputs")
+        mockFetchInstrumentDonor.return_value = self.sampleWS
+        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpPath:
+            mockCalibrationDataPath.return_value = tmpPath
+            groceryList = GroceryListItem.builder().native().diffcal_table(self.runNumber1).buildList()
+            diffCalTableName = wng.diffCalTable().runNumber(self.runNumber1).build()
+            diffCalTableFilename = diffCalTableName + ".h5"
+            shutil.copy2(self.sampleDiffCalFilePath, Path(tmpPath) / diffCalTableFilename)
+            assert (Path(tmpPath) / diffCalTableFilename).exists()
+            
+            assert not mtd.doesExist(diffCalTableName)
+            items = self.instance.fetchGroceryList(groceryList)
+            assert items[0] == diffCalTableName
+            assert mtd.doesExist(diffCalTableName)
+
+    @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
+    def test_fetch_grocery_list_diffcal_table_cached(self, mockCalibrationDataPath):
+        # Test of workspace type "diffcal_table" as `Input` argument in the `GroceryList`:
+        #   workspace already in ADS        
+        path = Resource.getPath("outputs")
+        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpPath:
+            mockCalibrationDataPath.return_value = "/does/not/exist"
+            groceryList = GroceryListItem.builder().native().diffcal_table(self.runNumber1).buildList()
+            diffCalTableName = wng.diffCalTable().runNumber(self.runNumber1).build()
+            CloneWorkspace(
+                InputWorkspace=self.sampleTableWS,
+                OutputWorkspace=diffCalTableName,
+            )
+            assert mtd.doesExist(diffCalTableName)
+            testTitle = "I'm a little teapot"
+            mtd[diffCalTableName].setTitle(testTitle)
+            items = self.instance.fetchGroceryList(groceryList)
+            assert items[0] == diffCalTableName
+            assert mtd.doesExist(diffCalTableName)
+            assert mtd[diffCalTableName].getTitle() == testTitle
+
+    @mock.patch.object(GroceryService, "_fetchInstrumentDonor")
+    @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
+    def test_fetch_grocery_list_diffcal_table_loads_mask(self, mockCalibrationDataPath, mockFetchInstrumentDonor):
+        # Test of workspace type "diffcal_table" as `Input` argument in the `GroceryList`:
+        #   * corresponding mask workspace is also loaded from the hdf5-format file.        
+        path = Resource.getPath("outputs")
+        mockFetchInstrumentDonor.return_value = self.sampleWS
+        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpPath:
+            mockCalibrationDataPath.return_value = tmpPath
+            groceryList = GroceryListItem.builder().native().diffcal_table(self.runNumber1).buildList()
+            diffCalTableName = wng.diffCalTable().runNumber(self.runNumber1).build()
+            diffCalMaskName = wng.diffCalMask().runNumber(self.runNumber1).build()
+            diffCalTableFilename = diffCalTableName + ".h5"
+            shutil.copy2(self.sampleDiffCalFilePath, Path(tmpPath) / diffCalTableFilename)
+            assert (Path(tmpPath) / diffCalTableFilename).exists()
+            
+            assert not mtd.doesExist(diffCalTableName)
+            assert not mtd.doesExist(diffCalMaskName)
+            items = self.instance.fetchGroceryList(groceryList)
+            assert items[0] == diffCalTableName
+            assert mtd.doesExist(diffCalTableName)
+            assert mtd.doesExist(diffCalMaskName)
+
+    @mock.patch.object(GroceryService, "_fetchInstrumentDonor")
+    @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
+    def test_fetch_grocery_list_diffcal_mask(self, mockCalibrationDataPath, mockFetchInstrumentDonor):
+        # Test of workspace type "diffcal_mask" as `Input` argument in the `GroceryList`        
+        path = Resource.getPath("outputs")
+        mockFetchInstrumentDonor.return_value = self.sampleWS
+        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpPath:
+            mockCalibrationDataPath.return_value = tmpPath
+            groceryList = GroceryListItem.builder().native().diffcal_mask(self.runNumber1).buildList()
+            diffCalMaskName = wng.diffCalMask().runNumber(self.runNumber1).build()
+            
+            # DiffCal filename is constructed from the table name
+            diffCalTableName = wng.diffCalTable().runNumber(self.runNumber1).build()
+            diffCalTableFilename = diffCalTableName + ".h5"
+            shutil.copy2(self.sampleDiffCalFilePath, Path(tmpPath) / diffCalTableFilename)
+            assert (Path(tmpPath) / diffCalTableFilename).exists()
+            
+            assert not mtd.doesExist(diffCalMaskName)
+            items = self.instance.fetchGroceryList(groceryList)
+            assert items[0] == diffCalMaskName
+            assert mtd.doesExist(diffCalMaskName)
+
+    @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
+    def test_fetch_grocery_list_diffcal_mask_cached(self, mockCalibrationDataPath):
+        # Test of workspace type "diffcal_mask" as `Input` argument in the `GroceryList`:
+        #   workspace already in ADS        
+        path = Resource.getPath("outputs")
+        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpPath:
+            mockCalibrationDataPath.return_value = "/does/not/exist"
+            groceryList = GroceryListItem.builder().native().diffcal_mask(self.runNumber1).buildList()
+            diffCalMaskName = wng.diffCalMask().runNumber(self.runNumber1).build()
+            CloneWorkspace(
+                InputWorkspace=self.sampleMaskWS,
+                OutputWorkspace=diffCalMaskName,
+            )
+            assert mtd.doesExist(diffCalMaskName)
+            testTitle = "I'm a little teapot"
+            mtd[diffCalMaskName].setTitle(testTitle)
+
+            # Reloading is triggered based on whether or not the corresponding table workspace is in the ADS.
+            diffCalTableName = wng.diffCalTable().runNumber(self.runNumber1).build()
+            CloneWorkspace(
+                InputWorkspace=self.sampleTableWS,
+                OutputWorkspace=diffCalTableName,
+            )
+            assert mtd.doesExist(diffCalTableName)
+
+            items = self.instance.fetchGroceryList(groceryList)
+            assert items[0] == diffCalMaskName
+            assert mtd.doesExist(diffCalMaskName)
+            assert mtd[diffCalMaskName].getTitle() == testTitle
+
+    @mock.patch.object(GroceryService, "_fetchInstrumentDonor")
+    @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
+    def test_fetch_grocery_list_diffcal_mask_loads_table(self, mockCalibrationDataPath, mockFetchInstrumentDonor):
+        # Test of workspace type "diffcal_mask" as `Input` argument in the `GroceryList`:
+        #   * corresponding table workspace is also loaded from the hdf5-format file.        
+        path = Resource.getPath("outputs")
+        mockFetchInstrumentDonor.return_value = self.sampleWS
+        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpPath:
+            mockCalibrationDataPath.return_value = tmpPath
+            groceryList = GroceryListItem.builder().native().diffcal_mask(self.runNumber1).buildList()
+            diffCalMaskName = wng.diffCalMask().runNumber(self.runNumber1).build()
+
+            # DiffCal filename is constructed from the table name
+            diffCalTableName = wng.diffCalTable().runNumber(self.runNumber1).build()
+            diffCalTableFilename = diffCalTableName + ".h5"
+            shutil.copy2(self.sampleDiffCalFilePath, Path(tmpPath) / diffCalTableFilename)
+            assert (Path(tmpPath) / diffCalTableFilename).exists()
+            
+            assert not mtd.doesExist(diffCalMaskName)
+            assert not mtd.doesExist(diffCalTableName)
+            items = self.instance.fetchGroceryList(groceryList)
+            assert items[0] == diffCalMaskName
+            assert mtd.doesExist(diffCalMaskName)
+            assert mtd.doesExist(diffCalTableName)
+            
     def test_fetch_grocery_list_unknown_type(self):
         groceryList = GroceryListItem.builder().native().diffcal_mask(self.runNumber).buildList()
         groceryList[0].workspaceType = "banana"
@@ -865,11 +1157,7 @@ class TestGroceryService(unittest.TestCase):
 
     @mock.patch.object(GroceryService, "fetchNeutronDataCached")
     @mock.patch.object(GroceryService, "fetchGroupingDefinition")
-    def test_fetch_grocery_list_with_prev(self, mockFetchGroup, mockFetchClean):
-        clerk = GroceryListItem.builder()
-        clerk.native().neutron(self.runNumber).add()
-        clerk.native().grouping(self.groupingScheme).fromPrev().add()
-        groceryList = clerk.buildList()
+    def test_fetch_grocery_list_with_source(self, mockFetchGroup, mockFetchClean):
 
         # expected workspaces
         cleanWorkspace = "unimportant"
@@ -878,20 +1166,159 @@ class TestGroceryService(unittest.TestCase):
         mockFetchClean.return_value = {"result": True, "workspace": cleanWorkspace}
         mockFetchGroup.return_value = {"result": True, "workspace": groupWorkspace}
 
-        groupItemWithoutPrev = (
-            clerk.native().grouping(self.groupingScheme).source(InstrumentDonor=cleanWorkspace).build()
+        clerk = GroceryListItem.builder()
+        clerk.native().neutron(self.runNumber).add()
+        clerk.native().grouping(self.runNumber, self.groupingScheme).source(InstrumentDonor=cleanWorkspace).add()
+        groceryList = clerk.buildList()
+
+        groupItemWithSource = (
+            clerk.native().grouping(self.runNumber, self.groupingScheme).source(InstrumentDonor=cleanWorkspace).build()
         )
 
         res = self.instance.fetchGroceryList(groceryList)
         assert res == [cleanWorkspace, groupWorkspace]
-        assert mockFetchGroup.called_with(groupItemWithoutPrev)
+        assert mockFetchGroup.called_with(groupItemWithSource)
         assert mockFetchClean.called_with(self.runNumber, False, "")
 
+    @mock.patch.object(GroceryService, "_getDetectorState")
+    def test_update_instrument_parameters(self, mockGetDetectorState):
+        mockGetDetectorState.return_value = self.detectorState1
+        tmpName = mtd.unique_hidden_name()
+        CloneWorkspace(
+            InputWorkspace=self.sampleWS,
+            OutputWorkspace=tmpName,
+        )
+        assert mtd.doesExist(tmpName)
+                
+        # Verify that there is a _zero_ relative location prior to updating instrument location parameters
+        ws = mtd[tmpName]        
+        # Exact float comparison is intended: these should match
+        assert ws.getInstrument().getComponentByName('West').getRelativeRot() == Quat(1.0, 0.0, 0.0, 0.0)
+        assert ws.getInstrument().getComponentByName('West').getRelativePos() == V3D(0.0, 0.0, 0.0)
+        assert ws.getInstrument().getComponentByName('East').getRelativeRot() == Quat(1.0, 0.0, 0.0, 0.0)
+        assert ws.getInstrument().getComponentByName('East').getRelativePos() == V3D(0.0, 0.0, 0.0)
+        
+        self.instance._updateInstrumentParameters(self.runNumber, tmpName)
+        
+        # Verify that all of the log-derived parameters have been added
+        sampleLogs = mapFromSampleLogs(tmpName, ('det_lin1', 'det_lin2', 'det_arc1', 'det_arc2'))
+
+        # Exact float comparison is intended: these should match
+        assert sampleLogs["det_lin1"] == self.detectorState1.lin[0]
+        assert sampleLogs["det_lin2"] == self.detectorState1.lin[1]
+        assert sampleLogs["det_arc1"] == self.detectorState1.arc[0]
+        assert sampleLogs["det_arc2"] == self.detectorState1.arc[1]
+        
+        # Verify that the relative location changes correctly after updating the instrument location parameters
+        ws = mtd[tmpName]
+        assert pytest.approx(tupleFromQuat(ws.getInstrument().getComponentByName('West').getRelativeRot()), 1.0e-6) ==\
+            (-0.008726535498373997, 0.0, 0.9999619230641713, 0.0)
+        assert pytest.approx(tupleFromV3D(ws.getInstrument().getComponentByName('West').getRelativePos()), 1.0e-6) ==\
+            (0.09598823540505931, 0.0, 5.499162323360152)
+        assert pytest.approx(tupleFromQuat(ws.getInstrument().getComponentByName('East').getRelativeRot()), 1.0e-6) ==\
+            (-0.017452406437283477, 0.0, 0.9998476951563913, 0.0)
+        assert pytest.approx(tupleFromV3D(ws.getInstrument().getComponentByName('East').getRelativePos()), 1.0e-6) ==\
+            (0.2268467285662563, 0.0, 6.496040375624123)
+    
+    @mock.patch.object(GroceryService, "_createRawNeutronWorkspaceName")
+    @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
+    @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
+    def test_fetch_instrument_donor_neutron_data(self, mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS, mockCreateRawNeutronWorkspaceName):
+        with mock.patch.dict(self.instance._loadedRuns, {(self.runNumber, self.useLiteMode): 0}) as mockLoadedRuns,\
+            mock.patch.dict(self.instance._loadedInstruments, {}) as mockLoadedInstruments:
+            mockCreateRawNeutronWorkspaceName.return_value = self.sampleWS
+            testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode)
+            assert testWS == self.sampleWS
+            
+    @mock.patch.object(GroceryService, "_createRawNeutronWorkspaceName")
+    @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
+    @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
+    def test_fetch_instrument_donor_neutron_data_is_cached(self, mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS, mockCreateRawNeutronWorkspaceName):
+        with mock.patch.dict(self.instance._loadedRuns, {(self.runNumber, self.useLiteMode): 0}) as mockLoadedRuns,\
+            mock.patch.dict(self.instance._loadedInstruments, {}) as mockLoadedInstruments:
+            mockCreateRawNeutronWorkspaceName.return_value = self.sampleWS
+            testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode)
+            assert mockLoadedInstruments == {(self.runNumber, self.useLiteMode): self.sampleWS}
+
+    @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
+    @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
+    def test_fetch_instrument_donor_cached(self, mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS):
+        with mock.patch.dict(self.instance._loadedRuns, {}) as mockLoadedRuns,\
+            mock.patch.dict(self.instance._loadedInstruments, {(self.runNumber, self.useLiteMode): self.sampleWS}) as mockLoadedInstruments:
+            testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode)
+            assert testWS == self.sampleWS
+            
+    @mock.patch.object(GroceryService, "_getDetectorState")
+    @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
+    @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
+    def test_fetch_instrument_donor_empty_instrument(self, mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS, mockGetDetectorState):
+        mockGetDetectorState.return_value = self.detectorState2
+        with mock.patch.dict(self.instance._loadedRuns, {}) as mockLoadedRuns,\
+            mock.patch.dict(self.instance._loadedInstruments, {}) as mockLoadedInstruments:
+            testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode)
+            assert mtd.doesExist(testWS)
+            assert not testWS == self.sampleWS
+        
+            # Verify that the instrument workspace has log-derived parameters from `self.detectorState2`.
+            sampleLogs = mapFromSampleLogs(testWS, ('det_lin1', 'det_lin2', 'det_arc1', 'det_arc2'))
+
+            # Exact float comparison is intended: these should match
+            assert sampleLogs["det_lin1"] == self.detectorState2.lin[0]
+            assert sampleLogs["det_lin2"] == self.detectorState2.lin[1]
+            assert sampleLogs["det_arc1"] == self.detectorState2.arc[0]
+            assert sampleLogs["det_arc2"] == self.detectorState2.arc[1]
+            
+    @mock.patch.object(GroceryService, "_getDetectorState")
+    @mock.patch.object(GroceryService, "_updateNeutronCacheFromADS")
+    @mock.patch.object(GroceryService, "_updateInstrumentCacheFromADS")
+    def test_fetch_instrument_donor_empty_instrument_is_cached(self, mockUpdateInstrumentCacheFromADS, mockUpdateNeutronCacheFromADS, mockGetDetectorState):
+        mockGetDetectorState.return_value = self.detectorState2
+        with mock.patch.dict(self.instance._loadedRuns, {}) as mockLoadedRuns,\
+            mock.patch.dict(self.instance._loadedInstruments, {}) as mockLoadedInstruments:
+            testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode)
+            assert mockLoadedInstruments == {(self.runNumber, self.useLiteMode): testWS}
+    
+    
+    @mock.patch.object(GroceryService, "_createRawNeutronWorkspaceName")
+    def test_update_instrument_cache_from_ADS_to_cache(self, mockCreateRawNeutronWorkspaceName):
+        mockCreateRawNeutronWorkspaceName.return_value = self.sampleWS
+        with mock.patch.dict(self.instance._loadedInstruments, {}) as mockLoadedInstruments:
+            self.instance._updateInstrumentCacheFromADS(self.runNumber, self.useLiteMode)
+            assert mockLoadedInstruments == {(self.runNumber, self.useLiteMode): self.sampleWS}
+    
+    @mock.patch.object(GroceryService, "_createRawNeutronWorkspaceName")
+    def test_update_instrument_cache_from_ADS_cache_del(self, mockCreateRawNeutronWorkspaceName):
+        testWSName = "not_any_workspace"
+        mockCreateRawNeutronWorkspaceName.return_value = testWSName
+        with mock.patch.dict(self.instance._loadedInstruments, {(self.runNumber, self.useLiteMode): testWSName}) as mockLoadedInstruments:
+            self.instance._updateInstrumentCacheFromADS(self.runNumber, self.useLiteMode)
+            assert mockLoadedInstruments == {}
+    
+    @mock.patch.object(LocalDataService, "readDetectorState")
+    def test_get_detector_state(self, mockReadDetectorState):
+        mockReadDetectorState.return_value = self.detectorState1
+        detectorState = self.instance._getDetectorState(self.runNumber)
+        assert detectorState == self.detectorState1
+ 
+    @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
+    def test_get_detector_state(self, mockConstructCalibrationDataPath):
+        testPath = "some/path/that/may_not_exist/"
+        mockConstructCalibrationDataPath.return_value = testPath
+        calibrationDataPath = self.instance._getCalibrationDataPath(self.runNumber, self.version)
+        assert calibrationDataPath == testPath
+
+    @mock.patch(ThisService + "mtd")
+    def test_unique_hidden_name(self, mockADS):
+        testWSName = "not_any_workspace"
+        mockADS.unique_hidden_name.return_value = testWSName
+        wsName = self.instance.uniqueHiddenName()
+        assert wsName == testWSName
+         
     @mock.patch.object(GroceryService, "fetchGroceryList")
     def test_fetch_grocery_dict(self, mockFetchList):
         clerk = GroceryListItem.builder()
         clerk.native().neutron(self.runNumber).name("InputWorkspace").add()
-        clerk.native().grouping(self.groupingScheme).fromPrev().name("GroupingWorkspace").add()
+        clerk.native().grouping(self.runNumber, self.groupingScheme).name("GroupingWorkspace").add()
         groceryDict = clerk.buildDict()
 
         # expected workspaces
@@ -908,7 +1335,7 @@ class TestGroceryService(unittest.TestCase):
     def test_fetch_grocery_dict_with_kwargs(self, mockFetchList):
         clerk = GroceryListItem.builder()
         clerk.native().neutron(self.runNumber).name("InputWorkspace").add()
-        clerk.native().grouping(self.groupingScheme).fromPrev().name("GroupingWorkspace").add()
+        clerk.native().grouping(self.runNumber, self.groupingScheme).name("GroupingWorkspace").add()
         groceryDict = clerk.buildDict()
 
         # expected workspaces
@@ -942,15 +1369,17 @@ class TestGroceryService(unittest.TestCase):
         assert mockLDS.reduceLiteData.called_once_with(workspacename, workspacename)
 
     def test_getCachedWorkspaces(self):
-        rawWsName = self.instance._createRawNeutronWorkspaceName(0, "a")
-        self.instance._loadedRuns = {(0, "a"): "b"}
-        self.instance._loadedGroupings = {(1, "c"): "d"}
-
-        assert self.instance.getCachedWorkspaces() == [rawWsName, "d"]
+        rawWsName = self.instance._createRawNeutronWorkspaceName("556854", False)
+        self.instance._loadedRuns = {("556854", False): 0}
+        self.instance._loadedGroupings = {("column", "556854", True): "d"}
+        self.instance._loadedInstruments =\
+            {("556854", False): rawWsName, ("556855", True): "hello"}
+        assert set(self.instance.getCachedWorkspaces()) == set([rawWsName, "d", "hello"])
 
     def test_getCachedWorkspaces_empty(self):
         self.instance._loadedRuns = {}
         self.instance._loadedGroupings = {}
+        self.instance._loadedInstruments = {}
 
         assert self.instance.getCachedWorkspaces() == []
 

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -894,7 +894,7 @@ class TestGroceryService(unittest.TestCase):
         groupingWorkspaceName = self.instance._createGroupingWorkspaceName(*testItem)
         groupKey = self.instance._key(*testItem)
 
-        res = self.instance.fetchLiteDataMap(self.runNumber)
+        res = self.instance.fetchLiteDataMap()
         assert res == groupingWorkspaceName
         assert self.instance._loadedGroupings == {groupKey: groupingWorkspaceName}
 
@@ -1274,9 +1274,8 @@ class TestGroceryService(unittest.TestCase):
         mockGetDetectorState
         ):
         mockGetDetectorState.return_value = self.detectorState2
-        with mock.patch.dict(self.instance._loadedRuns, {}) as mockLoadedRuns, mock.patch.dict(
-            self.instance._loadedInstruments, {}
-        ) as mockLoadedInstruments:
+        with mock.patch.dict(self.instance._loadedRuns, {}),\
+            mock.patch.dict(self.instance._loadedInstruments, {}):
             testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode)
             assert mtd.doesExist(testWS)
             assert not testWS == self.sampleWS
@@ -1299,9 +1298,8 @@ class TestGroceryService(unittest.TestCase):
         mockGetDetectorState
         ):
         mockGetDetectorState.return_value = self.detectorState2
-        with mock.patch.dict(self.instance._loadedRuns, {}) as mockLoadedRuns, mock.patch.dict(
-            self.instance._loadedInstruments, {}
-        ) as mockLoadedInstruments:
+        with mock.patch.dict(self.instance._loadedRuns, {}),\
+            mock.patch.dict(self.instance._loadedInstruments, {}) as mockLoadedInstruments:
             testWS = self.instance._fetchInstrumentDonor(self.runNumber, self.useLiteMode)
             assert mockLoadedInstruments == {(self.runNumber, self.useLiteMode): testWS}
 
@@ -1327,13 +1325,6 @@ class TestGroceryService(unittest.TestCase):
         mockReadDetectorState.return_value = self.detectorState1
         detectorState = self.instance._getDetectorState(self.runNumber)
         assert detectorState == self.detectorState1
-
-    @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
-    def test_get_detector_state(self, mockConstructCalibrationDataPath):
-        testPath = "some/path/that/may_not_exist/"
-        mockConstructCalibrationDataPath.return_value = testPath
-        calibrationDataPath = self.instance._getCalibrationDataPath(self.runNumber, self.version)
-        assert calibrationDataPath == testPath
 
     @mock.patch(ThisService + "mtd")
     def test_unique_hidden_name(self, mockADS):

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -422,7 +422,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
         assert actual.runNumber == "57514"
 
     @mock.patch("h5py.File", return_value="not None")
-    def test_readPVFile(h5pyMock): # noqa: ARG001
+    def test_readPVFile(h5pyMock):  # noqa: ARG001
         localDataService = LocalDataService()
         localDataService.instrumentConfig = getMockInstrumentConfig()
         localDataService._constructPVFilePath = mock.Mock()
@@ -722,8 +722,8 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
             mockConstructNormalizationCalibrationDataPath.return_value = str(basePath)
 
             # Workspace names need to match the names that are used in the test record.
-            runNumber = testNormalizationRecord.runNumber # noqa: F841
-            version = testNormalizationRecord.version # noqa: F841
+            runNumber = testNormalizationRecord.runNumber  # noqa: F841
+            version = testNormalizationRecord.version  # noqa: F841
             testWS0, testWS1, testWS2 = testNormalizationRecord.workspaceNames
 
             # Create sample workspaces.

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -426,7 +426,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
         assert actual.runNumber == "57514"
 
     @mock.patch("h5py.File", return_value="not None")
-    def test_readPVFile(h5pyMock):
+    def test_readPVFile(h5pyMock): # noqa: ARG002
         localDataService = LocalDataService()
         localDataService.instrumentConfig = getMockInstrumentConfig()
         localDataService._constructPVFilePath = mock.Mock()
@@ -720,8 +720,8 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
             mockConstructNormalizationCalibrationDataPath.return_value = str(basePath)
             
             # Workspace names need to match the names that are used in the test record.
-            runNumber = testNormalizationRecord.runNumber
-            version = testNormalizationRecord.version
+            runNumber = testNormalizationRecord.runNumber # noqa: F841
+            version = testNormalizationRecord.version # noqa: F841
             testWS0, testWS1, testWS2 = testNormalizationRecord.workspaceNames
             
             # Create sample workspaces.
@@ -738,7 +738,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
             localDataService.writeNormalizationWorkspaces(testNormalizationRecord)
 
             for wsName in testNormalizationRecord.workspaceNames:
-                ws = mtd[wsName]
                 filename = Path(wsName + ".nxs")
                 assert (basePath / filename).exists()
             mtd.clear()

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -422,7 +422,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
         assert actual.runNumber == "57514"
 
     @mock.patch("h5py.File", return_value="not None")
-    def test_readPVFile(h5pyMock): # noqa: ARG002
+    def test_readPVFile(h5pyMock): # noqa: ARG001
         localDataService = LocalDataService()
         localDataService.instrumentConfig = getMockInstrumentConfig()
         localDataService._constructPVFilePath = mock.Mock()

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -3,24 +3,38 @@ import os
 import shutil
 import socket
 import tempfile
-import unittest.mock as mock
 from pathlib import Path
 from typing import List
 
 import pytest
+import unittest.mock as mock
+
 from pydantic import parse_raw_as
 from pydantic.error_wrappers import ValidationError
+
+from util.helpers import createCompatibleDiffCalTable, createCompatibleMask
+
+from mantid.api import MatrixWorkspace, ITableWorkspace
+from mantid.simpleapi import (
+    mtd,
+    LoadEmptyInstrument,
+    CreateGroupingWorkspace,
+    CloneWorkspace,
+)
+from mantid.dataobjects import MaskWorkspace
+
 from snapred.backend.dao.state.CalibrantSample.CalibrantSamples import CalibrantSamples
 
 # NOTE this is necessary to prevent mocking out needed functions
 from snapred.backend.recipe.algorithm.WashDishes import WashDishes
 from snapred.meta.Config import Config, Resource
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as WNG
 from snapred.meta.redantic import write_model_pretty
 
 IS_ON_ANALYSIS_MACHINE = socket.gethostname().startswith("analysis")
 
 # Mock out of scope modules before importing DataExportService
-with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Mock()}):
+with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
     from snapred.backend.dao import StateConfig
     from snapred.backend.dao.calibration.Calibration import Calibration  # noqa: E402
     from snapred.backend.dao.calibration.CalibrationIndexEntry import CalibrationIndexEntry  # noqa: E402
@@ -34,6 +48,9 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
     from snapred.backend.dao.state.InstrumentState import InstrumentState
     from snapred.backend.data.LocalDataService import LocalDataService  # noqa: E402
 
+    ThisService = "snapred.backend.data.LocalDataService."
+
+    fakeInstrumentFilePath = Resource.getPath("inputs/testInstrument/fakeSNAP.xml")
     reductionIngredients = None
     with Resource.open("inputs/calibration/ReductionIngredients.json", "r") as file:
         reductionIngredients = parse_raw_as(ReductionIngredients, file.read())
@@ -82,7 +99,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         localDataService._readNormalizationCalibrant.return_value = (
             reductionIngredients.reductionState.stateConfig.normalizationCalibrant
         )
-        localDataService.groceryService.getIPTS = mock.Mock(return_value="IPTS-123")
+        localDataService.getIPTS = mock.Mock(return_value="IPTS-123")
         localDataService._readPVFile = mock.Mock()
         fileMock = mock.Mock()
         localDataService._readPVFile.return_value = fileMock
@@ -118,7 +135,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         localDataService._readNormalizationCalibrant.return_value = (
             reductionIngredients.reductionState.stateConfig.normalizationCalibrant
         )
-        localDataService.groceryService.getIPTS = mock.Mock(return_value="IPTS-123")
+        localDataService.getIPTS = mock.Mock(return_value="IPTS-123")
         localDataService._readPVFile = mock.Mock()
         fileMock = mock.Mock()
         localDataService._readPVFile.return_value = fileMock
@@ -155,7 +172,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         localDataService._readNormalizationCalibrant.return_value = (
             reductionIngredients.reductionState.stateConfig.normalizationCalibrant
         )
-        localDataService.groceryService.getIPTS = mock.Mock(return_value="IPTS-123")
+        localDataService.getIPTS = mock.Mock(return_value="IPTS-123")
         localDataService._readPVFile = mock.Mock()
         fileMock = mock.Mock()
         localDataService._readPVFile.return_value = fileMock
@@ -195,7 +212,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         localDataService._readNormalizationCalibrant.return_value = (
             reductionIngredients.reductionState.stateConfig.normalizationCalibrant
         )
-        localDataService.groceryService.getIPTS = mock.Mock(return_value="IPTS-123")
+        localDataService.getIPTS = mock.Mock(return_value="IPTS-123")
         localDataService._readPVFile = mock.Mock()
         fileMock = mock.Mock()
         localDataService._readPVFile.return_value = fileMock
@@ -241,7 +258,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
             localDataService._readNormalizationCalibrant.return_value = (
                 reductionIngredients.reductionState.stateConfig.normalizationCalibrant
             )
-            localDataService.groceryService.getIPTS = mock.Mock(return_value="IPTS-123")
+            localDataService.getIPTS = mock.Mock(return_value="IPTS-123")
             localDataService._readPVFile = mock.Mock()
             fileMock = mock.Mock()
             localDataService._readPVFile.return_value = fileMock
@@ -288,7 +305,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
             localDataService._readNormalizationCalibrant.return_value = (
                 reductionIngredients.reductionState.stateConfig.normalizationCalibrant
             )
-            localDataService.groceryService.getIPTS = mock.Mock(return_value="IPTS-123")
+            localDataService.getIPTS = mock.Mock(return_value="IPTS-123")
             localDataService._readPVFile = mock.Mock()
             fileMock = mock.Mock()
             localDataService._readPVFile.return_value = fileMock
@@ -301,6 +318,53 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
             localDataService.instrumentConfig = getMockInstrumentConfig()
             localDataService.readStateConfig("57514")
 
+    @mock.patch(ThisService + "GetIPTS")
+    def test_getIPTS(mockGetIPTS):
+        mockGetIPTS.return_value = "nowhere/"
+        localDataService = LocalDataService()
+        runNumber = "123456"
+        res = localDataService.getIPTS(runNumber)
+        assert res == mockGetIPTS.return_value
+        assert mockGetIPTS.called_with(
+            runNumber=runNumber,
+            instrumentName=Config["instrument.name"],
+        )
+        res = localDataService.getIPTS(runNumber, "CRACKLE")
+        assert res == mockGetIPTS.return_value
+        assert mockGetIPTS.called_with(
+            runNumber=runNumber,
+            instrumentName="CRACKLE",
+        )
+
+    def test_workspaceIsInstance():
+        localDataService = LocalDataService()
+        # Create a sample workspace.
+        testWS0 = "test_ws"
+        LoadEmptyInstrument (
+            Filename=fakeInstrumentFilePath,
+            OutputWorkspace=testWS0,
+        )
+        assert mtd.doesExist(testWS0)
+        assert localDataService.workspaceIsInstance(testWS0, MatrixWorkspace)
+ 
+        # Create diffraction-calibration table and mask workspaces.
+        tableWS = "test_table"
+        maskWS = "test_mask"
+        createCompatibleDiffCalTable(tableWS, testWS0)
+        createCompatibleMask(maskWS, testWS0, fakeInstrumentFilePath)
+        assert mtd.doesExist(tableWS)          
+        assert mtd.doesExist(maskWS)
+        assert localDataService.workspaceIsInstance(tableWS, ITableWorkspace)
+        assert localDataService.workspaceIsInstance(maskWS, MaskWorkspace)
+        mtd.clear()
+
+    def test_workspaceIsInstance_no_ws():
+        localDataService = LocalDataService()
+        # A sample workspace which doesn't exist.
+        testWS0 = "test_ws"
+        assert not mtd.doesExist(testWS0)
+        assert not localDataService.workspaceIsInstance(testWS0, MatrixWorkspace)
+    
     def test_write_model_pretty_StateConfig_excludes_grouping_map():
         # At present there is no `writeStateConfig` method, and there is no `readStateConfig` that doesn't
         #   actually build up the `StateConfig` from its components.
@@ -314,7 +378,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         localDataService._readNormalizationCalibrant.return_value = (
             reductionIngredients.reductionState.stateConfig.normalizationCalibrant
         )
-        localDataService.groceryService.getIPTS = mock.Mock(return_value="IPTS-123")
+        localDataService.getIPTS = mock.Mock(return_value="IPTS-123")
         localDataService._readPVFile = mock.Mock()
         fileMock = mock.Mock()
         localDataService._readPVFile.return_value = fileMock
@@ -355,13 +419,14 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
 
     def test__readRunConfig():
         localDataService = LocalDataService()
-        localDataService.groceryService.getIPTS = mock.Mock(return_value="IPTS-123")
+        localDataService.getIPTS = mock.Mock(return_value="IPTS-123")
         localDataService.instrumentConfig = getMockInstrumentConfig()
         actual = localDataService._readRunConfig("57514")
         assert actual is not None
         assert actual.runNumber == "57514"
 
-    def test_readPVFile():
+    @mock.patch("h5py.File", return_value="not None")
+    def test_readPVFile(h5pyMock):
         localDataService = LocalDataService()
         localDataService.instrumentConfig = getMockInstrumentConfig()
         localDataService._constructPVFilePath = mock.Mock()
@@ -374,7 +439,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         localDataService._readPVFile = mock.Mock()
         fileMock = mock.Mock()
         localDataService._readPVFile.return_value = fileMock
-        fileMock.get.side_effect = [[0.1], [0.1], [0.1], [0.1], [1]]
+        fileMock.get.side_effect = [[0.1], [0.1], [0.1], [0.1], [1], [0.1], [0.1]]
         actual, _ = localDataService._generateStateId(mock.Mock())
         assert actual == "9618b936a4419a6e"
 
@@ -557,6 +622,47 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualRecord.runNumber == "57514"
         assert actualRecord == testCalibrationRecord
 
+    @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
+    def test_writeCalibrationWorkspaces(mockConstructCalibrationDataPath):
+        localDataService = LocalDataService()
+        path = Resource.getPath("outputs")        
+        testCalibrationRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord.json"))
+        with tempfile.TemporaryDirectory(dir=path, suffix="/") as basePath:
+            basePath = Path(basePath)
+            mockConstructCalibrationDataPath.return_value = str(basePath)
+            
+            # Workspace names need to match the names that are used in the test record.
+            runNumber = testCalibrationRecord.runNumber
+            version = testCalibrationRecord.version
+            testWS0, testWS1, testWS2, tableWSName, maskWSName = testCalibrationRecord.workspaceNames
+            diffCalFilename = Path(WNG.diffCalTable().runNumber(runNumber).version(version).build() + ".h5") 
+            
+            # Create sample workspaces.
+            LoadEmptyInstrument (
+                Filename=fakeInstrumentFilePath,
+                OutputWorkspace=testWS0,
+            )
+            CloneWorkspace(InputWorkspace=testWS0, OutputWorkspace=testWS1)
+            CloneWorkspace(InputWorkspace=testWS0, OutputWorkspace=testWS2)            
+            assert mtd.doesExist(testWS0)
+            assert mtd.doesExist(testWS1)
+            assert mtd.doesExist(testWS2)
+            
+            # Create diffraction-calibration table and mask workspaces.
+            createCompatibleDiffCalTable(tableWSName, testWS0)
+            createCompatibleMask(maskWSName, testWS0, fakeInstrumentFilePath)
+            assert mtd.doesExist(tableWSName)          
+            assert mtd.doesExist(maskWSName)
+            
+            localDataService.writeCalibrationWorkspaces(testCalibrationRecord)
+
+            diffCalFilename = Path(WNG.diffCalTable().runNumber(runNumber).version(version).build() + ".h5") 
+            for wsName in testCalibrationRecord.workspaceNames:
+                ws = mtd[wsName]
+                filename = Path(wsName + ".nxs") if not (isinstance(ws, ITableWorkspace) or isinstance(ws, MaskWorkspace)) else diffCalFilename
+                assert (basePath / filename).exists()
+            mtd.clear()
+
     def test_readWriteNormalizationRecord_version_numbers():
         testNormalizationRecord = NormalizationRecord.parse_raw(
             Resource.read("inputs/normalization/NormalizationRecord.json")
@@ -604,6 +710,39 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         assert actualRecord.runNumber == "57514"
         assert actualRecord == testNormalizationRecord
 
+    @mock.patch.object(LocalDataService, "_constructNormalizationCalibrationDataPath")
+    def test_writeNormalizationWorkspaces(mockConstructNormalizationCalibrationDataPath):
+        localDataService = LocalDataService()
+        path = Resource.getPath("outputs")        
+        testNormalizationRecord = NormalizationRecord.parse_raw(Resource.read("inputs/normalization/NormalizationRecord.json"))
+        with tempfile.TemporaryDirectory(dir=path, suffix="/") as basePath:
+            basePath = Path(basePath)
+            mockConstructNormalizationCalibrationDataPath.return_value = str(basePath)
+            
+            # Workspace names need to match the names that are used in the test record.
+            runNumber = testNormalizationRecord.runNumber
+            version = testNormalizationRecord.version
+            testWS0, testWS1, testWS2 = testNormalizationRecord.workspaceNames
+            
+            # Create sample workspaces.
+            LoadEmptyInstrument (
+                Filename=fakeInstrumentFilePath,
+                OutputWorkspace=testWS0,
+            )
+            CloneWorkspace(InputWorkspace=testWS0, OutputWorkspace=testWS1)
+            CloneWorkspace(InputWorkspace=testWS0, OutputWorkspace=testWS2)            
+            assert mtd.doesExist(testWS0)
+            assert mtd.doesExist(testWS1)
+            assert mtd.doesExist(testWS2)
+
+            localDataService.writeNormalizationWorkspaces(testNormalizationRecord)
+
+            for wsName in testNormalizationRecord.workspaceNames:
+                ws = mtd[wsName]
+                filename = Path(wsName + ".nxs")
+                assert (basePath / filename).exists()
+            mtd.clear()
+
     def test_getCalibrationRecordPath():
         localDataService = LocalDataService()
         localDataService._generateStateId = mock.Mock()
@@ -646,32 +785,6 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         ]
         actualFile = localDataService._getLatestFile("Powder/1234/v_*/CalibrationRecord.json")
         assert actualFile == "Powder/1234/v_2/CalibrationRecord.json"
-
-    def test_writeCalibrationReductionResult():
-        from snapred.backend.data.LocalDataService import LocalDataService as LocalDataService2
-
-        localDataService = LocalDataService2()
-        localDataService._generateStateId = mock.Mock()
-        localDataService._generateStateId.return_value = ("123", "456")
-        localDataService._constructCalibrationStatePath = mock.Mock()
-        localDataService._constructCalibrationStatePath.return_value = Resource.getPath("outputs/")
-
-        filename = localDataService.writeCalibrationReductionResult("123", "ws", dryrun=True)
-        assert filename.endswith("tests/resources/outputs/123/ws_v1.nxs")
-
-    def test_writeCalibrationReductionResult_notdryrun():
-        from snapred.backend.data.LocalDataService import LocalDataService as LocalDataService2
-
-        localDataService = LocalDataService2()
-        localDataService.groceryService = mock.Mock()
-        localDataService._generateStateId = mock.Mock()
-        localDataService._generateStateId.return_value = ("123", "456")
-        localDataService._constructCalibrationStatePath = mock.Mock()
-        localDataService._constructCalibrationStatePath.return_value = Resource.getPath("outputs/")
-
-        filename = localDataService.writeCalibrationReductionResult("123", "ws", dryrun=False)
-        assert filename.endswith("tests/resources/outputs/123/ws_v1.nxs")
-        assert localDataService.groceryService.writeWorkspace.called_once_with(filename, "ws")
 
     def test__isApplicableEntry_equals():
         localDataService = LocalDataService()
@@ -813,9 +926,14 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
 
         localDataService = LocalDataService()
         localDataService._readPVFile = mock.Mock()
+        
         pvFileMock = mock.Mock()
-        pvFileMock.get.side_effect = [[1], [2], [1.1], [1.2], [1], [1], [2], [1.1], [1.2], [1], [1], [2]]
+        # 2X: seven required `readDetectorState` log entries:
+        #   * generated stateId hex-digest: 'ab8704b0bc2a2342',
+        #   * generated `DetectorInfo` matches that from 'inputs/calibration/CalibrationParameters.json' 
+        pvFileMock.get.side_effect = [[1], [2], [1.1], [1.2], [1], [1.0], [2.0], [1], [2], [1.1], [1.2], [1], [1.0], [2.0]]
         localDataService._readPVFile.return_value = pvFileMock
+        
         testCalibrationData = Calibration.parse_file(Resource.getPath("inputs/calibration/CalibrationParameters.json"))
 
         localDataService.readInstrumentConfig = mock.Mock()
@@ -979,3 +1097,78 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
 
         result = localDataService.readCifFilePath("testid")
         assert result == "/SNS/SNAP/shared/Calibration_dynamic/CalibrantSamples/EntryWithCollCode52054_diamond.cif"
+
+
+    ## TESTS OF WORKSPACE WRITE METHODS
+    
+    def test_writeWorkspace():
+        localDataService = LocalDataService()
+        path = Resource.getPath("outputs")
+        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpPath:
+            workspaceName = "test_workspace"
+            basePath = Path(tmpPath)
+            filename = Path(workspaceName + ".nxs")
+            # Create a test workspace to write.
+            LoadEmptyInstrument (
+                Filename=fakeInstrumentFilePath,
+                OutputWorkspace=workspaceName,
+            )
+            assert mtd.doesExist(workspaceName)
+            localDataService.writeWorkspace(basePath, filename, workspaceName)
+            assert (basePath / filename).exists()
+        mtd.clear()
+
+    def test_writeGroupingWorkspace():
+        localDataService = LocalDataService()
+        path = Resource.getPath("outputs")
+        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpPath:
+            workspaceName = "test_grouping"
+            basePath = Path(tmpPath)
+            filename = Path(workspaceName + ".h5")
+            # Create a test grouping workspace to write.
+            CreateGroupingWorkspace(
+                OutputWorkspace=workspaceName,
+                CustomGroupingString="1",
+                InstrumentFilename=fakeInstrumentFilePath,
+            )
+            localDataService.writeGroupingWorkspace(basePath, filename, workspaceName)
+            assert (basePath / filename).exists()
+        mtd.clear()
+
+    def test_writeDiffCalWorkspaces():
+        localDataService = LocalDataService()
+        path = Resource.getPath("outputs")        
+        with tempfile.TemporaryDirectory(dir=path, suffix="/") as basePath:
+            basePath = Path(basePath)
+            tableWSName = "test_table"
+            maskWSName = "test_mask"
+            filename = Path(tableWSName + ".h5") 
+            # Create an instrument workspace.
+            instrumentDonor = "test_instrument_donor"
+            LoadEmptyInstrument (
+                Filename=fakeInstrumentFilePath,
+                OutputWorkspace=instrumentDonor,
+            )
+            assert mtd.doesExist(instrumentDonor)
+            # Create table and mask workspaces to write.
+            createCompatibleMask(maskWSName, instrumentDonor, fakeInstrumentFilePath)
+            assert mtd.doesExist(maskWSName)
+            createCompatibleDiffCalTable(tableWSName, instrumentDonor)
+            assert mtd.doesExist(tableWSName)          
+            localDataService.writeDiffCalWorkspaces(basePath, filename, tableWorkspaceName=tableWSName, maskWorkspaceName=maskWSName)
+            assert (basePath / filename).exists()
+        mtd.clear()
+
+# this at teardown removes the loggers, eliminating logger error printouts
+# see https://github.com/pytest-dev/pytest/issues/5502#issuecomment-647157873
+@pytest.fixture(autouse=True)
+def clear_loggers():  # noqa: PT004
+    """Remove handlers from all loggers"""
+    import logging
+
+    yield  # ... teardown follows:
+    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
+    for logger in loggers:
+        handlers = getattr(logger, "handlers", [])
+        for handler in handlers:
+            logger.removeHandler(handler)

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -58,7 +58,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         )
         assert os.path.exists(cls.filepath)
 
-        cls.liteMapGroceryItem = GroceryListItem.builder().grouping("Lite").build()
+        cls.liteMapGroceryItem = GroceryListItem.builder().grouping(cls.runNumber, "Lite").build()
 
     def setUp(self) -> None:
         self.rx = Recipe()

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -58,7 +58,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         )
         assert os.path.exists(cls.filepath)
 
-        cls.liteMapGroceryItem = GroceryListItem.builder().grouping(cls.runNumber, "Lite").build()
+        cls.liteMapGroceryItem = GroceryListItem.builder().grouping("Lite").build()
 
     def setUp(self) -> None:
         self.rx = Recipe()

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -1,9 +1,10 @@
 # ruff: noqa: E402, ARG002
 import os
+from typing import List
+from pathlib import Path
 import tempfile
 import unittest
 import unittest.mock as mock
-from typing import List
 from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
@@ -64,6 +65,8 @@ with mock.patch.dict(
         calibrationService = CalibrationService()
         calibrationService.dataExportService.exportCalibrationRecord = mock.Mock()
         calibrationService.dataExportService.exportCalibrationRecord.return_value = MagicMock(version="1.0.0")
+        calibrationService.dataExportService.exportCalibrationWorkspaces = mock.Mock()
+        calibrationService.dataExportService.exportCalibrationWorkspaces.return_value = MagicMock(version="1.0.0")
         calibrationService.dataExportService.exportCalibrationIndexEntry = mock.Mock()
         calibrationService.dataExportService.exportCalibrationIndexEntry.return_value = "expected"
         calibrationService.save(mock.Mock())
@@ -240,7 +243,8 @@ class TestCalibrationServiceMethods(unittest.TestCase):
                     DataX=1,
                     DataY=1,
                 )
-                self.instance.dataFactoryService.writeWorkspace(os.path.join(tmpdir, ws_name + ".nxs"), ws_name)
+                filename = Path(ws_name + ".nxs")
+                self.instance.dataExportService.exportWorkspace(tmpdir, filename, ws_name)
 
             # Call the method to test. Use a mocked run and a mocked version
             runId = MagicMock()
@@ -267,7 +271,8 @@ class TestCalibrationServiceMethods(unittest.TestCase):
                     DataX=1,
                     DataY=1,
                 )
-                self.instance.dataFactoryService.writeWorkspace(os.path.join(tmpdir, ws_name + ".nxs"), ws_name)
+                filename = Path(ws_name + ".nxs")
+                self.instance.dataExportService.exportWorkspace(tmpdir, filename, ws_name)
 
             # Call the method to test. Use a mocked run and a mocked version
             mockRequest = MagicMock(runId=MagicMock(), version=MagicMock(), checkExistent=False)

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -1,10 +1,10 @@
 # ruff: noqa: E402, ARG002
 import os
-from typing import List
-from pathlib import Path
 import tempfile
 import unittest
 import unittest.mock as mock
+from pathlib import Path
+from typing import List
 from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -254,6 +254,7 @@ class TestNormalizationService(unittest.TestCase):
             "smoothedOutput": "dsp_apple_12345_fitted_van_cor",
         }
 
+
 # this at teardown removes the loggers, eliminating logger error printouts
 # see https://github.com/pytest-dev/pytest/issues/5502#issuecomment-647157873
 @pytest.fixture(autouse=True)

--- a/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
+++ b/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
@@ -1,5 +1,6 @@
-from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
+import pytest
 
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 
 def testRunNames():
     assert "tof_all_123" == wng.run().runNumber(123).build()
@@ -7,21 +8,46 @@ def testRunNames():
     assert "dsp_column_123" == wng.run().runNumber(123).unit(wng.Units.DSP).group(wng.Groups.COLUMN).build()
     assert (
         "dsp_column_123_test"
-        == wng.run().runNumber(123).unit(wng.Units.DSP).group(wng.Groups.COLUMN).auxilary("Test").build()
+        == wng.run().runNumber(123).unit(wng.Units.DSP).group(wng.Groups.COLUMN).auxiliary("Test").build()
     )
-
 
 def testDiffCalInputNames():
     assert "_tof_123_raw" == wng.diffCalInput().runNumber(123).build()
     assert "_dsp_123_raw" == wng.diffCalInput().runNumber(123).unit(wng.Units.DSP).build()
 
-
-def testDiffCalTableName():
+def testDiffCalTableNames():
     assert "_difc_123" == wng.diffCalTable().runNumber(123).build()
+    assert "_difc_123_24" == wng.diffCalTable().runNumber(123).version(24).build()
 
+def testDiffCalOutputNames():
+    assert "_tof_123_diffoc" == wng.diffCalOutput().runNumber(123).build()
+    assert "_dsp_123_diffoc" == wng.diffCalOutput().runNumber(123).unit(wng.Units.DSP).build()
+    assert "_dsp_123_25_diffoc" == wng.diffCalOutput().runNumber(123).unit(wng.Units.DSP).version(25).build()
 
-def testDiffCalMetricsName():
+def testDiffCalMaskNames():
+    assert "_difc_123_mask" == wng.diffCalMask().runNumber(123).build()
+    assert "_difc_123_26_mask" == wng.diffCalMask().runNumber(123).version(26).build()
+
+def testDiffCalMetricsNames():
     assert (
-        "123_1_calibration_metrics_strain"
-        == wng.diffCalMetrics().runNumber(123).version(1).metricName("strain").build()
+        "123_calibration_metrics_strain" ==\
+            wng.diffCalMetrics().runNumber(123).metricName("strain").build()
     )
+    assert (
+        "123_1_calibration_metrics_strain" ==\
+            wng.diffCalMetrics().runNumber(123).version(1).metricName("strain").build()
+    )
+
+# this at teardown removes the loggers, eliminating logger error printouts
+# see https://github.com/pytest-dev/pytest/issues/5502#issuecomment-647157873
+@pytest.fixture(autouse=True)
+def clear_loggers():  # noqa: PT004
+    """Remove handlers from all loggers"""
+    import logging
+
+    yield  # ... teardown follows:
+    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
+    for logger in loggers:
+        handlers = getattr(logger, "handlers", [])
+        for handler in handlers:
+            logger.removeHandler(handler)

--- a/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
+++ b/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
@@ -1,6 +1,6 @@
 import pytest
-
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
+
 
 def testRunNames():
     assert "tof_all_123" == wng.run().runNumber(123).build()
@@ -11,32 +11,35 @@ def testRunNames():
         == wng.run().runNumber(123).unit(wng.Units.DSP).group(wng.Groups.COLUMN).auxiliary("Test").build()
     )
 
+
 def testDiffCalInputNames():
     assert "_tof_123_raw" == wng.diffCalInput().runNumber(123).build()
     assert "_dsp_123_raw" == wng.diffCalInput().runNumber(123).unit(wng.Units.DSP).build()
 
+
 def testDiffCalTableNames():
     assert "_difc_123" == wng.diffCalTable().runNumber(123).build()
     assert "_difc_123_24" == wng.diffCalTable().runNumber(123).version(24).build()
+
 
 def testDiffCalOutputNames():
     assert "_tof_123_diffoc" == wng.diffCalOutput().runNumber(123).build()
     assert "_dsp_123_diffoc" == wng.diffCalOutput().runNumber(123).unit(wng.Units.DSP).build()
     assert "_dsp_123_25_diffoc" == wng.diffCalOutput().runNumber(123).unit(wng.Units.DSP).version(25).build()
 
+
 def testDiffCalMaskNames():
     assert "_difc_123_mask" == wng.diffCalMask().runNumber(123).build()
     assert "_difc_123_26_mask" == wng.diffCalMask().runNumber(123).version(26).build()
 
+
 def testDiffCalMetricsNames():
+    assert "123_calibration_metrics_strain" == wng.diffCalMetrics().runNumber(123).metricName("strain").build()
     assert (
-        "123_calibration_metrics_strain" ==\
-            wng.diffCalMetrics().runNumber(123).metricName("strain").build()
+        "123_1_calibration_metrics_strain"
+        == wng.diffCalMetrics().runNumber(123).version(1).metricName("strain").build()
     )
-    assert (
-        "123_1_calibration_metrics_strain" ==\
-            wng.diffCalMetrics().runNumber(123).version(1).metricName("strain").build()
-    )
+
 
 # this at teardown removes the loggers, eliminating logger error printouts
 # see https://github.com/pytest-dev/pytest/issues/5502#issuecomment-647157873

--- a/tests/util/helpers.py
+++ b/tests/util/helpers.py
@@ -13,6 +13,7 @@ from mantid.api import ITableWorkspace, MatrixWorkspace
 from mantid.dataobjects import GroupingWorkspace, MaskWorkspace
 from mantid.simpleapi import (
     CopyInstrumentParameters,
+    CreateEmptyTableWorkspace,
     DeleteWorkspace,
     ExtractMask,
     LoadInstrument,
@@ -22,6 +23,20 @@ from mantid.simpleapi import (
 )
 from snapred.meta.Config import Resource
 
+def createCompatibleDiffCalTable(tableWSName: str, templateWSName: str) -> ITableWorkspace:
+    """
+    Create an diffraction-calibration `ITableWorkspace` compatible with a template workspace.
+    """
+    ws = CreateEmptyTableWorkspace(OutputWorkspace=tableWSName)
+    ws.addColumn(type="int", name="detid", plottype=6)
+    ws.addColumn(type="float", name="difc", plottype=6)
+    ws.addColumn(type="float", name="difa", plottype=6)
+    ws.addColumn(type="float", name="tzero", plottype=6)
+    # Add same number of rows as the dummy mask workspace:
+    templateWS = mtd[templateWSName]
+    for n in range(templateWS.getInstrument().getNumberDetectors(True)):
+        ws.addRow({"detid": n, "difc": 1000.0, "difa": 0.0, "tzero": 0.0})
+    return ws
 
 def createCompatibleMask(maskWSName: str, templateWSName: str, instrumentFilePath: str) -> MaskWorkspace:
     """

--- a/tests/util/helpers.py
+++ b/tests/util/helpers.py
@@ -23,6 +23,7 @@ from mantid.simpleapi import (
 )
 from snapred.meta.Config import Resource
 
+
 def createCompatibleDiffCalTable(tableWSName: str, templateWSName: str) -> ITableWorkspace:
     """
     Create an diffraction-calibration `ITableWorkspace` compatible with a template workspace.
@@ -37,6 +38,7 @@ def createCompatibleDiffCalTable(tableWSName: str, templateWSName: str) -> ITabl
     for n in range(templateWS.getInstrument().getNumberDetectors(True)):
         ws.addRow({"detid": n, "difc": 1000.0, "difa": 0.0, "tzero": 0.0})
     return ws
+
 
 def createCompatibleMask(maskWSName: str, templateWSName: str, instrumentFilePath: str) -> MaskWorkspace:
     """

--- a/tests/util/instrument_helpers.py
+++ b/tests/util/instrument_helpers.py
@@ -1,16 +1,18 @@
-from typing import Dict
 from collections.abc import Sequence
+from typing import Dict
+
 from mantid.simpleapi import (
-    mtd,
     CreateLogPropertyTable,
     DeleteWorkspace,
-) 
+    mtd,
+)
+
 
 def mapFromSampleLogs(wsName: str, sampleLogKeys: Sequence[str]) -> Dict[str, float]:
     """
     Extract the workspace sample log entries, corresponding to the specified list of log names.
     """
-    # WARNING: `RuntimeError` is raised if any sample-log entries don't exist.       
+    # WARNING: `RuntimeError` is raised if any sample-log entries don't exist.
     logTableName = mtd.unique_hidden_name()
     CreateLogPropertyTable(
         InputWorkspaces=[wsName],

--- a/tests/util/instrument_helpers.py
+++ b/tests/util/instrument_helpers.py
@@ -1,0 +1,27 @@
+from typing import Dict
+from collections.abc import Sequence
+from mantid.simpleapi import (
+    mtd,
+    CreateLogPropertyTable,
+    DeleteWorkspace,
+) 
+
+def mapFromSampleLogs(wsName: str, sampleLogKeys: Sequence[str]) -> Dict[str, float]:
+    """
+    Extract the workspace sample log entries, corresponding to the specified list of log names.
+    """
+    # WARNING: `RuntimeError` is raised if any sample-log entries don't exist.       
+    logTableName = mtd.unique_hidden_name()
+    CreateLogPropertyTable(
+        InputWorkspaces=[wsName],
+        LogPropertyNames=list(sampleLogKeys),
+        OutputWorkspace=logTableName,
+    )
+    assert mtd.doesExist(logTableName)
+
+    logs: Dict[str, float] = {}
+    logTable = mtd[logTableName]
+    for index, name in enumerate(logTable.getColumnNames()):
+        logs[name] = float(logTable.column(index)[0])
+    DeleteWorkspace(logTableName)
+    return logs

--- a/tests/util/kernel_helpers.py
+++ b/tests/util/kernel_helpers.py
@@ -1,8 +1,11 @@
 from typing import Tuple
+
 from mantid.kernel import V3D, Quat
+
 
 def tupleFromV3D(v: V3D) -> Tuple[float, float, float]:
     return tuple([v[n] for n in range(3)])
-    
+
+
 def tupleFromQuat(q: Quat) -> Tuple[float, float, float, float]:
     return tuple([q[n] for n in range(4)])

--- a/tests/util/kernel_helpers.py
+++ b/tests/util/kernel_helpers.py
@@ -1,0 +1,8 @@
+from typing import Tuple
+from mantid.kernel import V3D, Quat
+
+def tupleFromV3D(v: V3D) -> Tuple[float, float, float]:
+    return tuple([v[n] for n in range(3)])
+    
+def tupleFromQuat(q: Quat) -> Tuple[float, float, float, float]:
+    return tuple([q[n] for n in range(4)])


### PR DESCRIPTION

## Description of work
Diffraction-calibration table and mask workspaces are simultaneously saved in a special hdf5 format, using Mantid's `SaveDiffCal` algorithm.  Unfortunately, this algorithm does not offload any of the associated instrument information.  When reloading these workspaces using `LoadDiffCal`, generally an instrument-donor workspace must be provided.  This is especially true considering the mutable detector _location_ parameters used by the SNAP instrument -- if these parameters are not restored correctly, the detector positions will be invalid

Since the primary responsibility of `GroceryService` is workspace loading and caching, it makes sense that it could also conveniently keep track of instrument-donor workspaces.  Previously this was accomplished using a `fromPrev` `GroceryListBuilder` method, however, in certain cases requiring the loading of a `MaskWorkspace`, no suitable `fromPrev` workspace would be available in the grocery list.  Since in many cases, a suitable instrument-donor workspace will already have been loaded by the service, caching the instrument donor is a straightforward solution.

An additional issue associated with loading and saving of these special workspaces is due to the fact that up to three workspaces are combined into one file on the disk.  This is also quite easy to deal with using the `GroceryService` caching mechanism, in combination with _consistently_ applying the `WorkspaceNameGenerator` naming scheme for these workspaces.

The last major issue dealt with by this pull request is removing all workspace _write_ methods from the `GroceryService`, and thereby removing all `GroceryService` methods from the `LocalDataService` "helper" class.  This then allows several required methods from the `LocalDataService` to be utilized within `GroceryService`, without generating circular import issues.

## Explanation of work
This commit includes the following changes:

  * All mask and table workspace I/O has now been centralized. Special workspace loading now includes automatic caching of suitable instrument-donor workspaces by the `GroceryService`.  These changes remove some of the complexity from the previous treatment of instrument donor in `GroceryService`.  The previous `GroceryListBuilder.source` method is _retained_, in order to allow the instrument-donor caching to be overridden if necessary.  The `GroceryListBuilder.fromPrev` method has been removed.

  * A standardized signature is now used for all workspace "write" methods (now in `LocalDataService`).  This signature is close to what we had already, but gets rid of the conflation of "path" (as base path) and "path" (as completely-specified file path) arguments.  These write methods are then used in the `DataExportService` `exportCalibrationWorkspaces` and `exportNormalizationWorkspaces` methods (new), called by their respective services.

  * All references to `GroceryService` have been moved out of `LocalDataService`:  this minor change allows `LocalDataService` to be _the_ "helper class", and allows `GroceryService` to call `LocalDataService` methods (where necessary) without any circular imports.  Additionally, this allows `GroceryService` to focus on workspace loading and caching, which is appropriate to its name.

  * `LocalDataService.writeCalibrationReductionResult` has been removed as _dead_ code -- mostly due to issues arising during fixups to its unit test.  Not only was this method unused, but its code and unit test were contradictory enough to the current data-file naming scheme that it was almost impossible to ascertain what the method had been intended to accomplish.  If necessary, this method can be added back in and reworked to be consistent with the scheme used in `LocalDataService.writeCalibrationWorkspaces` or `LocalDataService.writeNormalizationWorkspaces`.

  * Lots and lots of spelling corrections.

## To test
  * Extensive modifications to the existing unit tests have been implemented.

### CIS testing
  * These changes are largely SNAPRed internal.  No CIS-testing will be necessary.


## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#3856](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=3856>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
