### PR TITLE
Move initialization sequence for on-disk `GroupingMap` to `initializeState`

### DIFF
--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -660,7 +660,6 @@ class LocalDataService:
         -- side effect: updates version number of incoming `Calibration`.
         """
         stateId, _ = self._generateStateId(runId)
-        calibrationPath: str = self._constructCalibrationStateRootPath(stateId)
         previousVersion = self._getLatestCalibrationVersion(stateId)
         if not version:
             version = previousVersion + 1

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -788,7 +788,6 @@ class LocalDataService:
         #   to its separate JSON file at <state root>.
         self._writeGroupingMap(stateId, groupingMap)
 
-
     def checkCalibrationFileExists(self, runId: str):
         stateID, _ = self._generateStateId(runId)
         calibrationStatePath: str = self._constructCalibrationStateRootPath(stateID)

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -130,12 +130,10 @@ class LocalDataService:
         else:
             # If no `GroupingMap` JSON file is present at the <state root>,
             #   it is assumed that this is the first time that this state configuration has been initialized.
-            # Any `StateConfig`'s `GroupingMap` always starts as a copy of the default `GroupingMap`.
-            groupingMap = self._readDefaultGroupingMap()
-            groupingMap.coerceStateId(stateId)
-            # This is the _ONLY_ place that the grouping-schema map is written
-            #   to its separate JSON file at <state root>.
-            self._writeGroupingMap(stateId, groupingMap)
+            # WARNING: `_prepareStateRoot` is also called at `initializeState`: this allows
+            #   some order independence of initialization if the back-end is run separately (e.g. in unit tests).
+            self._prepareStateRoot(stateId)
+            groupingMap = self._readGroupingMap(stateId)
 
         return StateConfig(
             calibration=diffCalibration,
@@ -235,7 +233,7 @@ class LocalDataService:
 
         return fileList
 
-    def _constructCalibrationStatePath(self, stateId):
+    def _constructCalibrationStateRootPath(self, stateId):
         # TODO: Propagate pathlib through codebase
         return f"{self.instrumentConfig.calibrationDirectory}/Powder/{stateId}/"
 
@@ -247,7 +245,7 @@ class LocalDataService:
     def readCalibrationIndex(self, runId: str):
         # Need to run this because of its side effect, TODO: Remove side effect
         stateId, _ = self._generateStateId(runId)
-        calibrationPath: str = self._constructCalibrationStatePath(stateId)
+        calibrationPath: str = self._constructCalibrationStateRootPath(stateId)
         indexPath: str = calibrationPath + "CalibrationIndex.json"
         calibrationIndex: List[CalibrationIndexEntry] = []
         if os.path.exists(indexPath):
@@ -336,7 +334,7 @@ class LocalDataService:
         Generates the path for an instrument state's versioned calibration files.
         """
         stateId, _ = self._generateStateId(runId)
-        statePath = self._constructCalibrationStatePath(stateId)
+        statePath = self._constructCalibrationStateRootPath(stateId)
         cablibrationVersionPath: str = statePath + "v_{}/".format(version)
         return cablibrationVersionPath
 
@@ -360,7 +358,7 @@ class LocalDataService:
 
     def writeCalibrationIndexEntry(self, entry: CalibrationIndexEntry):
         stateId, _ = self._generateStateId(entry.runNumber)
-        calibrationPath: str = self._constructCalibrationStatePath(stateId)
+        calibrationPath: str = self._constructCalibrationStateRootPath(stateId)
         indexPath: str = calibrationPath + "CalibrationIndex.json"
         # append to index and write to file
         calibrationIndex = self.readCalibrationIndex(entry.runNumber)
@@ -412,7 +410,7 @@ class LocalDataService:
         """
         Ignoring the calibration index, whats the last set of calibration files to be generated.
         """
-        calibrationStatePath = self._constructCalibrationStatePath(stateId)
+        calibrationStatePath = self._constructCalibrationStateRootPath(stateId)
         calibrationVersionPath = f"{calibrationStatePath}v_*/"
         latestVersion = 0
         versionDirs = self._findMatchingDirList(calibrationVersionPath, throws=False)
@@ -610,7 +608,7 @@ class LocalDataService:
         version = self._getVersionFromNormalizationIndex(runId)
         return self.readNormalizationRecord(runId, version)
 
-    def getCalibrationStatePath(self, runId: str, version: str):
+    def _constructCalibrationParametersFilePath(self, runId: str, version: str):
         statePath: str = f"{self._constructCalibrationDataPath(runId, version)}CalibrationParameters.json"
         return statePath
 
@@ -624,7 +622,7 @@ class LocalDataService:
     def readCalibrationState(self, runId: str, version: str = None):
         # get stateId and check to see if such a folder exists, if not create it and initialize it
         stateId, _ = self._generateStateId(runId)
-        calibrationStatePath = self.getCalibrationStatePath(runId, "*")
+        calibrationStatePath = self._constructCalibrationParametersFilePath(runId, "*")
 
         latestFile = ""
         if version:
@@ -662,18 +660,22 @@ class LocalDataService:
         -- side effect: updates version number of incoming `Calibration`.
         """
         stateId, _ = self._generateStateId(runId)
-        calibrationPath: str = self._constructCalibrationStatePath(stateId)
+        calibrationPath: str = self._constructCalibrationStateRootPath(stateId)
         previousVersion = self._getLatestCalibrationVersion(stateId)
         if not version:
             version = previousVersion + 1
-        # check for the existenece of a calibration parameters file
-        calibrationParametersPath = self.getCalibrationStatePath(runId, version)
+        
+        # Check for the existence of a calibration parameters file
+        calibrationParametersFilePath = self._constructCalibrationParametersFilePath(runId, version)
+        if os.path.exists(calibrationParametersFilePath):
+            logger.warning(f"overwriting calibration parameters at {calibrationParametersFilePath}")
+
         calibration.version = version
-        calibrationPath = self._constructCalibrationDataPath(runId, version)
-        if not os.path.exists(calibrationPath):
-            os.makedirs(calibrationPath)
+        calibrationDataPath = self._constructCalibrationDataPath(runId, version)
+        if not os.path.exists(calibrationDataPath):
+            os.makedirs(calibrationDataPath)
         # write the calibration state.
-        write_model_pretty(calibration, calibrationParametersPath)
+        write_model_pretty(calibration, calibrationParametersFilePath)
 
     def writeNormalizationState(self, runId: str, normalization: Normalization, version: int = None):  # noqa: F821
         """
@@ -758,13 +760,39 @@ class LocalDataService:
             creationDate=datetime.datetime.now(),
             version=0,
         )
+
+        # Make sure that the state root directory has been initialized:
+        stateRootPath = self._constructCalibrationStateRootPath(stateId)
+        if not os.path.exists(stateRootPath):
+            # WARNING: `_prepareStateRoot` is also called at `readStateConfig`; this allows
+            #   some order independence of initialization if the back-end is run separately (e.g. in unit tests).
+            self._prepareStateRoot(stateId)
+
         self.writeCalibrationState(runId, calibration)
 
         return calibration
 
+    def _prepareStateRoot(self, stateId: str):
+        """
+        Create the state root directory, and populate it with any necessary metadata files.
+        """
+        stateRootPath = self._constructCalibrationStateRootPath(stateId)
+        if not os.path.exists(stateRootPath):
+            os.makedirs(stateRootPath)
+
+        # If no `GroupingMap` JSON file is present at the <state root>,
+        #   it is assumed that this is the first time that this state configuration has been initialized.
+        # Any `StateConfig`'s `GroupingMap` always starts as a copy of the default `GroupingMap`.
+        groupingMap = self._readDefaultGroupingMap()
+        groupingMap.coerceStateId(stateId)
+        # This is the _ONLY_ place that the grouping-schema map is written
+        #   to its separate JSON file at <state root>.
+        self._writeGroupingMap(stateId, groupingMap)
+
+
     def checkCalibrationFileExists(self, runId: str):
         stateID, _ = self._generateStateId(runId)
-        calibrationStatePath: str = self._constructCalibrationStatePath(stateID)
+        calibrationStatePath: str = self._constructCalibrationStateRootPath(stateID)
 
         if os.path.exists(calibrationStatePath):
             return True
@@ -811,7 +839,7 @@ class LocalDataService:
         return GroupingMap.calibrationGroupingHome() / "defaultGroupingMap.json"
 
     def _groupingMapPath(self, stateId) -> Path:
-        return Path(self._constructCalibrationStatePath(stateId)) / "groupingMap.json"
+        return Path(self._constructCalibrationStateRootPath(stateId)) / "groupingMap.json"
 
     def readGroupingFiles(self):
         groupingFolder = Config["instrument.calibration.powder.grouping.home"]

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -663,7 +663,7 @@ class LocalDataService:
         previousVersion = self._getLatestCalibrationVersion(stateId)
         if not version:
             version = previousVersion + 1
-        
+
         # Check for the existence of a calibration parameters file
         calibrationParametersFilePath = self._constructCalibrationParametersFilePath(runId, version)
         if os.path.exists(calibrationParametersFilePath):
@@ -774,7 +774,7 @@ class LocalDataService:
     def _prepareStateRoot(self, stateId: str):
         """
         Create the state root directory, and populate it with any necessary metadata files.
-        """        
+        """
         stateRootPath = self._constructCalibrationStateRootPath(stateId)
         if not os.path.exists(stateRootPath):
             os.makedirs(stateRootPath)

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -774,7 +774,7 @@ class LocalDataService:
     def _prepareStateRoot(self, stateId: str):
         """
         Create the state root directory, and populate it with any necessary metadata files.
-        """
+        """        
         stateRootPath = self._constructCalibrationStateRootPath(stateId)
         if not os.path.exists(stateRootPath):
             os.makedirs(stateRootPath)

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -1,16 +1,15 @@
+import importlib
 import json
+import logging
 import os
 import shutil
-import importlib
-import logging
 import socket
 import tempfile
+import unittest.mock as mock
 from pathlib import Path
 from typing import List
 
-import unittest.mock as mock
 import pytest
-
 from mantid.api import ITableWorkspace, MatrixWorkspace
 from mantid.dataobjects import MaskWorkspace
 from mantid.simpleapi import (
@@ -58,7 +57,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
         defaultLogger = logging.getLogger(LocalDataServiceModule.__name__ + "_patch")
         defaultLogger.propagate = True
         monkeypatch.setattr(LocalDataServiceModule, "logger", defaultLogger)
-    
+
     fakeInstrumentFilePath = Resource.getPath("inputs/testInstrument/fakeSNAP.xml")
     reductionIngredients = None
     with Resource.open("inputs/calibration/ReductionIngredients.json", "r") as file:
@@ -199,12 +198,8 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
 
         localDataService._groupingMapPath = mock.Mock()
         localDataService._groupingMapPath.side_effect = [
-            Path(
-                Resource.getPath("inputs/pixel_grouping/does_not_exist.json")
-            ),       
-            Path(
-                Resource.getPath("inputs/pixel_grouping/groupingMap.json")
-            ),
+            Path(Resource.getPath("inputs/pixel_grouping/does_not_exist.json")),
+            Path(Resource.getPath("inputs/pixel_grouping/groupingMap.json")),
         ]
         stateGroupingMap = GroupingMap.parse_file(Resource.getPath("inputs/pixel_grouping/groupingMap.json"))
         localDataService._readGroupingMap = mock.Mock()
@@ -215,7 +210,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
         actual = localDataService.readStateConfig("57514")
         assert actual is not None
         mockPrepareStateRoot.assert_called_once()
-        
+
     def test_prepareStateRoot_creates_state_root_directory():
         # Test that the <state root> directory is created when it doesn't exist.
         localDataService = LocalDataService()
@@ -224,23 +219,17 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
             stateId = "ab8704b0bc2a2342"
             stateRootPath = Path(tmpDir) / stateId
             groupingMapFilePath = stateRootPath / "groupingMap.json"
-            localDataService._constructCalibrationStateRootPath = mock.Mock(
-                return_value=str(stateRootPath)
-            )
+            localDataService._constructCalibrationStateRootPath = mock.Mock(return_value=str(stateRootPath))
             defaultGroupingMap = GroupingMap.parse_file(
                 Resource.getPath("inputs/pixel_grouping/defaultGroupingMap.json")
             )
-            localDataService._readDefaultGroupingMap = mock.Mock(
-                return_value=defaultGroupingMap 
-            )
-            localDataService._groupingMapPath = mock.Mock(
-                return_value = groupingMapFilePath
-            )
+            localDataService._readDefaultGroupingMap = mock.Mock(return_value=defaultGroupingMap)
+            localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
 
-            assert not stateRootPath.exists() 
-            localDataService._prepareStateRoot(stateId)            
+            assert not stateRootPath.exists()
+            localDataService._prepareStateRoot(stateId)
             assert stateRootPath.exists()
-        
+
     def test_prepareStateRoot_existing_state_root():
         # Test that an already existing <state root> directory is not an error.
         localDataService = LocalDataService()
@@ -249,22 +238,16 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
             stateId = "ab8704b0bc2a2342"
             stateRootPath = Path(tmpDir) / stateId
             os.makedirs(stateRootPath)
-            
+
             groupingMapFilePath = stateRootPath / "groupingMap.json"
-            localDataService._constructCalibrationStateRootPath = mock.Mock(
-                return_value=str(stateRootPath)
-            )
+            localDataService._constructCalibrationStateRootPath = mock.Mock(return_value=str(stateRootPath))
             defaultGroupingMap = GroupingMap.parse_file(
                 Resource.getPath("inputs/pixel_grouping/defaultGroupingMap.json")
             )
-            localDataService._readDefaultGroupingMap = mock.Mock(
-                return_value=defaultGroupingMap 
-            )
-            localDataService._groupingMapPath = mock.Mock(
-                return_value = groupingMapFilePath
-            )
-            assert stateRootPath.exists() 
-            localDataService._prepareStateRoot(stateId)            
+            localDataService._readDefaultGroupingMap = mock.Mock(return_value=defaultGroupingMap)
+            localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
+            assert stateRootPath.exists()
+            localDataService._prepareStateRoot(stateId)
 
     def test_prepareStateRoot_writes_grouping_map():
         # Test that the first time a <state root> directory is initialized,
@@ -275,21 +258,15 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
             stateId = "ab8704b0bc2a2342"
             stateRootPath = Path(tmpDir) / stateId
             groupingMapFilePath = stateRootPath / "groupingMap.json"
-            localDataService._constructCalibrationStateRootPath = mock.Mock(
-                return_value=str(stateRootPath)
-            )
+            localDataService._constructCalibrationStateRootPath = mock.Mock(return_value=str(stateRootPath))
             defaultGroupingMap = GroupingMap.parse_file(
                 Resource.getPath("inputs/pixel_grouping/defaultGroupingMap.json")
             )
-            localDataService._readDefaultGroupingMap = mock.Mock(
-                return_value=defaultGroupingMap 
-            )
-            localDataService._groupingMapPath = mock.Mock(
-                return_value = groupingMapFilePath
-            )
+            localDataService._readDefaultGroupingMap = mock.Mock(return_value=defaultGroupingMap)
+            localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
 
             assert not groupingMapFilePath.exists()
-            localDataService._prepareStateRoot(stateId)            
+            localDataService._prepareStateRoot(stateId)
             assert groupingMapFilePath.exists()
 
     def test_prepareStateRoot_sets_grouping_map_stateid():
@@ -301,20 +278,14 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
             stateId = "ab8704b0bc2a2342"
             stateRootPath = Path(tmpDir) / stateId
             groupingMapFilePath = stateRootPath / "groupingMap.json"
-            localDataService._constructCalibrationStateRootPath = mock.Mock(
-                return_value=str(stateRootPath)
-            )
+            localDataService._constructCalibrationStateRootPath = mock.Mock(return_value=str(stateRootPath))
             defaultGroupingMap = GroupingMap.parse_file(
                 Resource.getPath("inputs/pixel_grouping/defaultGroupingMap.json")
             )
-            localDataService._readDefaultGroupingMap = mock.Mock(
-                return_value=defaultGroupingMap 
-            )
-            localDataService._groupingMapPath = mock.Mock(
-                return_value = groupingMapFilePath
-            )
+            localDataService._readDefaultGroupingMap = mock.Mock(return_value=defaultGroupingMap)
+            localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
 
-            localDataService._prepareStateRoot(stateId)            
+            localDataService._prepareStateRoot(stateId)
 
             with open(groupingMapFilePath, "r") as file:
                 groupingMap = parse_raw_as(GroupingMap, file.read())
@@ -330,21 +301,15 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
             stateId = "ab8704b0bc2a2342"
             stateRootPath = Path(tmpDir) / stateId
             groupingMapFilePath = stateRootPath / "groupingMap.json"
-            defaultGroupingMapFilePath =  Resource.getPath("inputs/pixel_grouping/does_not_exist.json")
+            defaultGroupingMapFilePath = Resource.getPath("inputs/pixel_grouping/does_not_exist.json")
             with pytest.raises(  # noqa: PT012
                 FileNotFoundError,
                 match=f'required default grouping-schema map "{defaultGroupingMapFilePath}" does not exist',
             ):
-                localDataService._constructCalibrationStateRootPath = mock.Mock(
-                    return_value=str(stateRootPath)
-                )
-                localDataService._defaultGroupingMapPath = mock.Mock(
-                    return_value=Path(defaultGroupingMapFilePath)
-                )
-                localDataService._groupingMapPath = mock.Mock(
-                    return_value = groupingMapFilePath
-                )
-                localDataService._prepareStateRoot(stateId)            
+                localDataService._constructCalibrationStateRootPath = mock.Mock(return_value=str(stateRootPath))
+                localDataService._defaultGroupingMapPath = mock.Mock(return_value=Path(defaultGroupingMapFilePath))
+                localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
+                localDataService._prepareStateRoot(stateId)
 
     def test_prepareStateRoot_does_not_overwrite_grouping_map():
         # If a 'groupingMap.json' file already exists at the <state root> directory,
@@ -355,10 +320,10 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
             stateId = "ab8704b0bc2a2342"
             stateRootPath = Path(tmpDir) / stateId
             os.makedirs(stateRootPath)
-            
+
             defaultGroupingMapFilePath = Resource.getPath("inputs/pixel_grouping/defaultGroupingMap.json")
             groupingMapFilePath = stateRootPath / "groupingMap.json"
-            
+
             # Write a 'groupingMap.json' file to the <state root>, but with a different stateId;
             #   note that the _value_ of the stateId field is _not_ validated at this stage, except for its format.
             with open(defaultGroupingMapFilePath, "r") as file:
@@ -366,53 +331,37 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
             otherStateId = "bbbbaaaabbbbeeee"
             groupingMap.coerceStateId(otherStateId)
             write_model_pretty(groupingMap, groupingMapFilePath)
-            
-            localDataService._constructCalibrationStateRootPath = mock.Mock(
-                return_value=str(stateRootPath)
-            )
-            defaultGroupingMap = GroupingMap.parse_file(
-                defaultGroupingMapFilePath
-            )
-            localDataService._readDefaultGroupingMap = mock.Mock(
-                return_value=defaultGroupingMap 
-            )
-            localDataService._groupingMapPath = mock.Mock(
-                return_value = groupingMapFilePath
-            )
 
-            localDataService._prepareStateRoot(stateId)            
+            localDataService._constructCalibrationStateRootPath = mock.Mock(return_value=str(stateRootPath))
+            defaultGroupingMap = GroupingMap.parse_file(defaultGroupingMapFilePath)
+            localDataService._readDefaultGroupingMap = mock.Mock(return_value=defaultGroupingMap)
+            localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
+
+            localDataService._prepareStateRoot(stateId)
 
             with open(groupingMapFilePath, "r") as file:
                 groupingMap = parse_raw_as(GroupingMap, file.read())
             assert groupingMap.stateId == otherStateId
-    
+
     def test_calibrationFileExists():
         with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tmpDir:
             assert Path(tmpDir).exists()
             localDataService = LocalDataService()
-            localDataService._generateStateId = mock.Mock(
-                return_value = ("ab8704b0bc2a2342", None)
-            )
-            localDataService._constructCalibrationStateRootPath = mock.Mock(
-                return_value = tmpDir
-            )
+            localDataService._generateStateId = mock.Mock(return_value=("ab8704b0bc2a2342", None))
+            localDataService._constructCalibrationStateRootPath = mock.Mock(return_value=tmpDir)
             runNumber = "654321"
-            assert localDataService.checkCalibrationFileExists(runNumber)        
-    
+            assert localDataService.checkCalibrationFileExists(runNumber)
+
     def test_calibrationFileExists_not():
         with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tmpDir:
             localDataService = LocalDataService()
-            localDataService._generateStateId = mock.Mock(
-                return_value = ("ab8704b0bc2a2342", None)
-            )
+            localDataService._generateStateId = mock.Mock(return_value=("ab8704b0bc2a2342", None))
             nonExistentPath = Path(tmpDir) / "1755"
             assert not nonExistentPath.exists()
-            localDataService._constructCalibrationStateRootPath = mock.Mock(
-                return_value = str(nonExistentPath)
-            )
+            localDataService._constructCalibrationStateRootPath = mock.Mock(return_value=str(nonExistentPath))
             runNumber = "654321"
-            assert not localDataService.checkCalibrationFileExists(runNumber)        
-    
+            assert not localDataService.checkCalibrationFileExists(runNumber)
+
     @mock.patch(ThisService + "GetIPTS")
     def test_getIPTS(mockGetIPTS):
         mockGetIPTS.return_value = "nowhere/"
@@ -1040,11 +989,11 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
                 localDataService._constructCalibrationStateRootPath.return_value = f"{tmpDir}/"
                 localDataService._getCurrentCalibrationRecord = mock.Mock()
                 localDataService._getCurrentCalibrationRecord.return_value = Calibration.construct({"name": "test"})
-                
+
                 # Force the output path: otherwise it will be written to "v_2".
                 localDataService._constructCalibrationParametersFilePath = mock.Mock()
                 localDataService._constructCalibrationParametersFilePath.return_value = calibrationParametersFilePath
-                
+
                 calibration = Calibration.parse_raw(Resource.read("/inputs/calibration/CalibrationParameters.json"))
                 localDataService.writeCalibrationState("123", calibration)
                 assert os.path.exists(calibrationParametersFilePath)
@@ -1141,14 +1090,12 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
         with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tmpDir:
             stateId = "ab8704b0bc2a2342"
             stateRootPath = Path(tmpDir) / stateId
-            localDataService._constructCalibrationStateRootPath = mock.Mock(
-                return_value=str(stateRootPath)
-            )
-        
-            assert not stateRootPath.exists() 
+            localDataService._constructCalibrationStateRootPath = mock.Mock(return_value=str(stateRootPath))
+
+            assert not stateRootPath.exists()
             localDataService.initializeState("123", "test")
             mockPrepareStateRoot.assert_called_once()
-                
+
     # NOTE: This test fails on analysis because the instrument home actually does exist!
     @pytest.mark.skipif(
         IS_ON_ANALYSIS_MACHINE, reason="This test fails on analysis because the instrument home actually does exist!"

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -1031,6 +1031,7 @@ with mock.patch.dict("sys.modules", {"mantid.api": mock.Mock()}):
         localDataService.readInstrumentConfig = mock.Mock()
         localDataService.readInstrumentConfig.return_value = testCalibrationData.instrumentState.instrumentConfig
         localDataService.writeCalibrationState = mock.Mock()
+        localDataService._prepareStateRoot = mock.Mock()
         actual = localDataService.initializeState("123", "test")
         actual.creationDate = testCalibrationData.creationDate
 


### PR DESCRIPTION
Move initialization sequence for on disk `GroupingMap` at "<state root>.groupingMap.json" to `LocalDataService.initializeState`.

This commit includes the following changes:

  * Rename several `LocalDataService` path and file-path construction methods to enhance readability;

  * Separate out creation and initialization of the <state root> directory into a new method: `LocalDataService._prepareStateRoot`.

  * Call `_prepareStateRoot` at `initializeState` (when required): this allows the state root directory and its metadata files to be created whenever a state is first initialized -- this would usually be triggered by a front-end workflow.

  * Call `_prepareStateRoot` at `readStateConfig` (when required): this additionally allows `StateConfig` to be stand-alone, and not to depend on a specific initialization sequence -- this would usually be triggered by a back-end call (e.g. during unit tests).

  * The two previous initialization triggers should not be in any conflict.  Either or both may be triggered without any adverse consequences.

## Description of work


## To test
Extensive new unit tests were added.  Several tests previously connected to `readStateConfig` were rewritten for the new `_prepareStateRoot` method.

### CIS testing
This is mostly a back-end item.  However, there are behavior tests for this that are those associated with the original grouping-map story.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4203](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=4203)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
