### PR TITLE
Add peak intensity threshold and dMax to normalization controls

### DIFF
--- a/src/snapred/backend/dao/request/NormalizationCalibrationRequest.py
+++ b/src/snapred/backend/dao/request/NormalizationCalibrationRequest.py
@@ -16,4 +16,5 @@ class NormalizationCalibrationRequest(BaseModel):
     smoothingParameter: float = Config["calibration.parameters.default.smoothing"]
     crystalDMin: float = Config["constants.CrystallographicInfo.dMin"]
     crystalDMax: float = Config["constants.CrystallographicInfo.dMax"]
+    peakIntensityThreshold: float = Config["constants.PeakIntensityFractionThreshold"]
     nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]

--- a/src/snapred/backend/dao/request/SmoothDataExcludingPeaksRequest.py
+++ b/src/snapred/backend/dao/request/SmoothDataExcludingPeaksRequest.py
@@ -17,3 +17,4 @@ class SmoothDataExcludingPeaksRequest(BaseModel):
     smoothingParameter: float = Config["calibration.parameters.default.smoothing"]
     crystalDMin: float = Config["constants.CrystallographicInfo.dMin"]
     crystalDMax: float = Config["constants.CrystallographicInfo.dMax"]
+    peakIntensityThreshold: float = Config["constants.PeakIntensityFractionThreshold"]

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -72,6 +72,7 @@ class NormalizationService(Service):
             cifPath=cifPath,
             calibrantSamplePath=request.calibrantSamplePath,
             crystalDBounds=Limit(minimum=request.crystalDMin, maximum=request.crystalDMax),
+            peakIntensityThreshold=request.peakIntensityThreshold,
         )
         ingredients = self.sousChef.prepNormalizationIngredients(farmFresh)
 
@@ -204,6 +205,7 @@ class NormalizationService(Service):
             cifPath=cifPath,
             calibrantSamplePath=request.calibrantSamplePath,
             crystalDBounds=Limit(minimum=request.crystalDMin, maximum=request.crystalDMax),
+            peakIntensityThreshold=request.peakIntensityThreshold,
         )
         peaks = self.sousChef.prepDetectorPeaks(farmFresh)
 

--- a/src/snapred/ui/workflow/NormalizationCalibrationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationCalibrationWorkflow.py
@@ -55,9 +55,6 @@ class NormalizationCalibrationWorkflow:
             parent=parent,
         )
 
-        self.lastGroupingFile = None
-        self.lastSmoothingParameter = None
-
         self._specifyNormalizationView.signalValueChanged.connect(self.onNormalizationValueChange)
 
         self._saveNormalizationCalibrationView = SaveNormalizationCalibrationView(
@@ -93,24 +90,28 @@ class NormalizationCalibrationWorkflow:
         self.runNumber = view.getFieldText("runNumber")
         self.backgroundRunNumber = view.getFieldText("backgroundRunNumber")
         self.sampleIndex = (view.sampleDropDown.currentIndex()) - 1
-        self.initGroupingIndex = (view.groupingFileDropDown.currentIndex()) - 1
+        self.prevGroupingIndex = (view.groupingFileDropDown.currentIndex()) - 1
         self.samplePath = view.sampleDropDown.currentText()
         self.groupingPath = view.groupingFileDropDown.currentText()
-        self.initDMin = float(self._specifyNormalizationView.fielddMin.field.text())
+        self.prevDMin = float(self._specifyNormalizationView.fielddMin.field.text())
+        self.prevDMax = float(self._specifyNormalizationView.fielddMax.field.text())
+        self.prevThreshold = float(self._specifyNormalizationView.fieldThreshold.field.text())
 
+        # init the payload
         payload = NormalizationCalibrationRequest(
             runNumber=self.runNumber,
             backgroundRunNumber=self.backgroundRunNumber,
             calibrantSamplePath=str(self.samplePaths[self.sampleIndex]),
-            focusGroup=self.focusGroups[str(self.groupingFiles[self.initGroupingIndex])],
-            crystalDMin=self.initDMin,
+            focusGroup=self.focusGroups[str(self.groupingFiles[self.prevGroupingIndex])],
+            crystalDMin=self.prevDMin,
         )
-        self.initSmoothingParameter = payload.smoothingParameter
+        # take the default smoothing param from the default payload value
+        self.prevSmoothingParameter = payload.smoothingParameter
 
         self._specifyNormalizationView.updateFields(
             sampleIndex=self.sampleIndex,
-            groupingIndex=self.initGroupingIndex,
-            smoothingParameter=self.initSmoothingParameter,
+            groupingIndex=self.prevGroupingIndex,
+            smoothingParameter=self.prevSmoothingParameter,
         )
 
         self._specifyNormalizationView.updateRunNumber(self.runNumber)
@@ -132,24 +133,16 @@ class NormalizationCalibrationWorkflow:
         return response
 
     def _specifyNormalization(self, workflowPresenter):  # noqa: ARG002
-        if self.lastGroupingFile is not None and self.lastSmoothingParameter is not None:
-            payload = NormalizationCalibrationRequest(
-                runNumber=self.runNumber,
-                backgroundRunNumber=self.backgroundRunNumber,
-                calibrantSamplePath=str(self.samplePaths[self.sampleIndex]),
-                focusGroup=self.focusGroups[str(self.lastGroupingFile)],
-                smoothingParameter=self.lastSmoothingParameter,
-                crystalDMin=self.lastDMin,
-            )
-        else:
-            payload = NormalizationCalibrationRequest(
-                runNumber=self.runNumber,
-                backgroundRunNumber=self.backgroundRunNumber,
-                calibrantSamplePath=str(self.samplePaths[self.sampleIndex]),
-                focusGroup=self.focusGroups[str(self.groupingFiles[self.initGroupingIndex])],
-                smoothingParameter=self.initSmoothingParameter,
-                crystalDMin=self.initDMin,
-            )
+        payload = NormalizationCalibrationRequest(
+            runNumber=self.runNumber,
+            backgroundRunNumber=self.backgroundRunNumber,
+            calibrantSamplePath=str(self.samplePaths[self.sampleIndex]),
+            focusGroup=self.focusGroups[str(self.groupingFiles[self.prevGroupingIndex])],
+            smoothingParameter=self.prevSmoothingParameter,
+            crystalDMin=self.prevDMin,
+            crystalDMax=self.prevDMax,
+            peakIntensityThreshold=self.prevThreshold,
+        )
 
         request = SNAPRequest(path="normalization/assessment", payload=payload.json())
         response = self.interfaceController.executeRequest(request)
@@ -183,14 +176,16 @@ class NormalizationCalibrationWorkflow:
 
         return response
 
-    def callNormalizationCalibration(self, groupingFile, smoothingParameter, dMin):
+    def callNormalizationCalibration(self, index, smoothingParameter, dMin, dMax, peakThreshold):
         payload = NormalizationCalibrationRequest(
             runNumber=self.runNumber,
             backgroundRunNumber=self.backgroundRunNumber,
             calibrantSamplePath=self.samplePaths[self.sampleIndex],
-            focusGroup=self.focusGroups[groupingFile],
+            focusGroup=self.focusGroups[self.groupingFiles[index]],
             smoothingParameter=smoothingParameter,
             crystalDMin=dMin,
+            crystalDMax=dMax,
+            peakIntensityThreshold=peakThreshold,
         )
 
         request = SNAPRequest(path="normalization", payload=payload.json())
@@ -202,7 +197,7 @@ class NormalizationCalibrationWorkflow:
         peaks = self.responses[-1].data["detectorPeaks"]
         self._specifyNormalizationView.updateWorkspaces(focusWorkspace, smoothWorkspace, peaks)
 
-    def applySmoothingUpdate(self, index, smoothingValue, dMin):
+    def applySmoothingUpdate(self, index, smoothingValue, dMin, dMax, peakThreshold):
         focusWorkspace = self.responses[-1].data["focusedVanadium"]
         smoothWorkspace = self.responses[-1].data["smoothedVanadium"]
 
@@ -214,6 +209,8 @@ class NormalizationCalibrationWorkflow:
             runNumber=self.runNumber,
             smoothingParameter=smoothingValue,
             crystalDMin=dMin,
+            crystalDMax=dMax,
+            peakIntensityThreshold=peakThreshold,
         )
 
         request = SNAPRequest(path="normalization/smooth", payload=payload.json())
@@ -223,33 +220,47 @@ class NormalizationCalibrationWorkflow:
         peaks = response.data["detectorPeaks"]
         self._specifyNormalizationView.updateWorkspaces(focusWorkspace, smoothWorkspace, peaks)
 
-    def onNormalizationValueChange(self, index, smoothingValue, dMin):  # noqa: ARG002
+    def onNormalizationValueChange(self, index, smoothingValue, dMin, dMax, peakThreshold):  # noqa: ARG002
         if not self.initializationComplete:
             return
         # disable recalculate button
         self._specifyNormalizationView.disableRecalculateButton()
 
-        self.lastGroupingFile = self.groupingFiles[index]
-        self.lastSmoothingParameter = smoothingValue
-        self.lastDMin = dMin
 
-        groupingFileChanged = self.groupingFiles[self.initGroupingIndex] != self.lastGroupingFile
-        smoothingValueChanged = self.initSmoothingParameter != self.lastSmoothingParameter
-        dMinValueChanged = self.initDMin != self.lastDMin
+        # if the grouping file change, redo whole calculation
+        groupingFileChanged = index != self.prevGroupingIndex
+        # if peaks will change, redo only the smoothing
+        smoothingValueChanged = self.prevSmoothingParameter != smoothingValue
+        dMinValueChanged = dMin != self.prevDMin
+        dMaxValueChanged = dMax != self.prevDMax
+        thresholdChanged = peakThreshold != self.prevThreshold
+        peakListWillChange = smoothingValueChanged or dMinValueChanged or dMaxValueChanged or thresholdChanged
+
+        print(f"******* VALUE CHANGED? {thresholdChanged} -- {peakListWillChange} *******")
+
+        # check the case, apply correct update
         if groupingFileChanged:
-            self.initGroupingIndex = index
-            self.initSmoothingParameter = smoothingValue
-            self.callNormalizationCalibration(self.groupingFiles[index], smoothingValue, dMin)
-        elif smoothingValueChanged or dMinValueChanged:
-            self.applySmoothingUpdate(index, smoothingValue, dMin)
+            self.callNormalizationCalibration(index, smoothingValue, dMin, dMax, peakThreshold)
+        elif peakListWillChange:
+            self.applySmoothingUpdate(index, smoothingValue, dMin, dMax, peakThreshold)
         elif "focusedVanadium" in self.responses[-1].data and "smoothedVanadium" in self.responses[-1].data:
+            # if nothing changed but this function was called anyway... just replot stuff with old values
             focusWorkspace = self.responses[-1].data["focusedVanadium"]
             smoothWorkspace = self.responses[-1].data["smoothedVanadium"]
             peaks = self.responses[-1].data["detectorPeaks"]
             self._specifyNormalizationView.updateWorkspaces(focusWorkspace, smoothWorkspace, peaks)
         else:
             raise Exception("Expected data not found in the last response")
+
+        # renable button when graph is updated
         self._specifyNormalizationView.enableRecalculateButton()
+
+        # update the values for next call to this method
+        self.prevGroupingIndex = index
+        self.prevSmoothingParameter = smoothingValue
+        self.prevDMin = dMin
+        self.prevDMax = dMax
+        self.prevThreshold = peakThreshold
 
     @property
     def widget(self):


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

The users did not have control over the peak intensity threshold in normalization, nor control of dMax.  This exposes both to the user to control directly.

## Explanation of work

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

Added fields for both, included them in the requests being passed around.

Added extra line for dMax on the graphs.

## To test

### Dev testing

For better visualization, run normalization with
- 58882
- 58813
- silicon

And then play around with the various parameters, and watch in amazement as filled-in peaks vanish and appear.

### CIS testing

As above.


## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4069](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4069)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
