### PR TITLE
Added setting of appliesTo field in creation of IndexEntry objects

### DIFF
--- a/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
+++ b/src/snapred/ui/workflow/DiffractionCalibrationCreationWorkflow.py
@@ -155,6 +155,7 @@ class DiffractionCalibrationCreationWorkflow(WorkflowImplementer):
             runNumber=view.fieldRunNumber.get(),
             comments=view.fieldComments.get(),
             author=view.fieldAuthor.get(),
+            appliesTo=view.fieldAppliesTo.get(),
         )
 
         # if this is not the first iteration, account for choice.

--- a/src/snapred/ui/workflow/NormalizationCalibrationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationCalibrationWorkflow.py
@@ -189,6 +189,7 @@ class NormalizationCalibrationWorkflow(WorkflowImplementer):
             backgroundRunNumber=view.fieldBackgroundRunNumber.get(),
             comments=view.fieldComments.get(),
             author=view.fieldAuthor.get(),
+            appliesTo=view.fieldAppliesTo.get(),
         )
 
         payload = NormalizationExportRequest(


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->
AppliesTo field in IndexEntry objects was not being set. This work fixes that.
## Explanation of work
I added setting of appliesTo field in creation of IndexEntry objects, for both DiffCal and Normalization in their respective UI workflows.
<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing

Run DiffCal and Normalization. Go all the way to the save step and fill out the AppliesTo field. After clicking save, make sure that whatever you filled out in the GUI matches what's in the index file.

### CIS testing

See Dev testing.
## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4063](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4063)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
