### PR TITLE
Add fix to properly reset workflows, preventing bug caused by the int…

### DIFF
--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -61,6 +61,9 @@ class NormalizationService(Service):
 
     @FromString
     def normalization(self, request: NormalizationCalibrationRequest):
+        if not self._sameStates(request.runNumber, request.backgroundRunNumber):
+            raise ValueError("Run number and background run number must be of the same Instrument State.")
+
         groupingScheme = request.focusGroup.name
 
         # prepare ingredients
@@ -105,6 +108,9 @@ class NormalizationService(Service):
             self.groceryClerk.buildDict(),
         )
 
+        # NOTE: This used to point at other methods in this service to accomplish the same thing
+        #       It looks like it got reverted accidentally?
+        #       I'm leaving them as is but this should be fixed.
         # 1. correctiom
         RawVanadiumCorrectionRecipe().executeRecipe(
             InputWorkspace=groceries["inputWorkspace"],
@@ -133,6 +139,11 @@ class NormalizationService(Service):
             smoothedVanadium=smoothedVanadium,
             detectorPeaks=ingredients.detectorPeaks,
         ).dict()
+
+    def _sameStates(self, runnumber1, runnumber2):
+        stateId1 = self.dataFactoryService.constructStateId(runnumber1)
+        stateId2 = self.dataFactoryService.constructStateId(runnumber2)
+        return stateId1 == stateId2
 
     @FromString
     def normalizationAssessment(self, request: NormalizationCalibrationRequest):

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -46,7 +46,6 @@ class SousChef(Service):
         self.groceryClerk = GroceryListItem.builder()
         self.dataFactoryService = DataFactoryService()
         self._pixelGroupCache: Dict[Tuple[str, bool, str], PixelGroup] = {}
-        self._calibrationCache: Dict[str, Calibration] = {}
         self._peaksCache: Dict[Tuple[str, bool, str, float, float, float], List[GroupPeakList]] = {}
         self._xtalCache: Dict[Tuple[str, float, float], CrystallographicInfo] = {}
         return
@@ -56,9 +55,7 @@ class SousChef(Service):
         return "souschef"
 
     def prepCalibration(self, runNumber: str) -> Calibration:
-        if runNumber not in self._calibrationCache:
-            self._calibrationCache[runNumber] = self.dataFactoryService.getCalibrationState(runNumber)
-        return self._calibrationCache[runNumber]
+        return self.dataFactoryService.getCalibrationState(runNumber)
 
     def prepInstrumentState(self, runNumber: str) -> InstrumentState:
         return self.prepCalibration(runNumber).instrumentState

--- a/src/snapred/ui/presenter/WorkflowPresenter.py
+++ b/src/snapred/ui/presenter/WorkflowPresenter.py
@@ -54,6 +54,7 @@ class WorkflowPresenter(object):
     def resetAndClear(self):
         self.resetSoft()
         self.clearWorkspacesRequest()
+        self._iteration = 1
 
     def cancel(self):
         ActionPrompt(

--- a/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
+++ b/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
@@ -51,7 +51,7 @@ class DiffractionCalibrationCreationWorkflow(WorkflowImplementer):
         self._calibrationReductionView.runNumberField.editingFinished.connect(self._populateGroupingDropdown)
 
         self.workflow = (
-            WorkflowBuilder(cancelLambda=None, iterateLambda=self._iterate, parent=parent)
+            WorkflowBuilder(cancelLambda=self.resetWithPermission, iterateLambda=self._iterate, parent=parent)
             .addNode(
                 self._triggerCalibrationReduction,
                 self._calibrationReductionView,

--- a/src/snapred/ui/workflow/WorkflowImplementer.py
+++ b/src/snapred/ui/workflow/WorkflowImplementer.py
@@ -7,6 +7,8 @@ from snapred.backend.dao.request import (
 from snapred.backend.dao.SNAPResponse import SNAPResponse
 from snapred.backend.log.logger import snapredLogger
 from snapred.ui.view.IterateView import IterateView
+from snapred.ui.widget.ActionPrompt import ActionPrompt
+from snapred.ui.widget.Workflow import Workflow
 
 logger = snapredLogger.getLogger(__name__)
 
@@ -19,9 +21,8 @@ class WorkflowImplementer:
         self.collectiveOutputs = []
         self.interfaceController = InterfaceController()
         self.renameTemplate = "{workspaceName}_{iteration:02d}"
-
-        self._iterateView = IterateView(parent)
-        self.workflow = None
+        self.parent = parent
+        self.workflow: Workflow = None
 
     def _iterate(self, workflowPresenter):
         # rename output workspaces
@@ -41,9 +42,20 @@ class WorkflowImplementer:
         response = self.request(path="workspace/clear", payload=payload.json())
         return response
 
-    @property
-    def iterateStepTuple(self):
-        return (self._iterate, self._iterateView, "Go again?")
+    def reset(self):
+        self.workflow.presenter.resetAndClear()
+        self.requests = []
+        self.responses = []
+        self.outputs = []
+        self.collectiveOutputs = []
+
+    def resetWithPermission(self):
+        ActionPrompt(
+            "Are you sure?",
+            "Are you sure you want to cancel the workflow? This will clear all workspaces.",
+            self.reset,
+            self.workflow.widget,
+        )
 
     def request(self, path, payload=None):
         request = SNAPRequest(path=path, payload=payload)

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -34,7 +34,6 @@ class TestSousChef(unittest.TestCase):
 
     def test_prepCalibration_nocache(self):
         runNumber = self.ingredients.runNumber
-        assert self.instance._calibrationCache == {}
 
         mockCalibration = mock.Mock()
         self.instance.dataFactoryService.getCalibrationState = mock.Mock(return_value=mockCalibration)
@@ -43,17 +42,6 @@ class TestSousChef(unittest.TestCase):
 
         assert self.instance.dataFactoryService.getCalibrationState.called_once_with(runNumber)
         assert res == self.instance.dataFactoryService.getCalibrationState.return_value
-
-    def test_prepCalibration_cached(self):
-        key = self.ingredients.runNumber
-        # prepare the cache
-        self.instance._calibrationCache[key] = mock.Mock()
-
-        self.instance.dataFactoryService.getCalibrantSample = mock.Mock()
-        res = self.instance.prepCalibration(self.ingredients.runNumber)
-
-        assert not self.instance.dataFactoryService.getCalibrantSample.called
-        assert res == self.instance._calibrationCache[key]
 
     def test_prepInstrumentState(self):
         runNumber = "123"


### PR DESCRIPTION
…eraction between iterate and reset

removed cacheing from calibration metadata

## Description of work

NOTE:  This will doesnt really affect the NormalizationWorkflow as it operates via Recalculate

This PR Fixes:
* The interaction between iterations and resetting a workflow with the cancel button

This PR Removes:
* Caching of Calibration metadata

This PR adds:
* Validation to confirm background runs match state with runs submitted for Normalization


## To test

Testing may all occur through the UI.

1. Calibration Cache

Choose a run that hasnt been initialized yet (I've been using `46500`)  and attempt to calibrate.  
Then go to the normalization flow and click the initialize state button and initialize it.
Reattempt calibration, and see that it works and didnt cache a miss.

2. State Validation

Find any two run numbers from different states, attempt to use the NormalizationWorkflow on them. 
Maybe `46500` and one of our normal suspects( `46680` ?)

3. Iteraction/Cancel interaction
 
The easiest way I found to try and reproduce the issue from EWM4225 is to iterate calibration a couple times, cancel, and then try to run it again.  See that it doesnt die trying to delete a workspace that doesnt exist.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4225](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4225)
[EWM#4226](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4226)
[EWM#4227](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4227)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
