### PR TITLE
Save ragged workspaces 

### DIFF
--- a/src/snapred/backend/data/DataExportService.py
+++ b/src/snapred/backend/data/DataExportService.py
@@ -53,5 +53,11 @@ class DataExportService:
         """
         return self.dataService.writeWorkspace(path, filename, workspaceName)
 
+    def exportRaggedWorkspace(self, path: Path, filename: Path, workspaceName: WorkspaceName):
+        """
+        Write a MatrixWorkspace (derived) workspace to disk in nexus format.
+        """
+        return self.dataService.writeRaggedWorkspace(path, filename, workspaceName)
+
     def initializeState(self, runId: str, name: str):
         return self.dataService.initializeState(runId, name)

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -186,9 +186,10 @@ class GroceryService:
         return str(path)
 
     def _createDiffcalOutputWorkspaceFilename(self, runNumber: str, version: str, unit: str, group: str) -> str:
+        ext = Config["calibration.diffraction.output.extension"]
         return str(
             Path(self._getCalibrationDataPath(runNumber, version))
-            / (self._createDiffcalOutputWorkspaceName(runNumber, version, unit, group) + ".nxs")
+            / (self._createDiffcalOutputWorkspaceName(runNumber, version, unit, group) + ext)
         )
 
     def _createDiffcalTableFilename(self, runNumber: str, version: str) -> str:
@@ -725,6 +726,7 @@ class GroceryService:
                                 item.runNumber, item.version, item.unit, item.groupingScheme
                             ),
                             diffcalOutputWorkspaceName,
+                            loader="ReheatLeftovers",
                         )
                 case "diffcal_table":
                     tableWorkspaceName = self._createDiffcalTableWorkspaceName(item.runNumber, item.version)

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -606,8 +606,7 @@ class LocalDataService:
         for wsName in workspaces.pop(wngt.DIFFCAL_OUTPUT, []):
             # Rebuild the filename to strip any "iteration" number:
             #   * WARNING: this workaround does not work correctly if there are multiple workspaces of each "unit" type.
-            ext = "tar"
-            nameBuilder = wng.diffCalOutput().runNumber(record.runNumber).version(record.version)
+            ext = ".tar"
             if wng.Units.TOF.lower() in wsName:
                 filename = Path(
                     wng.diffCalOutput()

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -606,7 +606,7 @@ class LocalDataService:
         for wsName in workspaces.pop(wngt.DIFFCAL_OUTPUT, []):
             # Rebuild the filename to strip any "iteration" number:
             #   * WARNING: this workaround does not work correctly if there are multiple workspaces of each "unit" type.
-            ext = ".tar"
+            ext = Config["calibration.diffraction.output.extension"]
             if wng.Units.TOF.lower() in wsName:
                 filename = Path(
                     wng.diffCalOutput()

--- a/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
@@ -58,6 +58,7 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
                     "LoadNexus",
                     "LoadEventNexus",
                     "LoadNexusProcessed",
+                    "ReheatLeftovers",
                 ]
             ),
             direction=Direction.InOut,

--- a/src/snapred/backend/recipe/algorithm/data/ReheatLeftovers.py
+++ b/src/snapred/backend/recipe/algorithm/data/ReheatLeftovers.py
@@ -81,11 +81,9 @@ class ReheatLeftovers(PythonAlgorithm):
                         f"Conjoining Spectra {index}", InputWorkspace1=ws, InputWorkspace2=tmp, CheckOverlapping=False
                     )
                 self.mantidSnapper.executeQueue()
-
-        ws = mtd[self.outputWSName]
-        for index in range(0, ws.getNumberHistograms()):
-            spec = ws.getSpectrum(index)
-            spec.setSpectrumNo(index + 1)
+                wsInst = self.mantidSnapper.mtd[self.outputWSName]
+                spec = wsInst.getSpectrum(index)
+                spec.setSpectrumNo(index + 1)
 
         self.setProperty("OutputWorkspace", self.outputWSName)
 

--- a/src/snapred/backend/recipe/algorithm/data/ReheatLeftovers.py
+++ b/src/snapred/backend/recipe/algorithm/data/ReheatLeftovers.py
@@ -1,0 +1,98 @@
+import glob
+import json
+import os
+import tarfile
+import tempfile
+import time
+from typing import Dict, List, Tuple
+
+import numpy as np
+from mantid.api import (
+    AlgorithmFactory,
+    FileAction,
+    FileProperty,
+    MatrixWorkspace,
+    MatrixWorkspaceProperty,
+    PropertyMode,
+    PythonAlgorithm,
+)
+from mantid.kernel import Direction, StringArrayProperty
+from mantid.simpleapi import CloneWorkspace, mtd
+from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
+from snapred.meta.Config import Config
+
+
+class ReheatLeftovers(PythonAlgorithm):
+    """
+    Load ragged workspaces with a small number of histograms (< 20?) from a file.
+    """
+
+    def category(self):
+        return "SNAPRed Internal"
+
+    def PyInit(self):
+        # declare properties
+        self.declareProperty(
+            FileProperty(
+                "Filename",
+                defaultValue="",
+                action=FileAction.Load,
+                extensions=["tar"],
+                direction=Direction.Input,
+            ),
+            doc="Path to file to be loaded",
+        )
+        self.declareProperty(
+            "OutputWorkspace", defaultValue="", direction=Direction.Output, doc="Workspace to be loaded"
+        )
+        self.mantidSnapper = MantidSnapper(self, __name__)
+
+    def validate(self):
+        pass
+
+    def unbagGroceries(self):
+        self.outputWSName = self.getPropertyValue("OutputWorkspace")
+        self.filename = self.getPropertyValue("Filename")
+
+    def PyExec(self) -> None:
+        self.unbagGroceries()
+        self.validate()
+
+        # unzip the tar file
+        timestamp = str(time.time())
+        tempFolderName = Config["temp.directory"]
+        extractPath = tempfile.mkdtemp(prefix=f"{tempFolderName}/reheat_{timestamp}_")
+
+        with tarfile.open(self.filename, "r") as tar:
+            tar.extractall(path=extractPath, filter="data")
+
+        # collected all files in extractPath
+        files = glob.glob(f"{extractPath}/*")
+        files = [f for f in files if f.endswith(".nxs")]
+        files.sort()
+        ws = None
+        for file in files:
+            index = int(file.split("/")[-1].split(".")[0])
+            if ws is None:
+                self.mantidSnapper.LoadNexus(
+                    f"Loading Spectra {index}", Filename=file, OutputWorkspace=self.outputWSName
+                )
+                ws = self.outputWSName
+            else:
+                tmp = f"{self.outputWSName}_{index}"
+                self.mantidSnapper.LoadNexus(f"Loading Spectra {index}", Filename=file, OutputWorkspace=tmp)
+                self.mantidSnapper.ConjoinWorkspaces(
+                    f"Conjoining Spectra {index}", InputWorkspace1=ws, InputWorkspace2=tmp, CheckOverlapping=False
+                )
+            self.mantidSnapper.executeQueue()
+
+        ws = mtd[self.outputWSName]
+        for index in range(0, ws.getNumberHistograms()):
+            spec = ws.getSpectrum(index)
+            spec.setSpectrumNo(index + 1)
+
+        self.setProperty("OutputWorkspace", self.outputWSName)
+
+
+# Register algorithm with Mantid
+AlgorithmFactory.subscribe(ReheatLeftovers)

--- a/src/snapred/backend/recipe/algorithm/data/WrapLeftovers.py
+++ b/src/snapred/backend/recipe/algorithm/data/WrapLeftovers.py
@@ -1,0 +1,90 @@
+import json
+import os
+import tarfile
+import time
+from typing import Dict, List, Tuple
+
+import numpy as np
+from mantid.api import (
+    AlgorithmFactory,
+    FileAction,
+    FileProperty,
+    MatrixWorkspaceProperty,
+    PropertyMode,
+    PythonAlgorithm,
+)
+from mantid.kernel import Direction, StringArrayProperty
+from mantid.simpleapi import CloneWorkspace, mtd
+from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
+from snapred.meta.Config import Config
+
+
+class WrapLeftovers(PythonAlgorithm):
+    """
+    Saves ragged workspaces with a small number of histograms (< 20?) from a file.
+    """
+
+    def category(self):
+        return "SNAPRed Internal"
+
+    def PyInit(self):
+        # declare properties
+        self.declareProperty(
+            MatrixWorkspaceProperty("InputWorkspace", "", Direction.Input, PropertyMode.Mandatory),
+            doc="Workspace to be saved.",
+        )
+        self.declareProperty(
+            FileProperty(
+                "Filename",
+                defaultValue="",
+                action=FileAction.Save,
+                extensions=["tar"],
+                direction=Direction.Input,
+            ),
+            doc="Path to file to be loaded",
+        )
+
+        self.mantidSnapper = MantidSnapper(self, __name__)
+
+    def validate(self):
+        if self.inputWS.getNumberHistograms() > 30:
+            raise ValueError("Too many histograms to save, this isnt the write tool for the job!")
+
+    def unbagGroceries(self):
+        self.inputWS = self.mantidSnapper.mtd[self.getPropertyValue("InputWorkspace")]
+        self.filename = self.getPropertyValue("Filename")
+        self.tarFilename = self.filename
+        self.filename = self.filename[:-4] + "_{index}.nxs"
+
+    def PyExec(self) -> None:
+        self.unbagGroceries()
+        self.validate()
+
+        for index in range(0, self.inputWS.getNumberHistograms()):
+            # timestamp as name
+            tmp = str(time.time())
+            self.mantidSnapper.ExtractSpectra(
+                f"Extracting Spectra {index}",
+                InputWorkspace=self.inputWS,
+                OutputWorkspace=tmp,
+                StartWorkspaceIndex=index,
+                EndWorkspaceIndex=index,
+            )
+            self.mantidSnapper.SaveNexus(
+                f"Saving Spectra {index}", InputWorkspace=tmp, Filename=self.filename.format(index=index)
+            )
+            self.mantidSnapper.DeleteWorkspace(f"Deleting Spectra {index}", Workspace=tmp)
+            self.mantidSnapper.executeQueue()
+
+        # finally zip all outputs into a tarball
+        with tarfile.open(self.tarFilename, "w") as tar:
+            for index in range(0, self.inputWS.getNumberHistograms()):
+                tar.add(self.filename.format(index=index), arcname=f"{index}.nxs")
+
+        # clean up
+        for index in range(0, self.inputWS.getNumberHistograms()):
+            os.remove(self.filename.format(index=index))
+
+
+# Register algorithm with Mantid
+AlgorithmFactory.subscribe(WrapLeftovers)

--- a/src/snapred/backend/recipe/algorithm/data/WrapLeftovers.py
+++ b/src/snapred/backend/recipe/algorithm/data/WrapLeftovers.py
@@ -47,8 +47,9 @@ class WrapLeftovers(PythonAlgorithm):
         self.mantidSnapper = MantidSnapper(self, __name__)
 
     def validate(self):
-        if self.inputWS.getNumberHistograms() > 30:
-            raise ValueError("Too many histograms to save, this isnt the write tool for the job!")
+        numHisto = self.inputWS.getNumberHistograms()
+        if numHisto > 30:
+            raise ValueError(f"Too many histograms to save, this isnt the write tool for the job!: {numHisto}")
 
     def unbagGroceries(self):
         self.inputWS = self.mantidSnapper.mtd[self.getPropertyValue("InputWorkspace")]

--- a/src/snapred/backend/recipe/algorithm/data/WrapLeftovers.py
+++ b/src/snapred/backend/recipe/algorithm/data/WrapLeftovers.py
@@ -71,8 +71,12 @@ class WrapLeftovers(PythonAlgorithm):
                 StartWorkspaceIndex=index,
                 EndWorkspaceIndex=index,
             )
+            self.mantidSnapper.executeQueue()
+            wsInst = self.mantidSnapper.mtd[tmp]
+            spec = wsInst.getSpectrum(0)
+            specNum = spec.getSpectrumNo()
             self.mantidSnapper.SaveNexus(
-                f"Saving Spectra {index}", InputWorkspace=tmp, Filename=self.filename.format(index=index)
+                f"Saving Spectra {specNum}", InputWorkspace=tmp, Filename=self.filename.format(index=index)
             )
             self.mantidSnapper.DeleteWorkspace(f"Deleting Spectra {index}", Workspace=tmp)
             self.mantidSnapper.executeQueue()
@@ -80,7 +84,7 @@ class WrapLeftovers(PythonAlgorithm):
         # finally zip all outputs into a tarball
         with tarfile.open(self.tarFilename, "w") as tar:
             for index in range(0, self.inputWS.getNumberHistograms()):
-                tar.add(self.filename.format(index=index), arcname=f"{index}.nxs")
+                tar.add(self.filename.format(index=index), arcname=f"{str(index).zfill(2)}.nxs")
 
         # clean up
         for index in range(0, self.inputWS.getNumberHistograms()):

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -59,6 +59,8 @@ calibration:
       extension: .nxs
       format: "{}_calibration_reduction_result"
   diffraction:
+    output:
+      extension: .tar
     maximumIterations: 5
     convergenceThreshold: 0.5
     peakIntensityThreshold: 0.05
@@ -120,6 +122,9 @@ samples:
   home: ${instrument.calibration.home}/CalibrantSamples
 
 cis_mode: false
+
+temp:
+  directory: /SNAPRed
 
 constants:
   millisecondsPerSecond: 1000

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -123,9 +123,6 @@ samples:
 
 cis_mode: false
 
-temp:
-  directory: /SNAPRed
-
 constants:
   millisecondsPerSecond: 1000
   PeakIntensityFractionThreshold: 0.05

--- a/tests/cis_tests/leftovers_script.py
+++ b/tests/cis_tests/leftovers_script.py
@@ -1,0 +1,30 @@
+from snapred.backend.recipe.algorithm.data.WrapLeftovers import WrapLeftovers
+from snapred.backend.recipe.algorithm.data.ReheatLeftovers import ReheatLeftovers
+
+from mantid.simpleapi import *
+
+
+# Load focussed data
+Load(Filename='/SNS/users/wqp/SNAP/shared/Calibration_dynamic/Powder/04bd2c53f6bf6754/normalization/v_0014/tof_column_s+f-vanadium_058810_v0014.nxs', OutputWorkspace='raw')
+
+xMin = [0.05,0.06,0.1,0.07,0.04, 0.04]
+xMax = [0.36,0.41,0.64,0.48,0.48,0.48]
+delta = [-0.000401475,-0.000277182,-0.000323453,-0.000430986,-0.000430986,-0.000430986]
+# RebinRagged(InputWorkspace="raw", XMin=[0.05,0.06,0.1,0.07], XMax=[0.36,0.41,0.64,0.48], Delta=[-0.000401475,-0.000277182,-0.000323453,-0.000430986], PreserveEvents=False, OutputWorkspace="rebinRaggeded")
+RebinRagged(InputWorkspace="raw", XMin=[0.05,0.06,0.1,0.07,0.04, 0.04], XMax=[0.36,0.41,0.64,0.48,0.48,0.48], Delta=[-0.000401475,-0.000277182,-0.000323453,-0.000430986,-0.000430986,-0.000430986], PreserveEvents=False, OutputWorkspace="raw")
+
+filename = "~/tmp/leftovers.tar"
+wrapLeftovers = WrapLeftovers()
+wrapLeftovers.initialize()
+wrapLeftovers.setPropertyValue("InputWorkspace","raw")
+wrapLeftovers.setPropertyValue("Filename", filename)
+wrapLeftovers.execute()
+
+reheatLeftovers = ReheatLeftovers()
+reheatLeftovers.initialize()
+reheatLeftovers.setPropertyValue("OutputWorkspace","reheated")
+reheatLeftovers.setPropertyValue("Filename", filename)
+reheatLeftovers.execute()
+
+# CompareWorkspaces(Workspace1="raw", Workspace2="reheated") Doesnt work with ragged!
+    

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -61,6 +61,8 @@ calibration:
       extension: .nxs
       format: "{}_calibration_reduction_result"
   diffraction:
+    output:
+      extension: .tar
     convergenceThreshold: 0.5
     peakIntensityThreshold: 0.05
     nBinsAcrossPeakWidth: 10
@@ -124,6 +126,8 @@ logging:
 samples:
   home: ${instrument.calibration.home}/CalibrantSamples
 
+temp:
+  directory: ~/SNAPRed
 
 test:
   config:

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -126,8 +126,6 @@ logging:
 samples:
   home: ${instrument.calibration.home}/CalibrantSamples
 
-temp:
-  directory: ~/SNAPRed
 
 test:
   config:

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -1603,6 +1603,8 @@ def test_writeRaggedWorkspace():
         assert mtd.doesExist(workspaceName)
         localDataService.writeRaggedWorkspace(basePath, filename, workspaceName)
         assert (basePath / filename).exists()
+        localDataService.readRaggedWorkspace(basePath, filename, "test_out")
+        assert mtd.doesExist("test_out")
     mtd.clear()
 
 

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -805,7 +805,16 @@ def test_writeCalibrationWorkspaces(mockConstructCalibrationDataPath):
         # Create sample workspaces.
         CreateSampleWorkspace(
             OutputWorkspace=outputTOFWSName,
+            Function="One Peak",
+            NumBanks=1,
+            NumMonitors=1,
+            BankPixelWidth=5,
+            NumEvents=500,
+            Random=True,
             XUnit="TOF",
+            XMin=0,
+            XMax=8000,
+            BinWidth=100,
         )
         LoadInstrument(
             Workspace=outputTOFWSName,
@@ -814,7 +823,16 @@ def test_writeCalibrationWorkspaces(mockConstructCalibrationDataPath):
         )
         CreateSampleWorkspace(
             OutputWorkspace=outputDSPWSName,
+            Function="One Peak",
+            NumBanks=1,
+            NumMonitors=1,
+            BankPixelWidth=5,
+            NumEvents=500,
+            Random=True,
             XUnit="DSP",
+            XMin=0,
+            XMax=8000,
+            BinWidth=100,
         )
         LoadInstrument(
             Workspace=outputDSPWSName,
@@ -837,7 +855,7 @@ def test_writeCalibrationWorkspaces(mockConstructCalibrationDataPath):
             for wsName in wsNames:
                 ws = mtd[wsName]
                 filename = (
-                    Path(wsName + ".nxs")
+                    Path(wsName + Config["calibration.diffraction.output.extension"])
                     if not (isinstance(ws, ITableWorkspace) or isinstance(ws, MaskWorkspace))
                     else diffCalFilename
                 )
@@ -981,7 +999,9 @@ def test_writeNormalizationWorkspaces(mockConstructNormalizationCalibrationDataP
         localDataService.writeNormalizationWorkspaces(testNormalizationRecord)
 
         for wsName in testNormalizationRecord.workspaceNames:
-            filename = Path(wsName + "_" + wnvf.formatVersion(version) + ".nxs")
+            filename = Path(
+                wsName + "_" + wnvf.formatVersion(version) + Config["calibration.diffraction.output.extension"]
+            )
             assert (basePath / filename).exists()
         mtd.clear()
 

--- a/tests/unit/backend/recipe/algorithm/data/test_Leftovers.py
+++ b/tests/unit/backend/recipe/algorithm/data/test_Leftovers.py
@@ -1,0 +1,64 @@
+import tempfile
+
+import numpy as np
+from mantid.api import mtd
+from mantid.simpleapi import *
+from snapred.backend.recipe.algorithm.data.ReheatLeftovers import ReheatLeftovers
+from snapred.backend.recipe.algorithm.data.WrapLeftovers import WrapLeftovers
+
+
+def compareRaggedWorkspaces(ws1, ws2):
+    assert ws1.getNumberHistograms() == ws2.getNumberHistograms()
+
+    assert ws1.isRaggedWorkspace()
+    assert ws2.isRaggedWorkspace()
+
+    for i in range(ws1.getNumberHistograms()):
+        np.testing.assert_allclose(ws1.readX(i), ws2.readX(i))
+        np.testing.assert_allclose(ws1.readY(i), ws2.readY(i))
+        np.testing.assert_allclose(ws1.readE(i), ws2.readE(i))
+
+
+def test_saveLoad():
+    # Load focussed data
+    CreateSampleWorkspace(
+        OutputWorkspace="raw",
+        Function="One Peak",
+        NumBanks=1,
+        NumMonitors=1,
+        BankPixelWidth=5,
+        NumEvents=500,
+        Random=True,
+        XUnit="TOF",
+        XMin=0,
+        XMax=8000,
+        BinWidth=100,
+    )
+    LoadInstrument(Workspace="raw", RewriteSpectraMap=False, InstrumentName="SNAP")
+
+    xMin = [0.05] * 20
+    xMin.extend([0.05, 0.06, 0.1, 0.07, 0.04, 0.04])
+    xMax = [0.36] * 20
+    xMax.extend([0.36, 0.41, 0.64, 0.48, 0.48, 0.48])
+    delta = [-0.000401475] * 20
+    delta.extend([-0.000401475, -0.000277182, -0.000323453, -0.000430986, -0.000430986, -0.000430986])
+
+    RebinRagged(InputWorkspace="raw", XMin=xMin, XMax=xMax, Delta=delta, PreserveEvents=False, OutputWorkspace="raw")
+
+    with tempfile.TemporaryDirectory(prefix="/tmp/") as extractPath:
+        filename = f"{extractPath}/leftovers.tar"
+        wrapLeftovers = WrapLeftovers()
+        wrapLeftovers.initialize()
+        wrapLeftovers.setPropertyValue("InputWorkspace", "raw")
+        wrapLeftovers.setPropertyValue("Filename", filename)
+        wrapLeftovers.execute()
+
+        reheatLeftovers = ReheatLeftovers()
+        reheatLeftovers.initialize()
+        reheatLeftovers.setPropertyValue("OutputWorkspace", "reheated")
+        reheatLeftovers.setPropertyValue("Filename", filename)
+        reheatLeftovers.execute()
+        compareRaggedWorkspaces(mtd["raw"], mtd["reheated"])
+        DeleteWorkspace("raw")
+        DeleteWorkspace("reheated")
+    # CompareWorkspaces(Workspace1="raw", Workspace2="reheated") Doesnt work with ragged!

--- a/tests/unit/backend/recipe/algorithm/data/test_Leftovers.py
+++ b/tests/unit/backend/recipe/algorithm/data/test_Leftovers.py
@@ -26,7 +26,7 @@ def test_saveLoad():
         Function="One Peak",
         NumBanks=1,
         NumMonitors=1,
-        BankPixelWidth=5,
+        BankPixelWidth=3,
         NumEvents=500,
         Random=True,
         XUnit="TOF",

--- a/tests/unit/backend/recipe/algorithm/data/test_Leftovers.py
+++ b/tests/unit/backend/recipe/algorithm/data/test_Leftovers.py
@@ -20,6 +20,8 @@ def compareRaggedWorkspaces(ws1, ws2):
         spec1 = ws1.getSpectrum(i)
         spec2 = ws2.getSpectrum(i)
         assert spec1.getSpectrumNo() == spec2.getSpectrumNo()
+        for detId1, detId2 in zip(spec1.getDetectorIDs(), spec2.getDetectorIDs()):
+            assert detId1 == detId2
 
 
 def test_saveLoad():

--- a/tests/unit/backend/recipe/algorithm/data/test_Leftovers.py
+++ b/tests/unit/backend/recipe/algorithm/data/test_Leftovers.py
@@ -36,11 +36,12 @@ def test_saveLoad():
     )
     LoadInstrument(Workspace="raw", RewriteSpectraMap=False, InstrumentName="SNAP")
 
-    xMin = [0.05] * 20
+    numFillerSpectra = 10 - 6
+    xMin = [0.05] * numFillerSpectra
     xMin.extend([0.05, 0.06, 0.1, 0.07, 0.04, 0.04])
-    xMax = [0.36] * 20
+    xMax = [0.36] * numFillerSpectra
     xMax.extend([0.36, 0.41, 0.64, 0.48, 0.48, 0.48])
-    delta = [-0.000401475] * 20
+    delta = [-0.000401475] * numFillerSpectra
     delta.extend([-0.000401475, -0.000277182, -0.000323453, -0.000430986, -0.000430986, -0.000430986])
 
     RebinRagged(InputWorkspace="raw", XMin=xMin, XMax=xMax, Delta=delta, PreserveEvents=False, OutputWorkspace="raw")

--- a/tests/unit/backend/recipe/algorithm/data/test_Leftovers.py
+++ b/tests/unit/backend/recipe/algorithm/data/test_Leftovers.py
@@ -17,6 +17,9 @@ def compareRaggedWorkspaces(ws1, ws2):
         np.testing.assert_allclose(ws1.readX(i), ws2.readX(i))
         np.testing.assert_allclose(ws1.readY(i), ws2.readY(i))
         np.testing.assert_allclose(ws1.readE(i), ws2.readE(i))
+        spec1 = ws1.getSpectrum(i)
+        spec2 = ws2.getSpectrum(i)
+        assert spec1.getSpectrumNo() == spec2.getSpectrumNo()
 
 
 def test_saveLoad():

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -169,8 +169,8 @@ class TestCalibrationServiceMethods(unittest.TestCase):
                     case wngt.DIFFCAL_MASK:
                         maskWSName = wsName
                     case _:
-                        filename = Path(wsName + ".nxs")
-                        self.instance.dataExportService.exportWorkspace(path, filename, self.sampleWS)
+                        filename = Path(wsName + ".tar")
+                        self.instance.dataExportService.exportRaggedWorkspace(path, filename, self.sampleWS)
         # For the moment, only one set of 'table' + 'mask' workspace is assumed
         if tableWSName or maskWSName:
             filename = Path(tableWSName + ".h5")


### PR DESCRIPTION
## Description of work

This is a workaround to allow SNAPRed to save and load ragged workspaces as the existed at the time of Calibration/Normalization.

## Explanation of work

The interim solution is to just rip out each spectra and save it individually in a tar file, then recompose it on load.

This is not efficient for workspaces with a lot of histograms, and thus is validated for that.

## To test

Run the Calibration and Normalization workflows in your local copy of the Calibration folder, confirming the saving and loading functionalities in the workflow work.

For your convenience:

Calibration Runnumber: 57474, Diamond
Normaliztion: 58810, 58813, any. 

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4440](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4440)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
