### PR TITLE
fixed bug introduced in a rebase that prevented current iteration fro…

### DIFF
--- a/src/snapred/ui/threading/worker_pool.py
+++ b/src/snapred/ui/threading/worker_pool.py
@@ -25,14 +25,13 @@ class Worker(QObject):
     def run(self):
         """Long-running task."""
         try:
-            results = self.target(self.args)
+            if self.args is not None:
+                results = self.target(self.args)
+            else:
+                results = self.target()
             # results.code = 200 # set to 200 for testing
-            self.result.emit(results)
-            self.success.emit(results.code < ResponseCode.MAX_OK)
         except RecoverableException as e:
             results = SNAPResponse(code=ResponseCode.RECOVERABLE, message=e.errorMsg)
-            self.result.emit(results)
-            self.success.emit(False)
         except Exception as e:  # noqa: BLE001
             # print stacktrace
             import traceback
@@ -41,9 +40,8 @@ class Worker(QObject):
             traceback.print_exc()
 
             results = SNAPResponse(code=ResponseCode.ERROR, message=str(e))
-
-            self.result.emit(results)
-            self.success.emit(False)
+        self.result.emit(results)
+        self.success.emit(results.code < ResponseCode.MAX_OK)
         self.finished.emit()
 
 

--- a/src/snapred/ui/view/BackendRequestView.py
+++ b/src/snapred/ui/view/BackendRequestView.py
@@ -33,3 +33,6 @@ class BackendRequestView(QWidget):
 
     def _sampleDropDown(self, label, items=[]):
         return SampleDropDown(label, items, self)
+
+    def verify(self):
+        raise NotImplementedError("The verification for this step was not completed.")

--- a/src/snapred/ui/view/DiffCalAssessmentView.py
+++ b/src/snapred/ui/view/DiffCalAssessmentView.py
@@ -10,6 +10,7 @@ from snapred.ui.widget.JsonFormList import JsonFormList
 from snapred.ui.widget.LabeledField import LabeledField
 
 
+# TODO rebase on BackendRequestView
 @Resettable
 class DiffCalAssessmentView(QWidget):
     signalRunNumberUpdate = pyqtSignal(str)
@@ -82,3 +83,7 @@ class DiffCalAssessmentView(QWidget):
 
     def updateRunNumber(self, runNumber):
         self.signalRunNumberUpdate.emit(runNumber)
+
+    def verify(self):
+        # TODO vwhat fields need to be verified?
+        return True

--- a/src/snapred/ui/view/DiffCalRequestView.py
+++ b/src/snapred/ui/view/DiffCalRequestView.py
@@ -1,6 +1,3 @@
-from PyQt5.QtCore import pyqtSignal
-from qtpy.QtWidgets import QComboBox, QLineEdit
-
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
 from snapred.ui.view.BackendRequestView import BackendRequestView
@@ -10,22 +7,25 @@ from snapred.ui.widget.Toggle import Toggle
 @Resettable
 class DiffCalRequestView(BackendRequestView):
     def __init__(self, jsonForm, samples=[], groups=[], parent=None):
-        selection = "calibration/diffractionCalibration"
-        super().__init__(jsonForm, selection, parent=parent)
+        super().__init__(jsonForm, "", parent=parent)
 
+        # input fields
         self.runNumberField = self._labeledField("Run Number")
         self.litemodeToggle = self._labeledField("Lite Mode", Toggle(parent=self, state=True))
         self.fieldConvergenceThreshold = self._labeledField("Convergence Threshold")
         self.fieldPeakIntensityThreshold = self._labeledField("Peak Intensity Threshold")
-
         self.fieldNBinsAcrossPeakWidth = self._labeledField("Bins Across Peak Width")
+
+        # drop downs
         self.sampleDropdown = self._sampleDropDown("Sample", samples)
         self.groupingFileDropdown = self._sampleDropDown("Grouping File", groups)
         self.peakFunctionDropdown = self._sampleDropDown("Peak Function", [p.value for p in SymmetricPeakEnum])
 
+        # set field properties
         self.litemodeToggle.setEnabled(True)
         self.peakFunctionDropdown.setCurrentIndex(0)
 
+        # add all widgets to layout
         self.layout.addWidget(self.runNumberField, 0, 0)
         self.layout.addWidget(self.litemodeToggle, 0, 1)
         self.layout.addWidget(self.fieldConvergenceThreshold, 1, 0)
@@ -39,12 +39,12 @@ class DiffCalRequestView(BackendRequestView):
         self.groupingFileDropdown.setItems(groups)
 
     def verify(self):
+        if not self.runNumberField.text().isdigit():
+            raise ValueError("Please enter a valid run number")
         if self.sampleDropdown.currentIndex() < 0:
             raise ValueError("Please select a sample")
         if self.groupingFileDropdown.currentIndex() < 0:
             raise ValueError("Please select a grouping file")
-        if self.groupingFileDropdown.currentIndex() < 0:
-            raise ValueError("You must enter a run number to select a grouping defintion")
         if self.peakFunctionDropdown.currentIndex() < 0:
             raise ValueError("Please select a peak function")
         return True

--- a/src/snapred/ui/view/DiffCalSaveView.py
+++ b/src/snapred/ui/view/DiffCalSaveView.py
@@ -2,10 +2,10 @@ from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QComboBox, QGridLayout, QLabel, QLineEdit, QWidget
 
 from snapred.meta.decorators.Resettable import Resettable
-from snapred.ui.widget.JsonFormList import JsonFormList
 from snapred.ui.widget.LabeledField import LabeledField
 
 
+# TODO rebase on BackendRequestView
 @Resettable
 class DiffCalSaveView(QWidget):
     signalRunNumberUpdate = pyqtSignal(str)
@@ -63,3 +63,10 @@ class DiffCalSaveView(QWidget):
     def setIterationDropdown(self, iterations):
         self.iterationDropdown.clear()
         self.iterationDropdown.addItems(iterations)
+
+    def verify(self):
+        if self.fieldAuthor.text() == "":
+            raise ValueError("You must specify the author")
+        if self.fieldComments.text() == "":
+            raise ValueError("You must add comments")
+        return True

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -8,13 +8,10 @@ from mantid.simpleapi import mtd
 from pydantic import parse_obj_as
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
-    QComboBox,
-    QGridLayout,
     QHBoxLayout,
     QLineEdit,
     QMessageBox,
     QPushButton,
-    QWidget,
 )
 from workbench.plotting.figuremanager import FigureManagerWorkbench, MantidFigureCanvas
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
@@ -24,8 +21,6 @@ from snapred.meta.Config import Config
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
 from snapred.ui.view.BackendRequestView import BackendRequestView
-from snapred.ui.widget.JsonFormList import JsonFormList
-from snapred.ui.widget.LabeledField import LabeledField
 from snapred.ui.widget.Toggle import Toggle
 
 
@@ -99,18 +94,27 @@ class DiffCalTweakPeakView(BackendRequestView):
     def updateRunNumber(self, runNumber):
         self.signalRunNumberUpdate.emit(runNumber)
 
-    def updateFields(self, runNumber, sampleIndex, groupingIndex, peakIndex):  # noqa ARG002
-        # NOTE uncommenting the below -- inexplicably -- causes a segfault
-        # self.runNumberField.setText(runNumber)
+    def updateFields(self, sampleIndex, groupingIndex, peakIndex):
         self.sampleDropdown.setCurrentIndex(sampleIndex)
         self.groupingFileDropdown.setCurrentIndex(groupingIndex)
         self.peakFunctionDropdown.setCurrentIndex(peakIndex)
 
     def emitValueChange(self):
-        groupingIndex = self.groupingFileDropdown.currentIndex()
-        dMin = float(self.fielddMin.field.text())
-        dMax = float(self.fielddMax.field.text())
-        peakThreshold = float(self.fieldThreshold.text())
+        # verify the fields before recalculation
+        try:
+            groupingIndex = self.groupingFileDropdown.currentIndex()
+            dMin = float(self.fielddMin.field.text())
+            dMax = float(self.fielddMax.field.text())
+            peakThreshold = float(self.fieldThreshold.text())
+        except ValueError as e:
+            QMessageBox.warning(
+                self,
+                "Invalid Peak Parameters",
+                f"One of dMin, dMax, or peak threshold is invalid: {str(e)}",
+                QMessageBox.Ok,
+            )
+            return
+        # perform some checks on dMin, dMax values
         if dMin < 0.1:
             response = QMessageBox.warning(
                 self,
@@ -187,10 +191,9 @@ class DiffCalTweakPeakView(BackendRequestView):
     def verify(self):
         empties = [gpl for gpl in self.peaks if len(gpl.peaks) < 4]
         if len(empties) > 0:
-            raise ValueError(
-                "Proper calibration requires at least 4 peaks per group.  "
-                + f"Groups {[empty.groupID for empty in empties]} have "
-                + f"{[len(empty.peaks) for empty in empties]} peaks.  "
-                + "Adjust grouping, dMin, dMax, and peak intensity threshold to include more peaks."
-            )
+            msg = "Proper calibration requires at least 4 peaks per group.\n"
+            for empty in empties:
+                msg = msg + f"\tgroup {empty.groupID} has \t {len(empty.peaks)} peaks\n"
+            msg = msg + "Adjust grouping, dMin, dMax, and peak intensity threshold to include more peaks."
+            raise ValueError(msg)
         return True

--- a/src/snapred/ui/view/NormalizationRequestView.py
+++ b/src/snapred/ui/view/NormalizationRequestView.py
@@ -6,22 +6,26 @@ from snapred.ui.widget.Toggle import Toggle
 @Resettable
 class NormalizationRequestView(BackendRequestView):
     def __init__(self, jsonForm, samplePaths=[], groups=[], parent=None):
-        selection = "calibration/diffractionCalibration"
-        super(NormalizationRequestView, self).__init__(jsonForm, selection, parent=parent)
+        super(NormalizationRequestView, self).__init__(jsonForm, "", parent=parent)
+
+        # input fields
         self.runNumberField = self._labeledField("Run Number:", jsonForm.getField("runNumber"))
         self.litemodeToggle = self._labeledField("Lite Mode", Toggle(parent=self, state=True))
         self.backgroundRunNumberField = self._labeledField(
             "Background Run Number:", jsonForm.getField("backgroundRunNumber")
         )
 
-        self.litemodeToggle.setEnabled(False)
-        self.layout.addWidget(self.runNumberField, 0, 0)
-        self.layout.addWidget(self.litemodeToggle, 0, 1)
-        self.layout.addWidget(self.backgroundRunNumberField, 1, 0)
-
+        # drop downs
         self.sampleDropdown = self._sampleDropDown("Select Sample", samplePaths)
         self.groupingFileDropdown = self._sampleDropDown("Select Grouping File", groups)
 
+        # set field properties
+        self.litemodeToggle.setEnabled(False)
+
+        # add all widgets to layout
+        self.layout.addWidget(self.runNumberField, 0, 0)
+        self.layout.addWidget(self.litemodeToggle, 0, 1)
+        self.layout.addWidget(self.backgroundRunNumberField, 1, 0)
         self.layout.addWidget(self.sampleDropdown, 2, 0)
         self.layout.addWidget(self.groupingFileDropdown, 2, 1)
 
@@ -29,16 +33,14 @@ class NormalizationRequestView(BackendRequestView):
         self.groupingFileDropdown.setItems(groups)
 
     def verify(self):
+        if not self.runNumberField.text().isdigit():
+            raise ValueError("Please enter a valid run number")
+        if not self.backgroundRunNumberField.text().isdigit():
+            raise ValueError("Please enter a valid background run number")
         if self.sampleDropdown.currentIndex() < 0:
             raise ValueError("Please select a sample")
         if self.groupingFileDropdown.currentIndex() < 0:
             raise ValueError("Please select a grouping file")
-        if self.groupingFileDropdown.currentIndex() < 0:
-            raise ValueError("You must enter a run number to select a grouping defintion")
-        if self.runNumberField.text() == "":
-            raise ValueError("Please enter a run number")
-        if self.backgroundRunNumberField.text() == "":
-            raise ValueError("Please enter a background run number")
         return True
 
     def getRunNumber(self):

--- a/src/snapred/ui/view/NormalizationSaveView.py
+++ b/src/snapred/ui/view/NormalizationSaveView.py
@@ -6,6 +6,7 @@ from snapred.ui.widget.JsonFormList import JsonFormList
 from snapred.ui.widget.LabeledField import LabeledField
 
 
+# TODO rebase on BackendRequestView
 @Resettable
 class NormalizationSaveView(QWidget):
     signalRunNumberUpdate = pyqtSignal(str)
@@ -75,3 +76,10 @@ class NormalizationSaveView(QWidget):
 
     def updateBackgroundRunNumber(self, backgroundRunNumber):
         self.signalBackgroundRunNumberUpdate.emit(backgroundRunNumber)
+
+    def verify(self):
+        if self.fieldAuthor.text() == "":
+            raise ValueError("You must specify the author")
+        if self.fieldComments.text() == "":
+            raise ValueError("You must add comments")
+        return True

--- a/src/snapred/ui/view/NormalizationTweakPeakView.py
+++ b/src/snapred/ui/view/NormalizationTweakPeakView.py
@@ -7,16 +7,10 @@ from mantid.simpleapi import mtd
 from pydantic import parse_obj_as
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
-    QComboBox,
-    QGridLayout,
     QHBoxLayout,
-    QLabel,
     QLineEdit,
     QMessageBox,
     QPushButton,
-    QSlider,
-    QVBoxLayout,
-    QWidget,
 )
 from workbench.plotting.figuremanager import FigureManagerWorkbench, MantidFigureCanvas
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
@@ -25,7 +19,6 @@ from snapred.backend.dao import GroupPeakList
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.view.BackendRequestView import BackendRequestView
-from snapred.ui.widget.JsonFormList import JsonFormList
 from snapred.ui.widget.SmoothingSlider import SmoothingSlider
 from snapred.ui.widget.Toggle import Toggle
 
@@ -122,11 +115,22 @@ class NormalizationTweakPeakView(BackendRequestView):
         self.signalUpdateFields.emit(sampleIndex, groupingIndex, smoothingParameter)
 
     def emitValueChange(self):
-        index = self.groupingFileDropdown.currentIndex()
-        smoothingValue = self.smoothingSlider.field.value()
-        dMin = float(self.fielddMin.field.text())
-        dMax = float(self.fielddMax.field.text())
-        peakThreshold = float(self.fieldThreshold.text())
+        # verify the fields before recalculation
+        try:
+            index = self.groupingFileDropdown.currentIndex()
+            smoothingValue = self.smoothingSlider.field.value()
+            dMin = float(self.fielddMin.field.text())
+            dMax = float(self.fielddMax.field.text())
+            peakThreshold = float(self.fieldThreshold.text())
+        except ValueError as e:
+            QMessageBox.warning(
+                self,
+                "Invalid Peak Parameters",
+                f"One of dMin, dMax, smoothing, or peak threshold is invalid: {str(e)}",
+                QMessageBox.Ok,
+            )
+            return
+        # perform some checks on dMin, dMax values
         if dMin < 0.1:
             response = QMessageBox.warning(
                 self,
@@ -212,3 +216,7 @@ class NormalizationTweakPeakView(BackendRequestView):
 
     def populateGroupingDropdown(self, groups=["Enter a Run Number"]):
         self.signalPopulateGroupingDropdown.emit(groups)
+
+    def verify(self):
+        # TODO what needs to be verified?
+        return True

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -121,8 +121,6 @@ class DiffCalWorkflow(WorkflowImplementer):
 
     def _specifyRun(self, workflowPresenter):
         view = workflowPresenter.widget.tabView
-        # pull fields from view
-        self.verifyForm(view)
 
         # fetch the data from the view
         self.runNumber = view.runNumberField.text()
@@ -141,7 +139,6 @@ class DiffCalWorkflow(WorkflowImplementer):
 
         self._tweakPeakView.populateGroupingDropdown(list(self.groupingMap.getMap(self.useLiteMode).keys()))
         self._tweakPeakView.updateFields(
-            self.runNumber,
             view.sampleDropdown.currentIndex(),
             view.groupingFileDropdown.currentIndex(),
             view.peakFunctionDropdown.currentIndex(),
@@ -245,8 +242,6 @@ class DiffCalWorkflow(WorkflowImplementer):
 
     def _triggerDiffractionCalibration(self, workflowPresenter):
         view = workflowPresenter.widget.tabView
-        # pull fields from view for diffraction calibration
-        self.verifyForm(view)
 
         self.runNumber = view.runNumberField.text()
         self._saveView.updateRunNumber(self.runNumber)

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -111,7 +111,6 @@ class NormalizationWorkflow(WorkflowImplementer):
     def _triggerNormalizationCalibration(self, workflowPresenter):
         view = workflowPresenter.widget.tabView
         # pull fields from view for normalization
-        self.verifyForm(view)
 
         self.runNumber = view.getFieldText("runNumber")
         self.backgroundRunNumber = view.getFieldText("backgroundRunNumber")

--- a/src/snapred/ui/workflow/WorkflowImplementer.py
+++ b/src/snapred/ui/workflow/WorkflowImplementer.py
@@ -67,11 +67,8 @@ class WorkflowImplementer:
         return response
 
     def verifyForm(self, form):
-        try:
-            form.verify()
-            return True
-        except ValueError as e:
-            return SNAPResponse(code=ResponseCode.ERROR, message=f"Missing Fields!{e}")
+        form.verify()
+        return True
 
     def _handleComplications(self, result):
         if result.code >= ResponseCode.ERROR:

--- a/tests/unit/ui/widget/test_Workflow.py
+++ b/tests/unit/ui/widget/test_Workflow.py
@@ -25,6 +25,9 @@ class _TestView(QWidget):
     def handleContinueButtonClicked(self):
         pass
 
+    def verify(self):
+        return True
+
 
 def _generateWorkflow():
     # Create a mock WorkflowNodeModel


### PR DESCRIPTION
…m being saved correctly

## Description of work

It looks like during a refactor or rebase the special logic for the 0th entry of the iteration got lost(they dont contain an index in their name unlike the others)
Thus when you want to select current it would incorrectly append the index 00 to the end of the names, and find nothing.


## To test

run out of local copy of Calibration folder
Do a calibration(57474, diamond, all)
iterate
attempt to save current
Observe new label, where current iteration is called current and other iterations are indexes.
save 
workflow exits successfully.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4225](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4225)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
