### PR TITLE
Patch iteration of DiffCal outputs

### DIFF
--- a/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
@@ -276,6 +276,7 @@ class GroupDiffractionCalibration(PythonAlgorithm):
             CalibrationWorkspace=self.DIFCfinal,
         )
         self.convertAndFocusAndReturn(self.wsTOF, self.outputWStof, "after", "dSpacing")
+        self.setPropertyValue("OutputWorkspace", self.outputWStof)
 
     def convertAndFocusAndReturn(self, inputWS: str, outputWS: str, note: str, units: str):
         # Use workspace name generator

--- a/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
@@ -340,6 +340,7 @@ class PixelDiffractionCalibration(PythonAlgorithm):
         # now calculate and correct by offsets
         self.reexecute()
         self._counts += 1
+        self.setPropertyValue("CalibrationTable", self.DIFCpixel)
 
 
 # Register algorithm with Mantid


### PR DESCRIPTION
## Description of work

Arose from Hackathon 2024/02/19.

It was seen, even after PR #235, that if the workflow was iterated the output workspace would have a _name_ indicating d-spacing, but would in fact be in units of TOF.

This was due to not setting the output workspace property in the two diffcal algorithms.

## Explanation of work

Simply added to `PixelDiffractionCalibration`,
``` python
self.setPropertyValue("CalibrationTable", self.DIFCpixel)
```
and to `GroupDiffractionCalibration`,
``` python
self.setPropertyValue("OutputWorkspace", self.outputWStof)
```

*Note:* the variable name for the output workspace in `GroupDiffractionCalibration` is `self,outputWStof`, but it will actually be in d-spacing.  This should probably be fixed later for consistency.

## To test

### Dev testing

Hackathon, make Malcolm do it.

### CIS testing

Run diffraction calibration with run 48860 (or 58882, or whichever), then choose to iterate, and ensure the output is in units of d-spacing.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
