### PR TITLE
update validator to account for new symbols

### DIFF
--- a/src/snapred/backend/dao/calibration/CalibrationIndexEntry.py
+++ b/src/snapred/backend/dao/calibration/CalibrationIndexEntry.py
@@ -13,19 +13,31 @@ class CalibrationIndexEntry(BaseModel):
     author: str
     timestamp: Optional[int]
 
+    def parseAppliesTo(appliesTo: str):
+        symbols = [">=", "<=", "<", ">"]
+        # find first
+        symbol = next((s for s in symbols if s in appliesTo), "")
+        # parse runnumber
+        runNumber = appliesTo if symbol == "" else appliesTo.split(symbol)[-1]
+        return symbol, runNumber
+
     @validator("appliesTo", allow_reuse=True)
     def appliesToFormatChecker(cls, v):
         """
         This validator ensures that if appliesTo is present,
-        it is in the format of 'runNumber', '>runNumber', or '<runNumber'.
+        it is in the format of 'runNumber', or '{symbol}runNumber' where symbol is one of '>', '<', '>=', '<='.
         """
         testValue = v
         if testValue is not None:
-            if testValue.startswith(">") or testValue.startswith("<"):
+            symbol, _ = cls.parseAppliesTo(v)
+            if symbol != "":
                 testValue = testValue[1:]
-                try:
-                    int(testValue)
-                except ValueError:
-                    raise ValueError("appliesTo must be in the format of 'runNumber', '>runNumber', or '<runNumber'.")
+            try:
+                int(testValue)
+            except ValueError:
+                raise ValueError(
+                    "appliesTo must be in the format of 'runNumber',"
+                    "or '\{symbol\}runNumber' where symbol is one of '>', '<', '>=', '<='.."
+                )
 
         return v

--- a/src/snapred/backend/dao/calibration/CalibrationIndexEntry.py
+++ b/src/snapred/backend/dao/calibration/CalibrationIndexEntry.py
@@ -31,7 +31,7 @@ class CalibrationIndexEntry(BaseModel):
         if testValue is not None:
             symbol, _ = cls.parseAppliesTo(v)
             if symbol != "":
-                testValue = testValue[1:]
+                testValue = testValue.split(symbol)[-1]
             try:
                 int(testValue)
             except ValueError:

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -265,12 +265,7 @@ class LocalDataService:
         return normalizationIndex
 
     def _parseAppliesTo(self, appliesTo: str):
-        symbols = [">=", "<=", "<", ">"]
-        # find first
-        symbol = next((s for s in symbols if s in appliesTo), "")
-        # parse runnumber
-        runNumber = appliesTo if symbol == "" else appliesTo.split(symbol)[-1]
-        return symbol, runNumber
+        return CalibrationIndexEntry.parseAppliesTo(appliesTo)
 
     def _compareRunNumbers(self, runNumber1: str, runNumber2: str, symbol: str):
         expressions = {

--- a/tests/unit/backend/dao/test_CalibrationIndexEntry.py
+++ b/tests/unit/backend/dao/test_CalibrationIndexEntry.py
@@ -1,0 +1,57 @@
+import pytest
+from snapred.backend.dao.calibration.CalibrationIndexEntry import CalibrationIndexEntry
+
+testData = {
+    "runNumber": "1234",
+    "version": "1.0",
+    "appliesTo": "1234",
+    "comments": "test",
+    "author": "test",
+    "timestamp": 1234,
+}
+
+
+def test_correctData():
+    """
+    Test that the correct data is returned when the input is correct.
+    """
+    # Arrange
+    entry = CalibrationIndexEntry(**testData)
+    assert entry.appliesTo == testData["appliesTo"]
+
+
+def test_appliesTo():
+    """
+    Test that the appliesTo property is correctly parsed.
+    """
+    symbols = [">=", "<=", "<", ">"]
+    for symbol in symbols:
+        # Arrange
+        testDataSymbol = testData.copy()
+        testDataSymbol["appliesTo"] = f"{symbol}1234"
+        entry = CalibrationIndexEntry(**testDataSymbol)
+        assert symbol in entry.appliesTo
+
+
+def test_appliesToFailsValidation():
+    """
+    Test that the appliesTo property fails validation when the input is incorrect.
+    """
+    # Arrange
+    testDataSymbol = testData.copy()
+    testDataSymbol["appliesTo"] = "1234a"
+
+    with pytest.raises(ValueError, match="appliesTo must be in the format of"):
+        CalibrationIndexEntry(**testDataSymbol)
+
+
+def test_appliesToInvalidSymbol():
+    """
+    Test that the appliesTo property fails validation when the symbol is invalid.
+    """
+    # Arrange
+    testDataSymbol = testData.copy()
+    testDataSymbol["appliesTo"] = "*1234"
+
+    with pytest.raises(ValueError, match="appliesTo must be in the format of"):
+        CalibrationIndexEntry(**testDataSymbol)


### PR DESCRIPTION
## Description of work

While the local data service supports the new symbols, the validator was missed.  
This pr adds a fix to the validator and tests to catch future changes.

## To test

Tests pass.  New symbols in the calibration index can be interpreted AND read.