### PR TITLE
forward a lambda to let workflows reset their implementors

### DIFF
--- a/src/snapred/ui/presenter/WorkflowPresenter.py
+++ b/src/snapred/ui/presenter/WorkflowPresenter.py
@@ -25,6 +25,7 @@ class WorkflowPresenter(object):
         self.model = model
         self._cancelLambda = cancelLambda
         self._iterateLambda = iterateLambda
+        self.resetLambda = self.resetAndClear
         self._hookupSignals()
 
     @property
@@ -111,9 +112,12 @@ class WorkflowPresenter(object):
                 lambda: None,
                 self.view,
             )
-            self.resetAndClear()
+            self.resetLambda()
         else:
             self.view.advanceWorkflow()
+
+    def setResetLambda(self, resetLambda):
+        self.resetLambda = resetLambda
 
     def handleContinueButtonClicked(self, model):
         self.view.continueButton.setEnabled(False)

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -87,6 +87,7 @@ class DiffCalWorkflow(WorkflowImplementer):
             .addNode(self._saveCalibration, self._saveView, name="Saving")
             .build()
         )
+        self.workflow.presenter.setResetLambda(self.reset)
 
     def _populateGroupingDropdown(self):
         # when the run number is updated, freeze the drop down to populate it

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -73,6 +73,7 @@ class NormalizationWorkflow(WorkflowImplementer):
             .addNode(self._saveNormalizationCalibration, self._saveView, "Saving")
             .build()
         )
+        self.workflow.presenter.setResetLambda(self.reset)
 
     @EntryExitLogger(logger=logger)
     def _populateGroupingDropdown(self):


### PR DESCRIPTION
## Description of work

Merge this after PR#267 otherwise you wont be able to test this.

This resets the full state of a workflow upon completion, thus preventing the errant missing metrics bug. 
This bug is typically cause by an old workspace name being stored in the expected outputs after a workflow has been reset in some form.

## To test

Run diffraction calibration to completion (`46680`, Diamond, Col)
Run it again but this time try to iterate.
It should iterate without error.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
