### PR TITLE
Ewm4062 extend applies to to support greaterthanequals plus

### DIFF
--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -267,9 +267,9 @@ class LocalDataService:
     def _parseAppliesTo(self, appliesTo: str):
         symbols = [">=", "<=", "<", ">"]
         # find first
-        symbol = next((s for s in symbols if s in appliesTo), None)
+        symbol = next((s for s in symbols if s in appliesTo), "")
         # parse runnumber
-        runNumber = appliesTo.split(symbol)[-1]
+        runNumber = appliesTo if symbol == "" else appliesTo.split(symbol)[-1]
         return symbol, runNumber
 
     def _compareRunNumbers(self, runNumber1: str, runNumber2: str, symbol: str):
@@ -278,6 +278,7 @@ class LocalDataService:
             "<=": lambda x, y: x <= y,
             "<": lambda x, y: x < y,
             ">": lambda x, y: x > y,
+            "": lambda x, y: x == y,
         }
         return expressions[symbol](int(runNumber1), int(runNumber2))
 
@@ -285,8 +286,7 @@ class LocalDataService:
         """
         Checks to see if an entry in the calibration index applies to a given run id via numerical comparison.
         """
-        if calibrationIndexEntry.appliesTo == runId:
-            return True
+
         symbol, runNumber = self._parseAppliesTo(calibrationIndexEntry.appliesTo)
         return self._compareRunNumbers(runId, runNumber, symbol)
 

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -805,6 +805,22 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
         entry.appliesTo = "<123"
         assert localDataService._isApplicableEntry(entry, "99")
 
+    def test_isApplicableEntry_lessThanEquals():
+        localDataService = LocalDataService()
+        entry = mock.Mock()
+        entry.appliesTo = "<=123"
+        assert localDataService._isApplicableEntry(entry, "123")
+        assert localDataService._isApplicableEntry(entry, "99")
+        assert not localDataService._isApplicableEntry(entry, "456")
+
+    def test_isApplicableEntry_greaterThanEquals():
+        localDataService = LocalDataService()
+        entry = mock.Mock()
+        entry.appliesTo = ">=123"
+        assert localDataService._isApplicableEntry(entry, "123")
+        assert localDataService._isApplicableEntry(entry, "456")
+        assert not localDataService._isApplicableEntry(entry, "99")
+
     def test__getVersionFromCalibrationIndex():
         localDataService = LocalDataService()
         localDataService.readCalibrationIndex = mock.Mock()


### PR DESCRIPTION
## Description of work

This just extends the appliesTo field to allow for >= and <=

## Explanation of work

rewrote the parse method to be more clear and extensible.

## To test

Tests pass

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4062](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4062)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
