### PR TITLE
Adjust graph view row heights

### DIFF
--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -86,7 +86,7 @@ class DiffCalTweakPeakView(BackendRequestView):
         self.layout.addWidget(self.peakFunctionDropdown, 4, 2)
         self.layout.addWidget(self.recalculationButton, 5, 0, 1, 2)
 
-        self.layout.setRowStretch(1, 3)
+        self.layout.setRowStretch(2, 10)
 
         # store the initial layout without graphs
         self.initialLayoutHeight = self.size().height()

--- a/src/snapred/ui/view/NormalizationTweakPeakView.py
+++ b/src/snapred/ui/view/NormalizationTweakPeakView.py
@@ -92,7 +92,7 @@ class NormalizationTweakPeakView(BackendRequestView):
         self.layout.addWidget(self.groupingFileDropdown, 4, 1)
         self.layout.addWidget(self.recalculationButton, 5, 0, 1, 2)
 
-        self.layout.setRowStretch(1, 3)
+        self.layout.setRowStretch(1, 10)
 
         # store the initial layout without graphs
         self.initialLayoutHeight = self.size().height()


### PR DESCRIPTION
## Description of work

When Malcolm was testng in workbench, the view looked like this:
![image (7)](https://github.com/neutrons/SNAPRed/assets/52183986/f091c24b-c341-4bd3-92fe-7f89890efe3e)

We would like the canvas row to stretch and everything else remain the same height.

## Explanation of work

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

It seems the wrong row was given a row stretch factor.  It is now on the correct row for the canvas, and its stretch factor is much larger.

## To test

### Dev testing

<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing

<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

``` python
# replace with your test script below
```

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
