### PR TITLE
Grouping-schema map: preserve relative-path information

### DIFF
--- a/src/snapred/backend/dao/state/FocusGroup.py
+++ b/src/snapred/backend/dao/state/FocusGroup.py
@@ -4,5 +4,10 @@ from pydantic import BaseModel
 
 
 class FocusGroup(BaseModel):
-    name: str  # eg Column, Bank, All
-    definition: str  # eg SNS/SNAP/shared/IPTS_xxx/nexus/SNAP+123.nxs
+    # name of grouping schema:
+    # e.g. "Column", "Bank", "All"
+    name: str
+    
+    # relative or absolute file path:
+    # * a relative path here is relative to <instrument.calibration.powder.grouping.home>
+    definition: str

--- a/src/snapred/backend/dao/state/FocusGroup.py
+++ b/src/snapred/backend/dao/state/FocusGroup.py
@@ -7,7 +7,7 @@ class FocusGroup(BaseModel):
     # name of grouping schema:
     # e.g. "Column", "Bank", "All"
     name: str
-    
+
     # relative or absolute file path:
     # * a relative path here is relative to <instrument.calibration.powder.grouping.home>
     definition: str

--- a/src/snapred/backend/dao/state/GroupingMap.py
+++ b/src/snapred/backend/dao/state/GroupingMap.py
@@ -31,9 +31,9 @@ class GroupingMap(BaseModel):
     # * verify that this GroupingMap's file is at its expected location (e.g. it hasn't been moved or copied);
     stateId: ObjectSHA
 
-    # Although the public interface of `GroupingMap` is a mapping:
-    # *  for ease of editing, its JSON file is written using a list format:
-    # *  relative vs. absolute path format must also be retained in the JSON representation.
+    # Although the public interface to `GroupingMap` is a mapping, for ease of editing:
+    # *  the JSON representation is written using a list format:
+    # *  relative vs. absolute path information is retained in the representation.
     nativeFocusGroups: List[FocusGroup] = Field(default=None)
     liteFocusGroups: List[FocusGroup] = Field(default=None)
 
@@ -116,3 +116,8 @@ class GroupingMap(BaseModel):
         v["_liteMap"] = groups["lite"]
         v["_isDirty"] = False
         return v
+
+    class Config:
+        # All other forms of _exclusion_ do not seem to work in Pydantic 1.10 (for this `GroupingMap` class, specifically).
+        fields = {"liteFocusGroups": {"include": True}, "nativeFocusGroups": {"include": True}, "stateId": {"include": True}}
+ 

--- a/src/snapred/backend/dao/state/GroupingMap.py
+++ b/src/snapred/backend/dao/state/GroupingMap.py
@@ -118,6 +118,7 @@ class GroupingMap(BaseModel):
         return v
 
     class Config:
-        # All other forms of _exclusion_ do not seem to work in Pydantic 1.10 (for this `GroupingMap` class, specifically).
+        # All other forms of _exclusion_ do not seem to work in Pydantic 1.10,
+        # (for this `GroupingMap` class, specifically).
         fields = {"liteFocusGroups": {"include": True}, "nativeFocusGroups": {"include": True}, "stateId": {"include": True}}
  

--- a/src/snapred/backend/dao/state/GroupingMap.py
+++ b/src/snapred/backend/dao/state/GroupingMap.py
@@ -21,10 +21,19 @@ class GroupingMap(BaseModel):
     def calibrationGroupingHome(cls) -> Path:
         return Path(Config["instrument.calibration.powder.grouping.home"])
 
+    @classmethod
+    def _asAbsolutePath(cls, filePath: Path) -> Path:
+        if filePath.is_absolute():
+            return filePath
+        return cls.calibrationGroupingHome().join(filePath)
+
     # Use the StateId hash to enforce filesystem-as-database integrity requirements:
     # * verify that this GroupingMap's file is at its expected location (e.g. it hasn't been moved or copied);
     stateId: ObjectSHA
 
+    # Although the public interface of `GroupingMap` is a mapping:
+    # *  for ease of editing, its JSON file is written using a list format:
+    # *  relative vs. absolute path format must also be retained in the JSON representation.
     nativeFocusGroups: List[FocusGroup] = Field(default=None)
     liteFocusGroups: List[FocusGroup] = Field(default=None)
 
@@ -69,9 +78,10 @@ class GroupingMap(BaseModel):
         return v
 
     @root_validator(pre=False, allow_reuse=True)
-    def validate_GroupingMapFile(cls, v):
+    def validate_GroupingMap(cls, v):
         _native = {}
         _lite = {}
+        # Build `GroupingMap` from input lists:
         if v.get("nativeFocusGroups"):
             _native = {nfg.name: nfg for nfg in v["nativeFocusGroups"]}
         if v.get("liteFocusGroups"):
@@ -82,15 +92,17 @@ class GroupingMap(BaseModel):
             for group in groups[mode].copy():
                 fp = Path(groups[mode][group].definition)
                 # Check if path is relative
-                if not os.path.isabs(fp):
-                    fp = Path.joinpath(cls.calibrationGroupingHome(), fp)
-                    groups[mode][group].definition = fp
+                if not fp.is_absolute():
+                    # Do _not_ change the path in the original `FocusGroup`,
+                    #   otherwise the path will also change in the on-disk version.
+                    fp = cls._asAbsolutePath(fp)
+                    groups[mode][group] = FocusGroup(name=group, definition=str(fp))
                 if not fp.exists():
-                    logger.warning("File:" + str(fp) + " not found")
+                    logger.warning("File: " + str(fp) + " not found")
                     del groups[mode][group]
                     continue
                 if not fp.is_file():
-                    logger.warning("File:" + str(fp) + " is not valid")
+                    logger.warning("File: " + str(fp) + " is not valid")
                     del groups[mode][group]
                     continue
                 if not str(fp).endswith(supportedExtensions):

--- a/src/snapred/backend/dao/state/GroupingMap.py
+++ b/src/snapred/backend/dao/state/GroupingMap.py
@@ -25,7 +25,7 @@ class GroupingMap(BaseModel):
     def _asAbsolutePath(cls, filePath: Path) -> Path:
         if filePath.is_absolute():
             return filePath
-        return cls.calibrationGroupingHome().join(filePath)
+        return cls.calibrationGroupingHome().joinpath(filePath)
 
     # Use the StateId hash to enforce filesystem-as-database integrity requirements:
     # * verify that this GroupingMap's file is at its expected location (e.g. it hasn't been moved or copied);

--- a/src/snapred/backend/dao/state/GroupingMap.py
+++ b/src/snapred/backend/dao/state/GroupingMap.py
@@ -120,5 +120,8 @@ class GroupingMap(BaseModel):
     class Config:
         # All other forms of _exclusion_ do not seem to work in Pydantic 1.10,
         # (for this `GroupingMap` class, specifically).
-        fields = {"liteFocusGroups": {"include": True}, "nativeFocusGroups": {"include": True}, "stateId": {"include": True}}
- 
+        fields = {
+            "liteFocusGroups": {"include": True},
+            "nativeFocusGroups": {"include": True},
+            "stateId": {"include": True},
+        }

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -939,8 +939,9 @@ class LocalDataService:
 
         # Only write once and do not allow overwrite.
         if groupingMap.isDirty and not groupingMapPath.exists():
-            write_model_pretty(groupingMap, groupingMapPath)
+            # For consistency: write out `_isDirty` as False
             groupingMap.setDirty(False)
+            write_model_pretty(groupingMap, groupingMapPath)
 
     def _defaultGroupingMapPath(self) -> Path:
         return GroupingMap.calibrationGroupingHome() / "defaultGroupingMap.json"

--- a/tests/resources/inputs/pixel_grouping/defaultGroupingMap.json
+++ b/tests/resources/inputs/pixel_grouping/defaultGroupingMap.json
@@ -2,14 +2,30 @@
   "stateId": "aabbbcccdddeeeff",
   "liteFocusGroups": [
     {
-        "name": "name",
-        "definition": "relative/path/to/file"
-    }
+        "name": "all",
+        "definition": "SNAPFocGroup_All.lite.hdf"
+    },
+    {
+        "name": "column",
+        "definition": "SNAPFocGroup_Column.lite.hdf"
+    },
+    {
+        "name": "bank",
+        "definition": "SNAPFocGroup_Bank.lite.hdf"
+    }    
   ],
   "nativeFocusGroups": [
     {
-        "name": "name",
-        "definition": "relative/path/to/file"
+        "name": "all",
+        "definition": "SNAPFocGroup_All.hdf"
+    },
+    {
+        "name": "column",
+        "definition": "SNAPFocGroup_Column.hdf"
+    },
+    {
+        "name": "bank",
+        "definition": "SNAPFocGroup_Bank.hdf"
     }
   ]
 }

--- a/tests/resources/inputs/pixel_grouping/defaultGroupingMap.json
+++ b/tests/resources/inputs/pixel_grouping/defaultGroupingMap.json
@@ -12,7 +12,7 @@
     {
         "name": "bank",
         "definition": "SNAPFocGroup_Bank.lite.hdf"
-    }    
+    }
   ],
   "nativeFocusGroups": [
     {

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -372,6 +372,49 @@ def test_prepareStateRoot_does_not_overwrite_grouping_map():
         assert groupingMap.stateId == otherStateId
 
 
+def test_writeGroupingMap_relative_paths():
+    # Test that '_writeGroupingMap' preserves relative-path information.
+    localDataService = LocalDataService()
+    savePath = Config._config["instrument"]["calibration"]["powder"]["grouping"]["home"]
+    try:
+        Config._config["instrument"]["calibration"]["powder"]["grouping"]["home"] = Resource.getPath(
+            "inputs/pixel_grouping/"
+        )
+
+        with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tmpDir:
+            stateId = "ab8704b0bc2a2342"
+            stateRootPath = Path(tmpDir) / stateId
+            os.makedirs(stateRootPath)
+
+            defaultGroupingMapFilePath = Resource.getPath("inputs/pixel_grouping/defaultGroupingMap.json")
+            groupingMapFilePath = stateRootPath / "groupingMap.json"
+            localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
+
+            # Write a 'groupingMap.json' file to the <state root>, with the _correct_ stateId;
+            #   note that the _value_ of the stateId field is _not_ validated at this stage, except for its format.
+            with open(defaultGroupingMapFilePath, "r") as file:
+                groupingMap = parse_raw_as(GroupingMap, file.read())
+            groupingMap.coerceStateId(stateId)
+            localDataService._writeGroupingMap(stateId, groupingMap)
+
+            # read it back
+            groupingMap = GroupingMap.parse_file(groupingMapFilePath)
+            defaultGroupingMap = GroupingMap.parse_file(defaultGroupingMapFilePath)
+
+            # test that relative paths are preserved
+            relativePathCount = 0
+            for n, focusGroup in enumerate(groupingMap.liteFocusGroups):
+                assert focusGroup == defaultGroupingMap.liteFocusGroups[n]
+                if not Path(focusGroup.definition).is_absolute():
+                    relativePathCount += 1
+            for n, focusGroup in enumerate(groupingMap.nativeFocusGroups):
+                assert focusGroup == defaultGroupingMap.nativeFocusGroups[n]
+                if not Path(focusGroup.definition).is_absolute():
+                    relativePathCount += 1
+            assert relativePathCount > 0
+    finally:
+        Config._config["instrument"]["calibration"]["powder"]["grouping"]["home"] = savePath
+             
 @mock.patch(ThisService + "GetIPTS")
 def test_calibrationFileExists(GetIPTS):  # noqa ARG002
     with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tmpDir:
@@ -1475,7 +1518,6 @@ def test_readGroupingMap_initialized_state():
         shutil.copy(Path(Resource.getPath("inputs/pixel_grouping/groupingMap.json")), stateRoot)
         groupingMap = service._readGroupingMap(stateId)
         assert groupingMap.stateId == stateId
-
 
 @mock.patch("os.path.exists", return_value=True)
 def test_writeCalibrantSample_failure(mock1):  # noqa: ARG001

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -414,7 +414,8 @@ def test_writeGroupingMap_relative_paths():
             assert relativePathCount > 0
     finally:
         Config._config["instrument"]["calibration"]["powder"]["grouping"]["home"] = savePath
-             
+
+
 @mock.patch(ThisService + "GetIPTS")
 def test_calibrationFileExists(GetIPTS):  # noqa ARG002
     with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tmpDir:
@@ -1518,6 +1519,7 @@ def test_readGroupingMap_initialized_state():
         shutil.copy(Path(Resource.getPath("inputs/pixel_grouping/groupingMap.json")), stateRoot)
         groupingMap = service._readGroupingMap(stateId)
         assert groupingMap.stateId == stateId
+
 
 @mock.patch("os.path.exists", return_value=True)
 def test_writeCalibrantSample_failure(mock1):  # noqa: ARG001


### PR DESCRIPTION
## Preserve relative-path information in JSON representations of the `GroupingMap`. ##

## Description of work

  * Added additional comments in the `GroupingMap` code, to clarify design intentions;

  * Prevented overwriting of incoming `FocusGroup` information during `GroupingMap` validation.
  * Excluded non user-facing attributes of `GroupingMap` from its JSON representation.  This was quite difficult to do, as many of the Pydantic techniques (such as `Field(exclude=True)`) for some reason fail to work when applied to this `GroupingMap` class.  As things turned out, explicitly _including_ the required fields does work.

## To test

### Dev testing
A unit test has been added to cover these changes.

### CIS testing
TODO: link to original `GroupingMap` CIS-tests discussion  => no changes in behavior should be observed apart from the changes specific to this PR.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4448](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=4448)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
