### PR TITLE
this line was just defaulting to 0, replaced with line from neutrons …

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -5,7 +5,7 @@
 {% set url = data.get('url') %}
 # this will get the version set by environment variable
 {% set version = environ.get('VERSION') %}
-{% set version_number = environ.get('GIT_DESCRIBE_NUMBER', '0') | string %}
+{% set version_number = version.split('+')[0] %}
 
 package:
   name: snapred

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -6,6 +6,8 @@
 # this will get the version set by environment variable
 {% set version = environ.get('VERSION') %}
 {% set version_number = version.split('+')[0] %}
+# change the build number by hand if you want to rebuild the package
+{% set build_number = 0 %}
 
 package:
   name: snapred
@@ -19,7 +21,7 @@ source:
 build:
   noarch: python
   linux-64: python
-  number: {{ version_number }}
+  number: {{ build_number }}
   string: py{{py}}
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
 #  script: python setup.py install


### PR DESCRIPTION
…pyproject template repo
https://github.com/neutrons/python_project_template/blob/main/conda.recipe/meta.yaml


Check to see that builds pass and in the conda build step "Build conda libraray"  it no longer produces `snapred-0-py310.tar.bz2` but `snapred-{INSERT VERSION HERE}-py310.tar.bz2`