### PR TITLE
sort groupings and samples for consistent ui

### DIFF
--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -728,7 +728,9 @@ class LocalDataService:
             sampleFiles.update(self._findMatchingFileList(f"{sampleFolder}/*.{extension}", throws=False))
         if len(sampleFiles) < 1:
             raise RuntimeError(f"No samples found in {sampleFolder} for extensions {extensions}")
-        return list(sampleFiles)
+        sampleFiles = list(sampleFiles)
+        sampleFiles.sort()
+        return sampleFiles
 
     def _readGroupingMap(self, stateId: str) -> GroupingMap:
         path = self._groupingMapPath(stateId)
@@ -768,6 +770,7 @@ class LocalDataService:
             groupingFiles.extend(self._findMatchingFileList(f"{groupingFolder}/*.{extension}", throws=False))
         if len(groupingFiles) < 1:
             raise RuntimeError(f"No grouping files found in {groupingFolder} for extensions {extensions}")
+        groupingFiles.sort()
         return groupingFiles
 
     def readFocusGroups(self):

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -907,8 +907,10 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
         ]
         result = localDataService.readGroupingFiles()
         # 6 because there are 3 file types and the mock returns 2 files per
+        expected = [f"/group{x}.{ext}" for ext in ["xml", "nxs", "hdf"] for x in [1, 2]]
+        expected.sort()
         assert len(result) == 6
-        assert result == [f"/group{x}.{ext}" for ext in ["xml", "nxs", "hdf"] for x in [1, 2]]
+        assert result == expected
 
     def test_readNoGroupingFiles():
         localDataService = LocalDataService()
@@ -929,12 +931,13 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock(), "h5py": mock.Moc
             f"/group2.{path.split('/')[-1].split('.')[-1]}",
         ]
         result = localDataService.readFocusGroups()
+        expectedKeys = [f"/group{x}.{ext}" for ext in ["xml", "nxs", "hdf"] for x in [1, 2]]
+        expectedKeys.sort()
+        expectedVals = [FocusGroup(name=x.split("/")[-1].split(".")[0], definition=x) for x in expectedKeys]
         # 6 because there are 3 file types and the mock returns 2 files per
         assert len(result) == 6
-        assert list(result.keys()) == [f"/group{x}.{ext}" for ext in ["xml", "nxs", "hdf"] for x in [1, 2]]
-        assert list(result.values()) == [
-            FocusGroup(name=x.split("/")[-1].split(".")[0], definition=x) for x in list(result.keys())
-        ]
+        assert list(result.keys()) == expectedKeys
+        assert list(result.values()) == expectedVals
 
     @mock.patch("os.path.exists", return_value=True)
     def test_writeCalibrantSample_failure(mock1):  # noqa: ARG001


### PR DESCRIPTION
## Description of work
What it says on the tin

## To test

open and close the test panel a few times and see that the dropdowns are always in the same abc order.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4068](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4068)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
