### PR TITLE
fix error handling for invalid fields

### DIFF
--- a/src/snapred/ui/threading/worker_pool.py
+++ b/src/snapred/ui/threading/worker_pool.py
@@ -30,12 +30,8 @@ class Worker(QObject):
             else:
                 results = self.target()
             # results.code = 200 # set to 200 for testing
-            self.result.emit(results)
-            self.success.emit(results.code < ResponseCode.MAX_OK)
         except RecoverableException as e:
             results = SNAPResponse(code=ResponseCode.RECOVERABLE, message=e.errorMsg)
-            self.result.emit(results)
-            self.success.emit(False)
         except Exception as e:  # noqa: BLE001
             # print stacktrace
             import traceback
@@ -44,9 +40,8 @@ class Worker(QObject):
             traceback.print_exc()
 
             results = SNAPResponse(code=ResponseCode.ERROR, message=str(e))
-
-            self.result.emit(results)
-            self.success.emit(False)
+        self.result.emit(results)
+        self.success.emit(results.code < ResponseCode.MAX_OK)
         self.finished.emit()
 
 

--- a/src/snapred/ui/threading/worker_pool.py
+++ b/src/snapred/ui/threading/worker_pool.py
@@ -25,7 +25,10 @@ class Worker(QObject):
     def run(self):
         """Long-running task."""
         try:
-            results = self.target(self.args)
+            if self.args is not None:
+                results = self.target(self.args)
+            else:
+                results = self.target()
             # results.code = 200 # set to 200 for testing
             self.result.emit(results)
             self.success.emit(results.code < ResponseCode.MAX_OK)

--- a/src/snapred/ui/view/BackendRequestView.py
+++ b/src/snapred/ui/view/BackendRequestView.py
@@ -33,3 +33,6 @@ class BackendRequestView(QWidget):
 
     def _sampleDropDown(self, label, items=[]):
         return SampleDropDown(label, items, self)
+
+    def verify(self):
+        raise NotImplementedError("The verification for this step was not completed.")

--- a/src/snapred/ui/view/DiffCalAssessmentView.py
+++ b/src/snapred/ui/view/DiffCalAssessmentView.py
@@ -11,6 +11,7 @@ from snapred.ui.widget.JsonFormList import JsonFormList
 from snapred.ui.widget.LabeledField import LabeledField
 
 
+# TODO rebase on BackendRequestView
 @Resettable
 class DiffCalAssessmentView(QWidget):
     signalRunNumberUpdate = pyqtSignal(str)
@@ -85,5 +86,5 @@ class DiffCalAssessmentView(QWidget):
         self.signalRunNumberUpdate.emit(runNumber)
 
     def verify(self):
-        # TODO verify
+        # TODO vwhat fields need to be verified?
         return SNAPResponse(code=ResponseCode.OK, data=True)

--- a/src/snapred/ui/view/DiffCalAssessmentView.py
+++ b/src/snapred/ui/view/DiffCalAssessmentView.py
@@ -4,6 +4,7 @@ from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QComboBox, QGridLayout, QLabel, QMessageBox, QPushButton, QWidget
 
 from snapred.backend.dao.calibration import CalibrationIndexEntry
+from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.presenter.CalibrationAssessmentPresenter import CalibrationAssessmentPresenter
 from snapred.ui.widget.JsonFormList import JsonFormList
@@ -82,3 +83,7 @@ class DiffCalAssessmentView(QWidget):
 
     def updateRunNumber(self, runNumber):
         self.signalRunNumberUpdate.emit(runNumber)
+
+    def verify(self):
+        # TODO verify
+        return SNAPResponse(code=ResponseCode.OK, data=True)

--- a/src/snapred/ui/view/DiffCalAssessmentView.py
+++ b/src/snapred/ui/view/DiffCalAssessmentView.py
@@ -87,4 +87,4 @@ class DiffCalAssessmentView(QWidget):
 
     def verify(self):
         # TODO vwhat fields need to be verified?
-        return SNAPResponse(code=ResponseCode.OK, data=True)
+        return True

--- a/src/snapred/ui/view/DiffCalAssessmentView.py
+++ b/src/snapred/ui/view/DiffCalAssessmentView.py
@@ -4,7 +4,6 @@ from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QComboBox, QGridLayout, QLabel, QMessageBox, QPushButton, QWidget
 
 from snapred.backend.dao.calibration import CalibrationIndexEntry
-from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.presenter.CalibrationAssessmentPresenter import CalibrationAssessmentPresenter
 from snapred.ui.widget.JsonFormList import JsonFormList

--- a/src/snapred/ui/view/DiffCalRequestView.py
+++ b/src/snapred/ui/view/DiffCalRequestView.py
@@ -1,6 +1,7 @@
 from PyQt5.QtCore import pyqtSignal
 from qtpy.QtWidgets import QComboBox, QLineEdit
 
+from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
 from snapred.ui.view.BackendRequestView import BackendRequestView
@@ -39,6 +40,8 @@ class DiffCalRequestView(BackendRequestView):
         self.groupingFileDropdown.setItems(groups)
 
     def verify(self):
+        if not self.runNumberField.text().isdigit():
+            raise ValueError("Please enter a valid run number")
         if self.sampleDropdown.currentIndex() < 0:
             raise ValueError("Please select a sample")
         if self.groupingFileDropdown.currentIndex() < 0:
@@ -47,7 +50,7 @@ class DiffCalRequestView(BackendRequestView):
             raise ValueError("You must enter a run number to select a grouping defintion")
         if self.peakFunctionDropdown.currentIndex() < 0:
             raise ValueError("Please select a peak function")
-        return True
+        return SNAPResponse(code=ResponseCode.OK, data=True)
 
     def getRunNumber(self):
         return self.runNumberField.text()

--- a/src/snapred/ui/view/DiffCalRequestView.py
+++ b/src/snapred/ui/view/DiffCalRequestView.py
@@ -1,6 +1,3 @@
-from PyQt5.QtCore import pyqtSignal
-from qtpy.QtWidgets import QComboBox, QLineEdit
-
 from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
@@ -11,22 +8,25 @@ from snapred.ui.widget.Toggle import Toggle
 @Resettable
 class DiffCalRequestView(BackendRequestView):
     def __init__(self, jsonForm, samples=[], groups=[], parent=None):
-        selection = "calibration/diffractionCalibration"
-        super().__init__(jsonForm, selection, parent=parent)
+        super().__init__(jsonForm, "", parent=parent)
 
+        # input fields
         self.runNumberField = self._labeledField("Run Number")
         self.litemodeToggle = self._labeledField("Lite Mode", Toggle(parent=self, state=True))
         self.fieldConvergenceThreshold = self._labeledField("Convergence Threshold")
         self.fieldPeakIntensityThreshold = self._labeledField("Peak Intensity Threshold")
-
         self.fieldNBinsAcrossPeakWidth = self._labeledField("Bins Across Peak Width")
+
+        # drop downs
         self.sampleDropdown = self._sampleDropDown("Sample", samples)
         self.groupingFileDropdown = self._sampleDropDown("Grouping File", groups)
         self.peakFunctionDropdown = self._sampleDropDown("Peak Function", [p.value for p in SymmetricPeakEnum])
 
+        # set field properties
         self.litemodeToggle.setEnabled(True)
         self.peakFunctionDropdown.setCurrentIndex(0)
 
+        # add all widgets to layout
         self.layout.addWidget(self.runNumberField, 0, 0)
         self.layout.addWidget(self.litemodeToggle, 0, 1)
         self.layout.addWidget(self.fieldConvergenceThreshold, 1, 0)
@@ -46,8 +46,6 @@ class DiffCalRequestView(BackendRequestView):
             raise ValueError("Please select a sample")
         if self.groupingFileDropdown.currentIndex() < 0:
             raise ValueError("Please select a grouping file")
-        if self.groupingFileDropdown.currentIndex() < 0:
-            raise ValueError("You must enter a run number to select a grouping defintion")
         if self.peakFunctionDropdown.currentIndex() < 0:
             raise ValueError("Please select a peak function")
         return SNAPResponse(code=ResponseCode.OK, data=True)

--- a/src/snapred/ui/view/DiffCalRequestView.py
+++ b/src/snapred/ui/view/DiffCalRequestView.py
@@ -1,4 +1,3 @@
-from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
 from snapred.ui.view.BackendRequestView import BackendRequestView
@@ -48,7 +47,7 @@ class DiffCalRequestView(BackendRequestView):
             raise ValueError("Please select a grouping file")
         if self.peakFunctionDropdown.currentIndex() < 0:
             raise ValueError("Please select a peak function")
-        return SNAPResponse(code=ResponseCode.OK, data=True)
+        return True
 
     def getRunNumber(self):
         return self.runNumberField.text()

--- a/src/snapred/ui/view/DiffCalSaveView.py
+++ b/src/snapred/ui/view/DiffCalSaveView.py
@@ -1,9 +1,7 @@
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QComboBox, QGridLayout, QLabel, QLineEdit, QWidget
 
-from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.meta.decorators.Resettable import Resettable
-from snapred.ui.widget.JsonFormList import JsonFormList
 from snapred.ui.widget.LabeledField import LabeledField
 
 
@@ -71,4 +69,4 @@ class DiffCalSaveView(QWidget):
             raise ValueError("You must specify the author")
         if self.fieldComments.text() == "":
             raise ValueError("You must add comments")
-        return SNAPResponse(code=ResponseCode.OK, data=True)
+        return True

--- a/src/snapred/ui/view/DiffCalSaveView.py
+++ b/src/snapred/ui/view/DiffCalSaveView.py
@@ -1,6 +1,7 @@
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QComboBox, QGridLayout, QLabel, QLineEdit, QWidget
 
+from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.widget.JsonFormList import JsonFormList
 from snapred.ui.widget.LabeledField import LabeledField
@@ -63,3 +64,10 @@ class DiffCalSaveView(QWidget):
     def setIterationDropdown(self, iterations):
         self.iterationDropdown.clear()
         self.iterationDropdown.addItems(iterations)
+
+    def verify(self):
+        if self.fieldAuthor.text() == "":
+            raise ValueError("You must specify the author")
+        if self.fieldComments.text() == "":
+            raise ValueError("You must add comments")
+        return SNAPResponse(code=ResponseCode.OK, data=True)

--- a/src/snapred/ui/view/DiffCalSaveView.py
+++ b/src/snapred/ui/view/DiffCalSaveView.py
@@ -7,6 +7,7 @@ from snapred.ui.widget.JsonFormList import JsonFormList
 from snapred.ui.widget.LabeledField import LabeledField
 
 
+# TODO rebase on BackendRequestView
 @Resettable
 class DiffCalSaveView(QWidget):
     signalRunNumberUpdate = pyqtSignal(str)

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -8,13 +8,10 @@ from mantid.simpleapi import mtd
 from pydantic import parse_obj_as
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
-    QComboBox,
-    QGridLayout,
     QHBoxLayout,
     QLineEdit,
     QMessageBox,
     QPushButton,
-    QWidget,
 )
 from workbench.plotting.figuremanager import FigureManagerWorkbench, MantidFigureCanvas
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
@@ -25,8 +22,6 @@ from snapred.meta.Config import Config
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
 from snapred.ui.view.BackendRequestView import BackendRequestView
-from snapred.ui.widget.JsonFormList import JsonFormList
-from snapred.ui.widget.LabeledField import LabeledField
 from snapred.ui.widget.Toggle import Toggle
 
 
@@ -106,6 +101,7 @@ class DiffCalTweakPeakView(BackendRequestView):
         self.peakFunctionDropdown.setCurrentIndex(peakIndex)
 
     def emitValueChange(self):
+        # verify the fields before recalculation
         try:
             groupingIndex = self.groupingFileDropdown.currentIndex()
             dMin = float(self.fielddMin.field.text())
@@ -115,10 +111,11 @@ class DiffCalTweakPeakView(BackendRequestView):
             QMessageBox.warning(
                 self,
                 "Invalid Peak Parameters",
-                f"One of dMin, dMax, or threshold have error {str(e)}",
+                f"One of dMin, dMax, or peak threshold is invalid: {str(e)}",
                 QMessageBox.Ok,
             )
             return
+        # perform some checks on dMin, dMax values
         if dMin < 0.1:
             response = QMessageBox.warning(
                 self,

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -17,7 +17,6 @@ from workbench.plotting.figuremanager import FigureManagerWorkbench, MantidFigur
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
 
 from snapred.backend.dao import GroupPeakList
-from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
@@ -197,4 +196,4 @@ class DiffCalTweakPeakView(BackendRequestView):
                 msg = msg + f"\tgroup {empty.groupID} has \t {len(empty.peaks)} peaks\n"
             msg = msg + "Adjust grouping, dMin, dMax, and peak intensity threshold to include more peaks."
             raise ValueError(msg)
-        return SNAPResponse(code=ResponseCode.OK, data=True)
+        return True

--- a/src/snapred/ui/view/NormalizationRequestView.py
+++ b/src/snapred/ui/view/NormalizationRequestView.py
@@ -1,3 +1,4 @@
+from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.view.BackendRequestView import BackendRequestView
 from snapred.ui.widget.Toggle import Toggle
@@ -29,6 +30,8 @@ class NormalizationRequestView(BackendRequestView):
         self.groupingFileDropdown.setItems(groups)
 
     def verify(self):
+        if not self.runNumberField.text().isdigit():
+            raise ValueError("Please enter a valid run number")
         if self.sampleDropdown.currentIndex() < 0:
             raise ValueError("Please select a sample")
         if self.groupingFileDropdown.currentIndex() < 0:
@@ -39,7 +42,7 @@ class NormalizationRequestView(BackendRequestView):
             raise ValueError("Please enter a run number")
         if self.backgroundRunNumberField.text() == "":
             raise ValueError("Please enter a background run number")
-        return True
+        return SNAPResponse(code=ResponseCode.OK, data=True)
 
     def getRunNumber(self):
         return self.runNumberField.text()

--- a/src/snapred/ui/view/NormalizationRequestView.py
+++ b/src/snapred/ui/view/NormalizationRequestView.py
@@ -7,22 +7,26 @@ from snapred.ui.widget.Toggle import Toggle
 @Resettable
 class NormalizationRequestView(BackendRequestView):
     def __init__(self, jsonForm, samplePaths=[], groups=[], parent=None):
-        selection = "calibration/diffractionCalibration"
-        super(NormalizationRequestView, self).__init__(jsonForm, selection, parent=parent)
+        super(NormalizationRequestView, self).__init__(jsonForm, "", parent=parent)
+
+        # input fields
         self.runNumberField = self._labeledField("Run Number:", jsonForm.getField("runNumber"))
         self.litemodeToggle = self._labeledField("Lite Mode", Toggle(parent=self, state=True))
         self.backgroundRunNumberField = self._labeledField(
             "Background Run Number:", jsonForm.getField("backgroundRunNumber")
         )
 
-        self.litemodeToggle.setEnabled(False)
-        self.layout.addWidget(self.runNumberField, 0, 0)
-        self.layout.addWidget(self.litemodeToggle, 0, 1)
-        self.layout.addWidget(self.backgroundRunNumberField, 1, 0)
-
+        # drop downs
         self.sampleDropdown = self._sampleDropDown("Select Sample", samplePaths)
         self.groupingFileDropdown = self._sampleDropDown("Select Grouping File", groups)
 
+        # set field properties
+        self.litemodeToggle.setEnabled(False)
+
+        # add all widgets to layout
+        self.layout.addWidget(self.runNumberField, 0, 0)
+        self.layout.addWidget(self.litemodeToggle, 0, 1)
+        self.layout.addWidget(self.backgroundRunNumberField, 1, 0)
         self.layout.addWidget(self.sampleDropdown, 2, 0)
         self.layout.addWidget(self.groupingFileDropdown, 2, 1)
 
@@ -32,16 +36,12 @@ class NormalizationRequestView(BackendRequestView):
     def verify(self):
         if not self.runNumberField.text().isdigit():
             raise ValueError("Please enter a valid run number")
+        if not self.backgroundRunNumberField.text().isdigit():
+            raise ValueError("Please enter a valid background run number")
         if self.sampleDropdown.currentIndex() < 0:
             raise ValueError("Please select a sample")
         if self.groupingFileDropdown.currentIndex() < 0:
             raise ValueError("Please select a grouping file")
-        if self.groupingFileDropdown.currentIndex() < 0:
-            raise ValueError("You must enter a run number to select a grouping defintion")
-        if self.runNumberField.text() == "":
-            raise ValueError("Please enter a run number")
-        if self.backgroundRunNumberField.text() == "":
-            raise ValueError("Please enter a background run number")
         return SNAPResponse(code=ResponseCode.OK, data=True)
 
     def getRunNumber(self):

--- a/src/snapred/ui/view/NormalizationRequestView.py
+++ b/src/snapred/ui/view/NormalizationRequestView.py
@@ -1,4 +1,3 @@
-from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.view.BackendRequestView import BackendRequestView
 from snapred.ui.widget.Toggle import Toggle
@@ -42,7 +41,7 @@ class NormalizationRequestView(BackendRequestView):
             raise ValueError("Please select a sample")
         if self.groupingFileDropdown.currentIndex() < 0:
             raise ValueError("Please select a grouping file")
-        return SNAPResponse(code=ResponseCode.OK, data=True)
+        return True
 
     def getRunNumber(self):
         return self.runNumberField.text()

--- a/src/snapred/ui/view/NormalizationSaveView.py
+++ b/src/snapred/ui/view/NormalizationSaveView.py
@@ -7,6 +7,7 @@ from snapred.ui.widget.JsonFormList import JsonFormList
 from snapred.ui.widget.LabeledField import LabeledField
 
 
+# TODO rebase on BackendRequestView
 @Resettable
 class NormalizationSaveView(QWidget):
     signalRunNumberUpdate = pyqtSignal(str)

--- a/src/snapred/ui/view/NormalizationSaveView.py
+++ b/src/snapred/ui/view/NormalizationSaveView.py
@@ -1,6 +1,7 @@
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QGridLayout, QLabel, QWidget
 
+from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.widget.JsonFormList import JsonFormList
 from snapred.ui.widget.LabeledField import LabeledField
@@ -75,3 +76,10 @@ class NormalizationSaveView(QWidget):
 
     def updateBackgroundRunNumber(self, backgroundRunNumber):
         self.signalBackgroundRunNumberUpdate.emit(backgroundRunNumber)
+
+    def verify(self):
+        if self.fieldAuthor.text() == "":
+            raise ValueError("You must specify the author")
+        if self.fieldComments.text() == "":
+            raise ValueError("You must add comments")
+        return SNAPResponse(code=ResponseCode.OK, data=True)

--- a/src/snapred/ui/view/NormalizationSaveView.py
+++ b/src/snapred/ui/view/NormalizationSaveView.py
@@ -1,7 +1,6 @@
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QGridLayout, QLabel, QWidget
 
-from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.widget.JsonFormList import JsonFormList
 from snapred.ui.widget.LabeledField import LabeledField
@@ -83,4 +82,4 @@ class NormalizationSaveView(QWidget):
             raise ValueError("You must specify the author")
         if self.fieldComments.text() == "":
             raise ValueError("You must add comments")
-        return SNAPResponse(code=ResponseCode.OK, data=True)
+        return True

--- a/src/snapred/ui/view/NormalizationTweakPeakView.py
+++ b/src/snapred/ui/view/NormalizationTweakPeakView.py
@@ -7,16 +7,10 @@ from mantid.simpleapi import mtd
 from pydantic import parse_obj_as
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
-    QComboBox,
-    QGridLayout,
     QHBoxLayout,
-    QLabel,
     QLineEdit,
     QMessageBox,
     QPushButton,
-    QSlider,
-    QVBoxLayout,
-    QWidget,
 )
 from workbench.plotting.figuremanager import FigureManagerWorkbench, MantidFigureCanvas
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
@@ -26,7 +20,6 @@ from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.view.BackendRequestView import BackendRequestView
-from snapred.ui.widget.JsonFormList import JsonFormList
 from snapred.ui.widget.SmoothingSlider import SmoothingSlider
 from snapred.ui.widget.Toggle import Toggle
 
@@ -123,11 +116,22 @@ class NormalizationTweakPeakView(BackendRequestView):
         self.signalUpdateFields.emit(sampleIndex, groupingIndex, smoothingParameter)
 
     def emitValueChange(self):
-        index = self.groupingFileDropdown.currentIndex()
-        smoothingValue = self.smoothingSlider.field.value()
-        dMin = float(self.fielddMin.field.text())
-        dMax = float(self.fielddMax.field.text())
-        peakThreshold = float(self.fieldThreshold.text())
+        # verify the fields before recalculation
+        try:
+            index = self.groupingFileDropdown.currentIndex()
+            smoothingValue = self.smoothingSlider.field.value()
+            dMin = float(self.fielddMin.field.text())
+            dMax = float(self.fielddMax.field.text())
+            peakThreshold = float(self.fieldThreshold.text())
+        except ValueError as e:
+            QMessageBox.warning(
+                self,
+                "Invalid Peak Parameters",
+                f"One of dMin, dMax, smoothing, or peak threshold is invalid: {str(e)}",
+                QMessageBox.Ok,
+            )
+            return
+        # perform some checks on dMin, dMax values
         if dMin < 0.1:
             response = QMessageBox.warning(
                 self,
@@ -215,5 +219,5 @@ class NormalizationTweakPeakView(BackendRequestView):
         self.signalPopulateGroupingDropdown.emit(groups)
 
     def verify(self):
-        # TODO verify
+        # TODO what needs to be verified?
         return SNAPResponse(code=ResponseCode.OK, data=True)

--- a/src/snapred/ui/view/NormalizationTweakPeakView.py
+++ b/src/snapred/ui/view/NormalizationTweakPeakView.py
@@ -22,6 +22,7 @@ from workbench.plotting.figuremanager import FigureManagerWorkbench, MantidFigur
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
 
 from snapred.backend.dao import GroupPeakList
+from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.view.BackendRequestView import BackendRequestView
@@ -212,3 +213,7 @@ class NormalizationTweakPeakView(BackendRequestView):
 
     def populateGroupingDropdown(self, groups=["Enter a Run Number"]):
         self.signalPopulateGroupingDropdown.emit(groups)
+
+    def verify(self):
+        # TODO verify
+        return SNAPResponse(code=ResponseCode.OK, data=True)

--- a/src/snapred/ui/view/NormalizationTweakPeakView.py
+++ b/src/snapred/ui/view/NormalizationTweakPeakView.py
@@ -16,7 +16,6 @@ from workbench.plotting.figuremanager import FigureManagerWorkbench, MantidFigur
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
 
 from snapred.backend.dao import GroupPeakList
-from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.view.BackendRequestView import BackendRequestView
@@ -220,4 +219,4 @@ class NormalizationTweakPeakView(BackendRequestView):
 
     def verify(self):
         # TODO what needs to be verified?
-        return SNAPResponse(code=ResponseCode.OK, data=True)
+        return True

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -121,8 +121,6 @@ class DiffCalWorkflow(WorkflowImplementer):
 
     def _specifyRun(self, workflowPresenter):
         view = workflowPresenter.widget.tabView
-        # pull fields from view
-        self.verifyForm(view)
 
         # fetch the data from the view
         self.runNumber = view.runNumberField.text()
@@ -141,7 +139,6 @@ class DiffCalWorkflow(WorkflowImplementer):
 
         self._tweakPeakView.populateGroupingDropdown(list(self.groupingMap.getMap(self.useLiteMode).keys()))
         self._tweakPeakView.updateFields(
-            self.runNumber,
             view.sampleDropdown.currentIndex(),
             view.groupingFileDropdown.currentIndex(),
             view.peakFunctionDropdown.currentIndex(),
@@ -245,8 +242,6 @@ class DiffCalWorkflow(WorkflowImplementer):
 
     def _triggerDiffractionCalibration(self, workflowPresenter):
         view = workflowPresenter.widget.tabView
-        # pull fields from view for diffraction calibration
-        self.verifyForm(view)
 
         self.runNumber = view.runNumberField.text()
         self._saveView.updateRunNumber(self.runNumber)

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -111,7 +111,7 @@ class NormalizationWorkflow(WorkflowImplementer):
     def _triggerNormalizationCalibration(self, workflowPresenter):
         view = workflowPresenter.widget.tabView
         # pull fields from view for normalization
-        self.verifyForm(view)
+        # self.verifyForm(view)
 
         self.runNumber = view.getFieldText("runNumber")
         self.backgroundRunNumber = view.getFieldText("backgroundRunNumber")

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -111,7 +111,6 @@ class NormalizationWorkflow(WorkflowImplementer):
     def _triggerNormalizationCalibration(self, workflowPresenter):
         view = workflowPresenter.widget.tabView
         # pull fields from view for normalization
-        # self.verifyForm(view)
 
         self.runNumber = view.getFieldText("runNumber")
         self.backgroundRunNumber = view.getFieldText("backgroundRunNumber")

--- a/src/snapred/ui/workflow/WorkflowImplementer.py
+++ b/src/snapred/ui/workflow/WorkflowImplementer.py
@@ -67,11 +67,8 @@ class WorkflowImplementer:
         return response
 
     def verifyForm(self, form):
-        try:
-            form.verify()
-            return True
-        except ValueError as e:
-            return SNAPResponse(code=ResponseCode.ERROR, message=f"Missing Fields!{e}")
+        form.verify()
+        return True
 
     def _handleComplications(self, result):
         if result.code >= ResponseCode.ERROR:

--- a/tests/unit/ui/widget/test_Workflow.py
+++ b/tests/unit/ui/widget/test_Workflow.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QApplication, QGridLayout, QPushButton, QWidget
+from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.ui.model.WorkflowNodeModel import WorkflowNodeModel
 from snapred.ui.presenter.WorkflowPresenter import WorkflowPresenter
 from snapred.ui.view.WorkflowView import WorkflowView
@@ -24,6 +25,9 @@ class _TestView(QWidget):
 
     def handleContinueButtonClicked(self):
         pass
+
+    def verify(self):
+        return SNAPResponse(code=ResponseCode.OK, data=True)
 
 
 def _generateWorkflow():

--- a/tests/unit/ui/widget/test_Workflow.py
+++ b/tests/unit/ui/widget/test_Workflow.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock
 import pytest
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QApplication, QGridLayout, QPushButton, QWidget
-from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.ui.model.WorkflowNodeModel import WorkflowNodeModel
 from snapred.ui.presenter.WorkflowPresenter import WorkflowPresenter
 from snapred.ui.view.WorkflowView import WorkflowView
@@ -27,7 +26,7 @@ class _TestView(QWidget):
         pass
 
     def verify(self):
-        return SNAPResponse(code=ResponseCode.OK, data=True)
+        return True
 
 
 def _generateWorkflow():


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

The workflow views had `verify()` methods that were supposed to ensure fields had been filled in with valid information before running the workflow action and advancing to next step.

The verification step was occurring, but it was not properly raising the correct error message.

The error message that _was_ being raised was actually a python key-value error message, and because it said the name of the field in it I guess no one noticed it was not the intended message.

This will cause the `verify()` method to be called with the Continue button before running the workflow action, will produce the correct error pop-ups, and will allow the user to make the indicated change.

## Explanation of work

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

First: changed the `WorkflowPresenter`, on the method to handle the continue button being pressed, to first call the verification method and only call the workflow action if verification passes.

This uses a **worker** and I would like additional scrutiny placed on this aspect.

Second: all views in a workflow must have a `verify()` method as follows
``` python
def verify(self):
    if <fails verification>:
        raise ValidationError("you idiot!")
    return SNAPResponse(code=ResponseCode.OK, data=True)
```

**Ideally** all future backend workflow views will inherit from `BackendRequestView`, which implements a `verify()` method that will raise a `NotImplementedError` if devs don't fill out this method themselves.

## To test

Verify the **exact** wording of these error messages in the GUI.

### diffcal
Open GUI, open diffcal workflow.
- Press continue, verify the error message is "Please enter a valid run number".  Enter your favorite run number (mine is 46680)
- Press continue, verify the error message is "Please select a sample".  Select the sample for this run number (for 46680 it is diamond).
- Press continue, verify the error message is "Please select a grouping file".  Select your favorite grouping file.
- Press continue.  Verify it begins focusing data and loads the peak-tweak view.

Now in the peak-tweak view
- Delete the peak threshold and click something else.  Press "Recalculate" button.  Verify error message pops up telling you to enter either dMin, dMax, or peak threshold.
- Enter threshold = 0.0
- **Change dMin** to 1.5, press recalculation.  Verify there is a single shaded peak.  Press continue.
- Verify an error message is raised, "Proper calibration requires at least 4 peaks per group" + the groups without the correct number of peaks.
- Change dMin to 0.8.  Verify there are four/five peaks selected.  Press continue.  Verify if begins calibrating.

Now in assessment view, just press continue.

Now in save stage:
- Press continue, verify the error message is "You must specify the author".  Enter anything in this field.
- Press continue, verify the error message if "You must add comments".  Enter anything in this field.
- Press continue.  Verify it either saves, or (if you're trying to write to shared on analysis) fails because of write permissions.

### normalization
Open GUI, open normalization workflow.
- Press continue, verify the error message is "Please enter a valid run number".  Enter your favorite run number.
- Press continue, verify the error message is "Please select a sample".  Select one.
- Press continue, verify the error message is "Please select a grouping file".  Select one.
- Press continue, verify the error message is "Please enter a background run number".  Enter your favorite background.
- Press continue.  Verify it now begins calculating the raw vanadium correct.

Now in the tweak-peak view.
- Delete the peak threshold and click something else.  Press "Recalculate" button.  Verify error message pops up telling you to enter either smoothing param, dMin, dMax, or peak threshold.
- Enter value for threshold, verify all others have values.
- Press enter.  It will now go to save screen.

Now in the save view.
- Press continue, verify the error message is "You must specify the author".  Enter anything in this field.
- Press continue, verify the error message if "You must add comments".  Enter anything in this field.
- Press continue.  Verify it either saves, or (if you're trying to write to shared on analysis) fails because of write permissions.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4360](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4360)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
