### PR TITLE
It's not the test panel anymore

### DIFF
--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -79,11 +79,12 @@ class SNAPRedGUI(QMainWindow):
             traceback.print_exception(e)
             from qtpy.QtWidgets import QMessageBox
 
+            msg = "Sorry!  Error encountered while opening Calibration Panel.\n"
+            msg = msg + "This is usually caused by an issue with your file tree structure.\n"
+            msg = msg + "Contact an IS or CIS for help in resolving the file system issue."
             errorPopup = QMessageBox()
             errorPopup.setIcon(QMessageBox.Critical)
-            errorPopup.setText(
-                "Sorry!\nError Opening Calibration Panel!\nPlease try again avoiding whatever you just did."
-            )
+            errorPopup.setText(msg)
             errorPopup.setDetailedText(str(e))
             errorPopup.setFixedSize(500, 200)
             errorPopup.exec()

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -33,7 +33,7 @@ class SNAPRedGUI(QMainWindow):
         splitter.addWidget(logTable.widget)
 
         # add button to open new window
-        button = QPushButton("Open Test Panel")
+        button = QPushButton("Open Calibration Panel")
         button.clicked.connect(self.openNewWindow)
         splitter.addWidget(button)
 
@@ -70,7 +70,7 @@ class SNAPRedGUI(QMainWindow):
     def openNewWindow(self):
         try:
             self.newWindow = TestPanel(self)
-            self.newWindow.widget.setWindowTitle("Test Panel")
+            self.newWindow.widget.setWindowTitle("Calibration Panel")
             self.newWindow.widget.show()
         except Exception as e:  # noqa: BLE001
             # show error message as popup
@@ -81,7 +81,9 @@ class SNAPRedGUI(QMainWindow):
 
             errorPopup = QMessageBox()
             errorPopup.setIcon(QMessageBox.Critical)
-            errorPopup.setText("Sorry!\nError In TestPanel!\nPlease try again avoiding whatever you just did.")
+            errorPopup.setText(
+                "Sorry!\nError Opening Calibration Panel!\nPlease try again avoiding whatever you just did."
+            )
             errorPopup.setDetailedText(str(e))
             errorPopup.setFixedSize(500, 200)
             errorPopup.exec()

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -80,8 +80,9 @@ class SNAPRedGUI(QMainWindow):
             from qtpy.QtWidgets import QMessageBox
 
             msg = "Sorry!  Error encountered while opening Calibration Panel.\n"
-            msg = msg + "This is usually caused by an issue with your file tree structure.\n"
-            msg = msg + "Contact an IS or CIS for help in resolving the file system issue."
+            msg = msg + "This is usually caused by an issue with the file tree.\n"
+            msg = msg + "An expert user can correct this by editing the application.yml file.\n"
+            msg = msg + "Contact your IS or CIS for help in resolving this issue."
             errorPopup = QMessageBox()
             errorPopup.setIcon(QMessageBox.Critical)
             errorPopup.setText(msg)


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

@backmari  just asked me why the GUI window is called the Test Panel.

It is now called the Calibration Panel.

## Explanation of work

I changed the name.

I changed the error when loading the calibration panel.  I think this message is more helpful, as it says how an expert user could fix the issue, and who to contact if they need help.

## To test

### Dev testing

Open it, launch the calibration panel, make sure it is called Calibration Panel.

Try running something for good measure, but nothing should depend on the window title.

To verify the new error message occurs, edit your dev.yml to point somewhere that doesn't exist then try launching.

### CIS testing

Not needed.

**NOTE**: changing the name is just to avoid confusing users during the beta testing.  Changing the name does **NOT** signal this is the final form of the GUI.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
