### PR TITLE
Shade in detected peaks in normalization graphs

### DIFF
--- a/src/snapred/backend/dao/request/FocusSpectraRequest.py
+++ b/src/snapred/backend/dao/request/FocusSpectraRequest.py
@@ -5,9 +5,10 @@ from snapred.backend.dao.state.FocusGroup import FocusGroup
 
 
 class FocusSpectraRequest(BaseModel):
+    runNumber: str
+    useLiteMode: bool = True
+    focusGroup: FocusGroup
+
     inputWorkspace: str
     groupingWorkspace: str
-    runNumber: str
-    focusGroup: FocusGroup
-    useLiteMode: bool = True
     outputWorkspace: str

--- a/src/snapred/backend/dao/response/NormalizationResponse.py
+++ b/src/snapred/backend/dao/response/NormalizationResponse.py
@@ -1,7 +1,11 @@
+from typing import List
+
 from pydantic import BaseModel
+from snapred.backend.dao.GroupPeakList import GroupPeakList
 
 
 class NormalizationResponse(BaseModel):
     correctedVanadium: str
-    outputWorkspace: str
-    smoothedOutput: str
+    focusedVanadium: str
+    smoothedVanadium: str
+    detectorPeaks: List[GroupPeakList]

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -229,7 +229,7 @@ class LocalDataService:
 
     def _constructCalibrationStatePath(self, stateId):
         # TODO: Propagate pathlib through codebase
-        return f"{self.instrumentConfig.calibrationDirectory / 'Powder' / stateId}/"
+        return f"{self.instrumentConfig.calibrationDirectory}/Powder/{stateId}/"
 
     def _constructNormalizationCalibrationStatePath(self, stateId):
         # TODO: Propagate pathlib through codebase

--- a/src/snapred/backend/recipe/GenericRecipe.py
+++ b/src/snapred/backend/recipe/GenericRecipe.py
@@ -29,20 +29,13 @@ class GenericRecipe(Generic[T]):
         self.mantidSnapper = MantidSnapper(None, self.algo)
 
     def _baseModelsToStrings(self, **kwargs):
-        print("BASE MODELS TO STRINGS")
         for key, value in kwargs.items():
-            print(f"\tITEM {key}, {value.__class__}")
-            # if isBaseModel(value.__class__):
-            if issubclass(value.__class__, BaseModel):
+            if isBaseModel(value.__class__):
+                # if issubclass(value.__class__, BaseModel):
                 kwargs[key] = value.json()
-                print(f"\t\tNOT LIST {kwargs[key]}")
             # elif isListOfBaseModel(value.__class__):
             elif isinstance(value, list) and issubclass(value[0].__class__, BaseModel):
                 kwargs[key] = json.dumps([v.dict() for v in value])
-                print(f"\t\tLIST {kwargs[key]} -- type = {type(kwargs[key])}")
-            else:
-                print("\t\tIT IS NOTHING!  NOOOOTTHING!!!")
-        print("DONE!")
         return kwargs
 
     def executeRecipe(self, **kwargs):

--- a/src/snapred/backend/recipe/GenericRecipe.py
+++ b/src/snapred/backend/recipe/GenericRecipe.py
@@ -41,8 +41,6 @@ class GenericRecipe(Generic[T]):
     def executeRecipe(self, **kwargs):
         logger.info("Executing generic recipe for algo: %s" % self.algo)
         kwargs = self._baseModelsToStrings(**kwargs)
-        for key, value in kwargs.items():
-            print(f"{key} -- {value}")
 
         outputs = None
         try:
@@ -54,9 +52,8 @@ class GenericRecipe(Generic[T]):
         logger.info("Finished executing recipe for algo: %s" % self.algo)
 
         # unwrap callback wrappers
-        if type(outputs) is tuple:
-            for i in range(len(outputs)):
-                outputs[i] = outputs[i].get()
+        if isinstance(outputs, tuple):
+            outputs = [x.get() for x in list(outputs)]
         else:
             outputs = outputs.get()
         return outputs

--- a/src/snapred/backend/recipe/GenericRecipe.py
+++ b/src/snapred/backend/recipe/GenericRecipe.py
@@ -31,16 +31,15 @@ class GenericRecipe(Generic[T]):
     def _baseModelsToStrings(self, **kwargs):
         for key, value in kwargs.items():
             if isBaseModel(value.__class__):
-                # if issubclass(value.__class__, BaseModel):
                 kwargs[key] = value.json()
-            # elif isListOfBaseModel(value.__class__):
+            # NOTE the equivalent function isListOfBaseModel was not working
+            # in the case of the smoothing algo.  The below does work.
             elif isinstance(value, list) and issubclass(value[0].__class__, BaseModel):
                 kwargs[key] = json.dumps([v.dict() for v in value])
         return kwargs
 
     def executeRecipe(self, **kwargs):
         logger.info("Executing generic recipe for algo: %s" % self.algo)
-        print(f"**** DATA FOR {self.algo}****")
         kwargs = self._baseModelsToStrings(**kwargs)
         for key, value in kwargs.items():
             print(f"{key} -- {value}")

--- a/src/snapred/backend/recipe/GenericRecipe.py
+++ b/src/snapred/backend/recipe/GenericRecipe.py
@@ -3,6 +3,8 @@ from typing import Generic, TypeVar, get_args
 
 from mantid.simpleapi import ConvertTableToMatrixWorkspace
 
+from pydantic import BaseModel
+
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.CalibrationMetricExtractionAlgorithm import CalibrationMetricExtractionAlgorithm
 from snapred.backend.recipe.algorithm.DetectorPeakPredictor import DetectorPeakPredictor
@@ -28,17 +30,28 @@ class GenericRecipe(Generic[T]):
         self.mantidSnapper = MantidSnapper(None, self.algo)
 
     def _baseModelsToStrings(self, **kwargs):
+        print(f"BASE MODELS TO STRINGS")
         for key, value in kwargs.items():
-            if isBaseModel(value.__class__):
+            print(f"\tITEM {key}, {value.__class__}")
+            # if isBaseModel(value.__class__):
+            if issubclass(value.__class__, BaseModel):
                 kwargs[key] = value.json()
-            elif isListOfBaseModel(value.__class__):
+                print(f"\t\tNOT LIST {kwargs[key]}")
+            # elif isListOfBaseModel(value.__class__):
+            elif isinstance(value, list) and issubclass(value[0].__class__, BaseModel):
                 kwargs[key] = json.dumps([v.dict() for v in value])
+                print(f"\t\tLIST {kwargs[key]} -- type = {type(kwargs[key])}")
+            else:
+                print(f"\t\tIT IS NOTHING!  NOOOOTTHING!!!")
+        print(f"DONE!")
         return kwargs
 
     def executeRecipe(self, **kwargs):
         logger.info("Executing generic recipe for algo: %s" % self.algo)
-
+        print(f"**** DATA FOR {self.algo}****")
         kwargs = self._baseModelsToStrings(**kwargs)
+        for key, value in kwargs.items():
+            print(f"{key} -- {value}")
 
         outputs = None
         try:

--- a/src/snapred/backend/recipe/GenericRecipe.py
+++ b/src/snapred/backend/recipe/GenericRecipe.py
@@ -2,7 +2,6 @@ import json
 from typing import Generic, TypeVar, get_args
 
 from mantid.simpleapi import ConvertTableToMatrixWorkspace
-
 from pydantic import BaseModel
 
 from snapred.backend.log.logger import snapredLogger
@@ -30,7 +29,7 @@ class GenericRecipe(Generic[T]):
         self.mantidSnapper = MantidSnapper(None, self.algo)
 
     def _baseModelsToStrings(self, **kwargs):
-        print(f"BASE MODELS TO STRINGS")
+        print("BASE MODELS TO STRINGS")
         for key, value in kwargs.items():
             print(f"\tITEM {key}, {value.__class__}")
             # if isBaseModel(value.__class__):
@@ -42,8 +41,8 @@ class GenericRecipe(Generic[T]):
                 kwargs[key] = json.dumps([v.dict() for v in value])
                 print(f"\t\tLIST {kwargs[key]} -- type = {type(kwargs[key])}")
             else:
-                print(f"\t\tIT IS NOTHING!  NOOOOTTHING!!!")
-        print(f"DONE!")
+                print("\t\tIT IS NOTHING!  NOOOOTTHING!!!")
+        print("DONE!")
         return kwargs
 
     def executeRecipe(self, **kwargs):

--- a/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
@@ -43,7 +43,7 @@ class SmoothDataExcludingPeaksAlgo(PythonAlgorithm):
         )
         self.declareProperty("DetectorPeakIngredients", defaultValue="", direction=Direction.Input)
         self.declareProperty("DetectorPeaks", defaultValue="", direction=Direction.Input)
-        self.declareProperty("SmoothingParameter", defaultValue="", direction=Direction.Input)
+        self.declareProperty("SmoothingParameter", defaultValue=0.0, direction=Direction.Input)
         self.setRethrows(True)
         self.mantidSnapper = MantidSnapper(self, __name__)
 

--- a/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
@@ -71,7 +71,9 @@ class SmoothDataExcludingPeaksAlgo(PythonAlgorithm):
             )
         # validate sources of smoothing parameter
         ingredientSmoothParam = None
-        ingredientSmoothParam = json.loads(self.getPropertyValue("DetectorPeakIngredients") or '{}').get("smoothingParameter")
+        ingredientSmoothParam = json.loads(self.getPropertyValue("DetectorPeakIngredients") or "{}").get(
+            "smoothingParameter"
+        )
         specifiedIngredients = ingredientSmoothParam is not None
         specifiedProperties = not self.getProperty("SmoothingParameter").isDefault
         if not specifiedIngredients and not specifiedProperties:
@@ -110,7 +112,7 @@ class SmoothDataExcludingPeaksAlgo(PythonAlgorithm):
             "Calculating spectrum weights...",
             InputWorkspace=self.outputWorkspaceName,
             DetectorPeaks=self.getPropertyValue("DetectorPeaks"),
-            DetectorPeakIngredients=ingredients.json() if ingredients else '',
+            DetectorPeakIngredients=ingredients.json() if ingredients else "",
             WeightWorkspace=self.weightWorkspaceName,
         )
         self.mantidSnapper.executeQueue()

--- a/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
@@ -95,7 +95,7 @@ class SmoothDataExcludingPeaksAlgo(PythonAlgorithm):
         if not self.getProperty("DetectorPeakIngredients").isDefault:
             ingredients = Ingredients.parse_raw(self.getPropertyValue("DetectorPeakIngredients"))
         if self.getProperty("SmoothingParameter").isDefault:
-            self.lam = ingredients.get("smoothingParameter", 0.0)
+            self.lam = ingredients.smoothingParameter
         else:
             self.lam = float(self.getPropertyValue("SmoothingParameter"))
         self.unbagGroceries()

--- a/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
@@ -41,9 +41,9 @@ class SmoothDataExcludingPeaksAlgo(PythonAlgorithm):
             MatrixWorkspaceProperty("OutputWorkspace", "", Direction.Output, PropertyMode.Mandatory),
             doc="Workspace with removed peaks",
         )
-        self.declareProperty("DetectorPeakIngredients", defaultValue="", direction=Direction.Input)
+        self.declareProperty("DetectorPeakIngredients", defaultValue="{}", direction=Direction.Input)
         self.declareProperty("DetectorPeaks", defaultValue="", direction=Direction.Input)
-        self.declareProperty("SmoothingParameter", defaultValue=0.0, direction=Direction.Input)
+        self.declareProperty("SmoothingParameter", defaultValue=-1.0, direction=Direction.Input)
         self.setRethrows(True)
         self.mantidSnapper = MantidSnapper(self, __name__)
 
@@ -61,7 +61,7 @@ class SmoothDataExcludingPeaksAlgo(PythonAlgorithm):
         waysToGetPeaks = ["DetectorPeaks", "DetectorPeakIngredients"]
         definedWaysToGetPeaks = [x for x in waysToGetPeaks if not self.getProperty(x).isDefault]
         if len(definedWaysToGetPeaks) == 0:
-            msg = "Purse peaks requires either a list of peaks, or ingredients to detect peaks"
+            msg = "Purge peaks requires either a list of peaks, or ingredients to detect peaks"
             errors["DetectorPeaks"] = msg
             errors["DetectorPeakIngredients"] = msg
         elif len(definedWaysToGetPeaks) == 2:
@@ -70,12 +70,9 @@ class SmoothDataExcludingPeaksAlgo(PythonAlgorithm):
                 the list will be used and ingredients ignored"""
             )
         # validate sources of smoothing parameter
-        ingredientSmoothParam = None
-        ingredientSmoothParam = json.loads(self.getPropertyValue("DetectorPeakIngredients") or "{}").get(
-            "smoothingParameter"
-        )
-        specifiedIngredients = ingredientSmoothParam is not None
-        specifiedProperties = not self.getProperty("SmoothingParameter").isDefault
+        ingredients = json.loads(self.getPropertyValue("DetectorPeakIngredients"))
+        specifiedIngredients = ingredients.get("smoothingParameter") is not None
+        specifiedProperties = self.getProperty("SmoothingParameter").value >= 0
         if not specifiedIngredients and not specifiedProperties:
             msg = "You must specify smoothing parameter through either ingredients or property"
             errors["DetectorPeakIngredients"] = msg

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -207,14 +207,21 @@ class NormalizationService(Service):
         )
         peaks = self.sousChef.prepDetectorPeaks(farmFresh)
 
+        # execute recipe -- the output will be set by the algorithm
         SmoothDataExcludingPeaksRecipe().executeRecipe(
             InputWorkspace=request.inputWorkspace,
             OutputWorkspace=request.outputWorkspace,
             DetectorPeaks=peaks,
             SmoothingParameter=request.smoothingParameter,
         )
+
+        # we need the corrected vanadium workspace name to be in response
+        # if this endpoint is being called, the vanadium already exists with the below name
+        correctedVanadium = wng.rawVanadium().runNumber(request.runNumber).build()
+
+        # return response
         return NormalizationResponse(
-            correctedVanadium="",
+            correctedVanadium=correctedVanadium,
             focusedVanadium=request.inputWorkspace,
             smoothedVanadium=request.outputWorkspace,
             detectorPeaks=peaks,

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -5,7 +5,6 @@ from typing import Any, Dict
 from snapred.backend.dao import Limit
 from snapred.backend.dao.ingredients import (
     GroceryListItem,
-    NormalizationIngredients,
 )
 from snapred.backend.dao.normalization import (
     Normalization,
@@ -76,10 +75,8 @@ class NormalizationService(Service):
         )
         ingredients = self.sousChef.prepNormalizationIngredients(farmFresh)
 
-        # outputWorkspace=wng.run().runNumber(request.runNumber).group(groupingScheme).auxilary("S+F-Vanadium").build()
         correctedVanadium = wng.rawVanadium().runNumber(request.runNumber).build()
         focusedVanadium = wng.run().runNumber(request.runNumber).group(groupingScheme).auxilary("S+F-Vanadium").build()
-        # focusedVanadium = wng.focusedRawVanadium().runNumber(request.runNumber).group(groupingScheme).build()
         smoothedVanadium = wng.smoothedFocusedRawVanadium().runNumber(request.runNumber).group(groupingScheme).build()
 
         if (

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -77,7 +77,7 @@ class NormalizationService(Service):
 
         # prepare and check focus group workspaces -- see if grouping already calculated
         correctedVanadium = wng.rawVanadium().runNumber(request.runNumber).build()
-        focusedVanadium = wng.run().runNumber(request.runNumber).group(groupingScheme).auxilary("S+F-Vanadium").build()
+        focusedVanadium = wng.run().runNumber(request.runNumber).group(groupingScheme).auxiliary("S+F-Vanadium").build()
         smoothedVanadium = wng.smoothedFocusedRawVanadium().runNumber(request.runNumber).group(groupingScheme).build()
 
         if (

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -121,7 +121,7 @@ class NormalizationService(Service):
         SmoothDataExcludingPeaksRecipe().executeRecipe(
             InputWorkspace=focusedVanadium,
             DetectorPeaks=ingredients.detectorPeaks,
-            SmoothingParameter=str(request.smoothingParameter),
+            SmoothingParameter=request.smoothingParameter,
             OutputWorkspace=smoothedVanadium,
         )
         # done
@@ -209,7 +209,7 @@ class NormalizationService(Service):
             InputWorkspace=request.inputWorkspace,
             OutputWorkspace=request.outputWorkspace,
             DetectorPeaks=peaks,
-            SmoothingParameter=str(request.smoothingParameter),
+            SmoothingParameter=request.smoothingParameter,
         )
         return NormalizationResponse(
             correctedVanadium="",

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -124,7 +124,7 @@ class NormalizationService(Service):
         SmoothDataExcludingPeaksRecipe().executeRecipe(
             InputWorkspace=focusedVanadium,
             DetectorPeaks=ingredients.detectorPeaks,
-            SmoothingParameter=request.smoothingParameter,
+            SmoothingParameter=str(request.smoothingParameter),
             OutputWorkspace=smoothedVanadium,
         )
         # done

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 from snapred.backend.dao import Limit
 from snapred.backend.dao.ingredients import (
     GroceryListItem,
+    NormalizationIngredients,
 )
 from snapred.backend.dao.normalization import (
     Normalization,
@@ -63,6 +64,37 @@ class NormalizationService(Service):
     def normalization(self, request: NormalizationCalibrationRequest):
         groupingScheme = request.focusGroup.name
 
+        # prepare ingredients
+        cifPath = self.dataFactoryService.getCifFilePath(request.calibrantSamplePath.split("/")[-1].split(".")[0])
+        farmFresh = FarmFreshIngredients(
+            runNumber=request.runNumber,
+            useLiteMode=request.useLiteMode,
+            focusGroup=request.focusGroup,
+            cifPath=cifPath,
+            calibrantSamplePath=request.calibrantSamplePath,
+            crystalDBounds=Limit(minimum=request.crystalDMin, maximum=request.crystalDMax),
+        )
+        ingredients = self.sousChef.prepNormalizationIngredients(farmFresh)
+
+        # outputWorkspace=wng.run().runNumber(request.runNumber).group(groupingScheme).auxilary("S+F-Vanadium").build()
+        correctedVanadium = wng.rawVanadium().runNumber(request.runNumber).build()
+        focusedVanadium = wng.run().runNumber(request.runNumber).group(groupingScheme).auxilary("S+F-Vanadium").build()
+        # focusedVanadium = wng.focusedRawVanadium().runNumber(request.runNumber).group(groupingScheme).build()
+        smoothedVanadium = wng.smoothedFocusedRawVanadium().runNumber(request.runNumber).group(groupingScheme).build()
+
+        if (
+            self.groceryService.workspaceDoesExist(correctedVanadium)
+            and self.groceryService.workspaceDoesExist(focusedVanadium)
+            and self.groceryService.workspaceDoesExist(smoothedVanadium)
+        ):
+            return NormalizationResponse(
+                correctedVanadium=correctedVanadium,
+                focusedVanadium=focusedVanadium,
+                smoothedVanadium=smoothedVanadium,
+                detectorPeaks=ingredients.detectorPeaks,
+            ).dict()
+
+        # gather needed groceries and ingredients
         self.groceryClerk.name("inputWorkspace").neutron(request.runNumber).useLiteMode(request.useLiteMode).add()
         self.groceryClerk.name("backgroundWorkspace").neutron(request.backgroundRunNumber).useLiteMode(
             request.useLiteMode
@@ -70,74 +102,37 @@ class NormalizationService(Service):
         self.groceryClerk.name("groupingWorkspace").grouping(groupingScheme).useLiteMode(
             request.useLiteMode
         ).fromPrev().add()
-
-        outputWorkspace = wng.run().runNumber(request.runNumber).group(groupingScheme).auxilary("S+F-Vanadium").build()
-        correctedVanadium = wng.rawVanadium().runNumber(request.runNumber).build()
-        smoothedOutput = wng.smoothedFocusedRawVanadium().runNumber(request.runNumber).group(groupingScheme).build()
-
-        if (
-            self.groceryService.workspaceDoesExist(outputWorkspace)
-            and self.groceryService.workspaceDoesExist(correctedVanadium)
-            and self.groceryService.workspaceDoesExist(smoothedOutput)
-        ):
-            return NormalizationResponse(
-                correctedVanadium=correctedVanadium,
-                outputWorkspace=outputWorkspace,
-                smoothedOutput=smoothedOutput,
-            ).dict()
-
         groceries = self.groceryService.fetchGroceryDict(
             self.groceryClerk.buildDict(),
-            outputWorkspace=outputWorkspace,
-            smoothedOutput=smoothedOutput,
         )
 
-        # 1. correction
-        vanadiumCorrectionRequest = VanadiumCorrectionRequest(
-            runNumber=request.runNumber,
-            useLiteMode=request.useLiteMode,
-            focusGroup=request.focusGroup,
-            calibrantSamplePath=request.calibrantSamplePath,
-            inputWorkspace=groceries["inputWorkspace"],
-            backgroundWorkspace=groceries["backgroundWorkspace"],
-            outputWorkspace=groceries["outputWorkspace"],
-            crystalDMin=request.crystalDMin,
-            crystalDMax=request.crystalDMax,
+        # 1. correctiom
+        RawVanadiumCorrectionRecipe().executeRecipe(
+            InputWorkspace=groceries["inputWorkspace"],
+            BackgroundWorkspace=groceries["backgroundWorkspace"],
+            Ingredients=ingredients,
+            OutputWorkspace=correctedVanadium,
         )
-        outputWorkspace = self.vanadiumCorrection(vanadiumCorrectionRequest)
-        # clone output correctedVanadium
-        correctedVanadiumWs = correctedVanadium
-        self.groceryService.getCloneOfWorkspace(outputWorkspace, correctedVanadiumWs)
         # 2. focus
-        requestFs = FocusSpectraRequest(
-            inputWorkspace=correctedVanadiumWs,
-            groupingWorkspace=groceries["groupingWorkspace"],
-            runNumber=request.runNumber,
-            focusGroup=request.focusGroup,
-            useLiteMode=request.useLiteMode,
-            outputWorkspace=outputWorkspace,
+        FocusSpectraRecipe().executeRecipe(
+            InputWorkspace=correctedVanadium,
+            GroupingWorkspace=groceries["groupingWorkspace"],
+            Ingredients=ingredients.pixelGroup,
+            OutputWorkspace=focusedVanadium,
         )
-        outputWorkspace = self.focusSpectra(requestFs)
-        # clone output focussedVanadium
-        focusedVanadiumWs = wng.focusedRawVanadium().runNumber(request.runNumber).group(groupingScheme).build()
-        self.groceryService.getCloneOfWorkspace(outputWorkspace, focusedVanadiumWs)
         # 3. smooth
-
-        smoothRequest = SmoothDataExcludingPeaksRequest(
-            inputWorkspace=focusedVanadiumWs,
-            outputWorkspace=smoothedOutput,
-            calibrantSamplePath=request.calibrantSamplePath,
-            focusGroup=request.focusGroup,
-            useLiteMode=request.useLiteMode,
-            runNumber=request.runNumber,
-            smoothingParameter=request.smoothingParameter,
-            crystalDMin=request.crystalDMin,
-            crystalDMax=request.crystalDMax,
+        SmoothDataExcludingPeaksRecipe().executeRecipe(
+            InputWorkspace=focusedVanadium,
+            DetectorPeaks=ingredients.detectorPeaks,
+            SmoothingParameter=request.smoothingParameter,
+            OutputWorkspace=smoothedVanadium,
         )
-        outputWorkspace = self.smoothDataExcludingPeaks(smoothRequest)
-
+        # done
         return NormalizationResponse(
-            correctedVanadium=correctedVanadiumWs, outputWorkspace=focusedVanadiumWs, smoothedOutput=outputWorkspace
+            correctedVanadium=correctedVanadium,
+            focusedVanadium=focusedVanadium,
+            smoothedVanadium=smoothedVanadium,
+            detectorPeaks=ingredients.detectorPeaks,
         ).dict()
 
     @FromString
@@ -160,7 +155,6 @@ class NormalizationService(Service):
         entry.version = normalizationRecord.version
         self.saveNormalizationToIndex(entry)
 
-    @FromString
     def saveNormalizationToIndex(self, entry: NormalizationIndexEntry):
         if entry.appliesTo is None:
             entry.appliesTo = ">" + entry.runNumber
@@ -169,7 +163,6 @@ class NormalizationService(Service):
         logger.info(f"Saving normalization index entry for Run Number {entry.runNumber}")
         self.dataExportService.exportNormalizationIndexEntry(entry)
 
-    @FromString
     def vanadiumCorrection(self, request: VanadiumCorrectionRequest):
         cifPath = self.dataFactoryService.getCifFilePath(request.calibrantSamplePath.split("/")[-1].split(".")[0])
         farmFresh = FarmFreshIngredients(
@@ -188,7 +181,6 @@ class NormalizationService(Service):
             OutputWorkspace=request.outputWorkspace,
         )
 
-    @FromString
     def focusSpectra(self, request: FocusSpectraRequest):
         farmFresh = FarmFreshIngredients(
             runNumber=request.runNumber,
@@ -214,11 +206,12 @@ class NormalizationService(Service):
             calibrantSamplePath=request.calibrantSamplePath,
             crystalDBounds=Limit(minimum=request.crystalDMin, maximum=request.crystalDMax),
         )
-        ingredients = self.sousChef.prepPeakIngredients(farmFresh)
-        ingredients.smoothingParameter = request.smoothingParameter
+        peaks = self.sousChef.prepDetectorPeaks(farmFresh)
 
-        return SmoothDataExcludingPeaksRecipe().executeRecipe(
+        SmoothDataExcludingPeaksRecipe().executeRecipe(
             InputWorkspace=request.inputWorkspace,
             OutputWorkspace=request.outputWorkspace,
-            DetectorPeakIngredients=ingredients,
+            DetectorPeaks=peaks,
+            SmoothingParameter=request.smoothingParameter,
         )
+        return peaks

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -212,6 +212,11 @@ class NormalizationService(Service):
             InputWorkspace=request.inputWorkspace,
             OutputWorkspace=request.outputWorkspace,
             DetectorPeaks=peaks,
-            SmoothingParameter=request.smoothingParameter,
+            SmoothingParameter=str(request.smoothingParameter),
         )
-        return peaks
+        return NormalizationResponse(
+            correctedVanadium="",
+            focusedVanadium=request.inputWorkspace,
+            smoothedVanadium=request.outputWorkspace,
+            detectorPeaks=peaks,
+        ).dict()

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -47,7 +47,7 @@ class SousChef(Service):
         self.dataFactoryService = DataFactoryService()
         self._pixelGroupCache: Dict[Tuple[str, bool, str], PixelGroup] = {}
         self._calibrationCache: Dict[str, Calibration] = {}
-        self._peaksCache: Dict[Tuple[str, bool, str, float], List[GroupPeakList]] = {}
+        self._peaksCache: Dict[Tuple[str, bool, str, float, float, float], List[GroupPeakList]] = {}
         self._xtalCache: Dict[Tuple[str, float, float], CrystallographicInfo] = {}
         return
 
@@ -122,6 +122,8 @@ class SousChef(Service):
             ingredients.runNumber,
             ingredients.useLiteMode,
             ingredients.focusGroup.name,
+            ingredients.crystalDBounds.minimum,
+            ingredients.crystalDBounds.maximum,
             ingredients.peakIntensityThreshold,
         )
         if key not in self._peaksCache:

--- a/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
+++ b/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
@@ -33,9 +33,6 @@ class SpecifyNormalizationCalibrationView(QWidget):
         super().__init__(parent)
         self._jsonFormList = JsonFormList(name, jsonSchemaMap, parent=parent)
 
-        self.groupingSchema = None
-        self.subplots = []
-
         self.layout = QGridLayout()
         self.setLayout(self.layout)
 
@@ -177,15 +174,15 @@ class SpecifyNormalizationCalibrationView(QWidget):
             return
         self.signalValueChanged.emit(index, smoothingValue, dMin)
 
-    def updateWorkspaces(self, focusWorkspace, smoothedWorkspace):
+    def updateWorkspaces(self, focusWorkspace, smoothedWorkspace, peaks):
         self.focusWorkspace = focusWorkspace
         self.smoothedWorkspace = smoothedWorkspace
         self.groupingSchema = (
             str(self.groupingDropDown.currentText()).split("/")[-1].split(".")[0].replace("SNAPFocGroup_", "")
         )
-        self._updateGraphs()
+        self._updateGraphs(peaks)
 
-    def _updateGraphs(self):
+    def _updateGraphs(self, peaks):
         # get the updated workspaces and optimal graph grid
         focusedWorkspace = mtd[self.focusWorkspace]
         smoothedWorkspace = mtd[self.smoothedWorkspace]
@@ -203,6 +200,11 @@ class SpecifyNormalizationCalibrationView(QWidget):
             ax.set_title(f"Group ID: {i + 1}")
             ax.set_xlabel("d-Spacing (Å)")
             ax.set_ylabel("Intensity")
+            for peak in peaks[i].peaks:
+                # ax.fill_between(focusedWorkspace, wkspIndex=i, where=(x<peak.maximum and x>peak.minimum))
+                ax.vlines(peak.value, ymin=1e6, ymax=1e8, color="red")
+                ax.vlines(peak.minimum, ymin=1e6, ymax=1e8, color="orange")
+                ax.vlines(peak.maximum, ymin=1e6, ymax=1e8, color="orange")
 
         # resize window and redraw
         self.setMinimumHeight(self.initialLayoutHeight + int(self.figure.get_size_inches()[1] * self.figure.dpi))

--- a/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
+++ b/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
@@ -1,8 +1,11 @@
 import math
 import unittest.mock as mock
+from typing import List
 
 import matplotlib.pyplot as plt
+from mantid.plots.datafunctions import get_spectrum
 from mantid.simpleapi import mtd
+from pydantic import parse_obj_as
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
     QComboBox,
@@ -18,14 +21,10 @@ from PyQt5.QtWidgets import (
 from workbench.plotting.figuremanager import FigureManagerWorkbench, MantidFigureCanvas
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
 
+from snapred.backend.dao import GroupPeakList
 from snapred.meta.Config import Config
 from snapred.ui.widget.JsonFormList import JsonFormList
 from snapred.ui.widget.LabeledField import LabeledField
-from mantid.plots.datafunctions import get_spectrum
-
-from typing import List
-from pydantic import parse_obj_as
-from snapred.backend.dao import GroupPeakList
 
 
 class SpecifyNormalizationCalibrationView(QWidget):

--- a/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
+++ b/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
@@ -200,11 +200,20 @@ class SpecifyNormalizationCalibrationView(QWidget):
             ax.set_title(f"Group ID: {i + 1}")
             ax.set_xlabel("d-Spacing (Å)")
             ax.set_ylabel("Intensity")
+            # plot the min value for peaks
+            ax.axvline(x=float(self.fielddMin.field.text()), label="dMin", color="red")
+            # fill in the discovered peaks for easier viewing
+            x = mtd[focusedWorkspace].readX(i)
+            y = mtd[focusedWorkspace].readY(i)
+            # get the bin width to normalize the y-vector
+            dx = x[1:] - x[0:-1]
+            y = [yy / ddx for yy, ddx in zip(y, dx)]
+            # histograms have edges, the y-value at the center of both edges -- this matches x, y
+            x = 0.5 * (x[1:] + x[:-1])
+            # for each detected peak in this group, shade in the peak region
             for peak in peaks[i].peaks:
-                # ax.fill_between(focusedWorkspace, wkspIndex=i, where=(x<peak.maximum and x>peak.minimum))
-                ax.vlines(peak.value, ymin=1e6, ymax=1e8, color="red")
-                ax.vlines(peak.minimum, ymin=1e6, ymax=1e8, color="orange")
-                ax.vlines(peak.maximum, ymin=1e6, ymax=1e8, color="orange")
+                under_peaks = [(peak.minimum < xx and xx < peak.maximum) for xx in x]
+                ax.fill_between(x, y, where=under_peaks, color="blue", alpha=0.5)
 
         # resize window and redraw
         self.setMinimumHeight(self.initialLayoutHeight + int(self.figure.get_size_inches()[1] * self.figure.dpi))

--- a/src/snapred/ui/workflow/NormalizationCalibrationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationCalibrationWorkflow.py
@@ -225,7 +225,7 @@ class NormalizationCalibrationWorkflow:
         response = self.interfaceController.executeRequest(request)
         self.responses.append(response)
 
-        peaks = response.data
+        peaks = response.data["detectorPeaks"]
         self._specifyNormalizationView.updateWorkspaces(focusWorkspace, smoothWorkspace, peaks)
 
     def onNormalizationValueChange(self, index, smoothingValue, dMin):  # noqa: ARG002

--- a/src/snapred/ui/workflow/NormalizationCalibrationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationCalibrationWorkflow.py
@@ -1,12 +1,11 @@
 import json
-from typing import List
 
 from pydantic import parse_raw_as
 from PyQt5.QtCore import QObject, Qt, pyqtSignal
 from PyQt5.QtWidgets import QLabel, QMessageBox, QVBoxLayout, QWidget
 
 from snapred.backend.api.InterfaceController import InterfaceController
-from snapred.backend.dao import GroupPeakList, SNAPRequest, SNAPResponse
+from snapred.backend.dao import SNAPRequest, SNAPResponse
 from snapred.backend.dao.normalization import NormalizationIndexEntry, NormalizationRecord
 from snapred.backend.dao.request import (
     NormalizationCalibrationRequest,

--- a/src/snapred/ui/workflow/NormalizationCalibrationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationCalibrationWorkflow.py
@@ -130,7 +130,7 @@ class NormalizationCalibrationWorkflow:
 
         focusWorkspace = self.responses[-1].data["focusedVanadium"]
         smoothWorkspace = self.responses[-1].data["smoothedVanadium"]
-        peaks = parse_raw_as(List[GroupPeakList], self.responses[-1].data["detectorPeaks"])
+        peaks = self.responses[-1].data["detectorPeaks"]
 
         self._specifyNormalizationView.updateWorkspaces(focusWorkspace, smoothWorkspace, peaks)
         self.initializationComplete = True
@@ -204,7 +204,7 @@ class NormalizationCalibrationWorkflow:
 
         focusWorkspace = self.responses[-1].data["focusedVanadium"]
         smoothWorkspace = self.responses[-1].data["smoothedVanadium"]
-        peaks = parse_raw_as(List[GroupPeakList], self.responses[-1].data["detectorPeaks"])
+        peaks = self.responses[-1].data["detectorPeaks"]
         self._specifyNormalizationView.updateWorkspaces(focusWorkspace, smoothWorkspace, peaks)
 
     def applySmoothingUpdate(self, index, smoothingValue, dMin):
@@ -225,7 +225,7 @@ class NormalizationCalibrationWorkflow:
         response = self.interfaceController.executeRequest(request)
         self.responses.append(response)
 
-        peaks = parse_raw_as(List[GroupPeakList], response.data)
+        peaks = response.data
         self._specifyNormalizationView.updateWorkspaces(focusWorkspace, smoothWorkspace, peaks)
 
     def onNormalizationValueChange(self, index, smoothingValue, dMin):  # noqa: ARG002
@@ -250,7 +250,7 @@ class NormalizationCalibrationWorkflow:
         elif "focusedVanadium" in self.responses[-1].data and "smoothedVanadium" in self.responses[-1].data:
             focusWorkspace = self.responses[-1].data["focusedVanadium"]
             smoothWorkspace = self.responses[-1].data["smoothedVanadium"]
-            peaks = parse_raw_as(List[GroupPeakList], self.responses[-1].data["detectorPeaks"])
+            peaks = self.responses[-1].data["detectorPeaks"]
             self._specifyNormalizationView.updateWorkspaces(focusWorkspace, smoothWorkspace, peaks)
         else:
             raise Exception("Expected data not found in the last response")

--- a/tests/cis_tests/shade_detector_peaks.py
+++ b/tests/cis_tests/shade_detector_peaks.py
@@ -22,7 +22,7 @@ snapredLogger._level = 20
 
 runNumber = '58882'#58409'
 cifPath = '/SNS/SNAP/shared/Calibration/CalibrantSamples/Silicon_NIST_640d.cif'
-groupingScheme = "All"
+groupingScheme = "Column"
 isLite = True
 # SET TO TRUE TO STOP WASHING DISHES
 Config._config['cis_mode'] = False
@@ -31,7 +31,7 @@ Config._config['cis_mode'] = False
 ### FETCH GROCERIES
 clerk = GroceryListItem.builder()
 clerk.neutron(runNumber).useLiteMode(isLite).add()
-clerk.grouping(groupingScheme).useLiteMode(isLite).fromPrev().add()
+clerk.grouping(groupingScheme).useLiteMode(isLite).fromRun(runNumber).add()
 groceries = GroceryService().fetchGroceryList(clerk.buildList())
 
 ConvertUnits(
@@ -61,9 +61,14 @@ farmFresh = FarmFreshIngredients(
 )
 peakList = SousChef().prepDetectorPeaks(farmFresh)
 
+numSpec = len(peakList)
+ncols = min(numSpec, 3)
+nrows = int(np.ceil( (numSpec-ncols)/ncols )) + 1
+
+figure = plt.figure(constrained_layout=True)
 for i,group in enumerate(peakList):
     tableName = f'peakProperties{i+1}'
-    fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
+    ax = figure.add_subplot(nrows, ncols, i + 1, projection="mantid")
     ax.plot(mtd[groceries[0]], wkspIndex=i, normalize_by_bin_width=True)
     ax.axvline(x=farmFresh.crystalDBounds.minimum, color="red")
     ax.axvline(x=farmFresh.crystalDBounds.maximum, color="red")
@@ -71,4 +76,4 @@ for i,group in enumerate(peakList):
     for peak in group.peaks:
         ax.fill_between(x, y, where=[(peak.minimum < xx and xx < peak.maximum) for xx in x], color="blue", alpha=0.5)
     ax.legend() # show the legend
-    fig.show()
+figure.show()

--- a/tests/cis_tests/shade_detector_peaks.py
+++ b/tests/cis_tests/shade_detector_peaks.py
@@ -1,0 +1,74 @@
+from mantid.simpleapi import *
+from mantid.plots.datafunctions import get_spectrum
+import matplotlib.pyplot as plt
+import numpy as np
+import json
+
+from snapred.backend.recipe.algorithm.DetectorPeakPredictor import DetectorPeakPredictor
+from snapred.backend.log.logger import snapredLogger
+from snapred.meta.Config import Config
+
+# for loading data
+from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
+from snapred.backend.data.GroceryService import GroceryService
+
+# for creating ingredients
+from snapred.backend.dao.request.FarmFreshIngredients import FarmFreshIngredients
+from snapred.backend.service.SousChef import SousChef
+
+snapredLogger._level = 20
+
+#User inputs ###########################
+
+runNumber = '58882'#58409'
+cifPath = '/SNS/SNAP/shared/Calibration/CalibrantSamples/Silicon_NIST_640d.cif'
+groupingScheme = "All"
+isLite = True
+# SET TO TRUE TO STOP WASHING DISHES
+Config._config['cis_mode'] = False
+#######################################
+
+### FETCH GROCERIES
+clerk = GroceryListItem.builder()
+clerk.neutron(runNumber).useLiteMode(isLite).add()
+clerk.grouping(groupingScheme).useLiteMode(isLite).fromPrev().add()
+groceries = GroceryService().fetchGroceryList(clerk.buildList())
+
+ConvertUnits(
+    InputWorkspace = groceries[0],
+    OutputWorkspace = groceries[0],
+    Target="dSpacing",
+)
+DiffractionFocussing(
+    InputWorkspace = groceries[0],
+    OutputWorkspace = groceries[0],
+    GroupingWorkspace = groceries[1],
+)
+Rebin(
+    InputWorkspace = groceries[0],
+    OutputWorkspace = groceries[0],
+    Params = (-1./73.),
+)
+
+### PREP INGREDIENTS
+farmFresh = FarmFreshIngredients(
+    runNumber=runNumber,
+    useLiteMode=isLite,
+    focusGroup={"name":groupingScheme, "definition":""},
+    cifPath=cifPath,
+    peakIntensityThreshold=0.1,
+    crystalDBounds={"minimum": 1.5, "maximum": 3},
+)
+peakList = SousChef().prepDetectorPeaks(farmFresh)
+
+for i,group in enumerate(peakList):
+    tableName = f'peakProperties{i+1}'
+    fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
+    ax.plot(mtd[groceries[0]], wkspIndex=i, normalize_by_bin_width=True)
+    ax.axvline(x=farmFresh.crystalDBounds.minimum, color="red")
+    ax.axvline(x=farmFresh.crystalDBounds.maximum, color="red")
+    x, y, _, _ = get_spectrum(mtd[groceries[0]], i, normalize_by_bin_width=True)
+    for peak in group.peaks:
+        ax.fill_between(x, y, where=[(peak.minimum < xx and xx < peak.maximum) for xx in x], color="blue", alpha=0.5)
+    ax.legend() # show the legend
+    fig.show()

--- a/tests/unit/backend/recipe/algorithm/test_SmoothDataExcludingPeaksAlgo.py
+++ b/tests/unit/backend/recipe/algorithm/test_SmoothDataExcludingPeaksAlgo.py
@@ -1,16 +1,22 @@
+import json
 import unittest
 import unittest.mock as mock
+from typing import List
 
 import pytest
 from mantid.simpleapi import (
+    CreateSingleValuedWorkspace,
+    CreateWorkspace,
     DeleteWorkspace,
     LoadNexusProcessed,
     mtd,
 )
+from pydantic import parse_raw_as
 from snapred.backend.dao.calibration.Calibration import Calibration
 from snapred.backend.dao.CrystallographicInfo import CrystallographicInfo
+from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.ingredients import PeakIngredients as Ingredients
-from snapred.backend.recipe.algorithm.SmoothDataExcludingPeaksAlgo import SmoothDataExcludingPeaksAlgo
+from snapred.backend.recipe.algorithm.SmoothDataExcludingPeaksAlgo import SmoothDataExcludingPeaksAlgo as Algo
 from snapred.meta.Config import Resource
 
 
@@ -24,6 +30,75 @@ class TestSmoothDataAlgo(unittest.TestCase):
                 DeleteWorkspace(workspace)
             except ValueError:
                 print(f"Workspace {workspace} doesn't exist!")
+
+    def test_unbag_groceries(self):
+        testWS = CreateSingleValuedWorkspace()
+        algo = Algo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", testWS)
+        algo.setPropertyValue("OutputWorkspace", "test_out_ws")
+        algo.unbagGroceries()
+        assert algo.getPropertyValue("InputWorkspace") == testWS.name()
+        assert algo.getPropertyValue("Outputworkspace") == "test_out_ws"
+
+    def test_validate_success_with_peaks(self):
+        testWS = CreateSingleValuedWorkspace()
+        algo = Algo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", testWS)
+        algo.setPropertyValue("OutputWorkspace", "test_out_ws")
+        algo.setProperty("DetectorPeaks", "[{}]")
+        algo.setProperty("SmoothingParameter", 0.0)
+        errors = algo.validateInputs()
+        assert errors == {}
+
+    def test_validate_success_with_ingredients(self):
+        testWS = CreateSingleValuedWorkspace()
+        ingredientString = Resource.read("inputs/predict_peaks/input_fake_ingredients.json")
+        algo = Algo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", testWS)
+        algo.setPropertyValue("OutputWorkspace", "test_out_ws")
+        algo.setPropertyValue("DetectorPeakIngredients", ingredientString)
+        algo.setProperty("SmoothingParameter", 0.0)
+        errors = algo.validateInputs()
+        assert errors == {}
+
+    def test_validate_fail_no_peaks(self):
+        # check that it will fail if it is not given a way to find peaks
+        testWS = CreateSingleValuedWorkspace()
+        algo = Algo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", testWS)
+        algo.setPropertyValue("OutputWorkspace", "test_out_ws")
+        algo.setProperty("SmoothingParameter", 0.0)
+        errors = algo.validateInputs()
+        assert errors.get("DetectorPeaks") is not None
+        assert errors.get("DetectorPeakIngredients") is not None
+
+    def test_validate_fail_no_smoothing(self):
+        # check that it will fail if it is not given a way to find peaks
+        testWS = CreateSingleValuedWorkspace()
+        algo = Algo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", testWS)
+        algo.setPropertyValue("OutputWorkspace", "test_out_ws")
+        algo.setProperty("DetectorPeaks", "[{}]")
+        errors = algo.validateInputs()
+        assert errors.get("DetectorPeakIngredients") is not None
+        assert errors.get("SmoothingParameter")
+
+    def test_execute_with_peaks(self):
+        # input data
+        testWS = CreateWorkspace(DataX=[0, 1, 2, 3, 4, 5, 6], DataY=[2, 2, 2, 2, 2, 2])
+        jsonString = '[{"groupID": 1, "peaks": [{"position": {"value":1, "minimum":0, "maximum":2} }]}]'
+        algo = Algo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", testWS)
+        algo.setPropertyValue("OutputWorkspace", "test_out_ws")
+        algo.setProperty("DetectorPeaks", jsonString)
+        algo.setProperty("SmoothingParameter", 0.0)
+        assert algo.execute()
 
     def test_SmoothDataExcludingPeaksAlgo(self):
         # input data
@@ -40,7 +115,7 @@ class TestSmoothDataAlgo(unittest.TestCase):
         ingredients = Ingredients.parse_file(Resource.getPath("inputs/predict_peaks/input_fake_ingredients.json"))
 
         # initialize and run smoothdata algo
-        smoothDataAlgo = SmoothDataExcludingPeaksAlgo()
+        smoothDataAlgo = Algo()
         smoothDataAlgo.initialize()
         smoothDataAlgo.setPropertyValue("InputWorkspace", test_ws_name)
         smoothDataAlgo.setPropertyValue("OutputWorkspace", "_output")

--- a/tests/unit/backend/recipe/test_GenericRecipe.py
+++ b/tests/unit/backend/recipe/test_GenericRecipe.py
@@ -1,7 +1,12 @@
 import unittest
+from typing import List
 from unittest import mock
 
 import pytest
+from mantid.api import AlgorithmFactory, MatrixWorkspaceProperty, PythonAlgorithm
+from mantid.kernel import Direction
+from mantid.simpleapi import CloneWorkspace, CompareWorkspaces, CreateSingleValuedWorkspace
+from pydantic import BaseModel, parse_raw_as
 from snapred.backend.dao.ingredients import ReductionIngredients
 from snapred.backend.recipe.GenericRecipe import GenericRecipe
 
@@ -28,8 +33,21 @@ class TestGenericRecipe(unittest.TestCase):
         # self.GenericRecipe.mantidSnapper.DummyAlgo = lambda x:"Mocked result"
         self.GenericRecipe.mantidSnapper.DummyAlgo.return_value = self.mockReturn
 
-    @mock.patch("snapred.backend.recipe.GenericRecipe.MantidSnapper")
-    def test_execute_successful(self, mock_MantidSnapper):  # noqa: ARG002
+    def test_baseModelsToStrings(self):
+        pydanticObject = BaseModel(val="yes")
+        kwargs = {
+            "string": "a string",
+            "float": 0.0,
+            "baseModel": pydanticObject,
+            "listOfBaseModels": [pydanticObject],
+        }
+        result = self.GenericRecipe._baseModelsToStrings(**kwargs)
+        assert result["string"] == "a string"
+        assert result["float"] == 0.0
+        assert result["baseModel"] == pydanticObject.json()
+        assert result["listOfBaseModels"] == f"[{pydanticObject.json()}]"
+
+    def test_execute_successful(self):
         result = self.GenericRecipe.executeRecipe(Input=self.mock_reductionIngredients)
 
         assert result == "Mocked result"
@@ -37,8 +55,7 @@ class TestGenericRecipe(unittest.TestCase):
             "", Input=self.mock_reductionIngredients.json()
         )
 
-    @mock.patch("snapred.backend.recipe.GenericRecipe.MantidSnapper")
-    def test_execute_unsuccessful(self, mock_MantidSnapper):  # noqa: ARG002
+    def test_execute_unsuccessful(self):
         self.GenericRecipe.mantidSnapper.executeQueue.side_effect = RuntimeError("passed")
 
         try:
@@ -52,3 +69,122 @@ class TestGenericRecipe(unittest.TestCase):
         self.GenericRecipe.mantidSnapper.DummyAlgo.assert_called_once_with(
             "", Input=self.mock_reductionIngredients.json()
         )
+
+
+class InputOutputAlgo(PythonAlgorithm):
+    def PyInit(self):
+        self.declareProperty("InputValue", "", direction=Direction.Input)
+        self.declareProperty("OutputValue", "incorrect", direction=Direction.Output)
+
+    def PyExec(self):
+        self.setPropertyValue("OutputValue", self.getPropertyValue("InputValue"))
+
+
+class PrimitivePropertyAlgo(PythonAlgorithm):
+    def PyInit(self):
+        self.declareProperty("IntProperty", int(1), direction=Direction.Input)
+        self.declareProperty("FloatProperty", 0.0, direction=Direction.Input)
+        self.declareProperty("TupleProperty", tuple([0.0]), direction=Direction.Input)
+        self.declareProperty("IntOut", int(1), direction=Direction.Output)
+        self.declareProperty("FloatOut", 0.0, direction=Direction.Output)
+        self.declareProperty("TupleOut", tuple([0.0]), direction=Direction.Output)
+
+    def PyExec(self):
+        intProperty = self.getProperty("IntProperty").value
+        floatProperty = self.getProperty("FloatProperty").value
+        tupleProperty = self.getProperty("TupleProperty").value
+        assert isinstance(intProperty, int)
+        assert isinstance(floatProperty, float)
+        self.setProperty("IntOut", intProperty)
+        self.setProperty("FloatOut", floatProperty)
+        self.setProperty("TupleOut", tupleProperty)
+
+
+class MatrixPropertyAlgo(PythonAlgorithm):
+    def PyInit(self):
+        self.declareProperty(MatrixWorkspaceProperty("InputWorkspace", "", Direction.Input))
+        self.declareProperty(MatrixWorkspaceProperty("OutputWorkspace", "", Direction.Output))
+
+    def PyExec(self):
+        CloneWorkspace(
+            InputWorkspace=self.getPropertyValue("InputWorkspace"),
+            Outputworkspace=self.getPropertyValue("Outputworkspace"),
+        )
+        self.setPropertyValue("OutputWorkspace", self.getPropertyValue("OutputWorkspace"))
+
+
+class DAOPropertyAlgo(PythonAlgorithm):
+    def PyInit(self):
+        self.declareProperty("ScalarDAO", "", direction=Direction.Input)
+        self.declareProperty("ListDAO", "", direction=Direction.Input)
+        self.declareProperty("EmptyDAO", "{}", direction=Direction.Input)
+
+    def PyExec(self):
+        assert BaseModel.parse_raw(self.getPropertyValue("ScalarDAO"))
+        assert parse_raw_as(List[BaseModel], self.getPropertyValue("ListDAO"))
+        assert BaseModel.parse_raw(self.getPropertyValue("EmptyDAO"))
+
+
+class TestGenericRecipeInputsAndOutputs(unittest.TestCase):
+    def test_in_and_out(self):
+        # register the algorithm and define the recipe
+        AlgorithmFactory.subscribe(InputOutputAlgo)
+
+        class TestInAndOut(GenericRecipe[InputOutputAlgo]):
+            pass
+
+        # run the recipe and make sure correct result is given
+        res = TestInAndOut().executeRecipe(InputValue="correct", OutputValue="incorrect")
+        assert isinstance(res, str)
+        assert res != "incorrect"
+
+    def test_failure_set_string_with_float(self):
+        # register the algorithm and define the recipe
+        AlgorithmFactory.subscribe(InputOutputAlgo)
+
+        class TestInAndOut(GenericRecipe[InputOutputAlgo]):
+            pass
+
+        # try to set the string with a float --- will fail, reproducing an old error
+        with pytest.raises(TypeError):
+            TestInAndOut().executeRecipe(InputValue=0.0, OutputValue="incorrect")
+
+    def test_workspaces(self):
+        # register the algorithm and define the recipe
+        AlgorithmFactory.subscribe(MatrixPropertyAlgo)
+
+        class TestMatrixProp(GenericRecipe[MatrixPropertyAlgo]):
+            pass
+
+        # run the recipe and make sure correct result is given
+        CreateSingleValuedWorkspace(OutputWorkspace="okay")
+        res = TestMatrixProp().executeRecipe(InputWorkspace="okay", OutputWorkspace="hurray")
+        assert CompareWorkspaces(Workspace1="okay", Workspace2=res)
+
+    def test_primitives(self):
+        # register the algorithm and define the recipe
+        AlgorithmFactory.subscribe(PrimitivePropertyAlgo)
+
+        class TestPrimitives(GenericRecipe[PrimitivePropertyAlgo]):
+            pass
+
+        # run the recipe and make sure correct result is given
+        res = TestPrimitives().executeRecipe(IntProperty=2, FloatProperty=1.0, TupleProperty=(2.0, 3.0))
+        # NOTE the isinstance asserts should work, for unknown reasons they are broken
+        # assert isinstance(res[0], int)
+        # assert isinstance(res[1], float)
+        # assert isinstance(res[2], tuple)
+        assert res[0] == 2
+        assert res[1] == 1.0
+        # NOTE the result should be a tuple, but it is remaining a std_vector_dbl object
+        # assert res[2] == (2.,3.)
+
+    def test_daos(self):
+        # register the algorithm and define the recipe
+        AlgorithmFactory.subscribe(DAOPropertyAlgo)
+
+        class TestDAOs(GenericRecipe[DAOPropertyAlgo]):
+            pass
+
+        # run the recipe and make sure correct result is given
+        TestDAOs().executeRecipe(ScalarDAO=BaseModel(), ListDAO=[BaseModel()])

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -169,7 +169,7 @@ class TestNormalizationService(unittest.TestCase):
         )
 
         self.instance = NormalizationService()
-        self.instance.sousChef.prepDetectorPeaks = MagicMock(return_value={"groupID": 0, "peaks": []})
+        self.instance.sousChef.prepDetectorPeaks = MagicMock(return_value=[{"groupID": 0, "peaks": []}])
         self.instance.dataFactoryService.getCifFilePath = MagicMock(return_value="path/to/cif")
 
         mockRecipeInst = mockRecipe.return_value

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -203,6 +203,8 @@ class TestSousChef(unittest.TestCase):
             self.ingredients.runNumber,
             self.ingredients.useLiteMode,
             self.ingredients.focusGroup.name,
+            Config["constants.CrystallographicInfo.dMin"],
+            Config["constants.CrystallographicInfo.dMax"],
             self.ingredients.peakIntensityThreshold,
         )
         # ensure the cache is clear
@@ -224,6 +226,8 @@ class TestSousChef(unittest.TestCase):
             self.ingredients.runNumber,
             self.ingredients.useLiteMode,
             self.ingredients.focusGroup.name,
+            Config["constants.CrystallographicInfo.dMin"],
+            Config["constants.CrystallographicInfo.dMax"],
             self.ingredients.peakIntensityThreshold,
         )
         # ensure the cache is prepared


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

When performing normalization, we perform a smoothing operation with depends upon the vanadium peaks.  Not all peaks are included in the calculation, only those with d-values between to bounds, and only those with peak intensities above a threshold.  As these are adjusted, different peaks will appear in the calculation.

Which peaks are included is largely opaque to users.  This aims to make it more visibly obvious when peaks are excluded from the calculation.  It does so by displaying dmin on the graph, and by highlighting the peaks that are included and smoothed over.

## Explanation of work

Getting the peaks *into* the view required rearranging some of the normalization service, in particular the call to smoothing.

Because the graphs are normalized by bin width, the x,y values must be extracted from the workspace using mantid's `get_spectrum()` method, which can return the bin-normalized y value, which can then be used to plot the fill.  Maybe a future mantid update should include its own fill-between method.

The smoothing algorithm had the option to accept a list of peaks instead of peak ingredients, but this functionality had apparently gone untested and was not working.  Also for reasons unknown to mere mortals, the change to the graphing inside the view caused GenericRecipe to refuse to parse floats into strings to mantid algorithms.

Several methods in the normalization service were labeled "fromString" but did not have defined paths.  They probably should have defined paths in the future, but to avoid ambiguity I removed the "fromStrings" that I noticed were superfluous.

## To test

### Dev testing

Make sure all unit tests pass.

In workbench, run the script I will post in the comments below.  Verify the control over the peaks by adjusting dMin and peakIntensityThreshold.

Next run the GUI, and check everything as described in CIS testing below.

### CIS testing

For better visualization, first test using
- run = 58882
- background = 58813
- sample = silicon

Initial run should look something like this.  The red line indicates dMin, the blue-filled curves are those included in the peak list.
![image](https://github.com/neutrons/SNAPRed/assets/52183986/bd33ce0b-9756-45f8-a619-f5302d6dfdbe)

Try adjusting dMin, and watch the red line move up and fewer peaks be included.
![image](https://github.com/neutrons/SNAPRed/assets/52183986/f12b3f07-7f69-4d39-bfb7-e9ab958ffbb0)

Once you are satisfied, try with vanadium, such as run 58810 and vanadium sample.  It will look something like the following:
![image](https://github.com/neutrons/SNAPRed/assets/52183986/509bfe10-779e-4137-9d28-d2e20855c45f)

Try switching groups from Column --> All (will calculate) --> Column.  The change back to Column should be instantaneous, if no other parameters were touched.

**PLEASE VERIFY THAT SAVING WORKS**
The correct vanadium workspace should be saved with the focused/smoothed workspaces when the normalization is saved.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4071](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4071)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
