### PR TITLE
EWM4066 Remove smoothing param from first page of normalization and Add a label for it on the second

### DIFF
--- a/src/snapred/backend/dao/request/NormalizationCalibrationRequest.py
+++ b/src/snapred/backend/dao/request/NormalizationCalibrationRequest.py
@@ -13,7 +13,7 @@ class NormalizationCalibrationRequest(BaseModel):
     useLiteMode: bool = True  # TODO turn this on inside the view and workflow
     focusGroup: FocusGroup
     calibrantSamplePath: str
-    smoothingParameter: float
+    smoothingParameter: float = Config["calibration.parameters.default.smoothing"]
     crystalDMin: float = Config["constants.CrystallographicInfo.dMin"]
     crystalDMax: float = Config["constants.CrystallographicInfo.dMax"]
     nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]

--- a/src/snapred/backend/dao/request/SmoothDataExcludingPeaksRequest.py
+++ b/src/snapred/backend/dao/request/SmoothDataExcludingPeaksRequest.py
@@ -14,6 +14,6 @@ class SmoothDataExcludingPeaksRequest(BaseModel):
     inputWorkspace: str
     outputWorkspace: str
 
-    smoothingParameter: float
+    smoothingParameter: float = Config["calibration.parameters.default.smoothing"]
     crystalDMin: float = Config["constants.CrystallographicInfo.dMin"]
     crystalDMax: float = Config["constants.CrystallographicInfo.dMax"]

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -80,6 +80,7 @@ calibration:
         - 2.0
         - 2.0
       peakTailCoefficient: 2.0
+      smoothing: 0.5
 
 mantid:
   workspace:

--- a/src/snapred/ui/view/NormalizationCalibrationRequestView.py
+++ b/src/snapred/ui/view/NormalizationCalibrationRequestView.py
@@ -15,15 +15,11 @@ class NormalizationCalibrationRequestView(BackendRequestView):
         self.backgroundRunNumberField = self._labeledField(
             "Background Run Number:", jsonForm.getField("backgroundRunNumber")
         )
-        self.smoothingParameterField = self._labeledField(
-            "Smoothing Parameter:", jsonForm.getField("smoothingParameter")
-        )
 
         self.litemodeToggle.setEnabled(False)
         self.layout.addWidget(self.runNumberField, 0, 0)
         self.layout.addWidget(self.litemodeToggle, 0, 1)
         self.layout.addWidget(self.backgroundRunNumberField, 1, 0)
-        self.layout.addWidget(self.smoothingParameterField, 1, 1)
 
         self.sampleDropDown = QComboBox()
         self.sampleDropDown.addItem("Select Sample")
@@ -43,8 +39,6 @@ class NormalizationCalibrationRequestView(BackendRequestView):
             raise ValueError("Please select a sample")
         if self.groupingFileDropDown.currentIndex() == 0:
             raise ValueError("Please select a grouping file")
-        if self.smoothingParameterField.text() == "":
-            raise ValueError("Please enter a smoothing parameter")
         if self.runNumberField.text() == "":
             raise ValueError("Please enter a run number")
         if self.backgroundRunNumberField.text() == "":

--- a/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
+++ b/src/snapred/ui/view/SpecifyNormalizationCalibrationView.py
@@ -13,6 +13,7 @@ from PyQt5.QtWidgets import (
     QMessageBox,
     QPushButton,
     QSlider,
+    QVBoxLayout,
     QWidget,
 )
 from workbench.plotting.figuremanager import FigureManagerWorkbench, MantidFigureCanvas
@@ -90,11 +91,12 @@ class SpecifyNormalizationCalibrationView(QWidget):
         )
 
         self.smoothingLineEdit = QLineEdit("1e-9")
-        self.smoothingLineEdit.setFixedWidth(50)
+        self.smoothingLineEdit.setMinimumWidth(128)
         self.smoothingSlider.valueChanged.connect(self.updateLineEditFromSlider)
         self.smoothingLineEdit.returnPressed.connect(
             lambda: self.updateSliderFromLineEdit(self.smoothingLineEdit.text())
         )
+        self.smoothingLabel = QLabel("Smoothing :")
 
         self.fielddMin = LabeledField("dMin :", QLineEdit(str(Config["constants.CrystallographicInfo.dMin"])), self)
 
@@ -102,16 +104,19 @@ class SpecifyNormalizationCalibrationView(QWidget):
         self.recalculationButton.clicked.connect(self.emitValueChange)
 
         smoothingLayout = QHBoxLayout()
+        smoothingLayout.addWidget(self.smoothingLabel)
         smoothingLayout.addWidget(self.smoothingSlider)
         smoothingLayout.addWidget(self.smoothingLineEdit)
         smoothingLayout.addWidget(self.fielddMin)
+
+        # self.fieldLayout = QGridLayout()
 
         # add all elements to the grid layout
         self.layout.addWidget(self.navigationBar, 0, 0)
         self.layout.addWidget(self.canvas, 1, 0, 1, -1)
         self.layout.addWidget(self.fieldRunNumber, 2, 0)
         self.layout.addWidget(self.fieldBackgroundRunNumber, 2, 1)
-        self.layout.addLayout(smoothingLayout, 3, 0)
+        self.layout.addLayout(smoothingLayout, 3, 0, 1, 2)
         self.layout.addWidget(LabeledField("Sample :", self.sampleDropDown, self), 4, 0)
         self.layout.addWidget(LabeledField("Grouping File :", self.groupingDropDown, self), 4, 1)
         self.layout.addWidget(self.recalculationButton, 5, 0, 1, 2)

--- a/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
+++ b/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
@@ -97,6 +97,7 @@ class DiffractionCalibrationCreationWorkflow(WorkflowImplementer):
         assessmentResponse = response.data
         self.calibrationRecord = assessmentResponse.record
         self.calibrationRecord.workspaceNames.append(self.responses[-2].data["calibrationTable"])
+        self.calibrationRecord.workspaceNames.append(self.responses[-2].data["maskWorkspace"])
 
         self.outputs.extend(assessmentResponse.metricWorkspaces)
         self.outputs.extend(self.calibrationRecord.workspaceNames)

--- a/src/snapred/ui/workflow/NormalizationCalibrationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationCalibrationWorkflow.py
@@ -93,10 +93,18 @@ class NormalizationCalibrationWorkflow:
         self.backgroundRunNumber = view.getFieldText("backgroundRunNumber")
         self.sampleIndex = (view.sampleDropDown.currentIndex()) - 1
         self.initGroupingIndex = (view.groupingFileDropDown.currentIndex()) - 1
-        self.initSmoothingParameter = float(view.getFieldText("smoothingParameter"))
         self.samplePath = view.sampleDropDown.currentText()
         self.groupingPath = view.groupingFileDropDown.currentText()
         self.initDMin = float(self._specifyNormalizationView.fielddMin.field.text())
+
+        payload = NormalizationCalibrationRequest(
+            runNumber=self.runNumber,
+            backgroundRunNumber=self.backgroundRunNumber,
+            calibrantSamplePath=str(self.samplePaths[self.sampleIndex]),
+            focusGroup=self.focusGroups[str(self.groupingFiles[self.initGroupingIndex])],
+            crystalDMin=self.initDMin,
+        )
+        self.initSmoothingParameter = payload.smoothingParameter
 
         self._specifyNormalizationView.updateFields(
             sampleIndex=self.sampleIndex,
@@ -109,15 +117,6 @@ class NormalizationCalibrationWorkflow:
 
         self._saveNormalizationCalibrationView.updateRunNumber(self.runNumber)
         self._saveNormalizationCalibrationView.updateBackgroundRunNumber(self.backgroundRunNumber)
-
-        payload = NormalizationCalibrationRequest(
-            runNumber=self.runNumber,
-            backgroundRunNumber=self.backgroundRunNumber,
-            calibrantSamplePath=str(self.samplePaths[self.sampleIndex]),
-            focusGroup=self.focusGroups[str(self.groupingFiles[self.initGroupingIndex])],
-            smoothingParameter=self.initSmoothingParameter,
-            crystalDMin=self.initDMin,
-        )
 
         request = SNAPRequest(path="normalization", payload=payload.json())
         response = self.interfaceController.executeRequest(request)

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -84,6 +84,7 @@ calibration:
         - -2
         - 2
       peakTailCoefficient: 2.0
+      smoothing: 0.5
 
 mantid:
     workspace:


### PR DESCRIPTION

## Description of work

* removed redundant initial smoothing parameter field in normalization workflow

* added label to the smoothing parameter in the second step of normalization workflow expanded smoothing parameter line edit box to be legible

## To test

Open normalization workflow
 1. Observed no smoothing parameter field.
 2. Proceed with the following inputs

    run = 58813
    background = 58813
    sample = silicon

3. Observe labeled smoothing fields
4. Observe smoothing edit box is now long enough to be legible.



## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4066](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4066)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
