### PR TITLE
PixelGroupingParametersCalculation: optional 'MaskWorkspace' argument

### DIFF
--- a/src/snapred/backend/recipe/PixelGroupingParametersCalculationRecipe.py
+++ b/src/snapred/backend/recipe/PixelGroupingParametersCalculationRecipe.py
@@ -34,7 +34,9 @@ class PixelGroupingParametersCalculationRecipe:
 
         algo.setProperty("Ingredients", ingredients.json())
         algo.setProperty("GroupingWorkspace", groceries["groupingWorkspace"])
-        algo.setProperty("MaskWorkspace", groceries["maskWorkspace"])
+        
+        # MaskWorkspace: optional argument
+        algo.setProperty("MaskWorkspace", groceries.get("maskWorkspace", ""))
 
         try:
             data["result"] = algo.execute()

--- a/src/snapred/backend/recipe/PixelGroupingParametersCalculationRecipe.py
+++ b/src/snapred/backend/recipe/PixelGroupingParametersCalculationRecipe.py
@@ -34,7 +34,7 @@ class PixelGroupingParametersCalculationRecipe:
 
         algo.setProperty("Ingredients", ingredients.json())
         algo.setProperty("GroupingWorkspace", groceries["groupingWorkspace"])
-        
+
         # MaskWorkspace: optional argument
         algo.setProperty("MaskWorkspace", groceries.get("maskWorkspace", ""))
 

--- a/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
@@ -87,7 +87,7 @@ class PixelGroupingParametersCalculationAlgorithm(PythonAlgorithm):
             InputWorkspace=self.groupingWorkspaceName,
             OutputWorkspace=tmpGroupingWSName,
         )
-        
+
         # If the optional mask workspace is present, apply it to the grouping workspace:
         if self.maskWorkspaceName:
             self.mantidSnapper.MaskDetectorFlags(

--- a/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
@@ -43,7 +43,7 @@ class PixelGroupingParametersCalculationAlgorithm(PythonAlgorithm):
             + "with instrument-location parameters initialized according to the run number",
         )
         self.declareProperty(
-            MaskWorkspaceProperty("MaskWorkspace", "", Direction.Input, PropertyMode.Mandatory),
+            MaskWorkspaceProperty("MaskWorkspace", "", Direction.Input, PropertyMode.Optional),
             doc="The mask workspace for a specified calibration run number and version",
         )
         self.declareProperty(
@@ -87,11 +87,14 @@ class PixelGroupingParametersCalculationAlgorithm(PythonAlgorithm):
             InputWorkspace=self.groupingWorkspaceName,
             OutputWorkspace=tmpGroupingWSName,
         )
-        self.mantidSnapper.MaskDetectorFlags(
-            "Setting grouping workspace mask flags",
-            MaskWorkspace=self.maskWorkspaceName,
-            OutputWorkspace=tmpGroupingWSName,
-        )
+        
+        # If the optional mask workspace is present, apply it to the grouping workspace:
+        if self.maskWorkspaceName:
+            self.mantidSnapper.MaskDetectorFlags(
+                "Setting grouping workspace mask flags",
+                MaskWorkspace=self.maskWorkspaceName,
+                OutputWorkspace=tmpGroupingWSName,
+            )
         self.mantidSnapper.executeQueue()
 
         # Create a grouped-by-detector workspace from the grouping workspace

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -75,15 +75,14 @@ class SousChef(Service):
                 instrumentState=instrumentState,
                 nBinsAcrossPeakWidth=ingredients.nBinsAcrossPeakWidth,
             )
-            getGrouping = (
-                self.groceryClerk.fromRun(ingredients.runNumber)
-                .grouping(ingredients.focusGroup.name)
-                .useLiteMode(ingredients.useLiteMode)
-                .source(InstrumentFilename=self._getInstrumentDefinitionFilename(ingredients.useLiteMode))
-                .buildList()
-            )
-            groupingWS = self.groceryService.fetchGroceryList(getGrouping)[0]
-            data = PixelGroupingParametersCalculationRecipe().executeRecipe(pixelIngredients, groupingWS)
+            self.groceryClerk.name("groupingWorkspace")\
+            .fromRun(ingredients.runNumber)\
+            .grouping(ingredients.focusGroup.name)\
+            .useLiteMode(ingredients.useLiteMode)\
+            .add()
+            groceries = self.groceryService.fetchGroceryDict(self.groceryClerk.buildDict())
+            data = PixelGroupingParametersCalculationRecipe().executeRecipe(pixelIngredients, groceries)
+            
             self._pixelGroupCache[key] = PixelGroup(
                 focusGroup=ingredients.focusGroup,
                 pixelGroupingParameters=data["parameters"],

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -75,14 +75,12 @@ class SousChef(Service):
                 instrumentState=instrumentState,
                 nBinsAcrossPeakWidth=ingredients.nBinsAcrossPeakWidth,
             )
-            self.groceryClerk.name("groupingWorkspace")\
-            .fromRun(ingredients.runNumber)\
-            .grouping(ingredients.focusGroup.name)\
-            .useLiteMode(ingredients.useLiteMode)\
-            .add()
+            self.groceryClerk.name("groupingWorkspace").fromRun(ingredients.runNumber).grouping(
+                ingredients.focusGroup.name
+            ).useLiteMode(ingredients.useLiteMode).add()
             groceries = self.groceryService.fetchGroceryDict(self.groceryClerk.buildDict())
             data = PixelGroupingParametersCalculationRecipe().executeRecipe(pixelIngredients, groceries)
-            
+
             self._pixelGroupCache[key] = PixelGroup(
                 focusGroup=ingredients.focusGroup,
                 pixelGroupingParameters=data["parameters"],


### PR DESCRIPTION
  * These changes allow the 'MaskWorkspace' argument of 'PixelGroupingParametersCalculationAlgorithm' to be optional;

  * A mask workspace needs to be provided to the calculation on a case-by-case basis; for example, some workflows require a mask workspace, but others, such as an initial normalization workflow, may not;

  * For applicable workflows, when it isn't sufficient to use the _latest_ calibration data: a 'MaskWorkspace' selection dropdown may need to be implemented in the GUI panels.


[EWM#4342](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=4342)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
