### PR TITLE
A file-by-file rebase onto the 'SNAPRed / next' branch from the 'ewm3702_saving_calibration_records' branch.

### DIFF
--- a/src/snapred/backend/dao/calibration/CalibrationRecord.py
+++ b/src/snapred/backend/dao/calibration/CalibrationRecord.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel
 
@@ -6,7 +6,7 @@ from snapred.backend.dao.calibration.Calibration import Calibration
 from snapred.backend.dao.calibration.FocusGroupMetric import FocusGroupMetric
 from snapred.backend.dao.CrystallographicInfo import CrystallographicInfo
 from snapred.backend.dao.state.PixelGroup import PixelGroup
-from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName, WorkspaceType
 
 
 class CalibrationRecord(BaseModel):
@@ -15,7 +15,7 @@ class CalibrationRecord(BaseModel):
     runNumber: str
     crystalInfo: CrystallographicInfo
     calibrationFittingIngredients: Calibration
-    pixelGroups: Optional[List[PixelGroup]]  # TODO: really shouldnt be optional, will be when sns data fixed
+    pixelGroups: Optional[List[PixelGroup]]  # TODO: really shouldn't be optional, will be when sns data fixed
     focusGroupCalibrationMetrics: FocusGroupMetric
-    workspaceNames: List[WorkspaceName]
+    workspaces: Dict[WorkspaceType, List[WorkspaceName]]
     version: Optional[int]

--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, root_validator
 
 from snapred.backend.log.logger import snapredLogger
 from snapred.meta.Config import Config
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 
 logger = snapredLogger.getLogger(__name__)
 
@@ -26,11 +27,13 @@ class GroceryListItem(BaseModel):
     # -- "" tells FetchGroceries to choose the loader
     loader: Literal["", "LoadGroupingDefinition", "LoadNexus", "LoadEventNexus", "LoadNexusProcessed"] = ""
 
-    # the correct combinaton of the below must be set -- neutron and grouping require a runNumber,
+    # the correct combination of the below must be set -- neutron and grouping require a runNumber,
     #   grouping additionally requires a groupingScheme
     runNumber: Optional[str]
     version: Optional[str]
     groupingScheme: Optional[str]
+
+    unit: Optional[Literal[wng.Units.TOF, wng.Units.DSP]]
 
     # SpecialWorkspace2D-derived workspaces (e.g. grouping or mask workspaces)
     #   require an instrument definition, these next two properties indicate
@@ -67,13 +70,16 @@ class GroceryListItem(BaseModel):
         if v.get("instrumentSource") is not None:
             if v.get("instrumentPropertySource") is None:
                 raise ValueError("if 'instrumentSource' is specified then 'instrumentPropertySource' must be specified")
-
+        if v.get("unit") is not None:
+            unit_ = v.get("unit")
+            if unit_ not in (wng.Units.TOF, wng.Units.DSP):
+                raise ValueError(f"unknown unit '{unit_}' specified")
         match v["workspaceType"]:
             case "neutron":
                 if v.get("runNumber") is None:
                     raise ValueError("Loading neutron data requires a run number")
                 if v.get("groupingScheme") is not None:
-                    v["groupingScheme"] = None
+                    del v["groupingScheme"]
                 if v.get("instrumentPropertySource") is not None:
                     raise ValueError("Loading neutron data should not specify an instrument")
             case "grouping":
@@ -105,19 +111,15 @@ class GroceryListItem(BaseModel):
             case "diffcal_output":
                 if v.get("runNumber") is None:
                     raise ValueError(f"diffraction-calibration {v['workspaceType']} requires a run number")
-                if v.get("isOutput") is False:
-                    raise ValueError(
-                        f"diffraction-calibration {v['workspaceType']} output specification is special-order only"
-                    )
                 if v.get("instrumentPropertySource") is not None:
                     raise ValueError("Loading diffcal-output data should not specify an instrument")
+                if not v.get("useLiteMode"):
+                    v["useLiteMode"] = True  # don't care
             case "diffcal_table" | "diffcal_mask":
                 if v.get("runNumber") is None:
                     raise ValueError(f"diffraction-calibration {v['workspaceType']} requires a run number")
-                if v.get("isOutput") is False:
-                    raise ValueError(
-                        f"diffraction-calibration {v['workspaceType']} output specification is special-order only"
-                    )
+                if not v.get("useLiteMode"):
+                    v["useLiteMode"] = True  # don't care
             case _:
                 raise ValueError(f"unrecognized 'workspaceType': '{v['workspaceType']}'")
         return v

--- a/src/snapred/backend/dao/request/CalibrationAssessmentRequest.py
+++ b/src/snapred/backend/dao/request/CalibrationAssessmentRequest.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Dict, List
 
 from pydantic import BaseModel
 
@@ -6,6 +6,7 @@ from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.meta.Config import Config
 from snapred.meta.mantid.AllowedPeakTypes import ALLOWED_PEAK_TYPES
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName, WorkspaceType
 
 
 class CalibrationAssessmentRequest(BaseModel):
@@ -15,7 +16,7 @@ class CalibrationAssessmentRequest(BaseModel):
     """
 
     run: RunConfig
-    workspace: str
+    workspaces: Dict[WorkspaceType, List[WorkspaceName]]
     focusGroup: FocusGroup
     calibrantSamplePath: str
     useLiteMode: bool

--- a/src/snapred/backend/data/DataExportService.py
+++ b/src/snapred/backend/data/DataExportService.py
@@ -55,9 +55,3 @@ class DataExportService:
 
     def initializeState(self, runId: str, name: str):
         return self.dataService.initializeState(runId, name)
-
-    def deleteWorkspace(self, name):
-        return self.groceryService.deleteWorkspace(name)
-
-    def deleteWorkspaceUnconditional(self, name):
-        return self.groceryService.deleteWorkspaceUnconditional(name)

--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -112,6 +112,7 @@ class DataFactoryService:
     def workspaceDoesExist(self, name):
         return self.groceryService.workspaceDoesExist(name)
 
+    # TODO: these are _write_ methods: move to `DataExportService` via `LocalDataService`
     def deleteWorkspace(self, name):
         return self.groceryService.deleteWorkspace(name)
 

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -142,15 +142,16 @@ class GroceryService:
             path = groupingMap.getMap(useLiteMode)[groupingScheme].definition
         return str(path)
 
-    def _createDiffcalOutputWorkspaceFilename(self, runId: str, version: str) -> str:
+    def _createDiffcalOutputWorkspaceFilename(self, runId: str, version: str, unit: str) -> str:
         return str(
             Path(self._getCalibrationDataPath(runId, version))
-            / (self._createDiffcalOutputWorkspaceName(runId) + ".nxs")
+            / (self._createDiffcalOutputWorkspaceName(runId, version, unit) + ".nxs")
         )
 
     def _createDiffcalTableFilename(self, runId: str, version: str) -> str:
         return str(
-            Path(self._getCalibrationDataPath(runId, version)) / (self._createDiffcalTableWorkspaceName(runId) + ".h5")
+            Path(self._getCalibrationDataPath(runId, version))
+            / (self._createDiffcalTableWorkspaceName(runId, version) + ".h5")
         )
 
     ## WORKSPACE NAME METHODS
@@ -180,14 +181,14 @@ class GroceryService:
     def _createDiffcalInputWorkspaceName(self, runId: str) -> WorkspaceName:
         return wng.diffCalInput().runNumber(runId).build()
 
-    def _createDiffcalOutputWorkspaceName(self, runId: str) -> WorkspaceName:
-        return wng.diffCalOutput().runNumber(runId).build()
+    def _createDiffcalOutputWorkspaceName(self, runId: str, version: str, unit: str) -> WorkspaceName:
+        return wng.diffCalOutput().unit(unit).runNumber(runId).version(version).build()
 
-    def _createDiffcalTableWorkspaceName(self, runId: str) -> WorkspaceName:
-        return wng.diffCalTable().runNumber(runId).build()
+    def _createDiffcalTableWorkspaceName(self, runId: str, version: str = "") -> WorkspaceName:
+        return wng.diffCalTable().runNumber(runId).version(version).build()
 
-    def _createDiffcalMaskWorkspaceName(self, runId: str) -> WorkspaceName:
-        return wng.diffCalMask().runNumber(runId).build()
+    def _createDiffcalMaskWorkspaceName(self, runId: str, version: str = "") -> WorkspaceName:
+        return wng.diffCalMask().runNumber(runId).version(version).build()
 
     ## ACCESSING WORKSPACES
     """
@@ -503,8 +504,8 @@ class GroceryService:
         """
 
         runNumber, version, useLiteMode = item.runNumber, item.version, item.useLiteMode
-        tableWorkspaceName = self._createDiffcalTableWorkspaceName(runNumber)
-        maskWorkspaceName = self._createDiffcalMaskWorkspaceName(runNumber)
+        tableWorkspaceName = self._createDiffcalTableWorkspaceName(runNumber, version)
+        maskWorkspaceName = self._createDiffcalMaskWorkspaceName(runNumber, version)
 
         if self.workspaceDoesExist(tableWorkspaceName):
             data = {
@@ -564,25 +565,27 @@ class GroceryService:
                     )
                 # for diffraction-calibration workspaces
                 case "diffcal_output":
-                    diffcalOutputWorkspaceName = self._createDiffcalOutputWorkspaceName(item.runNumber)
+                    diffcalOutputWorkspaceName = self._createDiffcalOutputWorkspaceName(
+                        item.runNumber, item.version, item.unit
+                    )
                     if item.isOutput:
                         res = {"result": True, "workspace": diffcalOutputWorkspaceName}
                     else:
                         res = self.fetchWorkspace(
-                            self._createDiffcalOutputWorkspaceFilename(item.runNumber, item.version),
+                            self._createDiffcalOutputWorkspaceFilename(item.runNumber, item.version, item.unit),
                             diffcalOutputWorkspaceName,
                         )
                 case "diffcal_table":
-                    tableWorkspaceName = self._createDiffcalTableWorkspaceName(item.runNumber)
+                    tableWorkspaceName = self._createDiffcalTableWorkspaceName(item.runNumber, item.version)
                     if item.isOutput:
                         res = {"result": True, "workspace": tableWorkspaceName}
                     else:
                         res = self.fetchCalibrationWorkspaces(item)
                         res["workspace"] = tableWorkspaceName
                 case "diffcal_mask":
-                    maskWorkspaceName = self._createDiffcalMaskWorkspaceName(item.runNumber)
+                    maskWorkspaceName = self._createDiffcalMaskWorkspaceName(item.runNumber, item.version)
                     if item.isOutput:
-                        res = {"result": True, "workspace": self._createDiffcalMaskWorkspaceName(item.runNumber)}
+                        res = {"result": True, "workspace": maskWorkspaceName}
                     else:
                         res = self.fetchCalibrationWorkspaces(item)
                         res["workspace"] = maskWorkspaceName
@@ -619,6 +622,7 @@ class GroceryService:
 
     ## CLEANUP METHODS
 
+    # TODO: move `deleteWorkspace` methods to `DataExportService` via `LocalDataService`
     def deleteWorkspace(self, name: WorkspaceName):
         """
         Deletes a workspace from Mantid.
@@ -628,6 +632,7 @@ class GroceryService:
         deleteAlgo.setProperty("Workspace", name)
         deleteAlgo.execute()
 
+    # TODO: move `deleteWorkspace` methods to `DataExportService` via `LocalDataService`
     def deleteWorkspaceUnconditional(self, name: WorkspaceName):
         """
         Deletes a workspace from Mantid, regardless of CIS mode.

--- a/src/snapred/backend/recipe/GenerateCalibrationMetricsWorkspaceRecipe.py
+++ b/src/snapred/backend/recipe/GenerateCalibrationMetricsWorkspaceRecipe.py
@@ -26,13 +26,13 @@ class GenerateCalibrationMetricsWorkspaceRecipe:
         runId = ingredients.calibrationRecord.runNumber
 
         if ingredients.timestamp is not None:
-            calibVersionOrTimeStamp = "ts" + str(ingredients.timestamp)
-            logger.info(f"Executing recipe {__name__} for run: {runId} timestamp: {calibVersionOrTimeStamp}")
+            timestamp = str(ingredients.timestamp)
+            ws_table = wng.diffCalTimedMetric().runNumber(runId).timestamp(timestamp).metricName("table").build()
+            logger.info(f"Executing recipe {__name__} for run: {runId} timestamp: {timestamp}")
         else:
-            calibVersionOrTimeStamp = "v" + str(ingredients.calibrationRecord.version)
-            logger.info(f"Executing recipe {__name__} for run: {runId} calibration version: {calibVersionOrTimeStamp}")
-
-        ws_table = wng.diffCalMetrics().runNumber(runId).version(calibVersionOrTimeStamp).metricName("table").build()
+            version = str(ingredients.calibrationRecord.version)
+            ws_table = wng.diffCalMetric().runNumber(runId).version(version).metricName("table").build()
+            logger.info(f"Executing recipe {__name__} for run: {runId} calibration version: {version}")
 
         try:
             # create a table workspace with all metrics
@@ -43,9 +43,12 @@ class GenerateCalibrationMetricsWorkspaceRecipe:
             outputs = []
             # convert the table workspace to 2 matrix workspaces: sigma vs. twoTheta and strain vs. twoTheta
             for metric in ["sigma", "strain"]:
-                ws_metric = (
-                    wng.diffCalMetrics().runNumber(runId).version(calibVersionOrTimeStamp).metricName(metric).build()
-                )
+                if ingredients.timestamp is not None:
+                    ws_metric = (
+                        wng.diffCalTimedMetric().metricName(metric).runNumber(runId).timestamp(timestamp).build()
+                    )
+                else:
+                    ws_metric = wng.diffCalMetric().metricName(metric).runNumber(runId).version(version).build()
                 ConvertTableToMatrixWorkspaceRecipe().executeRecipe(
                     InputWorkspace=ws_table,
                     ColumnX="twoThetaAverage",

--- a/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
@@ -130,7 +130,7 @@ class GroupDiffractionCalibration(PythonAlgorithm):
         # TODO: use workspace namer
         self.DIFCprev: str = ""
         if self.getProperty("PreviousCalibrationTable").isDefault:
-            self.DIFCprev = f"difc_prev_{self.runNumber}"
+            self.DIFCprev = f"diffract_consts_prev_{self.runNumber}"
             self.mantidSnapper.CalculateDiffCalTable(
                 "Initialize the DIFC table from input",
                 InputWorkspace=self.wsTOF,

--- a/src/snapred/meta/builder/GroceryListBuilder.py
+++ b/src/snapred/meta/builder/GroceryListBuilder.py
@@ -36,19 +36,22 @@ class GroceryListBuilder:
         self._tokens["runNumber"] = runId
         return self
 
-    def diffcal_output(self, runId: str):
+    def diffcal_output(self, runId: str, version: str = ""):
         self._tokens["workspaceType"] = "diffcal_output"
         self._tokens["runNumber"] = runId
+        self._tokens["version"] = version
         return self
 
-    def diffcal_table(self, runId: str):
+    def diffcal_table(self, runId: str, version: str = ""):
         self._tokens["workspaceType"] = "diffcal_table"
         self._tokens["runNumber"] = runId
+        self._tokens["version"] = version
         return self
 
-    def diffcal_mask(self, runId: str):
+    def diffcal_mask(self, runId: str, version: str = ""):
         self._tokens["workspaceType"] = "diffcal_mask"
         self._tokens["runNumber"] = runId
+        self._tokens["version"] = version
         return self
 
     def native(self):
@@ -61,6 +64,10 @@ class GroceryListBuilder:
 
     def useLiteMode(self, useLiteMode: bool):
         self._tokens["useLiteMode"] = useLiteMode
+        return self
+
+    def unit(self, unit_: str):
+        self._tokens["unit"] = unit_
         return self
 
     def source(self, **kwarg):

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Dict, List
 
 from snapred.meta.Config import Config
@@ -6,6 +7,21 @@ from snapred.meta.Config import Config
 class WorkspaceName(str):
     def __str__(self):
         return self
+
+
+class WorkspaceType(str, Enum):
+    # TODO: not yet completely connected: should be a mixin to the WNG class itself...
+    #   For the moment: the <enum>.value will be `_WorkspaceNameGenerator` method name
+    RUN = "run"
+    DIFFCAL_INPUT = "diffCalInput"
+    DIFFCAL_OUTPUT = "diffCalOutput"
+    DIFFCAL_TABLE = "diffCalTable"
+    DIFFCAL_MASK = "diffCalMask"
+    DIFFCAL_METRIC = "diffCalMetric"
+    DIFFCAL_TIMED_METRIC = "diffCalTimedMetric"
+    RAW_VANADIUM = "rawVanadium"
+    FOCUSED_RAW_VANADIUM = "focusedRawVanadium"
+    SMOOTHED_FOCUSED_RAW_VANADIUM = "smoothedFocusedRawVanadium"
 
 
 class NameBuilder:
@@ -20,6 +36,7 @@ class NameBuilder:
             raise RuntimeError(f"Key [{key}] not a valid property for given name.")
 
         def setValue(value):
+            value = ValueFormatter.formatValueByKey(key, value)
             self.props[key] = value
             return self
 
@@ -31,21 +48,53 @@ class NameBuilder:
         return WorkspaceName(self.delimiter.join(tokens))
 
 
+class ValueFormatter:
+    @staticmethod
+    def formatRunNumber(runNumber: str):
+        return str(runNumber).zfill(6)
+
+    @staticmethod
+    def formatVersion(version, use_v_prefix: bool = True):
+        if version == "":
+            return version
+        if not version == "*":
+            version = str(version).zfill(4)
+        return "v" + version if use_v_prefix else version
+
+    @staticmethod
+    def formatTimestamp(timestamp: str):
+        return "ts" + timestamp
+
+    @staticmethod
+    def formatValueByKey(key: str, value: any):
+        if key == "runNumber":
+            value = ValueFormatter.formatRunNumber(value)
+        elif key == "version":
+            value = ValueFormatter.formatVersion(value)
+        elif key == "timestamp":
+            value = ValueFormatter.formatTimestamp(value)
+        return value
+
+
 class _WorkspaceNameGenerator:
+    # TODO: define <workspace type> Enum
+
     _templateRoot = "mantid.workspace.nameTemplate"
     _delimiter = Config[f"{_templateRoot}.delimiter"]
     _runTemplate = Config[f"{_templateRoot}.run"]
     _runTemplateKeys = ["runNumber", "auxiliary", "lite", "unit", "group"]
     _diffCalInputTemplate = Config[f"{_templateRoot}.diffCal.input"]
-    _diffCalInputTemplateKeys = ["runNumber", "unit"]
+    _diffCalInputTemplateKeys = ["unit", "runNumber"]
     _diffCalTableTemplate = Config[f"{_templateRoot}.diffCal.table"]
     _diffCalTableTemplateKeys = ["runNumber", "version"]
     _diffCalOutputTemplate = Config[f"{_templateRoot}.diffCal.output"]
-    _diffCalOutputTemplateKeys = ["runNumber", "version", "unit"]
+    _diffCalOutputTemplateKeys = ["unit", "runNumber", "version"]
     _diffCalMaskTemplate = Config[f"{_templateRoot}.diffCal.mask"]
     _diffCalMaskTemplateKeys = ["runNumber", "version"]
     _diffCalMetricTemplate = Config[f"{_templateRoot}.diffCal.metric"]
-    _diffCalMetricTemplateKeys = ["runNumber", "version", "metricName"]
+    _diffCalMetricTemplateKeys = ["metricName", "runNumber", "version"]
+    _diffCalTimedMetricTemplate = Config[f"{_templateRoot}.diffCal.timed_metric"]
+    _diffCalTimedMetricTemplateKeys = ["metricName", "runNumber", "timestamp"]
     _rawVanadiumTemplate = Config[f"{_templateRoot}.normCal.rawVanadium"]
     _rawVanadiumTemplateKeys = ["unit", "group", "runNumber"]
     _focusedRawVanadiumTemplate = Config[f"{_templateRoot}.normCal.focusedRawVanadium"]
@@ -102,8 +151,11 @@ class _WorkspaceNameGenerator:
     def diffCalMask(self):
         return NameBuilder(self._diffCalMaskTemplate, self._diffCalMaskTemplateKeys, self._delimiter, version="")
 
-    def diffCalMetrics(self):
+    def diffCalMetric(self):
         return NameBuilder(self._diffCalMetricTemplate, self._diffCalMetricTemplateKeys, self._delimiter, version="")
+
+    def diffCalTimedMetric(self):
+        return NameBuilder(self._diffCalTimedMetricTemplate, self._diffCalTimedMetricTemplateKeys, self._delimiter)
 
     def rawVanadium(self):
         return NameBuilder(

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -85,13 +85,14 @@ mantid:
   workspace:
     nameTemplate:
       delimiter: "_"
-      run: "{unit},{group},{lite},{runNumber},{auxiliary}"
+      run: "{unit},{group},{lite},{auxiliary},{runNumber}"
       diffCal:
         input: "{unit},{runNumber},raw"
-        table: "DIFC,{runNumber},{version}"
-        output: "{unit},{runNumber},{version},diffoc"
-        mask: "DIFC,{runNumber},{version},mask"
-        metric: "{runNumber},{version},calibration_metrics,{metricName}"
+        table: "diffract_consts,{runNumber},{version}"
+        output: "{unit},diffoc,{runNumber},{version}"
+        mask: "diffract_consts,mask,{runNumber},{version}"
+        metric: "calib_metrics,{metricName},{runNumber},{version}"
+        timed_metric: "calib_metrics,{metricName},{runNumber},{timestamp}"
       normCal:
         rawVanadium: "{unit},{group},{runNumber},raw_van_corr"
         focusedRawVanadium: "{unit},{group},{runNumber},raw_van_corr"

--- a/src/snapred/ui/view/DiffCalAssessmentView.py
+++ b/src/snapred/ui/view/DiffCalAssessmentView.py
@@ -79,3 +79,6 @@ class DiffCalAssessmentView(QWidget):
         msgBox.setText(msg)
         msgBox.setFixedSize(500, 200)
         msgBox.exec()
+
+    def updateRunNumber(self, runNumber):
+        self.signalRunNumberUpdate.emit(runNumber)

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -87,17 +87,18 @@ mantid:
     workspace:
       nameTemplate:
         delimiter: "_"
-        run: "{unit},{group},{lite},{runNumber},{auxiliary}"
+        run: "{unit},{group},{lite},{auxiliary},{runNumber}"
         diffCal:
           input: "_{unit},{runNumber},raw"
-          table: "_DIFC,{runNumber},{version}"
-          output: "_{unit},{runNumber},{version},diffoc"
-          mask: "_DIFC,{runNumber},{version},mask"
-          metric: "{runNumber},{version},calibration_metrics,{metricName}"
+          table: "_diffract_consts,{runNumber},{version}"
+          output: "_{unit},diffoc,{runNumber},{version}"
+          mask: "_diffract_consts,mask,{runNumber},{version}"
+          metric: "_calib_metrics,{metricName},{runNumber},{version}"
+          timed_metric: "_calib_metrics,{metricName},{runNumber},{timestamp}"
         normCal:
-          rawVanadium: "{unit},{group},{runNumber},raw_van_corr"
-          focusedRawVanadium: "{unit},{group},{runNumber},raw_van_corr"
-          smoothedFocusedRawVanadium: "{unit},{group},{runNumber},fitted_van_cor"
+          rawVanadium: "{unit},{group},raw_van_corr,{runNumber}"
+          focusedRawVanadium: "{unit},{group},raw_van_corr,{runNumber}"
+          smoothedFocusedRawVanadium: "{unit},{group},fitted_van_cor,{runNumber}"
         units:
           dSpacing: dsp
           timeOfFlight: tof

--- a/tests/resources/inputs/calibration/CalibrationRecord_v0001.json
+++ b/tests/resources/inputs/calibration/CalibrationRecord_v0001.json
@@ -1,0 +1,633 @@
+{
+  "runNumber": 57514,
+  "crystalInfo": {
+    "peaks": [
+        {
+            "hkl": [
+                1,
+                1,
+                1
+            ],
+            "dSpacing": 3.13592994862768,
+            "fSquared": 535.9619564273586,
+            "multiplicity": 8
+        },
+        {
+            "hkl": [
+                2,
+                2,
+                0
+            ],
+            "dSpacing": 1.9203570608125202,
+            "fSquared": 1023.9787120274582,
+            "multiplicity": 12
+        },
+        {
+            "hkl": [
+                3,
+                1,
+                1
+            ],
+            "dSpacing": 1.6376860040951353,
+            "fSquared": 498.1235946287523,
+            "multiplicity": 24
+        },
+        {
+            "hkl": [
+                3,
+                3,
+                1
+            ],
+            "dSpacing": 1.2460922059340045,
+            "fSquared": 462.95658217953996,
+            "multiplicity": 24
+        },
+        {
+            "hkl": [
+                3,
+                3,
+                3
+            ],
+            "dSpacing": 1.0453099828758932,
+            "fSquared": 430.2723245685628,
+            "multiplicity": 8
+        },
+        {
+            "hkl": [
+                4,
+                0,
+                0
+            ],
+            "dSpacing": 1.3578975000000002,
+            "fSquared": 951.6868701996577,
+            "multiplicity": 6
+        },
+        {
+            "hkl": [
+                4,
+                2,
+                2
+            ],
+            "dSpacing": 1.108718666000307,
+            "fSquared": 884.4987579059488,
+            "multiplicity": 24
+        },
+        {
+            "hkl": [
+                4,
+                4,
+                0
+            ],
+            "dSpacing": 0.9601785304062601,
+            "fSquared": 822.0540571007734,
+            "multiplicity": 12
+        },
+        {
+            "hkl": [
+                4,
+                4,
+                4
+            ],
+            "dSpacing": 0.78398248715692,
+            "fSquared": 710.0790122848589,
+            "multiplicity": 8
+        },
+        {
+            "hkl": [
+                5,
+                1,
+                1
+            ],
+            "dSpacing": 1.0453099828758932,
+            "fSquared": 430.27232456856234,
+            "multiplicity": 24
+        },
+        {
+            "hkl": [
+                5,
+                3,
+                1
+            ],
+            "dSpacing": 0.9181062796881728,
+            "fSquared": 399.8955418627943,
+            "multiplicity": 48
+        },
+        {
+            "hkl": [
+                5,
+                3,
+                3
+            ],
+            "dSpacing": 0.8283097096328722,
+            "fSquared": 371.6633287118501,
+            "multiplicity": 24
+        },
+        {
+            "hkl": [
+                5,
+                5,
+                1
+            ],
+            "dSpacing": 0.7605747301605699,
+            "fSquared": 345.42428071520527,
+            "multiplicity": 24
+        },
+        {
+            "hkl": [
+                5,
+                5,
+                3
+            ],
+            "dSpacing": 0.7071327869943331,
+            "fSquared": 321.0376824669837,
+            "multiplicity": 24
+        },
+        {
+            "hkl": [
+                5,
+                5,
+                5
+            ],
+            "dSpacing": 0.627185989725536,
+            "fSquared": 277.3079440497553,
+            "multiplicity": 8
+        },
+        {
+            "hkl": [
+                6,
+                2,
+                0
+            ],
+            "dSpacing": 0.8588097858096985,
+            "fSquared": 764.0178878212722,
+            "multiplicity": 24
+        },
+        {
+            "hkl": [
+                6,
+                4,
+                2
+            ],
+            "dSpacing": 0.7258267444795525,
+            "fSquared": 659.9481657756581,
+            "multiplicity": 48
+        },
+        {
+            "hkl": [
+                6,
+                6,
+                0
+            ],
+            "dSpacing": 0.64011902027084,
+            "fSquared": 570.054168172224,
+            "multiplicity": 12
+        },
+        {
+            "hkl": [
+                6,
+                6,
+                4
+            ],
+            "dSpacing": 0.5790094394749851,
+            "fSquared": 492.4049667879426,
+            "multiplicity": 24
+        },
+        {
+            "hkl": [
+                7,
+                1,
+                1
+            ],
+            "dSpacing": 0.7605747301605699,
+            "fSquared": 345.4242807152059,
+            "multiplicity": 24
+        },
+        {
+            "hkl": [
+                7,
+                3,
+                1
+            ],
+            "dSpacing": 0.7071327869943332,
+            "fSquared": 321.03768246698314,
+            "multiplicity": 48
+        },
+        {
+            "hkl": [
+                7,
+                3,
+                3
+            ],
+            "dSpacing": 0.663574332271264,
+            "fSquared": 298.37275292395174,
+            "multiplicity": 24
+        },
+        {
+            "hkl": [
+                7,
+                5,
+                1
+            ],
+            "dSpacing": 0.627185989725536,
+            "fSquared": 277.30794404975575,
+            "multiplicity": 48
+        },
+        {
+            "hkl": [
+                7,
+                5,
+                3
+            ],
+            "dSpacing": 0.5961944569174021,
+            "fSquared": 257.73028897414855,
+            "multiplicity": 48
+        },
+        {
+            "hkl": [
+                7,
+                5,
+                5
+            ],
+            "dSpacing": 0.5458953346983784,
+            "fSquared": 222.6238864097245,
+            "multiplicity": 24
+        },
+        {
+            "hkl": [
+                7,
+                7,
+                1
+            ],
+            "dSpacing": 0.5458953346983784,
+            "fSquared": 222.62388640972324,
+            "multiplicity": 24
+        },
+        {
+            "hkl": [
+                7,
+                7,
+                3
+            ],
+            "dSpacing": 0.5250916246535536,
+            "fSquared": 206.90686944991165,
+            "multiplicity": 24
+        },
+        {
+            "hkl": [
+                8,
+                0,
+                0
+            ],
+            "dSpacing": 0.6789487500000001,
+            "fSquared": 613.3565053686378,
+            "multiplicity": 6
+        },
+        {
+            "hkl": [
+                8,
+                2,
+                2
+            ],
+            "dSpacing": 0.64011902027084,
+            "fSquared": 570.054168172224,
+            "multiplicity": 24
+        },
+        {
+            "hkl": [
+                8,
+                4,
+                0
+            ],
+            "dSpacing": 0.6072702232954043,
+            "fSquared": 529.8089313574962,
+            "multiplicity": 24
+        },
+        {
+            "hkl": [
+                8,
+                4,
+                4
+            ],
+            "dSpacing": 0.5543593330001535,
+            "fSquared": 457.64168357107144,
+            "multiplicity": 24
+        },
+        {
+            "hkl": [
+                8,
+                6,
+                2
+            ],
+            "dSpacing": 0.5326112192276046,
+            "fSquared": 425.33265232468636,
+            "multiplicity": 48
+        },
+        {
+            "hkl": [
+                9,
+                1,
+                1
+            ],
+            "dSpacing": 0.5961944569174022,
+            "fSquared": 257.7302889741486,
+            "multiplicity": 24
+        },
+        {
+            "hkl": [
+                9,
+                3,
+                1
+            ],
+            "dSpacing": 0.5693853436290405,
+            "fSquared": 239.53479617150862,
+            "multiplicity": 48
+        },
+        {
+            "hkl": [
+                9,
+                3,
+                3
+            ],
+            "dSpacing": 0.5458953346983784,
+            "fSquared": 222.62388640972318,
+            "multiplicity": 24
+        },
+        {
+            "hkl": [
+                9,
+                5,
+                1
+            ],
+            "dSpacing": 0.5250916246535536,
+            "fSquared": 206.90686944991126,
+            "multiplicity": 48
+        },
+        {
+            "hkl": [
+                9,
+                5,
+                3
+            ],
+            "dSpacing": 0.5064983791390006,
+            "fSquared": 192.29945769059668,
+            "multiplicity": 48
+        },
+        {
+            "hkl": [
+                10,
+                2,
+                0
+            ],
+            "dSpacing": 0.5326112192276046,
+            "fSquared": 425.33265232468636,
+            "multiplicity": 24
+        }
+    ]
+},
+    "calibrationFittingIngredients": {
+      "instrumentState": {
+        "id": "ab8704b0bc2a2342",
+        "peakTailCoefficient": 1.1,
+        "instrumentConfig": {
+          "version": "1.4",
+          "facility": "SNS",
+          "name": "SNAP",
+          "nexusFileExtension": ".nxs.h5",
+          "nexusFilePrefix": "SNAP_",
+          "calibrationFileExtension": "json",
+          "calibrationFilePrefix": "SNAPcalibLog",
+          "calibrationDirectory": "/SNS/SNAP/shared/Calibration/",
+          "pixelGroupingDirectory": "PixelGroupingDefinitions/",
+          "sharedDirectory": "shared/",
+          "nexusDirectory": "nexus/",
+          "reducedDataDirectory": "shared/manualReduced/",
+          "reductionRecordDirectory": "shared/manualReduced/reductionRecord/",
+          "bandwidth": 3,
+          "maxBandwidth": 3.2,
+          "L1": 15,
+          "L2": 0.5,
+          "delTOverT": 0.002,
+          "delLOverL": 0.00006452,
+          "delThNoGuide": 0.0006667,
+          "delThWithGuide": 0.0032
+        },
+        "detectorState": {
+          "arc": [
+            -65.3,
+            104.95
+          ],
+          "wav": 2.1,
+          "freq": 60,
+          "guideStat": 1,
+          "lin": [
+            0.045,
+            0.043
+          ]
+        },
+        "gsasParameters": {
+          "alpha": 0.1,
+          "beta": [
+            0.02,
+            0.05
+          ]
+        },
+        "particleBounds": {
+          "wavelength": {
+            "minimum": 0.7,
+            "maximum": 3.5
+          },
+          "tof": {
+            "minimum": 2742.6,
+            "maximum": 13713
+          }
+        },
+        "defaultGroupingSliceValue": 5,
+        "fwhmMultiplierLimit": {
+          "minimum": 1.3,
+          "maximum": 1.3
+        }
+      },
+      "seedRun": 57514,
+      "creationDate": "2023-06-05T15:49:59.583421",
+      "name": "test",
+      "version": 0
+    },
+    "pixelGroups":[
+      {
+        "focusGroup": {
+          "name": "Column",
+          "definition": ""
+        },
+        "timeOfFlight": {
+          "minimum": 2742.6,
+          "maximum": 13713,
+          "binWidth": 1,
+          "binningMode": 1
+        },
+        "pixelGroupingParameters": [
+          {
+            "groupID": 0,
+            "twoTheta": 2.1108948177427838,
+            "dResolution": {
+              "minimum": 0.40224298673776404,
+              "maximum": 2.0112149336888203
+            },
+            "dRelativeResolution": 0.002771822370612031
+          },
+          {
+            "groupID": 1,
+            "twoTheta": 1.82310673131693,
+            "dResolution": {
+              "minimum": 0.44278229953817677,
+              "maximum": 2.213911497690884
+            },
+            "dRelativeResolution": 0.003234525153614593
+          },
+          {
+            "groupID": 2,
+            "twoTheta": 1.5352228379083572,
+            "dResolution": {
+              "minimum": 0.5040188478793922,
+              "maximum": 2.5200942393969608
+            },
+            "dRelativeResolution": 0.004014748859873182
+          },
+          {
+            "groupID": 3,
+            "twoTheta": 1.440276389170165,
+            "dResolution": {
+              "minimum": 0.530714277849788,
+              "maximum": 2.6535713892489396
+            },
+            "dRelativeResolution": 0.004309856397320412
+          },
+          {
+            "groupID": 4,
+            "twoTheta": 1.1543988461042238,
+            "dResolution": {
+              "minimum": 0.6414024711539658,
+              "maximum": 3.207012355769829
+            },
+            "dRelativeResolution": 0.005408489642872038
+          },
+          {
+            "groupID": 5,
+            "twoTheta": 0.8690010092470938,
+            "dResolution": {
+              "minimum": 0.831438096217031,
+              "maximum": 4.157190481085156
+            },
+            "dRelativeResolution": 0.007548513084996265
+          }
+        ]
+      },
+      {
+        "focusGroup": {
+          "name": "Bank",
+          "definition": ""
+        },
+        "timeOfFlight": {
+          "minimum": 2742.6,
+          "maximum": 13713,
+          "binWidth": 1,
+          "binningMode": 1
+        },
+        "pixelGroupingParameters": [
+          {
+            "groupID": 0,
+            "twoTheta": 1.8230747956560218,
+            "dResolution": {
+              "minimum": 0.4427877783643468,
+              "maximum": 2.2139388918217344
+            },
+            "dRelativeResolution": 0.003379514789208845
+          },
+          {
+            "groupID": 1,
+            "twoTheta": 1.1545587481738246,
+            "dResolution": {
+              "minimum": 0.641323731469231,
+              "maximum": 3.2066186573461555
+            },
+            "dRelativeResolution": 0.005910630879382727
+          }
+        ]
+      },
+      {
+        "focusGroup": {
+          "name": "All",
+          "definition": ""
+        },
+        "timeOfFlight": {
+          "minimum": 2742.6,
+          "maximum": 13713,
+          "binWidth": 1,
+          "binningMode": 1
+        },
+        "pixelGroupingParameters": [
+          {
+            "groupID": 0,
+            "twoTheta": 1.4888167719149363,
+            "dResolution": {
+              "minimum": 0.5165770976155033,
+              "maximum": 2.5828854880775167
+            },
+            "dRelativeResolution": 0.004814388725622084
+          }
+        ]
+      }
+    ],
+    "focusGroupCalibrationMetrics":{
+      "focusGroupName": "Column",
+      "calibrationMetric": [
+        {
+          "sigmaAverage": 0.002517952998136214,
+          "sigmaStandardDeviation": 0.00000878421857231147,
+          "strainAverage": 0.1515216185900471,
+          "strainStandardDeviation": 0.013151225165758604,
+          "twoThetaAverage": 2.110894794556694
+        },
+        {
+          "sigmaAverage": 0.003176206362503416,
+          "sigmaStandardDeviation": 0.000014979115537326051,
+          "strainAverage": 0.11967297872183888,
+          "strainStandardDeviation": 0.010670589671407833,
+          "twoThetaAverage": 1.8231067294302894
+        },
+        {
+          "sigmaAverage": 0.0020173258481625943,
+          "sigmaStandardDeviation": 0.0011833789198171258,
+          "strainAverage": 2.9472523966464146,
+          "strainStandardDeviation": 1.7234726438089345,
+          "twoThetaAverage": 1.5352228117682118
+        },
+        {
+          "sigmaAverage": 0.0019681238298694874,
+          "sigmaStandardDeviation": 0.0012719855843628899,
+          "strainAverage": 2.97560355438957,
+          "strainStandardDeviation": 1.7073076840182733,
+          "twoThetaAverage": 1.440276416886144
+        },
+        {
+          "sigmaAverage": 0.002792254157654066,
+          "sigmaStandardDeviation": 0.0018788822023715769,
+          "strainAverage": 2.6968257593469005,
+          "strainStandardDeviation": 1.5521868842356747,
+          "twoThetaAverage": 1.1543988480234637
+        },
+        {
+          "sigmaAverage": 0.0035439650966407016,
+          "sigmaStandardDeviation": 0.0026213074118901255,
+          "strainAverage": 2.9942330576453013,
+          "strainStandardDeviation": 1.7458314136551056,
+          "twoThetaAverage": 0.8690010316506124
+        }
+      ]
+    },
+    "workspaces": {
+      "diffCalOutput": ["_tof_diffoc_057514_v0001", "_dsp_diffoc_057514_v0001"],
+      "diffCalTable": ["_diffract_consts_057514_v0001"],
+      "diffCalMask": ["_diffract_consts_mask_057514_v0001"]
+    },
+    "version": 1
+  }

--- a/tests/resources/inputs/calibration/CalibrationRecord_v0002.json
+++ b/tests/resources/inputs/calibration/CalibrationRecord_v0002.json
@@ -624,12 +624,10 @@
         }
       ]
     },
-    "workspaceNames": [
-      "fitted_strippedFocussedData_stripped_0",
-      "fitted_strippedFocussedData_stripped_1",
-      "fitted_strippedFocussedData_stripped_2",
-      "_difc_57514",
-      "_difc_57514_mask"
-    ],
-    "version": 7
+    "workspaces": {
+      "diffCalOutput": ["_tof_diffoc_057514_v0002"],
+      "diffCalTable": ["_diffract_consts_057514_v0002"],
+      "diffCalMask": ["_diffract_consts_mask_057514_v0002"]
+    },
+    "version": 2
   }

--- a/tests/unit/backend/dao/test_AllowedPeaks.py
+++ b/tests/unit/backend/dao/test_AllowedPeaks.py
@@ -2,6 +2,7 @@ import pytest
 from pydantic.error_wrappers import ValidationError
 from snapred.backend.dao.request.CalibrationAssessmentRequest import CalibrationAssessmentRequest
 from snapred.meta.mantid.AllowedPeakTypes import allowed_peak_type_list
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceType as wngt
 
 
 def test_literal_bad():
@@ -10,7 +11,7 @@ def test_literal_bad():
     with pytest.raises(ValidationError) as e:
         CalibrationAssessmentRequest(
             run={"runNumber": "123"},
-            workspace="nope",
+            workspaces={wngt.DIFFCAL_OUTPUT: ["nope"]},
             focusGroup={"name": "nope", "definition": "nope"},
             calibrantSamplePath="nope",
             useLiteMode=False,
@@ -24,11 +25,11 @@ def test_literal_good():
         try:
             CalibrationAssessmentRequest(
                 run={"runNumber": "123"},
-                workspace="nope",
+                workspaces={wngt.DIFFCAL_OUTPUT: ["nope"]},
                 focusGroup={"name": "nope", "definition": "nope"},
                 calibrantSamplePath="nope",
                 useLiteMode=False,
                 peakType=good,
             )
         except ValidationError:
-            assert pytest.fails()
+            pytest.fail("unexpected `ValidationError` during test")

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -16,11 +16,11 @@ from mantid.api import ITableWorkspace, MatrixWorkspace
 from mantid.dataobjects import MaskWorkspace
 from mantid.simpleapi import (
     CloneWorkspace,
-    CreateSampleWorkspace,
-    CreateGroupingWorkspace,
-    LoadInstrument,
-    LoadEmptyInstrument,
     ConvertUnits,
+    CreateGroupingWorkspace,
+    CreateSampleWorkspace,
+    LoadEmptyInstrument,
+    LoadInstrument,
     mtd,
 )
 from pydantic import parse_raw_as
@@ -666,8 +666,12 @@ def readReductionIngredientsFromFile():
 
 
 def test_readWriteCalibrationRecord_version_numbers():
-    testCalibrationRecord_v0001 = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json"))
-    testCalibrationRecord_v0002 = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0002.json"))
+    testCalibrationRecord_v0001 = CalibrationRecord.parse_raw(
+        Resource.read("inputs/calibration/CalibrationRecord_v0001.json")
+    )
+    testCalibrationRecord_v0002 = CalibrationRecord.parse_raw(
+        Resource.read("inputs/calibration/CalibrationRecord_v0002.json")
+    )
     with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tempdir:
         localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
@@ -695,8 +699,12 @@ def test_readWriteCalibrationRecord_version_numbers():
 
 
 def test_readWriteCalibrationRecord_specified_version():
-    testCalibrationRecord_v0001 = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json"))
-    testCalibrationRecord_v0002 = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0002.json"))
+    testCalibrationRecord_v0001 = CalibrationRecord.parse_raw(
+        Resource.read("inputs/calibration/CalibrationRecord_v0001.json")
+    )
+    testCalibrationRecord_v0002 = CalibrationRecord.parse_raw(
+        Resource.read("inputs/calibration/CalibrationRecord_v0002.json")
+    )
     with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tempdir:
         localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
@@ -741,7 +749,9 @@ def test_readWriteCalibrationRecord_with_version():
 
 
 def test_readWriteCalibrationRecord():
-    testCalibrationRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json"))
+    testCalibrationRecord = CalibrationRecord.parse_raw(
+        Resource.read("inputs/calibration/CalibrationRecord_v0001.json")
+    )
     with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tempdir:
         localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
@@ -761,7 +771,9 @@ def test_readWriteCalibrationRecord():
 def test_writeCalibrationWorkspaces(mockConstructCalibrationDataPath):
     localDataService = LocalDataService()
     path = Resource.getPath("outputs")
-    testCalibrationRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json"))
+    testCalibrationRecord = CalibrationRecord.parse_raw(
+        Resource.read("inputs/calibration/CalibrationRecord_v0001.json")
+    )
     with tempfile.TemporaryDirectory(dir=path, suffix="/") as basePath:
         basePath = Path(basePath)
         mockConstructCalibrationDataPath.return_value = str(basePath)
@@ -823,24 +835,26 @@ def test_writeCalibrationWorkspaces(mockConstructCalibrationDataPath):
 @mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
 def test_writeCalibrationWorkspaces_no_units(
     mockConstructCalibrationDataPath,
-    mockWriteWorkspace  # noqa: ARG001
-    ):
+    mockWriteWorkspace,  # noqa: ARG001
+):
     # test that diffraction-calibration output workspace names require units
     localDataService = LocalDataService()
-    testCalibrationRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json"))
+    testCalibrationRecord = CalibrationRecord.parse_raw(
+        Resource.read("inputs/calibration/CalibrationRecord_v0001.json")
+    )
     testCalibrationRecord.workspaces = {
-      wngt.DIFFCAL_OUTPUT: ["_diffoc_057514_v0001", "_dsp_diffoc_057514_v0001"],
-      wngt.DIFFCAL_TABLE: ["_diffract_consts_057514_v0001"],
-      wngt.DIFFCAL_MASK: ["_diffract_consts_mask_057514_v0001"]
+        wngt.DIFFCAL_OUTPUT: ["_diffoc_057514_v0001", "_dsp_diffoc_057514_v0001"],
+        wngt.DIFFCAL_TABLE: ["_diffract_consts_057514_v0001"],
+        wngt.DIFFCAL_MASK: ["_diffract_consts_mask_057514_v0001"],
     }
-    with pytest.raises( # noqa: PT012
-            RuntimeError,
-            match=f"cannot save a workspace-type: {wngt.DIFFCAL_OUTPUT} without a units token in its name",
-        ):
+    with pytest.raises(  # noqa: PT012
+        RuntimeError,
+        match=f"cannot save a workspace-type: {wngt.DIFFCAL_OUTPUT} without a units token in its name",
+    ):
         mockConstructCalibrationDataPath.return_value = "not/a/path"
         localDataService.writeCalibrationWorkspaces(testCalibrationRecord)
 
- 
+
 def test_readWriteNormalizationRecord_version_numbers():
     testNormalizationRecord = NormalizationRecord.parse_raw(
         Resource.read("inputs/normalization/NormalizationRecord.json")
@@ -870,6 +884,7 @@ def test_readWriteNormalizationRecord_version_numbers():
     assert actualRecord.runNumber == "57514"
     assert actualRecord == testNormalizationRecord
 
+
 def test_readWriteNormalizationRecord_specified_version():
     testNormalizationRecord = NormalizationRecord.parse_raw(
         Resource.read("inputs/normalization/NormalizationRecord.json")
@@ -897,6 +912,7 @@ def test_readWriteNormalizationRecord_specified_version():
         assert actualRecord.version == 1
         actualRecord = localDataService.readNormalizationRecord("57514", "2")
         assert actualRecord.version == 2
+
 
 def test_readWriteNormalizationRecord():
     testNormalizationRecord = NormalizationRecord.parse_raw(
@@ -1219,10 +1235,10 @@ def test_readDetectorState():
         [2.0],
     ]
     localDataService._readPVFile.return_value = pvFileMock
-    
+
     testCalibration = Calibration.parse_file(Resource.getPath("inputs/calibration/CalibrationParameters.json"))
     testDetectorState = testCalibration.instrumentState.detectorState
-    
+
     actualDetectorState = localDataService.readDetectorState("123")
     assert actualDetectorState == testDetectorState
 
@@ -1560,10 +1576,10 @@ def test_writeDiffCalWorkspaces():
 def test_writeDiffCalWorkspaces_bad_path():
     localDataService = LocalDataService()
     path = Resource.getPath("outputs")
-    with pytest.raises( # noqa: PT012
+    with pytest.raises(  # noqa: PT012
         RuntimeError,
         match="specify filename including '.h5' extension",
-        ):
+    ):
         with tempfile.TemporaryDirectory(dir=path, suffix="/") as basePath:
             basePath = Path(basePath)
             tableWSName = "test_table"

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -16,21 +16,15 @@ from mantid.api import ITableWorkspace, MatrixWorkspace
 from mantid.dataobjects import MaskWorkspace
 from mantid.simpleapi import (
     CloneWorkspace,
+    CreateSampleWorkspace,
     CreateGroupingWorkspace,
+    LoadInstrument,
     LoadEmptyInstrument,
+    ConvertUnits,
     mtd,
 )
 from pydantic import parse_raw_as
 from pydantic.error_wrappers import ValidationError
-from snapred.backend.dao.state.CalibrantSample.CalibrantSamples import CalibrantSamples
-from snapred.backend.error.RecoverableException import RecoverableException
-from snapred.meta.Config import Config, Resource
-from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as WNG
-from snapred.meta.redantic import write_model_pretty
-from util.helpers import createCompatibleDiffCalTable, createCompatibleMask
-
-IS_ON_ANALYSIS_MACHINE = socket.gethostname().startswith("analysis")
-
 from snapred.backend.dao import StateConfig
 from snapred.backend.dao.calibration.Calibration import Calibration
 from snapred.backend.dao.calibration.CalibrationIndexEntry import CalibrationIndexEntry
@@ -39,11 +33,21 @@ from snapred.backend.dao.ingredients import ReductionIngredients
 from snapred.backend.dao.normalization.Normalization import Normalization
 from snapred.backend.dao.normalization.NormalizationIndexEntry import NormalizationIndexEntry
 from snapred.backend.dao.normalization.NormalizationRecord import NormalizationRecord
+from snapred.backend.dao.state.CalibrantSample.CalibrantSamples import CalibrantSamples
 from snapred.backend.dao.state.GroupingMap import GroupingMap
 from snapred.backend.data.LocalDataService import LocalDataService
+from snapred.backend.error.RecoverableException import RecoverableException
+from snapred.meta.Config import Config, Resource
+from snapred.meta.mantid.WorkspaceNameGenerator import ValueFormatter as wnvf
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as WNG
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceType as wngt
+from snapred.meta.redantic import write_model_pretty
+from util.helpers import createCompatibleDiffCalTable, createCompatibleMask
 
 LocalDataServiceModule = importlib.import_module(LocalDataService.__module__)
 ThisService = "snapred.backend.data.LocalDataService."
+
+IS_ON_ANALYSIS_MACHINE = socket.gethostname().startswith("analysis")
 
 
 @pytest.fixture(autouse=True)
@@ -232,7 +236,7 @@ def test_prepareStateRoot_creates_state_root_directory():
         stateId = "ab8704b0bc2a2342"
         stateRootPath = Path(tmpDir) / stateId
         groupingMapFilePath = stateRootPath / "groupingMap.json"
-        localDataService._constructCalibrationStateRootPath = mock.Mock(return_value=str(stateRootPath))
+        localDataService._constructCalibrationStateRoot = mock.Mock(return_value=str(stateRootPath))
         defaultGroupingMap = GroupingMap.parse_file(Resource.getPath("inputs/pixel_grouping/defaultGroupingMap.json"))
         localDataService._readDefaultGroupingMap = mock.Mock(return_value=defaultGroupingMap)
         localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
@@ -252,7 +256,7 @@ def test_prepareStateRoot_existing_state_root():
         os.makedirs(stateRootPath)
 
         groupingMapFilePath = stateRootPath / "groupingMap.json"
-        localDataService._constructCalibrationStateRootPath = mock.Mock(return_value=str(stateRootPath))
+        localDataService._constructCalibrationStateRoot = mock.Mock(return_value=str(stateRootPath))
         defaultGroupingMap = GroupingMap.parse_file(Resource.getPath("inputs/pixel_grouping/defaultGroupingMap.json"))
         localDataService._readDefaultGroupingMap = mock.Mock(return_value=defaultGroupingMap)
         localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
@@ -269,7 +273,7 @@ def test_prepareStateRoot_writes_grouping_map():
         stateId = "ab8704b0bc2a2342"
         stateRootPath = Path(tmpDir) / stateId
         groupingMapFilePath = stateRootPath / "groupingMap.json"
-        localDataService._constructCalibrationStateRootPath = mock.Mock(return_value=str(stateRootPath))
+        localDataService._constructCalibrationStateRoot = mock.Mock(return_value=str(stateRootPath))
         defaultGroupingMap = GroupingMap.parse_file(Resource.getPath("inputs/pixel_grouping/defaultGroupingMap.json"))
         localDataService._readDefaultGroupingMap = mock.Mock(return_value=defaultGroupingMap)
         localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
@@ -288,7 +292,7 @@ def test_prepareStateRoot_sets_grouping_map_stateid():
         stateId = "ab8704b0bc2a2342"
         stateRootPath = Path(tmpDir) / stateId
         groupingMapFilePath = stateRootPath / "groupingMap.json"
-        localDataService._constructCalibrationStateRootPath = mock.Mock(return_value=str(stateRootPath))
+        localDataService._constructCalibrationStateRoot = mock.Mock(return_value=str(stateRootPath))
         defaultGroupingMap = GroupingMap.parse_file(Resource.getPath("inputs/pixel_grouping/defaultGroupingMap.json"))
         localDataService._readDefaultGroupingMap = mock.Mock(return_value=defaultGroupingMap)
         localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
@@ -315,7 +319,7 @@ def test_prepareStateRoot_no_default_grouping_map():
             FileNotFoundError,
             match=f'required default grouping-schema map "{defaultGroupingMapFilePath}" does not exist',
         ):
-            localDataService._constructCalibrationStateRootPath = mock.Mock(return_value=str(stateRootPath))
+            localDataService._constructCalibrationStateRoot = mock.Mock(return_value=str(stateRootPath))
             localDataService._defaultGroupingMapPath = mock.Mock(return_value=Path(defaultGroupingMapFilePath))
             localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
             localDataService._prepareStateRoot(stateId)
@@ -342,7 +346,7 @@ def test_prepareStateRoot_does_not_overwrite_grouping_map():
         groupingMap.coerceStateId(otherStateId)
         write_model_pretty(groupingMap, groupingMapFilePath)
 
-        localDataService._constructCalibrationStateRootPath = mock.Mock(return_value=str(stateRootPath))
+        localDataService._constructCalibrationStateRoot = mock.Mock(return_value=str(stateRootPath))
         defaultGroupingMap = GroupingMap.parse_file(defaultGroupingMapFilePath)
         localDataService._readDefaultGroupingMap = mock.Mock(return_value=defaultGroupingMap)
         localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
@@ -360,7 +364,7 @@ def test_calibrationFileExists(GetIPTS):  # noqa ARG002
         assert Path(tmpDir).exists()
         localDataService = LocalDataService()
         localDataService._generateStateId = mock.Mock(return_value=("ab8704b0bc2a2342", None))
-        localDataService._constructCalibrationStateRootPath = mock.Mock(return_value=tmpDir)
+        localDataService._constructCalibrationStateRoot = mock.Mock(return_value=tmpDir)
         runNumber = "654321"
         assert localDataService.checkCalibrationFileExists(runNumber)
 
@@ -397,7 +401,7 @@ def test_calibrationFileExists_not(GetIPTS):  # noqa ARG002
         localDataService._generateStateId = mock.Mock(return_value=("ab8704b0bc2a2342", None))
         nonExistentPath = Path(tmpDir) / "1755"
         assert not nonExistentPath.exists()
-        localDataService._constructCalibrationStateRootPath = mock.Mock(return_value=str(nonExistentPath))
+        localDataService._constructCalibrationStateRoot = mock.Mock(return_value=str(nonExistentPath))
         runNumber = "654321"
         assert not localDataService.checkCalibrationFileExists(runNumber)
 
@@ -496,6 +500,7 @@ def test_write_model_pretty_StateConfig_excludes_grouping_map():
 
 
 def test_readRunConfig():
+    # test of public `readRunConfig` method
     localDataService = LocalDataService()
     localDataService._readRunConfig = mock.Mock()
     localDataService._readRunConfig.return_value = reductionIngredients.runConfig
@@ -505,6 +510,7 @@ def test_readRunConfig():
 
 
 def test__readRunConfig():
+    # Test of private `_readRunConfig` method
     localDataService = LocalDataService()
     localDataService.getIPTS = mock.Mock(return_value="IPTS-123")
     localDataService.instrumentConfig = getMockInstrumentConfig()
@@ -547,8 +553,8 @@ def test_readCalibrationIndexMissing():
     localDataService._generateStateId = mock.Mock()
     localDataService._generateStateId.return_value = ("123", "456")
     localDataService._readReductionParameters = mock.Mock()
-    localDataService._constructCalibrationStateRootPath = mock.Mock()
-    localDataService._constructCalibrationStateRootPath.return_value = Resource.getPath("outputs")
+    localDataService._constructCalibrationStateRoot = mock.Mock()
+    localDataService._constructCalibrationStateRoot.return_value = Resource.getPath("outputs")
     assert len(localDataService.readCalibrationIndex("123")) == 0
 
 
@@ -558,8 +564,8 @@ def test_readNormalizationIndexMissing():
     localDataService._generateStateId = mock.Mock()
     localDataService._generateStateId.return_value = ("123", "456")
     localDataService._readReductionParameters = mock.Mock()
-    localDataService._constructCalibrationStateRootPath = mock.Mock()
-    localDataService._constructCalibrationStateRootPath.return_value = Resource.getPath("outputs")
+    localDataService._constructCalibrationStateRoot = mock.Mock()
+    localDataService._constructCalibrationStateRoot.return_value = Resource.getPath("outputs")
     assert len(localDataService.readNormalizationIndex("123")) == 0
 
 
@@ -569,8 +575,8 @@ def test_writeCalibrationIndexEntry():
     localDataService._generateStateId = mock.Mock()
     localDataService._generateStateId.return_value = ("123", "456")
     localDataService._readReductionParameters = mock.Mock()
-    localDataService._constructCalibrationStateRootPath = mock.Mock()
-    localDataService._constructCalibrationStateRootPath.return_value = Resource.getPath("outputs")
+    localDataService._constructCalibrationStatePath = mock.Mock()
+    localDataService._constructCalibrationStatePath.return_value = Resource.getPath("outputs")
     expectedFilePath = Resource.getPath("outputs") + "CalibrationIndex.json"
     localDataService.writeCalibrationIndexEntry(
         CalibrationIndexEntry(runNumber="57514", comments="test comment", author="test author")
@@ -620,8 +626,8 @@ def test_readCalibrationIndexExisting():
     localDataService._generateStateId = mock.Mock()
     localDataService._generateStateId.return_value = ("123", "456")
     localDataService._readReductionParameters = mock.Mock()
-    localDataService._constructCalibrationStateRootPath = mock.Mock()
-    localDataService._constructCalibrationStateRootPath.return_value = Resource.getPath("outputs")
+    localDataService._constructCalibrationStatePath = mock.Mock()
+    localDataService._constructCalibrationStatePath.return_value = Resource.getPath("outputs")
     expectedFilePath = Resource.getPath("outputs") + "CalibrationIndex.json"
     localDataService.writeCalibrationIndexEntry(
         CalibrationIndexEntry(runNumber="57514", comments="test comment", author="test author")
@@ -660,31 +666,60 @@ def readReductionIngredientsFromFile():
 
 
 def test_readWriteCalibrationRecord_version_numbers():
-    testCalibrationRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord.json"))
+    testCalibrationRecord_v0001 = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json"))
+    testCalibrationRecord_v0002 = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0002.json"))
     with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tempdir:
         localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("ab8704b0bc2a2342", None)
         localDataService._readReductionParameters = mock.Mock()
-        localDataService._constructCalibrationStateRootPath = mock.Mock()
-        localDataService._constructCalibrationStateRootPath.return_value = f"{tempdir}/"
+        localDataService._constructCalibrationStateRoot = mock.Mock()
+        localDataService._constructCalibrationStateRoot.return_value = f"{tempdir}/"
         localDataService.groceryService = mock.Mock()
         # WARNING: 'writeCalibrationRecord' modifies <incoming record>.version,
         #   and <incoming record>.calibrationFittingIngredients.version.
 
         # write: version == 1
-        localDataService.writeCalibrationRecord(testCalibrationRecord)
+        localDataService.writeCalibrationRecord(testCalibrationRecord_v0001)
         actualRecord = localDataService.readCalibrationRecord("57514")
         assert actualRecord.version == 1
         assert actualRecord.calibrationFittingIngredients.version == 1
         # write: version == 2
-        localDataService.writeCalibrationRecord(testCalibrationRecord)
+        localDataService.writeCalibrationRecord(testCalibrationRecord_v0002)
         actualRecord = localDataService.readCalibrationRecord("57514")
         assert actualRecord.version == 2
         assert actualRecord.calibrationFittingIngredients.version == 2
     assert actualRecord.runNumber == "57514"
-    assert actualRecord == testCalibrationRecord
+    assert actualRecord == testCalibrationRecord_v0002
+
+
+def test_readWriteCalibrationRecord_specified_version():
+    testCalibrationRecord_v0001 = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json"))
+    testCalibrationRecord_v0002 = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0002.json"))
+    with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tempdir:
+        localDataService = LocalDataService()
+        localDataService.instrumentConfig = mock.Mock()
+        localDataService._generateStateId = mock.Mock()
+        localDataService._generateStateId.return_value = ("ab8704b0bc2a2342", None)
+        localDataService._readReductionParameters = mock.Mock()
+        localDataService._constructCalibrationStateRoot = mock.Mock()
+        localDataService._constructCalibrationStateRoot.return_value = f"{tempdir}/"
+        localDataService.groceryService = mock.Mock()
+        # WARNING: 'writeCalibrationRecord' modifies <incoming record>.version,
+        #   and <incoming record>.calibrationFittingIngredients.version.
+
+        # write: version == 1
+        localDataService.writeCalibrationRecord(testCalibrationRecord_v0001)
+        actualRecord = localDataService.readCalibrationRecord("57514")
+        assert actualRecord.version == 1
+        assert actualRecord.calibrationFittingIngredients.version == 1
+        # write: version == 2
+        localDataService.writeCalibrationRecord(testCalibrationRecord_v0002)
+        actualRecord = localDataService.readCalibrationRecord("57514", "1")
+        assert actualRecord.version == 1
+        actualRecord = localDataService.readCalibrationRecord("57514", "2")
+        assert actualRecord.version == 2
 
 
 def test_readWriteCalibrationRecord_with_version():
@@ -694,11 +729,11 @@ def test_readWriteCalibrationRecord_with_version():
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
         localDataService._readReductionParameters = mock.Mock()
-        localDataService._constructCalibrationStateRootPath = mock.Mock()
-        localDataService._constructCalibrationStateRootPath.return_value = f"{tempdir}/"
+        localDataService._constructCalibrationStateRoot = mock.Mock()
+        localDataService._constructCalibrationStateRoot.return_value = f"{tempdir}/"
         localDataService.groceryService = mock.Mock()
         localDataService.writeCalibrationRecord(
-            CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord.json"))
+            CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json"))
         )
         actualRecord = localDataService.readCalibrationRecord("57514", "1")
     assert actualRecord.runNumber == "57514"
@@ -706,15 +741,15 @@ def test_readWriteCalibrationRecord_with_version():
 
 
 def test_readWriteCalibrationRecord():
-    testCalibrationRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord.json"))
+    testCalibrationRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json"))
     with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tempdir:
         localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("ab8704b0bc2a2342", None)
         localDataService._readReductionParameters = mock.Mock()
-        localDataService._constructCalibrationStateRootPath = mock.Mock()
-        localDataService._constructCalibrationStateRootPath.return_value = f"{tempdir}/"
+        localDataService._constructCalibrationStateRoot = mock.Mock()
+        localDataService._constructCalibrationStateRoot.return_value = f"{tempdir}/"
         localDataService.groceryService = mock.Mock()
         localDataService.writeCalibrationRecord(testCalibrationRecord)
         actualRecord = localDataService.readCalibrationRecord("57514")
@@ -722,51 +757,90 @@ def test_readWriteCalibrationRecord():
     assert actualRecord == testCalibrationRecord
 
 
-def test_writeCalibrationWorkspaces():
+@mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
+def test_writeCalibrationWorkspaces(mockConstructCalibrationDataPath):
     localDataService = LocalDataService()
     path = Resource.getPath("outputs")
-    testCalibrationRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord.json"))
+    testCalibrationRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json"))
     with tempfile.TemporaryDirectory(dir=path, suffix="/") as basePath:
         basePath = Path(basePath)
-        localDataService._constructCalibrationDataPath = mock.Mock(return_value=str(basePath))
+        mockConstructCalibrationDataPath.return_value = str(basePath)
 
         # Workspace names need to match the names that are used in the test record.
+        workspaces = testCalibrationRecord.workspaces.copy()
         runNumber = testCalibrationRecord.runNumber
         version = testCalibrationRecord.version
-        testWS0, testWS1, testWS2, tableWSName, maskWSName = testCalibrationRecord.workspaceNames
-        diffCalFilename = Path(WNG.diffCalTable().runNumber(runNumber).version(version).build() + ".h5")
+        outputTOFWSName, outputDSPWSName = workspaces.pop(wngt.DIFFCAL_OUTPUT)
+        tableWSName = workspaces.pop(wngt.DIFFCAL_TABLE)[0]
+        maskWSName = workspaces.pop(wngt.DIFFCAL_MASK)[0]
+        if workspaces:
+            raise RuntimeError(f"unexpected workspace-types in record.workspaces: {workspaces}")
 
         # Create sample workspaces.
-        LoadEmptyInstrument(
-            Filename=fakeInstrumentFilePath,
-            OutputWorkspace=testWS0,
+        CreateSampleWorkspace(
+            OutputWorkspace=outputTOFWSName,
+            XUnit="TOF",
         )
-        CloneWorkspace(InputWorkspace=testWS0, OutputWorkspace=testWS1)
-        CloneWorkspace(InputWorkspace=testWS0, OutputWorkspace=testWS2)
-        assert mtd.doesExist(testWS0)
-        assert mtd.doesExist(testWS1)
-        assert mtd.doesExist(testWS2)
+        LoadInstrument(
+            Workspace=outputTOFWSName,
+            Filename=fakeInstrumentFilePath,
+            RewriteSpectraMap=True,
+        )
+        CreateSampleWorkspace(
+            OutputWorkspace=outputDSPWSName,
+            XUnit="DSP",
+        )
+        LoadInstrument(
+            Workspace=outputDSPWSName,
+            Filename=fakeInstrumentFilePath,
+            RewriteSpectraMap=True,
+        )
+        assert mtd.doesExist(outputTOFWSName)
+        assert mtd.doesExist(outputDSPWSName)
 
         # Create diffraction-calibration table and mask workspaces.
-        createCompatibleDiffCalTable(tableWSName, testWS0)
-        createCompatibleMask(maskWSName, testWS0, fakeInstrumentFilePath)
+        createCompatibleDiffCalTable(tableWSName, outputTOFWSName)
+        createCompatibleMask(maskWSName, outputTOFWSName, fakeInstrumentFilePath)
         assert mtd.doesExist(tableWSName)
         assert mtd.doesExist(maskWSName)
 
         localDataService.writeCalibrationWorkspaces(testCalibrationRecord)
 
         diffCalFilename = Path(WNG.diffCalTable().runNumber(runNumber).version(version).build() + ".h5")
-        for wsName in testCalibrationRecord.workspaceNames:
-            ws = mtd[wsName]
-            filename = (
-                Path(wsName + ".nxs")
-                if not (isinstance(ws, ITableWorkspace) or isinstance(ws, MaskWorkspace))
-                else diffCalFilename
-            )
-            assert (basePath / filename).exists()
+        for wsNames in testCalibrationRecord.workspaces.values():
+            for wsName in wsNames:
+                ws = mtd[wsName]
+                filename = (
+                    Path(wsName + ".nxs")
+                    if not (isinstance(ws, ITableWorkspace) or isinstance(ws, MaskWorkspace))
+                    else diffCalFilename
+                )
+                assert (basePath / filename).exists()
         mtd.clear()
 
 
+@mock.patch.object(LocalDataService, "writeWorkspace")
+@mock.patch.object(LocalDataService, "_constructCalibrationDataPath")
+def test_writeCalibrationWorkspaces_no_units(
+    mockConstructCalibrationDataPath,
+    mockWriteWorkspace  # noqa: ARG001
+    ):
+    # test that diffraction-calibration output workspace names require units
+    localDataService = LocalDataService()
+    testCalibrationRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json"))
+    testCalibrationRecord.workspaces = {
+      wngt.DIFFCAL_OUTPUT: ["_diffoc_057514_v0001", "_dsp_diffoc_057514_v0001"],
+      wngt.DIFFCAL_TABLE: ["_diffract_consts_057514_v0001"],
+      wngt.DIFFCAL_MASK: ["_diffract_consts_mask_057514_v0001"]
+    }
+    with pytest.raises( # noqa: PT012
+            RuntimeError,
+            match=f"cannot save a workspace-type: {wngt.DIFFCAL_OUTPUT} without a units token in its name",
+        ):
+        mockConstructCalibrationDataPath.return_value = "not/a/path"
+        localDataService.writeCalibrationWorkspaces(testCalibrationRecord)
+
+ 
 def test_readWriteNormalizationRecord_version_numbers():
     testNormalizationRecord = NormalizationRecord.parse_raw(
         Resource.read("inputs/normalization/NormalizationRecord.json")
@@ -796,6 +870,33 @@ def test_readWriteNormalizationRecord_version_numbers():
     assert actualRecord.runNumber == "57514"
     assert actualRecord == testNormalizationRecord
 
+def test_readWriteNormalizationRecord_specified_version():
+    testNormalizationRecord = NormalizationRecord.parse_raw(
+        Resource.read("inputs/normalization/NormalizationRecord.json")
+    )
+    with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tempdir:
+        localDataService = LocalDataService()
+        localDataService.instrumentConfig = mock.Mock()
+        localDataService._generateStateId = mock.Mock()
+        localDataService._generateStateId.return_value = ("ab8704b0bc2a2342", None)
+        localDataService._readReductionParameters = mock.Mock()
+        localDataService._constructNormalizationCalibrationStatePath = mock.Mock()
+        localDataService._constructNormalizationCalibrationStatePath.return_value = f"{tempdir}/"
+        localDataService.groceryService = mock.Mock()
+        # WARNING: 'writeNormalizationRecord' modifies <incoming record>.version,
+        # and <incoming record>.normalization.version.
+
+        # write: version == 1
+        localDataService.writeNormalizationRecord(testNormalizationRecord)
+        actualRecord = localDataService.readNormalizationRecord("57514")
+        assert actualRecord.version == 1
+        assert actualRecord.calibration.version == 1
+        # write: version == 2
+        localDataService.writeNormalizationRecord(testNormalizationRecord)
+        actualRecord = localDataService.readNormalizationRecord("57514", "1")
+        assert actualRecord.version == 1
+        actualRecord = localDataService.readNormalizationRecord("57514", "2")
+        assert actualRecord.version == 2
 
 def test_readWriteNormalizationRecord():
     testNormalizationRecord = NormalizationRecord.parse_raw(
@@ -846,7 +947,7 @@ def test_writeNormalizationWorkspaces(mockConstructNormalizationCalibrationDataP
         localDataService.writeNormalizationWorkspaces(testNormalizationRecord)
 
         for wsName in testNormalizationRecord.workspaceNames:
-            filename = Path(wsName + ".nxs")
+            filename = Path(wsName + "_" + wnvf.formatVersion(version) + ".nxs")
             assert (basePath / filename).exists()
         mtd.clear()
 
@@ -855,10 +956,10 @@ def test_getCalibrationRecordPath():
     localDataService = LocalDataService()
     localDataService._generateStateId = mock.Mock()
     localDataService._generateStateId.return_value = ("123", "456")
-    localDataService._constructCalibrationStateRootPath = mock.Mock()
-    localDataService._constructCalibrationStateRootPath.return_value = Resource.getPath("outputs/")
+    localDataService._constructCalibrationStatePath = mock.Mock()
+    localDataService._constructCalibrationStatePath.return_value = Resource.getPath("outputs/")
     actualPath = localDataService.getCalibrationRecordPath("57514", 1)
-    assert actualPath == Resource.getPath("outputs") + "/v_1/CalibrationRecord.json"
+    assert actualPath == Resource.getPath("outputs") + "/v_0001/CalibrationRecord.json"
 
 
 def test_getNormalizationRecordPath():
@@ -868,12 +969,12 @@ def test_getNormalizationRecordPath():
     localDataService._constructNormalizationCalibrationStatePath = mock.Mock()
     localDataService._constructNormalizationCalibrationStatePath.return_value = Resource.getPath("outputs/")
     actualPath = localDataService.getNormalizationRecordPath("57514", 1)
-    assert actualPath == Resource.getPath("outputs") + "/v_1/NormalizationRecord.json"
+    assert actualPath == Resource.getPath("outputs") + "/v_0001/NormalizationRecord.json"
 
 
 def test_extractFileVersion():
     localDataService = LocalDataService()
-    actualVersion = localDataService._extractFileVersion("Powder/1234/v_4/CalibrationRecord.json")
+    actualVersion = localDataService._extractFileVersion("Powder/1234/v_0004/CalibrationRecord.json")
     assert actualVersion == 4
 
 
@@ -881,22 +982,22 @@ def test__getFileOfVersion():
     localDataService = LocalDataService()
     localDataService._findMatchingFileList = mock.Mock()
     localDataService._findMatchingFileList.return_value = [
-        "/v_1/CalibrationRecord.json",
-        "/v_3/CalibrationRecord.json",
+        "/v_0001/CalibrationRecord.json",
+        "/v_0003/CalibrationRecord.json",
     ]
     actualFile = localDataService._getFileOfVersion("/v_*/CalibrationRecord", 3)
-    assert actualFile == "/v_3/CalibrationRecord.json"
+    assert actualFile == "/v_0003/CalibrationRecord.json"
 
 
 def test__getLatestFile():
     localDataService = LocalDataService()
     localDataService._findMatchingFileList = mock.Mock()
     localDataService._findMatchingFileList.return_value = [
-        "Powder/1234/v_1/CalibrationRecord.json",
-        "Powder/1234/v_2/CalibrationRecord.json",
+        "Powder/1234/v_0001/CalibrationRecord.json",
+        "Powder/1234/v_0002/CalibrationRecord.json",
     ]
     actualFile = localDataService._getLatestFile("Powder/1234/v_*/CalibrationRecord.json")
-    assert actualFile == "Powder/1234/v_2/CalibrationRecord.json"
+    assert actualFile == "Powder/1234/v_0002/CalibrationRecord.json"
 
 
 def test__isApplicableEntry_equals():
@@ -943,7 +1044,7 @@ def test__getVersionFromCalibrationIndex():
     localDataService.readCalibrationIndex = mock.Mock()
     localDataService.readCalibrationIndex.return_value = [mock.Mock()]
     localDataService.readCalibrationIndex.return_value[0] = CalibrationIndexEntry(
-        timestamp=123, version=1, appliesTo="123", runNumber="123", comments="", author=""
+        timestamp=123, version="1", appliesTo="123", runNumber="123", comments="", author=""
     )
     actualVersion = localDataService._getVersionFromCalibrationIndex("123")
     assert actualVersion == "1"
@@ -955,7 +1056,7 @@ def test__getVersionFromNormalizationIndex():
     localDataService.readNormalizationIndex.return_value = [mock.Mock()]
     localDataService.readNormalizationIndex.return_value[0] = NormalizationIndexEntry(
         timestamp=123,
-        version=1,
+        version="1",
         appliesTo="123",
         runNumber="123",
         backgroundRunNumber="456",
@@ -992,10 +1093,10 @@ def test__constructCalibrationParametersFilePath():
     localDataService = LocalDataService()
     localDataService._generateStateId = mock.Mock()
     localDataService._generateStateId.return_value = ("ab8704b0bc2a2342", None)
-    localDataService._constructCalibrationStateRootPath = mock.Mock()
-    localDataService._constructCalibrationStateRootPath.return_value = Resource.getPath("outputs/")
+    localDataService._constructCalibrationStatePath = mock.Mock()
+    localDataService._constructCalibrationStatePath.return_value = Resource.getPath("outputs/")
     actualPath = localDataService._constructCalibrationParametersFilePath("57514", 1)
-    assert actualPath == Resource.getPath("outputs") + "/v_1/CalibrationParameters.json"
+    assert actualPath == Resource.getPath("outputs") + "/v_0001/CalibrationParameters.json"
 
 
 def test_readCalibrationState():
@@ -1004,7 +1105,7 @@ def test_readCalibrationState():
     localDataService._generateStateId.return_value = ("ab8704b0bc2a2342", None)
     localDataService._constructCalibrationParametersFilePath = mock.Mock()
     localDataService._constructCalibrationParametersFilePath.return_value = Resource.getPath(
-        "ab8704b0bc2a2342/v_1/CalibrationParameters.json"
+        "ab8704b0bc2a2342/v_0001/CalibrationParameters.json"
     )
     localDataService._getLatestFile = mock.Mock()
     localDataService._getLatestFile.return_value = Resource.getPath("inputs/calibration/CalibrationParameters.json")
@@ -1020,7 +1121,7 @@ def test_readCalibrationState_no_file():
     localDataService._generateStateId.return_value = ("ab8704b0bc2a2342", None)
     localDataService._constructCalibrationParametersFilePath = mock.Mock()
     localDataService._constructCalibrationParametersFilePath.return_value = Resource.getPath(
-        "ab8704b0bc2a2342/v_1/CalibrationParameters.json"
+        "ab8704b0bc2a2342/v_0001/CalibrationParameters.json"
     )
     localDataService._getLatestFile = mock.Mock()
     localDataService._getLatestFile.return_value = None
@@ -1034,7 +1135,7 @@ def test_readNormalizationState():
     localDataService._generateStateId.return_value = ("ab8704b0bc2a2342", None)
     localDataService.getNormalizationStatePath = mock.Mock()
     localDataService.getNormalizationStatePath.return_value = Resource.getPath(
-        "ab8704b0bc2a2342/v_1/NormalizationParameters.json"
+        "ab8704b0bc2a2342/v_0001/NormalizationParameters.json"
     )
     localDataService._getLatestFile = mock.Mock()
     localDataService._getLatestFile.return_value = Resource.getPath("inputs/normalization/NormalizationParameters.json")
@@ -1049,20 +1150,20 @@ def test_writeCalibrationState():
         localDataService = LocalDataService()
         localDataService._generateStateId = mock.Mock()
         localDataService._generateStateId.return_value = ("123", "456")
-        localDataService._constructCalibrationStateRootPath = mock.Mock()
-        localDataService._constructCalibrationStateRootPath.return_value = f"{tempdir}/"
+        localDataService._constructCalibrationStatePath = mock.Mock()
+        localDataService._constructCalibrationStatePath.return_value = f"{tempdir}/"
         localDataService._getCurrentCalibrationRecord = mock.Mock()
         localDataService._getCurrentCalibrationRecord.return_value = Calibration.construct({"name": "test"})
         calibration = Calibration.parse_raw(Resource.read("/inputs/calibration/CalibrationParameters.json"))
         localDataService.writeCalibrationState("123", calibration)
-        assert os.path.exists(tempdir + "/v_1/CalibrationParameters.json")
+        assert os.path.exists(tempdir + "/v_0001/CalibrationParameters.json")
 
 
 def test_writeCalibrationState_overwrite_warning(caplog):
     # Test that overwriting an existing calibration logs a warning.
     with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tmpDir:
         with caplog.at_level(logging.WARNING):
-            calibrationDataPath = Path(tmpDir) / "v_1"
+            calibrationDataPath = Path(tmpDir) / "v_0001"
             calibrationParametersFilePath = calibrationDataPath / "CalibrationParameters.json"
             calibration = Calibration.parse_raw(Resource.read("/inputs/calibration/CalibrationParameters.json"))
             os.makedirs(calibrationDataPath)
@@ -1071,8 +1172,8 @@ def test_writeCalibrationState_overwrite_warning(caplog):
             localDataService = LocalDataService()
             localDataService._generateStateId = mock.Mock()
             localDataService._generateStateId.return_value = ("123", "456")
-            localDataService._constructCalibrationStateRootPath = mock.Mock()
-            localDataService._constructCalibrationStateRootPath.return_value = f"{tmpDir}/"
+            localDataService._constructCalibrationStatePath = mock.Mock()
+            localDataService._constructCalibrationStatePath.return_value = f"{tmpDir}/"
             localDataService._getCurrentCalibrationRecord = mock.Mock()
             localDataService._getCurrentCalibrationRecord.return_value = Calibration.construct({"name": "test"})
 
@@ -1098,7 +1199,56 @@ def test_writeNormalizationState():
         with Resource.open("/inputs/normalization/NormalizationParameters.json", "r") as f:
             normalization = Normalization.parse_raw(f.read())
         localDataService.writeNormalizationState("123", normalization)
-        assert os.path.exists(tempdir + "/v_1/NormalizationParameters.json")
+        assert os.path.exists(tempdir + "/v_0001/NormalizationParameters.json")
+
+
+def test_readDetectorState():
+    localDataService = LocalDataService()
+    localDataService._readPVFile = mock.Mock()
+
+    pvFileMock = mock.Mock()
+    # 1X: seven required `readDetectorState` log entries:
+    #   * generated `DetectorInfo` matches that from 'inputs/calibration/CalibrationParameters.json'
+    pvFileMock.get.side_effect = [
+        [1],
+        [2],
+        [1.1],
+        [1.2],
+        [1],
+        [1.0],
+        [2.0],
+    ]
+    localDataService._readPVFile.return_value = pvFileMock
+    
+    testCalibration = Calibration.parse_file(Resource.getPath("inputs/calibration/CalibrationParameters.json"))
+    testDetectorState = testCalibration.instrumentState.detectorState
+    
+    actualDetectorState = localDataService.readDetectorState("123")
+    assert actualDetectorState == testDetectorState
+
+
+def test_readDetectorState_bad_logs():
+    localDataService = LocalDataService()
+    localDataService._constructPVFilePath = mock.Mock()
+    localDataService._constructPVFilePath.return_value = "/not/a/path"
+    localDataService._readPVFile = mock.Mock()
+
+    pvFileMock = mock.Mock()
+    # 1X: seven required `readDetectorState` log entries:
+    #   * generated `DetectorInfo` matches that from 'inputs/calibration/CalibrationParameters.json'
+    pvFileMock.get.side_effect = [
+        "glitch",
+        [2],
+        [1.1],
+        [1.2],
+        [1],
+        [1.0],
+        [2.0],
+    ]
+    localDataService._readPVFile.return_value = pvFileMock
+
+    with pytest.raises(ValueError, match="Could not find all required logs"):
+        localDataService.readDetectorState("123")
 
 
 def test_initializeState():
@@ -1179,7 +1329,7 @@ def test_initializeState_calls_prepareStateRoot(mockPrepareStateRoot):
     with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tmpDir:
         stateId = "ab8704b0bc2a2342"
         stateRootPath = Path(tmpDir) / stateId
-        localDataService._constructCalibrationStateRootPath = mock.Mock(return_value=str(stateRootPath))
+        localDataService._constructCalibrationStateRoot = mock.Mock(return_value=str(stateRootPath))
 
         assert not stateRootPath.exists()
         localDataService.initializeState("123", "test")
@@ -1285,8 +1435,8 @@ def test_readGroupingMap_initialized_state():
         service = LocalDataService()
         stateId = "ab8704b0bc2a2342"
         stateRoot = Path(f"{tempdir}/{stateId}")
-        service._constructCalibrationStateRootPath = mock.Mock()
-        service._constructCalibrationStateRootPath.return_value = str(stateRoot)
+        service._constructCalibrationStateRoot = mock.Mock()
+        service._constructCalibrationStateRoot.return_value = str(stateRoot)
         stateRoot.mkdir()
         shutil.copy(Path(Resource.getPath("inputs/pixel_grouping/groupingMap.json")), stateRoot)
         groupingMap = service._readGroupingMap(stateId)
@@ -1404,6 +1554,38 @@ def test_writeDiffCalWorkspaces():
             basePath, filename, tableWorkspaceName=tableWSName, maskWorkspaceName=maskWSName
         )
         assert (basePath / filename).exists()
+    mtd.clear()
+
+
+def test_writeDiffCalWorkspaces_bad_path():
+    localDataService = LocalDataService()
+    path = Resource.getPath("outputs")
+    with pytest.raises( # noqa: PT012
+        RuntimeError,
+        match="specify filename including '.h5' extension",
+        ):
+        with tempfile.TemporaryDirectory(dir=path, suffix="/") as basePath:
+            basePath = Path(basePath)
+            tableWSName = "test_table"
+            maskWSName = "test_mask"
+            # do not add required: ".h5" suffix
+            filename = Path(tableWSName)
+            # Create an instrument workspace.
+            instrumentDonor = "test_instrument_donor"
+            LoadEmptyInstrument(
+                Filename=fakeInstrumentFilePath,
+                OutputWorkspace=instrumentDonor,
+            )
+            assert mtd.doesExist(instrumentDonor)
+            # Create table and mask workspaces to write.
+            createCompatibleMask(maskWSName, instrumentDonor, fakeInstrumentFilePath)
+            assert mtd.doesExist(maskWSName)
+            createCompatibleDiffCalTable(tableWSName, instrumentDonor)
+            assert mtd.doesExist(tableWSName)
+            localDataService.writeDiffCalWorkspaces(
+                basePath, filename, tableWorkspaceName=tableWSName, maskWorkspaceName=maskWSName
+            )
+            assert (basePath / filename).exists()
     mtd.clear()
 
 

--- a/tests/unit/backend/recipe/algorithm/test_PixelGroupingParametersCalculationAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_PixelGroupingParametersCalculationAlgorithm.py
@@ -35,12 +35,7 @@ IS_ON_ANALYSIS_MACHINE = socket.gethostname().startswith("analysis")
 class PixelGroupCalculation(unittest.TestCase):
     @classmethod
     def getInstrumentState(cls):
-        if IS_ON_ANALYSIS_MACHINE:
-            calibrationPath = (
-                "/SNS/SNAP/shared/Calibration_Prototype/Powder/04bd2c53f6bf6754/CalibrationParameters.json"
-            )
-        else:
-            calibrationPath = Resource.getPath("inputs/pixel_grouping/CalibrationParameters.json")
+        calibrationPath = Resource.getPath("inputs/pixel_grouping/CalibrationParameters.json")
         return parse_file_as(Calibration, calibrationPath).instrumentState
 
     @classmethod
@@ -291,17 +286,21 @@ class PixelGroupCalculation(unittest.TestCase):
         assert len(pixelGroupingParams_ref["dMax"]) == number_of_groupings_calc
         assert len(pixelGroupingParams_ref["delDOverD"]) == number_of_groupings_calc
 
+        # The golden data used here is questionable (for tests on analysis):
+        #   * this is dealt with in PR#256, not in this PR (#249);
+        #   * new treatment of instrument location parameters also needs to be verified again.
+
         for index, param in enumerate(pixelGroupingParams_ref["twoTheta"]):
-            assert abs(float(param) - pixelGroupingParams_calc[index].twoTheta) == 0
+            assert pytest.approx(float(param), 1.0e-4) == pixelGroupingParams_calc[index].twoTheta
 
         for index, param in enumerate(pixelGroupingParams_ref["dMin"]):
-            assert abs(float(param) - pixelGroupingParams_calc[index].dResolution.minimum) == 0
+            assert pytest.approx(float(param), 1.0e-4) == pixelGroupingParams_calc[index].dResolution.minimum
 
         for index, param in enumerate(pixelGroupingParams_ref["dMax"]):
-            assert abs(float(param) - pixelGroupingParams_calc[index].dResolution.maximum) == 0
+            assert pytest.approx(float(param), 1.0e-4) == pixelGroupingParams_calc[index].dResolution.maximum
 
         for index, param in enumerate(pixelGroupingParams_ref["delDOverD"]):
-            assert abs(float(param) - pixelGroupingParams_calc[index].dRelativeResolution) < 1.0e-3
+            assert pytest.approx(float(param), abs=1.0e-3) == pixelGroupingParams_calc[index].dRelativeResolution
 
     # LOCAL TESTS ON TEST INSTRUMENT
 

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -225,7 +225,9 @@ class TestCalibrationServiceMethods(unittest.TestCase):
     @patch(
         thisService + "CalibrationMetricsWorkspaceIngredients",
         return_value=MagicMock(
-            calibrationRecord=CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json")),
+            calibrationRecord=CalibrationRecord.parse_raw(
+                Resource.read("inputs/calibration/CalibrationRecord_v0001.json")
+            ),
             timestamp="123",
         ),
     )
@@ -386,9 +388,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             # Assert all "persistent" workspaces have been loaded
             for wsNames in calibRecord.workspaces.values():
                 for wsName in wsNames:
-                    assert self.instance.dataFactoryService.workspaceDoesExist(
-                        wsName
-                    )
+                    assert self.instance.dataFactoryService.workspaceDoesExist(wsName)
 
     def test_load_quality_assessment_no_units(self):
         with pytest.raises(RuntimeError, match=r"without a units token in its name"):  # noqa: PT012

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -3,16 +3,27 @@ import os
 import tempfile
 import unittest
 import unittest.mock as mock
+from copy import deepcopy
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 from mantid.simpleapi import (
     CreateSingleValuedWorkspace,
+    DeleteWorkspace,
+    LoadEmptyInstrument,
     mtd,
 )
+from snapred.backend.dao.calibration.Calibration import Calibration
+from snapred.backend.dao.request.InitializeStateRequest import InitializeStateRequest
+from snapred.backend.dao.RunConfig import RunConfig
+from snapred.backend.dao.StateConfig import StateConfig
+from snapred.meta.Config import Config
+from snapred.meta.mantid.WorkspaceNameGenerator import ValueFormatter as wnvf
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName, WorkspaceType
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceType as wngt
 
 # Mock out of scope modules before importing DataExportService
 
@@ -36,13 +47,16 @@ with mock.patch.dict(
     from snapred.backend.dao.request.CalibrationAssessmentRequest import CalibrationAssessmentRequest
     from snapred.backend.dao.request.DiffractionCalibrationRequest import DiffractionCalibrationRequest
     from snapred.backend.dao.request.FarmFreshIngredients import FarmFreshIngredients
-    from snapred.backend.dao.RunConfig import RunConfig
     from snapred.backend.dao.state import PixelGroup
     from snapred.backend.dao.state.FocusGroup import FocusGroup
     from snapred.backend.recipe.DiffractionCalibrationRecipe import DiffractionCalibrationRecipe
     from snapred.backend.service.CalibrationService import CalibrationService
     from snapred.backend.service.SousChef import SousChef
-    from snapred.meta.Config import Config, Resource
+    from snapred.meta.Config import Resource
+    from util.helpers import (
+        createCompatibleDiffCalTable,
+        createCompatibleMask,
+    )
 
     thisService = "snapred.backend.service.CalibrationService."
 
@@ -93,9 +107,36 @@ from snapred.backend.service.CalibrationService import CalibrationService  # noq
 
 
 class TestCalibrationServiceMethods(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.runNumber = "555"
+        cls.version = "1"
+
+        cls.SNAPInstrumentFilePath = Config["instrument"]["native"]["definition"]["file"]
+        cls.instrumentFilePath = Resource.getPath("inputs/testInstrument/fakeSNAP.xml")
+        Config["instrument"]["native"]["definition"]["file"] = cls.instrumentFilePath
+
+        cls.SNAPLiteInstrumentFilePath = Config["instrument"]["lite"]["definition"]["file"]
+        cls.instrumentLiteFilePath = Resource.getPath("inputs/testInstrument/fakeSNAPLite.xml")
+        Config["instrument"]["lite"]["definition"]["file"] = cls.instrumentLiteFilePath
+
+        # create some sample data
+        cls.sampleWS = "_sample_data"
+        cls.sampleTableWS = "_sample_diffcal_table"
+        cls.sampleMaskWS = "_sample_diffcal_mask"
+
+        LoadEmptyInstrument(
+            Filename=cls.instrumentFilePath,
+            OutputWorkspace=cls.sampleWS,
+        )
+        createCompatibleDiffCalTable(cls.sampleTableWS, cls.sampleWS)
+        createCompatibleMask(cls.sampleMaskWS, cls.sampleWS, cls.instrumentFilePath)
+
+        # cleanup at per-test teardown
+        cls.excludeAtTeardown = [cls.sampleWS, cls.sampleTableWS, cls.sampleMaskWS]
+
     def setUp(self):
         self.instance = CalibrationService()
-        self.runId = "test_run_id"
         self.outputNameFormat = "{}_calibration_reduction_result"
         # Mock the _calculatePixelGroupingParameters method to return a predefined value
         self.instance._calculatePixelGroupingParameters = lambda calib, focus_def, lite_mode, nBins: {  # noqa: ARG005
@@ -106,12 +147,38 @@ class TestCalibrationServiceMethods(unittest.TestCase):
     def clearoutWorkspaces(self) -> None:
         # Delete the workspaces created by loading
         for ws in mtd.getObjectNames():
-            self.instance.dataFactoryService.deleteWorkspace(ws)
+            if ws not in self.excludeAtTeardown:
+                DeleteWorkspace(ws)
 
     def tearDown(self) -> None:
         # At the end of each test, clear out the workspaces
         self.clearoutWorkspaces()
         return super().tearDown()
+
+    def create_fake_diffcal_files(self, path: Path, workspaces: Dict[WorkspaceType, List[WorkspaceName]], version: str):
+        tableWSName = None
+        maskWSName = None
+        # Note: this form allows testing of partial-write behavior:
+        #   e.g. no _mask_ or _table_ workspace in the 'workspaces' dict.
+        for key, wsNames in workspaces.items():
+            for wsName in wsNames:
+                match key:
+                    case wngt.DIFFCAL_TABLE:
+                        tableWSName = wsName
+                    case wngt.DIFFCAL_MASK:
+                        maskWSName = wsName
+                    case _:
+                        filename = Path(wsName + ".nxs")
+                        self.instance.dataExportService.exportWorkspace(path, filename, self.sampleWS)
+        # For the moment, only one set of 'table' + 'mask' workspace is assumed
+        if tableWSName or maskWSName:
+            filename = Path(tableWSName + ".h5")
+            self.instance.dataExportService.dataService.writeDiffCalWorkspaces(
+                path,
+                filename,
+                tableWorkspaceName=self.sampleTableWS if tableWSName else "",
+                maskWorkspaceName=self.sampleMaskWS if maskWSName else "",
+            )
 
     @patch(thisService + "parse_raw_as")
     @patch(thisService + "CalibrationMetricExtractionRecipe")
@@ -158,7 +225,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
     @patch(
         thisService + "CalibrationMetricsWorkspaceIngredients",
         return_value=MagicMock(
-            calibrationRecord=CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord.json")),
+            calibrationRecord=CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json")),
             timestamp="123",
         ),
     )
@@ -189,8 +256,12 @@ class TestCalibrationServiceMethods(unittest.TestCase):
 
         # Call the method to test
         request = CalibrationAssessmentRequest(
-            workspace="mock workspace",
-            run=RunConfig(runNumber="123"),
+            workspaces={
+                wngt.DIFFCAL_OUTPUT: [self.sampleWS],
+                wngt.DIFFCAL_TABLE: [self.sampleTableWS],
+                wngt.DIFFCAL_MASK: [self.sampleMaskWS],
+            },
+            run=RunConfig(runNumber=self.runNumber),
             useLiteMode=True,
             focusGroup={"name": fakeMetrics.focusGroupName, "definition": ""},
             calibrantSamplePath="egg/muffin/biscuit",
@@ -207,12 +278,12 @@ class TestCalibrationServiceMethods(unittest.TestCase):
 
         # Assert expected calibration metric workspaces have been generated
         for metric in ["sigma", "strain"]:
-            ws_name = wng.diffCalMetrics().runNumber("57514").version("ts123").metricName(metric).build()
-            assert self.instance.dataFactoryService.workspaceDoesExist(ws_name)
+            wsName = wng.diffCalTimedMetric().runNumber("57514").timestamp("123").metricName(metric).build()
+            assert self.instance.dataFactoryService.workspaceDoesExist(wsName)
 
     def test_load_quality_assessment_no_calibration_record_exception(self):
         self.instance.dataFactoryService.getCalibrationRecord = MagicMock(return_value=None)
-        mockRequest = MagicMock(runId=MagicMock(), version=MagicMock(), checkExistent=False)
+        mockRequest = MagicMock(runId=self.runNumber, version=self.version, checkExistent=False)
         with pytest.raises(ValueError) as excinfo:  # noqa: PT011
             self.instance.loadQualityAssessment(mockRequest)
         assert str(mockRequest.runId) in str(excinfo.value)
@@ -223,67 +294,149 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         self,
         mockCalibrationMetricsWorkspaceIngredients,
     ):
-        mockRequest = MagicMock(runId=MagicMock(), version=MagicMock(), checkExistent=False)
-        calibRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord.json"))
+        mockRequest = MagicMock(runId=self.runNumber, version=self.version, checkExistent=False)
+        calibRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json"))
         self.instance.dataFactoryService.getCalibrationRecord = MagicMock(return_value=calibRecord)
         with pytest.raises(Exception) as excinfo:  # noqa: PT011
             self.instance.loadQualityAssessment(mockRequest)
         assert "The input table is empty" in str(excinfo.value)
 
-    def test_load_quality_assessment_check_existent(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            calibRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord.json"))
+    def test_load_quality_assessment_check_existent_metrics(self):
+        path = Resource.getPath("outputs")
+        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpDir:
+            calibRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json"))
             self.instance.dataFactoryService.getCalibrationRecord = MagicMock(return_value=calibRecord)
 
             # Under a mocked calibration data path, create fake "persistent" workspace files
-            self.instance.dataFactoryService.getCalibrationDataPath = MagicMock(return_value=tmpdir)
-            for ws_name in calibRecord.workspaceNames:
-                CreateSingleValuedWorkspace(OutputWorkspace=ws_name)
-                filename = Path(ws_name + ".nxs")
-                self.instance.dataExportService.exportWorkspace(tmpdir, filename, ws_name)
+            self.instance.dataFactoryService.getCalibrationDataPath = MagicMock(return_value=tmpDir)
+            self.create_fake_diffcal_files(Path(tmpDir), calibRecord.workspaces, calibRecord.version)
 
-            # Call the method to test. Use a mocked run and a mocked version
-            runId = MagicMock()
-            version = MagicMock()
-            mockRequest = MagicMock(runId=runId, version=version, checkExistent=False)
+            mockRequest = MagicMock(runId=calibRecord.runNumber, version=calibRecord.version, checkExistent=False)
+            self.instance.groceryService._getCalibrationDataPath = MagicMock(return_value=tmpDir)
+            self.instance.groceryService._fetchInstrumentDonor = MagicMock(return_value=self.sampleWS)
+
+            # Load the assessment workspaces:
             self.instance.loadQualityAssessment(mockRequest)
-            with pytest.raises(ValueError) as excinfo:  # noqa: PT011
-                self.instance.loadQualityAssessment(MagicMock(runId=runId, version=version, checkExistent=True))
+
+            # Delete any existing _data_ workspaces:
+            for wss in calibRecord.workspaces.values():
+                for ws in wss:
+                    DeleteWorkspace(Workspace=ws)
+
+            mockRequest = MagicMock(runId=calibRecord.runNumber, version=calibRecord.version, checkExistent=True)
+            with pytest.raises(RuntimeError) as excinfo:  # noqa: PT011
+                self.instance.loadQualityAssessment(mockRequest)
             assert "is already loaded" in str(excinfo.value)
-            with pytest.raises(ValueError) as excinfo:  # noqa: PT011
-                self.instance.loadQualityAssessment(MagicMock(runId="57514", version="7", checkExistent=True))
+
+    def test_load_quality_assessment_check_existent_data(self):
+        path = Resource.getPath("outputs")
+        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpDir:
+            calibRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json"))
+            self.instance.dataFactoryService.getCalibrationRecord = MagicMock(return_value=calibRecord)
+
+            # Under a mocked calibration data path, create fake "persistent" workspace files
+            self.instance.dataFactoryService.getCalibrationDataPath = MagicMock(return_value=tmpDir)
+            self.create_fake_diffcal_files(Path(tmpDir), calibRecord.workspaces, calibRecord.version)
+
+            mockRequest = MagicMock(runId=calibRecord.runNumber, version=calibRecord.version, checkExistent=False)
+            self.instance.groceryService._getCalibrationDataPath = MagicMock(return_value=tmpDir)
+            self.instance.groceryService._fetchInstrumentDonor = MagicMock(return_value=self.sampleWS)
+
+            # Load the assessment workspaces:
+            self.instance.loadQualityAssessment(mockRequest)
+
+            # Delete any existing _metric_ workspaces:
+            for ws in mtd.getObjectNames():
+                if "sigma" in ws or "strain" in ws:
+                    DeleteWorkspace(Workspace=ws)
+
+            mockRequest = MagicMock(runId=calibRecord.runNumber, version=calibRecord.version, checkExistent=True)
+            with pytest.raises(RuntimeError) as excinfo:  # noqa: PT011
+                self.instance.loadQualityAssessment(mockRequest)
             assert "is already loaded" in str(excinfo.value)
 
     def test_load_quality_assessment(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            calibRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord.json"))
+        path = Resource.getPath("outputs")
+        with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpDir:
+            calibRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json"))
             self.instance.dataFactoryService.getCalibrationRecord = MagicMock(return_value=calibRecord)
 
             # Under a mocked calibration data path, create fake "persistent" workspace files
-            self.instance.dataFactoryService.getCalibrationDataPath = MagicMock(return_value=tmpdir)
-            for ws_name in calibRecord.workspaceNames:
-                CreateSingleValuedWorkspace(OutputWorkspace=ws_name)
-                filename = Path(ws_name + ".nxs")
-                self.instance.dataExportService.exportWorkspace(tmpdir, filename, ws_name)
+            self.instance.dataFactoryService.getCalibrationDataPath = MagicMock(return_value=tmpDir)
+            self.create_fake_diffcal_files(Path(tmpDir), calibRecord.workspaces, calibRecord.version)
 
             # Call the method to test. Use a mocked run and a mocked version
-            mockRequest = MagicMock(runId=MagicMock(), version=MagicMock(), checkExistent=False)
+            mockRequest = MagicMock(runId=calibRecord.runNumber, version=calibRecord.version, checkExistent=False)
+            self.instance.groceryService._getCalibrationDataPath = MagicMock(return_value=tmpDir)
+            self.instance.groceryService._fetchInstrumentDonor = MagicMock(return_value=self.sampleWS)
             self.instance.loadQualityAssessment(mockRequest)
 
             # Assert the expected calibration metric workspaces have been generated
             for metric in ["sigma", "strain"]:
                 ws_name = (
-                    wng.diffCalMetrics()
+                    wng.diffCalMetric()
+                    .metricName(metric)
                     .runNumber(calibRecord.runNumber)
-                    .version("v" + str(calibRecord.version))
+                    .version(str(calibRecord.version))
                     .metricName(metric)
                     .build()
                 )
                 assert self.instance.dataFactoryService.workspaceDoesExist(ws_name)
 
-            # Assert the "persistent" workspaces have been loaded
-            for ws_name in calibRecord.workspaceNames:
-                assert self.instance.dataFactoryService.workspaceDoesExist(ws_name)
+            # Assert all "persistent" workspaces have been loaded
+            for wsNames in calibRecord.workspaces.values():
+                for wsName in wsNames:
+                    assert self.instance.dataFactoryService.workspaceDoesExist(
+                        wsName
+                    )
+
+    def test_load_quality_assessment_no_units(self):
+        with pytest.raises(RuntimeError, match=r"without a units token in its name"):  # noqa: PT012
+            calibRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json"))
+            calibRecord.workspaces = {
+                "diffCalOutput": ["_diffoc_057514"],
+                "diffCalTable": ["_diffract_consts_057514"],
+                "diffCalMask": ["_diffract_consts_mask_057514"],
+            }
+            self.instance.dataFactoryService.getCalibrationRecord = MagicMock(return_value=calibRecord)
+
+            # Call the method to test. Use a mocked run and a mocked version
+            mockRequest = MagicMock(runId=calibRecord.runNumber, version=calibRecord.version, checkExistent=False)
+            self.instance.loadQualityAssessment(mockRequest)
+
+    def test_load_quality_assessment_dsp_and_tof(self):
+        calibRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json"))
+        calibRecord.workspaces = {
+            "diffCalOutput": ["_dsp_diffoc_057514", "_tof_diffoc_057514"],
+            "diffCalTable": ["_diffract_consts_057514"],
+            "diffCalMask": ["_diffract_consts_mask_057514"],
+        }
+        self.instance.dataFactoryService.getCalibrationRecord = mock.Mock(return_value=calibRecord)
+
+        mockFetchGroceryDict = mock.Mock(return_value={})
+        self.instance.groceryService.fetchGroceryDict = mockFetchGroceryDict
+
+        # Call the method to test. Use a mocked run and a mocked version
+        mockRequest = MagicMock(runId=calibRecord.runNumber, version=calibRecord.version, checkExistent=False)
+        self.instance.loadQualityAssessment(mockRequest)
+        calledWithDict = mockFetchGroceryDict.call_args[0][0]
+        assert calledWithDict["diffCalOutput_0000"].unit == wng.Units.DSP
+        assert calledWithDict["diffCalOutput_0001"].unit == wng.Units.TOF
+
+    def test_load_quality_assessment_unexpected_type(self):
+        with pytest.raises(RuntimeError, match=r"not implemented: unable to load unexpected"):  # noqa: PT012
+            calibRecord = CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json"))
+            calibRecord.workspaces = {
+                "diffCalOutput": ["_tof_diffoc_057514"],
+                "diffCalTable": ["_diffract_consts_057514"],
+                "diffCalMask": ["_diffract_consts_mask_057514"],
+                "rawVanadium": ["_unexpected_workspace_type"],
+            }
+            self.instance.dataFactoryService.getCalibrationRecord = MagicMock(return_value=calibRecord)
+
+            # Call the method to test. Use a mocked run and a mocked version
+            mockRequest = MagicMock(runId=calibRecord.runNumber, version=calibRecord.version, checkExistent=False)
+            self.instance.loadQualityAssessment(mockRequest)
 
     @patch(thisService + "FarmFreshIngredients", spec_set=FarmFreshIngredients)
     def test_prepDiffractionCalibrationIngredients(self, FarmFreshIngredients):
@@ -422,3 +575,50 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         # assert that the recipe is not called and the correct workspaces are returned
         assert FocusSpectraRecipe().executeRecipe.call_count == 0
         assert res == (focusedWorkspace, groupingWorkspace)
+
+    def test_initializeState(self):
+        testCalibration = Calibration.parse_file(Resource.getPath("inputs/calibration/CalibrationParameters.json"))
+        mockInitializeState = mock.Mock(return_value=testCalibration.instrumentState)
+        self.instance.dataExportService.initializeState = mockInitializeState
+        request = InitializeStateRequest(
+            runId=testCalibration.seedRun,
+            humanReadableName="friendly name",
+        )
+        self.instance.initializeState(request)
+        mockInitializeState.assert_called_once_with(request.runId, request.humanReadableName)
+
+    def test_getState(self):
+        testCalibration = Calibration.parse_file(Resource.getPath("inputs/calibration/CalibrationParameters.json"))
+        testConfig = StateConfig.construct()
+        testConfig.calibration = testCalibration
+        states = [deepcopy(testConfig), deepcopy(testConfig), deepcopy(testConfig)]
+        states[0].calibration.instrumentState.id = "0000000000000000"
+        states[1].calibration.instrumentState.id = "1111111111111111"
+        states[2].calibration.instrumentState.id = "2222222222222222"
+        runs = [RunConfig(runNumber="0"), RunConfig(runNumber="1"), RunConfig(runNumber="2")]
+        mockDataFactoryService = mock.Mock()
+        mockDataFactoryService.getStateConfig.side_effect = states
+        self.instance.dataFactoryService = mockDataFactoryService
+        actual = self.instance.getState(runs)
+        assert actual == states
+
+    def test_hasState(self):
+        mockCheckCalibrationStateExists = mock.Mock(return_value=True)
+        self.instance.dataFactoryService.checkCalibrationStateExists = mockCheckCalibrationStateExists
+        self.instance.hasState(self.runNumber)
+        mockCheckCalibrationStateExists.assert_called_once_with(self.runNumber)
+
+
+# this at teardown removes the loggers, eliminating logger error printouts
+# see https://github.com/pytest-dev/pytest/issues/5502#issuecomment-647157873
+@pytest.fixture(autouse=True)
+def clear_loggers():  # noqa: PT004
+    """Remove handlers from all loggers"""
+    import logging
+
+    yield  # ... teardown follows:
+    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
+    for logger in loggers:
+        handlers = getattr(logger, "handlers", [])
+        for handler in handlers:
+            logger.removeHandler(handler)

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -86,7 +86,7 @@ class TestNormalizationService(unittest.TestCase):
 
     def clearoutWorkspaces(self) -> None:
         for ws in mtd.getObjectNames():
-            self.instance.dataExportService.deleteWorkspace(ws)
+            self.instance.groceryService.deleteWorkspace(ws)
 
     def tearDown(self) -> None:
         self.clearoutWorkspaces()
@@ -257,9 +257,9 @@ class TestNormalizationService(unittest.TestCase):
         self.instance.dataFactoryService.getCifFilePath = MagicMock(return_value="path/to/cif")
         result = self.instance.normalization(self.request)
         assert result == {
-            "correctedVanadium": "tof_unfoc_12345_raw_van_corr",
-            "focusedVanadium": f"tof_{self.request.focusGroup.name}_12345_s+f-vanadium",
-            "smoothedVanadium": "dsp_apple_12345_fitted_van_cor",
+            "correctedVanadium": "tof_unfoc_raw_van_corr_012345",
+            "focusedVanadium": f"tof_{self.request.focusGroup.name}_s+f-vanadium_012345",
+            "smoothedVanadium": "dsp_apple_fitted_van_cor_012345",
             "detectorPeaks": self.instance.sousChef.prepNormalizationIngredients.return_value.detectorPeaks,
         }
 

--- a/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
+++ b/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
@@ -1,44 +1,63 @@
 import pytest
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 
+runNumber = 123
+fRunNumber = str(runNumber).zfill(6)
+version = 1
+fVersion = "v" + str(version).zfill(4)
+
 
 def testRunNames():
-    assert "tof_all_123" == wng.run().runNumber(123).build()
-    assert "dsp_all_123" == wng.run().runNumber(123).unit(wng.Units.DSP).build()
-    assert "dsp_column_123" == wng.run().runNumber(123).unit(wng.Units.DSP).group(wng.Groups.COLUMN).build()
+    assert "tof_all_" + fRunNumber == wng.run().runNumber(runNumber).build()
+    assert "dsp_all_" + fRunNumber == wng.run().runNumber(runNumber).unit(wng.Units.DSP).build()
     assert (
-        "dsp_column_123_test"
-        == wng.run().runNumber(123).unit(wng.Units.DSP).group(wng.Groups.COLUMN).auxiliary("Test").build()
+        "dsp_column_" + fRunNumber
+        == wng.run().runNumber(runNumber).unit(wng.Units.DSP).group(wng.Groups.COLUMN).build()
+    )
+    assert (
+        "dsp_column_test_" + fRunNumber
+        == wng.run().runNumber(runNumber).unit(wng.Units.DSP).group(wng.Groups.COLUMN).auxiliary("Test").build()
     )
 
 
 def testDiffCalInputNames():
-    assert "_tof_123_raw" == wng.diffCalInput().runNumber(123).build()
-    assert "_dsp_123_raw" == wng.diffCalInput().runNumber(123).unit(wng.Units.DSP).build()
+    assert "_tof_" + fRunNumber + "_raw" == wng.diffCalInput().runNumber(runNumber).build()
+    assert "_dsp_" + fRunNumber + "_raw" == wng.diffCalInput().runNumber(runNumber).unit(wng.Units.DSP).build()
 
 
-def testDiffCalTableNames():
-    assert "_difc_123" == wng.diffCalTable().runNumber(123).build()
-    assert "_difc_123_24" == wng.diffCalTable().runNumber(123).version(24).build()
+def testDiffCalOutputName():
+    assert f"_tof_diffoc_{fRunNumber}" == wng.diffCalOutput().runNumber(runNumber).build()
+    assert f"_tof_diffoc_{fRunNumber}_{fVersion}" == wng.diffCalOutput().runNumber(runNumber).version(version).build()
 
 
-def testDiffCalOutputNames():
-    assert "_tof_123_diffoc" == wng.diffCalOutput().runNumber(123).build()
-    assert "_dsp_123_diffoc" == wng.diffCalOutput().runNumber(123).unit(wng.Units.DSP).build()
-    assert "_dsp_123_25_diffoc" == wng.diffCalOutput().runNumber(123).unit(wng.Units.DSP).version(25).build()
+def testDiffCalTableName():
+    assert f"_diffract_consts_{fRunNumber}" == wng.diffCalTable().runNumber(runNumber).build()
+    assert (
+        f"_diffract_consts_{fRunNumber}_{fVersion}" == wng.diffCalTable().runNumber(runNumber).version(version).build()
+    )
 
 
-def testDiffCalMaskNames():
-    assert "_difc_123_mask" == wng.diffCalMask().runNumber(123).build()
-    assert "_difc_123_26_mask" == wng.diffCalMask().runNumber(123).version(26).build()
+def testDiffCalMaskName():
+    assert f"_diffract_consts_mask_{fRunNumber}" == wng.diffCalMask().runNumber(runNumber).build()
+    assert (
+        f"_diffract_consts_mask_{fRunNumber}_{fVersion}"
+        == wng.diffCalMask().runNumber(runNumber).version(version).build()
+    )
 
 
 def testDiffCalMetricsNames():
-    assert "123_calibration_metrics_strain" == wng.diffCalMetrics().runNumber(123).metricName("strain").build()
     assert (
-        "123_1_calibration_metrics_strain"
-        == wng.diffCalMetrics().runNumber(123).version(1).metricName("strain").build()
+        f"_calib_metrics_strain_{fRunNumber}" == wng.diffCalMetric().runNumber(runNumber).metricName("strain").build()
     )
+    assert (
+        f"_calib_metrics_strain_{fRunNumber}_{fVersion}"
+        == wng.diffCalMetric().metricName("strain").runNumber(runNumber).version(version).build()
+    )
+
+
+def testInvalidKey():
+    with pytest.raises(RuntimeError, match=r"Key \[unit\] not a valid property"):
+        wng.diffCalMask().runNumber(runNumber).unit(wng.Units.TOF).build()
 
 
 # this at teardown removes the loggers, eliminating logger error printouts


### PR DESCRIPTION
**I've kept most of the changes from the original branch, except for the following:**

  * Workspace I/O methods are updated to be consistent with the current service layer.

  * `CalibrationRecord` <workspace list> functionality has been modified to no longer use the proposed `WorkspaceInfo` class.  The information contained in this class was _derivable_ from the workspaces themselves, and so using this class didn't really make much sense.

  * `CalibrationRecord` now uses a **workspace dict** keyed by `WorkspaceNameGenerator` workspace types.  At each key there can be a list containing several workspaces.  This is only "loosely" connected to the WNG-types at the moment, but will serve as a placeholder until this can be done more completely.

  * Arguably, since the workspaces in the `CalibrationRecord` are always the same, the only purpose of storing this information in the record would be if for some reason the end users need to see this information.  We need to check with Malcolm about this point.  If this information is unnecessary, the actual list should be moved to `application.yml`, and be by WNG-type.

  * All unit tests are presently passing.

  * All UI and Filesystem functionality of the original story is functioning as expected.

## Description of work

A calibration record file has a list of workspaces that are saved as files in the same directory.  The names of the workspaces and their filenames must meet certain criteria:

- The name should end with a run number followed by a version number, for example
`diffract_consts_046680_v0015` for a workspace and
`diffract_consts_046680_v0015.h5` for the corresponding file
 - Run numbers and version numbers should be zero-padded as shown in the example above
 - Workspace names should be easy to interpret. For example, instead of the current `difc`, use `diffract_consts`

The above rules also apply to the calibration **metric** workspaces.  The metric workspaces are not saved as files, but are listed in the Workspace window of the SNAPRed UI.

The names of calibration version directories should also be zero-padded, e.g. `v_0015` instead of the current `v_15`.

Filename extensions must reflect the corresponding workspace Mantid types.

Calibration and Normalization records must be saved in separate directories:
```
../Calibration/Powder/04bd2c53f6bf6754/diffraction
../Calibration/Powder/04bd2c53f6bf6754/normalization

```
**ATTENTION:**

This PR also fixes a UI bug introduced by [PR#288](https://github.com/neutrons/SNAPRed/pull/228): on the Assessing tab the `CalibrationIndex` drop-down list  is always empty. To fix the bug, a missing call to `CalibrationAssesmentView` `updateRunNumber` was re-instated:
``` python
   def _triggerCalibrationReduction(self, workflowPresenter):
    ....
        self._calibrationAssessmentView.updateRunNumber(self.runNumber)
```
Correspondingly, the implementation of `updateRunNumber` was also re-instated.

**KNOWN ISSUES**

- If the workspace name contains an iteration number, the number is positioned after the run number. It should be positioned before the run number.
- Before saving a workspace the iteration number needs to be removed from the workspace name.
- Because this does _not_ occur, although multiple iterations will execute without any issues,  they cannot be correctly reloaded by the "assessment" panel.
- Correct implementation of this feature probably requires a WNG-name parser.
- **THIS MAY STILL NEED SOME WORK**, in another story...

## Explanation of work

For the purposes of `WorkspaceNameGenerator` (WNG), all relevant name templates have been updated to make sure that the run number and version tokens are positioned as required. Also, token name changes like `difc` -> `diffract_consts` were made.

Zero-padding of run number and version number is accomplished with the help of a new class `ValueFormatter`.
Correspondingly, a one-line change to `NameBuilder` `__getattr__` method:

  ``` python
    def __getattr__(self, key):
        if key not in self.keys:
            raise RuntimeError(f"Key [{key}] not a valid property for given name.")

        def setValue(value):
            
             # FORMAT THE VALUE
             value = ValueFormatter.formatValueByKey(key, value)
            
            self.props[key] = value
            return self
  ```
allows for **automatic** formatting of the corresponding name tokens without any changes to the client code. For example, an existent line of code 
``` python
wng.diffCalInput().runNumber(runId).build()
```
will result in automatic formatting of `runId`.

Filenames, unlike workspace names, might not be built exclusively with WNG: a version suffix (as well as a filename extension) may be added "by hand" immediately before saving the workspace. To format the version number in such cases a call is placed directly to `ValueFormater`, e.g.
``` python
        if version:
            filePath += "_" + ValueFormatter.formatVersion(version)
            filePath += ".h5"
 
```
The same applies to formatting a calibration version directory name, e.g.
``` python
   def _constructCalibrationDataPath(self, runId: str, version: str):
        stateId, _ = self._generateStateId(runId)
        statePath = self._constructCalibrationStatePath(stateId)
        calibrationVersionPath: str = statePath + "v_{}/".format(
            ValueFormatter.formatVersion(version=version, use_v_prefix=False)
        )
        return calibrationVersionPath
```

A new name template was added to WNG to account for metric workspaces that are not assigned a version yet, but have a timestamp instead: `workspace:nameTemplate:timed_metric`.

## To test

Set up a directory structure:
../Calibration/Powder

Set up a directory structure:
../Calibration/Powder

For testing diffraction calibration use the following parameters:
Run Number: 46680
Convergence Threshold: 0.1
Peak Intensity Threshold: 0.0001
Bins Across Peak Width: 10
Sample: Diamond_001.json
Grouping File: Column lite

For testing normalization calibration use the following parameters:
Run Number: 58882
Background Number: 58813
Smoothing Parameter: 0.000001
Sample: Silicon_NIST_640D_001
Grouping File: Column lite

TEST 1

1. From the `Test Panel` `Calibrating` tab run Diffraction Calibration
2. When `Assessing` tab is shown, click Continue
3. On the `Saving` tab fill in the fields and click Continue
4. Check that the saved `CalibrationRecord.json` has the correct list of persistent workspaces.  Check that the corresponding filenames are also correct.

Close and reopen UI

TEST 2
1. From the `Test Panel` `Diffraction Calibration`/`Calibrating` tab run diffraction calibration
2. When `Assessing` tab is shown, verify that version 2 calibration is present in the drop-down list
3. Click Load. Check the Workspaces window to make sure that all expected workspaces have been created

Close and reopen UI

TEST 3
1. From the `Test Panel` `Normalization Calibration`/`Normalization Calibration` tab run normalization calibration.
2. When `Tweak Parameters` tab is shown, click Continue
3.  On the `Saving` tab fill in the fields and click Continue
4. Check that the saved `NormalizationRecord.json` has the correct list of persistent workspaces.  Check that the corresponding filenames are also correct.



## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#3702](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3702)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
