### PR TITLE
Fix sous chef to call the grouping map when needed

### DIFF
--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -45,6 +45,9 @@ class DataFactoryService:
 
         return reductionState
 
+    def fileExists(self, filepath: str) -> bool:
+        return self.lookupService.fileExists(filepath)
+
     def getRunConfig(self, runId: str) -> RunConfig:  # noqa: ARG002
         return self.lookupService.readRunConfig(runId)
 

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -79,6 +79,9 @@ class LocalDataService:
         self.verifyPaths = Config["localdataservice.config.verifypaths"]
         self.instrumentConfig = self.readInstrumentConfig()
 
+    def fileExists(self, path):
+        return os.path.isfile(path)
+
     def _determineInstrConfigPaths(self) -> None:
         """This method locates the instrument configuration path and
         sets the instance variable ``instrumentConfigPath``."""

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -68,7 +68,7 @@ class SousChef(Service):
         return self.dataFactoryService.getCalibrantSample(calibrantSamplePath)
 
     def prepFocusGroup(self, ingredients: FarmFreshIngredients) -> FocusGroup:
-        if os.path.isfile(ingredients.focusGroup.definition):
+        if self.dataFactoryService.fileExists(ingredients.focusGroup.definition):
             return ingredients.focusGroup
         else:
             groupingMap = self.dataFactoryService.getGroupingMap(ingredients.runNumber)

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -1,4 +1,5 @@
 import json
+import os.path
 import time
 from datetime import date
 from functools import lru_cache
@@ -66,36 +67,44 @@ class SousChef(Service):
     def prepCalibrantSample(self, calibrantSamplePath: str) -> CalibrantSamples:
         return self.dataFactoryService.getCalibrantSample(calibrantSamplePath)
 
-    def prepPixelGroup(self, ingredients: FarmFreshIngredients):
+    def prepFocusGroup(self, ingredients: FarmFreshIngredients) -> FocusGroup:
+        if os.path.isfile(ingredients.focusGroup.definition):
+            return ingredients.focusGroup
+        else:
+            groupingMap = self.dataFactoryService.getGroupingMap(ingredients.runNumber)
+            return groupingMap.getMap(ingredients.useLiteMode)[ingredients.focusGroup.name]
+
+    def prepPixelGroup(self, ingredients: FarmFreshIngredients) -> PixelGroup:
         groupingSchema = ingredients.focusGroup.name
         key = (ingredients.runNumber, ingredients.useLiteMode, groupingSchema)
         if key not in self._pixelGroupCache:
+            focusGroup = self.prepFocusGroup(ingredients)
             instrumentState = self.prepInstrumentState(ingredients.runNumber)
             pixelIngredients = PixelGroupingIngredients(
                 instrumentState=instrumentState,
                 nBinsAcrossPeakWidth=ingredients.nBinsAcrossPeakWidth,
             )
             self.groceryClerk.name("groupingWorkspace").fromRun(ingredients.runNumber).grouping(
-                ingredients.focusGroup.name
+                focusGroup.name
             ).useLiteMode(ingredients.useLiteMode).add()
             groceries = self.groceryService.fetchGroceryDict(self.groceryClerk.buildDict())
             data = PixelGroupingParametersCalculationRecipe().executeRecipe(pixelIngredients, groceries)
 
             self._pixelGroupCache[key] = PixelGroup(
-                focusGroup=ingredients.focusGroup,
+                focusGroup=focusGroup,
                 pixelGroupingParameters=data["parameters"],
                 timeOfFlight=data["tof"],
                 nBinsAcrossPeakWidth=ingredients.nBinsAcrossPeakWidth,
             )
         return self._pixelGroupCache[key]
 
-    def _getInstrumentDefinitionFilename(self, useLiteMode: bool):
+    def _getInstrumentDefinitionFilename(self, useLiteMode: bool) -> str:
         if useLiteMode is True:
             return Config["instrument.lite.definition.file"]
         elif useLiteMode is False:
             return Config["instrument.native.definition.file"]
 
-    def prepCrystallographicInfo(self, ingredients: FarmFreshIngredients):
+    def prepCrystallographicInfo(self, ingredients: FarmFreshIngredients) -> CrystallographicInfo:
         if not ingredients.cifPath:
             samplePath = ingredients.calibrantSamplePath.split("/")[-1].split(".")[0]
             ingredients.cifPath = self.dataFactoryService.getCifFilePath(samplePath)

--- a/tests/cis_tests/new_diffcal_script.py
+++ b/tests/cis_tests/new_diffcal_script.py
@@ -28,7 +28,7 @@ from snapred.meta.Config import Config
 
 #User input ###########################
 runNumber = "58882"
-groupingScheme = "Column"
+groupingScheme = "Column (Lite)"
 cifPath = "/SNS/SNAP/shared/Calibration/CalibrantSamples/Silicon_NIST_640d.cif"
 calibrantSamplePath = "SNS/SNAP/shared/Calibration/CalibrationSamples/Silicon_NIST_640D_001.json"
 peakThreshold = 0.05

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -1,3 +1,5 @@
+import os.path
+import tempfile
 import unittest.mock as mock
 from unittest.mock import MagicMock
 
@@ -15,12 +17,23 @@ from snapred.backend.dao.StateConfig import StateConfig
 with mock.patch.dict(
     "sys.modules",
     {
-        "snapred.backend.data.LocalDataService": mock.Mock(),
         "snapred.backend.log": mock.Mock(),
         "snapred.backend.log.logger": mock.Mock(),
     },
 ):
     from snapred.backend.data.DataFactoryService import DataFactoryService
+
+    def test_fileExists_yes():
+        # create a temp file that exists, and verify it exists
+        with tempfile.NamedTemporaryFile(suffix=".biscuit") as existent:
+            assert DataFactoryService().fileExists(existent.name)
+
+    def test_fileExists_no():
+        # assert that a file that does not exist, does not exist
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nonexistent = tmpdir + "/0x0f.biscuit"
+            assert not os.path.isfile(nonexistent)
+            assert not DataFactoryService().fileExists(nonexistent)
 
     def test_getReductionState():
         dataExportService = DataFactoryService()

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -66,6 +66,20 @@ with Resource.open("inputs/calibration/ReductionIngredients.json", "r") as file:
     reductionIngredients = parse_raw_as(ReductionIngredients, file.read())
 
 
+def test_fileExists_yes():
+    # create a temp file that exists, and verify it exists
+    with tempfile.NamedTemporaryFile(suffix=".biscuit") as existent:
+        assert LocalDataService().fileExists(existent.name)
+
+
+def test_fileExists_no():
+    # assert that a file that does not exist, does not exist
+    with tempfile.TemporaryDirectory() as tmpdir:
+        nonexistent = tmpdir + "/0x0f.biscuit"
+        assert not os.path.isfile(nonexistent)
+        assert not LocalDataService().fileExists(nonexistent)
+
+
 def _readInstrumentParameters():
     instrumentParmaeters = None
     with Resource.open("inputs/SNAPInstPrm.json", "r") as file:

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -88,7 +88,6 @@ class TestSousChef(unittest.TestCase):
         res = self.instance.prepCalibrantSample(self.ingredients)
         assert res == self.instance.dataFactoryService.lookupService.readCalibrantSample.return_value
 
-    @mock.patch(thisService + "os.path.isfile", mock.Mock(return_value=True))
     @mock.patch(thisService + "PixelGroup")
     @mock.patch(thisService + "PixelGroupingParametersCalculationRecipe")
     @mock.patch(thisService + "PixelGroupingIngredients")
@@ -109,7 +108,10 @@ class TestSousChef(unittest.TestCase):
         self.instance.groceryService.fetchGroceryList = mock.Mock(return_value="banana")
 
         # call the method to be tested
-        res = self.instance.prepPixelGroup(self.ingredients)
+        # make sure the focus group definition exists, by pointing it to a tmp file
+        with tempfile.NamedTemporaryFile() as existent:
+            self.ingredients.focusGroup.definition = existent.name
+            res = self.instance.prepPixelGroup(self.ingredients)
 
         # make necessary assertions
         assert PixelGroupingIngredients.called_once_with(

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -1,3 +1,4 @@
+import os.path
 import tempfile
 import unittest
 from unittest import mock
@@ -41,15 +42,20 @@ class TestSousChef(unittest.TestCase):
             res = self.instance.prepFocusGroup(self.ingredients)
             assert res == self.ingredients.focusGroup
 
-    @mock.patch(thisService + "os.path.isfile", mock.Mock(return_value=False))
     def test_prepFocusGroup_notExists(self):
-        # ensure the file does not exist by mocking out os.path.isfile to say it doesn't exist
+        # ensure the file does not exist
         # make sure the grouping map is accessed in this case instead
+
+        # create the mock grouping map dictionary
         mockGroupingDictionary = {self.ingredients.focusGroup.name: "passed"}
         mockGroupingMap = mock.Mock(getMap=mock.Mock(return_value=mockGroupingDictionary))
         self.instance.dataFactoryService.getGroupingMap = mock.Mock(return_value=mockGroupingMap)
 
-        res = self.instance.prepFocusGroup(self.ingredients)
+        # ensure the file does not exist by looking inside a temporary file
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.ingredients.focusGroup.definition = tmpdir + "/muffin.egg"
+            assert not os.path.isfile(self.ingredients.focusGroup.definition)
+            res = self.instance.prepFocusGroup(self.ingredients)
 
         assert res == mockGroupingDictionary[self.ingredients.focusGroup.name]
 


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

Using a combination of SousChef and GroceryService allows SNAPRed functionality to also be easily run from scripts.

With some changes to how SousChef gets the focus group paths, in order for SousChef to always have valid focus group definitions, it is necessary for it to check the definitions it has, then load them from a grouping map otherwise.

This is not just about scripts.  It makes sure the focus group object passed to the SousChef is always a valid grouping file.

## Explanation of work

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing
Open the CIS test script new_diffcal_script inside workbench.

Check the new unit tests, and verify they pass.

You may have to change the name of the grouping, maybe from "Column (Lite)" to "Column" or "Column (Default Lite)" depending on your setup.

Run, and make sure it reaches the first `assert False` stop statement.  If it did, then the ingredients were successfully constructed.

### CIS testing
Make sure you can run the new_diffcal_script inside workbench up to the first `assert False` stop.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
