### PR TITLE
EWM4072 and EWM 4069 

### DIFF
--- a/src/snapred/backend/dao/ingredients/DiffractionCalibrationIngredients.py
+++ b/src/snapred/backend/dao/ingredients/DiffractionCalibrationIngredients.py
@@ -6,6 +6,7 @@ from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.dao.state.PixelGroup import PixelGroup
 from snapred.meta.Config import Config
+from snapred.meta.mantid.PeakFunctionEnum import PeakFunctionEnum
 
 
 class DiffractionCalibrationIngredients(BaseModel):
@@ -15,4 +16,5 @@ class DiffractionCalibrationIngredients(BaseModel):
     pixelGroup: PixelGroup
     groupedPeakLists: List[GroupPeakList]
     convergenceThreshold: float
+    peakFunction: PeakFunctionEnum
     maxOffset: float = Config["calibration.diffraction.maximumOffset"]

--- a/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
+++ b/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
@@ -1,10 +1,11 @@
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel
 
 from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.meta.Config import Config
+from snapred.meta.mantid.PeakFunctionEnum import PeakFunctionEnum
 
 
 class DiffractionCalibrationRequest(BaseModel):
@@ -17,6 +18,7 @@ class DiffractionCalibrationRequest(BaseModel):
     calibrantSamplePath: str
     focusGroup: FocusGroup
     useLiteMode: bool
+    peakFunction: PeakFunctionEnum = Config["calibration.diffraction.peakFunction"]
     convergenceThreshold: Optional[float] = Config["calibration.diffraction.convergenceThreshold"]
     peakIntensityThreshold: Optional[float] = Config["calibration.diffraction.peakIntensityThreshold"]
     nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]

--- a/src/snapred/backend/dao/request/FarmFreshIngredients.py
+++ b/src/snapred/backend/dao/request/FarmFreshIngredients.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, validator
 from snapred.backend.dao.Limit import Limit
 from snapred.backend.dao.state import FocusGroup
 from snapred.meta.Config import Config
+from snapred.meta.mantid.PeakFunctionEnum import PeakFunctionEnum
 
 
 class FarmFreshIngredients(BaseModel):
@@ -29,6 +30,7 @@ class FarmFreshIngredients(BaseModel):
     convergenceThreshold: float = Config["calibration.diffraction.convergenceThreshold"]
     nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]
     peakIntensityThreshold: float = Config["calibration.diffraction.peakIntensityThreshold"]
+    peakFunction: PeakFunctionEnum = Config["calibration.diffraction.peakFunction"]
     maxOffset: float = Config["calibration.diffraction.maximumOffset"]
     crystalDBounds: Limit[float] = Limit(
         minimum=Config["constants.CrystallographicInfo.dMin"],

--- a/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
@@ -77,6 +77,7 @@ class GroupDiffractionCalibration(PythonAlgorithm):
         # from the pixel group, read the overall min/max TOF and binning
         self.TOF = ingredients.pixelGroup.timeOfFlight
 
+        self.peakFunction: str = ingredients.peakFunction.value
         # for each group, need a list of peaks and boundaries of peaks
         # this is found from the groupedPeakList in the ingredients
         self.groupIDs: List[int] = []
@@ -210,7 +211,7 @@ class GroupDiffractionCalibration(PythonAlgorithm):
                 f"Perform PDCalibration on group {groupID}",
                 InputWorkspace=self.outputWStof,
                 TofBinning=self.TOF.params,
-                PeakFunction="Gaussian",
+                PeakFunction=self.peakFunction,
                 BackgroundType="Linear",
                 PeakPositions=self.groupedPeaks[groupID],
                 PeakWindow=self.groupedPeakBoundaries[groupID],

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -99,15 +99,21 @@ class CalibrationService(Service):
             focusGroup=request.focusGroup,
             cifPath=cifPath,
             calibrantSamplePath=request.calibrantSamplePath,
+            peakFunction=request.peakFunction,
             # fiddly-bits
             peakIntensityThreshold=request.peakIntensityThreshold,
             convergenceThreshold=request.convergenceThreshold,
             nBinsAcrossPeakWidth=request.nBinsAcrossPeakWidth,
         )
         ingredients = self.sousChef.prepDiffractionCalibrationIngredients(farmFresh)
-        empties = [gpl for gpl in ingredients.groupedPeakLists if len(gpl.peaks) < 2]
+        empties = [gpl for gpl in ingredients.groupedPeakLists if len(gpl.peaks) < 4]
         if len(empties) > 0:
-            raise RuntimeError(f"Insufficient peaks for groups {[gpl.groupID for gpl in empties]}")
+            raise RuntimeError(
+                (
+                    f"Insufficient peaks for groups {[gpl.groupID for gpl in empties]} \n"
+                    "Consider decreasing the Peak Intensity Threshold."
+                )
+            )
 
         # groceries
         self.groceryClerk.name("inputWorkspace").neutron(request.runNumber).useLiteMode(request.useLiteMode).add()

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -154,6 +154,7 @@ class SousChef(Service):
             runConfig=self.prepRunConfig(ingredients.runNumber),
             pixelGroup=self.prepPixelGroup(ingredients),
             groupedPeakLists=self.prepDetectorPeaks(ingredients),
+            peakFunction=ingredients.peakFunction,
             convergenceThreshold=ingredients.convergenceThreshold,
             maxOffset=ingredients.maxOffset,
         )

--- a/src/snapred/meta/mantid/PeakFunctionEnum.py
+++ b/src/snapred/meta/mantid/PeakFunctionEnum.py
@@ -1,0 +1,7 @@
+import enum
+
+
+class PeakFunctionEnum(str, enum.Enum):
+    GAUSSIAN = "Gaussian"
+    LORENTZIAN = "Lorentzian"
+    PSEUDO_VOIGT = "PseudoVoigt"

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -68,6 +68,7 @@ calibration:
     nBinsAcrossPeakWidth: 10
     maximumOffset: 10
     maxDSpaceShiftFactor: 2.5
+    peakFunction: Gaussian
   parameters:
     default:
       # degrees

--- a/src/snapred/ui/view/CalibrationReductionRequestView.py
+++ b/src/snapred/ui/view/CalibrationReductionRequestView.py
@@ -2,6 +2,7 @@ from PyQt5.QtCore import pyqtSignal
 from qtpy.QtWidgets import QComboBox, QLineEdit
 
 from snapred.meta.decorators.Resettable import Resettable
+from snapred.meta.mantid.PeakFunctionEnum import PeakFunctionEnum
 from snapred.ui.view.BackendRequestView import BackendRequestView
 from snapred.ui.widget.Toggle import Toggle
 
@@ -20,6 +21,8 @@ class CalibrationReductionRequestView(BackendRequestView):
         self.sampleDropdown = self._sampleDropDown("Sample", samples)
         self.groupingFileDropdown = self._sampleDropDown("Grouping File", groups)
 
+        self.peakFunctionDropdown = self._sampleDropDown("Peak Function", [p.value for p in PeakFunctionEnum])
+
         self.litemodeToggle.setEnabled(True)
         self.layout.addWidget(self.runNumberField, 0, 0)
         self.layout.addWidget(self.litemodeToggle, 0, 1)
@@ -28,10 +31,13 @@ class CalibrationReductionRequestView(BackendRequestView):
         self.layout.addWidget(self.fieldNBinsAcrossPeakWidth, 1, 2)
         self.layout.addWidget(self.sampleDropdown, 2, 0)
         self.layout.addWidget(self.groupingFileDropdown, 2, 1)
+        self.layout.addWidget(self.peakFunctionDropdown, 2, 2)
 
     def verify(self):
         if self.sampleDropdown.currentIndex() == 0:
             raise ValueError("Please select a sample")
         if self.groupingFileDropdown.currentIndex() == 0:
             raise ValueError("Please select a grouping file")
+        if self.peakFunctionDropdown.currentIndex() == 0:
+            raise ValueError("Please select a peak function")
         return True

--- a/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
+++ b/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
@@ -70,12 +70,14 @@ class DiffractionCalibrationCreationWorkflow(WorkflowImplementer):
         self.focusGroupPath = view.groupingFileDropdown.currentText()
         self.useLiteMode = view.litemodeToggle.field.getState()
         self.calibrantSamplePath = view.sampleDropdown.currentText()
+        self.peakFunction = view.peakFunctionDropdown.currentText()
 
         payload = DiffractionCalibrationRequest(
             runNumber=self.runNumber,
             calibrantSamplePath=self.calibrantSamplePath,
             focusGroup=self.focusGroups[self.focusGroupPath],
             useLiteMode=self.useLiteMode,
+            peakFunction=self.peakFunction,
         )
         payload.convergenceThreshold = view.fieldConvergnceThreshold.get(payload.convergenceThreshold)
         payload.peakIntensityThreshold = view.fieldPeakIntensityThreshold.get(payload.peakIntensityThreshold)

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -72,6 +72,7 @@ calibration:
     maximumIterations: 5
     maximumOffset: 10
     maxDSpaceShiftFactor: 2.5
+    peakFunction: Gaussian
   parameters:
     default:
       # degrees


### PR DESCRIPTION


## Description of work

expanded minimum peak requirment for difcals
exposed peak function to diffractioncalibration flow


## To test

Select a peak type other than Gauss and observe in the logs pdcalibration using it.

To test the min peaks validation you probably need to adjust the peak intensity threshold till it goes below 4.

```
On analysis.sns.gov
From SNAPRed directory and environment
python -m snapred
Open "Test Panel" and enter:
Run Number: 46680
Convergence Threshold: 0.1
Peak Intensity Threshold: 0.0001
Bins Across Peak Width: 10
Sample: Diamond_001.json
Grouping File: column lite
```

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4072](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4072)
[EWM#4069](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4069)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
