### PR TITLE
fix calib/normalization version forwarding

### DIFF
--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -460,6 +460,8 @@ class LocalDataService:
         stateId, _ = self._generateStateId(runNumber)
         previousVersion = self._getLatestNormalizationCalibrationVersionNumber(stateId)
         if not version:
+            version = record.version
+        if not version:
             version = previousVersion + 1
         recordPath: str = self.getNormalizationRecordPath(runNumber, version)
         record.version = version
@@ -512,6 +514,8 @@ class LocalDataService:
         runNumber = record.runNumber
         stateId, _ = self._generateStateId(runNumber)
         previousVersion: int = self._getLatestCalibrationVersionNumber(stateId)
+        if not version:
+            version = record.version
         if not version:
             version = previousVersion + 1
         recordPath: str = self.getCalibrationRecordPath(runNumber, str(version))

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -183,10 +183,11 @@ class CalibrationService(Service):
     @FromString
     def save(self, request: CalibrationExportRequest):
         entry = request.calibrationIndexEntry
+        version = entry.version
         calibrationRecord = request.calibrationRecord
+        calibrationRecord.version = version
         calibrationRecord = self.dataExportService.exportCalibrationRecord(calibrationRecord)
         calibrationRecord = self.dataExportService.exportCalibrationWorkspaces(calibrationRecord)
-        entry.version = calibrationRecord.version
         self.saveCalibrationToIndex(entry)
 
     @FromString

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -160,10 +160,11 @@ class NormalizationService(Service):
     @FromString
     def saveNormalization(self, request: NormalizationExportRequest):
         entry = request.normalizationIndexEntry
+        version = entry.version
         normalizationRecord = request.normalizationRecord
+        normalizationRecord.version = version
         normalizationRecord = self.dataExportService.exportNormalizationRecord(normalizationRecord)
         normalizationRecord = self.dataExportService.exportNormalizationWorkspaces(normalizationRecord)
-        entry.version = normalizationRecord.version
         self.saveNormalizationToIndex(entry)
 
     def saveNormalizationToIndex(self, entry: NormalizationIndexEntry):

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -1,4 +1,5 @@
 import json
+from sys import version
 
 from snapred.backend.dao import RunConfig
 from snapred.backend.dao.calibration import CalibrationIndexEntry
@@ -303,6 +304,7 @@ class DiffCalWorkflow(WorkflowImplementer):
             comments=view.fieldComments.get(),
             author=view.fieldAuthor.get(),
             appliesTo=view.fieldAppliesTo.get(),
+            version=view.fieldVersion.get(None),
         )
 
         # if this is not the first iteration, account for choice.

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -1,4 +1,5 @@
 import json
+from sys import version
 
 from pydantic import parse_raw_as
 from PyQt5.QtCore import QObject, Qt, pyqtSignal
@@ -185,6 +186,7 @@ class NormalizationWorkflow(WorkflowImplementer):
             comments=view.fieldComments.get(),
             author=view.fieldAuthor.get(),
             appliesTo=view.fieldAppliesTo.get(),
+            version=view.fieldVersion.get(None),
         )
 
         payload = NormalizationExportRequest(

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -859,6 +859,7 @@ def test_readWriteNormalizationRecord_version_numbers():
     testNormalizationRecord = NormalizationRecord.parse_raw(
         Resource.read("inputs/normalization/NormalizationRecord.json")
     )
+    testNormalizationRecord.version = None
     with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tempdir:
         localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
@@ -877,6 +878,7 @@ def test_readWriteNormalizationRecord_version_numbers():
         assert actualRecord.version == 1
         assert actualRecord.calibration.version == 1
         # write: version == 2
+        testNormalizationRecord.version = 2
         localDataService.writeNormalizationRecord(testNormalizationRecord)
         actualRecord = localDataService.readNormalizationRecord("57514")
         assert actualRecord.version == 2
@@ -889,6 +891,7 @@ def test_readWriteNormalizationRecord_specified_version():
     testNormalizationRecord = NormalizationRecord.parse_raw(
         Resource.read("inputs/normalization/NormalizationRecord.json")
     )
+    testNormalizationRecord.version = None
     with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tempdir:
         localDataService = LocalDataService()
         localDataService.instrumentConfig = mock.Mock()
@@ -907,6 +910,7 @@ def test_readWriteNormalizationRecord_specified_version():
         assert actualRecord.version == 1
         assert actualRecord.calibration.version == 1
         # write: version == 2
+        testNormalizationRecord.version = None
         localDataService.writeNormalizationRecord(testNormalizationRecord)
         actualRecord = localDataService.readNormalizationRecord("57514", "1")
         assert actualRecord.version == 1


### PR DESCRIPTION
## Description of work

Version saving had not been fixed in the rework to saving calibs and normalization, this pr fixes it instead.

## To test

In your local Calibration Folder
Run a calibration/normalization (49525, diamond, col)
Go all the way to save
Set version to 999
Save
Observe new entry and folder for version 999
repeat
Set version to 1
Save
Observe that version 1 had been overwritten.
Receive warning stating that you have overwritten version 1.

