### PR TITLE
Removed logging of warning InstrumentDonor relating to XML format issue

### DIFF
--- a/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
@@ -10,13 +10,10 @@ from mantid.api import (
     PropertyMode,
     PythonAlgorithm,
 )
-from mantid.kernel import Direction
+from mantid.kernel import Direction, logger
 
-from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
-
-logger = snapredLogger.getLogger(__name__)
 
 
 class LoadGroupingDefinition(PythonAlgorithm):
@@ -91,6 +88,10 @@ class LoadGroupingDefinition(PythonAlgorithm):
         # TODO this validation SHOULD occur as part of property validation
         if groupingFileExt not in self.all_extensions:
             errors["GroupingFilename"] = f"Grouping file extension {groupingFileExt} not supported"
+
+        if groupingFileExt not in self.supported_xml_file_extensions:
+            if not self.getProperty("InstrumentDonor").isDefault:
+                logger.warning("InstrumentDonor will only be used if GroupingFilename is in XML format.")
 
         instrumentSources = ["InstrumentDonor", "InstrumentName", "InstrumentFilename"]
         specifiedSources = [s for s in instrumentSources if not self.getProperty(s).isDefault]

--- a/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
@@ -92,10 +92,6 @@ class LoadGroupingDefinition(PythonAlgorithm):
         if groupingFileExt not in self.all_extensions:
             errors["GroupingFilename"] = f"Grouping file extension {groupingFileExt} not supported"
 
-        if groupingFileExt not in self.supported_xml_file_extensions:
-            if not self.getProperty("InstrumentDonor").isDefault:
-                logger.warning("InstrumentDonor will only be used if GroupingFilename is in XML format.")
-
         instrumentSources = ["InstrumentDonor", "InstrumentName", "InstrumentFilename"]
         specifiedSources = [s for s in instrumentSources if not self.getProperty(s).isDefault]
         if len(specifiedSources) > 1:


### PR DESCRIPTION
## Description of work

Removed logging of warning InstrumentDonor relating to XML format issue

## Explanation of work


## To test

Run Normalization on the GUI and make sure the following warning isn't logged: "InstrumentDonor will only be used if GroupingFilename is in XML format."


EWM: https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=4065

