### PR TITLE
Allow Peak Function Selection in Tweak Peak Peek

### DIFF
--- a/docs/source/api/snapred.ui.view.rst
+++ b/docs/source/api/snapred.ui.view.rst
@@ -52,7 +52,7 @@ snapred.ui.view.DiffCalTweakPeakView module
 .. automodule:: snapred.ui.view.DiffCalTweakPeakView
    :members:
    :undoc-members:
-   :exclude-members: signalRunNumberUpdate, signalValueChanged, signalUpdateRecalculationButton
+   :exclude-members: signalRunNumberUpdate, signalValueChanged, signalUpdateRecalculationButton, signalPeakThresholdUpdate
    :show-inheritance:
 
 snapred.ui.view.FitMultiplePeaksView module

--- a/src/snapred/backend/dao/request/FitMultiplePeaksRequest.py
+++ b/src/snapred/backend/dao/request/FitMultiplePeaksRequest.py
@@ -3,6 +3,8 @@ from typing import List
 from pydantic import BaseModel
 
 from snapred.backend.dao.GroupPeakList import GroupPeakList
+from snapred.meta.Config import Config
+from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
 
@@ -10,3 +12,4 @@ class FitMultiplePeaksRequest(BaseModel):
     inputWorkspace: WorkspaceName
     outputWorkspaceGroup: WorkspaceName
     detectorPeaks: List[GroupPeakList]
+    peakFunction: SymmetricPeakEnum = SymmetricPeakEnum[Config["calibration.diffraction.peakFunction"]]

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -200,6 +200,7 @@ class CalibrationService(Service):
         return FitMultiplePeaksRecipe().executeRecipe(
             InputWorkspace=request.inputWorkspace,
             DetectorPeaks=request.detectorPeaks,
+            PeakType=request.peakFunction,
             OutputWorkspaceGroup=request.outputWorkspaceGroup,
         )
 

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -46,7 +46,7 @@ class DiffCalTweakPeakView(BackendRequestView):
     MAX_CHI_SQ = Config["constants.GroupDiffractionCalibration.MaxChiSq"]
 
     signalRunNumberUpdate = Signal(str)
-    signalValueChanged = Signal(int, float, float, float)
+    signalValueChanged = Signal(int, float, float, float, SymmetricPeakEnum)
     signalUpdateRecalculationButton = Signal(bool)
 
     def __init__(self, jsonForm, samples=[], groups=[], parent=None):
@@ -69,7 +69,7 @@ class DiffCalTweakPeakView(BackendRequestView):
         self.peakFunctionDropdown = self._sampleDropDown("Peak Function", [p.value for p in SymmetricPeakEnum])
 
         # disable run number, lite mode, sample, peak fucnction -- cannot be changed now
-        for x in [self.runNumberField, self.litemodeToggle, self.sampleDropdown, self.peakFunctionDropdown]:
+        for x in [self.runNumberField, self.litemodeToggle, self.sampleDropdown]:
             x.setEnabled(False)
 
         # create the peak adustment controls
@@ -121,6 +121,7 @@ class DiffCalTweakPeakView(BackendRequestView):
             dMin = float(self.fielddMin.field.text())
             dMax = float(self.fielddMax.field.text())
             peakThreshold = float(self.fieldThreshold.text())
+            peakFunction = SymmetricPeakEnum(self.peakFunctionDropdown.currentText())
         except ValueError as e:
             QMessageBox.warning(
                 self,
@@ -147,7 +148,7 @@ class DiffCalTweakPeakView(BackendRequestView):
                 QMessageBox.Ok,
             )
             return
-        self.signalValueChanged.emit(groupingIndex, dMin, dMax, peakThreshold)
+        self.signalValueChanged.emit(groupingIndex, dMin, dMax, peakThreshold, peakFunction)
 
     def updateGraphs(self, workspace, peaks, diagnostic):
         # get the updated workspaces and optimal graph grid

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -46,6 +46,7 @@ class DiffCalTweakPeakView(BackendRequestView):
     MAX_CHI_SQ = Config["constants.GroupDiffractionCalibration.MaxChiSq"]
 
     signalRunNumberUpdate = Signal(str)
+    signalPeakThresholdUpdate = Signal(str)
     signalValueChanged = Signal(int, float, float, float, SymmetricPeakEnum)
     signalUpdateRecalculationButton = Signal(bool)
 
@@ -57,6 +58,7 @@ class DiffCalTweakPeakView(BackendRequestView):
         self.runNumberField = self._labeledField("Run Number")
         self.litemodeToggle = self._labeledField("Lite Mode", Toggle(parent=self, state=True))
         self.signalRunNumberUpdate.connect(self._updateRunNumber)
+        self.signalPeakThresholdUpdate.connect(self._updatePeakThreshold)
 
         # create the graph elements
         self.figure = plt.figure(constrained_layout=True)
@@ -108,6 +110,12 @@ class DiffCalTweakPeakView(BackendRequestView):
 
     def updateRunNumber(self, runNumber):
         self.signalRunNumberUpdate.emit(runNumber)
+
+    def _updatePeakThreshold(self, peakThreshold):
+        self.fieldThreshold.setText(peakThreshold)
+
+    def updatePeakThreshold(self, peakThreshold):
+        self.signalPeakThresholdUpdate.emit(peakThreshold)
 
     def updateFields(self, sampleIndex, groupingIndex, peakIndex):
         self.sampleDropdown.setCurrentIndex(sampleIndex)

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -155,6 +155,7 @@ class DiffCalWorkflow(WorkflowImplementer):
             view.groupingFileDropdown.currentIndex(),
             view.peakFunctionDropdown.currentIndex(),
         )
+        self._tweakPeakView.updatePeakThreshold(self.peakThreshold)
 
         payload = DiffractionCalibrationRequest(
             runNumber=self.runNumber,


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

While testing, Malcolm noticed a defect when running diffcal with the following:
- run number = 49525
- grouping = Column (but irrelevant)
- peak function = PseudoVoigt
- dMin = 0.4 (mostly irrelevant)
- dMax = 100 (mostly irrelevant)
- peak threshold = 0.05 (mostly irrelevant)

On the initial tweak peak peek, some peaks showed as poorly fitting, but also many showed up as blue:
![Pasted Graphic 1](https://github.com/neutrons/SNAPRed/assets/52183986/f33438b4-f33a-4327-b4cc-e8cab7322fb1)

However, when Malcolm selected to continue, PDCalibration ran and failed to fit **any** peaks for **any** of the groups.

The reason for failing to fit **all** peaks is a failure of the PseudoVoigt fitting function, which has some problem inside mantid's `FitPeaks` algorithm.

However, the failure for SNAPRed is that it was not properly passing the fit function parameter to `FitPeaks` during the tweak peak peek.  This function was **only** being passed during calibration, which represented a difference in the two processes.   This is why the peak peek would show good fits but PDCalibration would find bad fits.

This PR will
1. properly propagate the user's peak function selection to `FitMultiplePeaks`
2. allow the user to change the peak function during tweak peak peek.

**ALSO** will fix the issue raised in testing meeting, so that the peak intensity threshold is propagated form first screen to second.

## Explanation of work

Added 

## To test

### Dev testing

Wait until Malcolm leaves an approving comment.

### CIS testing

Open in CIS mode.  Try doing exactly what you did to generate this error, including using PseudoVoigt.  It might be easier to use "**All**" grouping to have fewer tables to open.

**ALSO** enter whatever peak intensity threshold you like, but not 0.05.

Verify on the Tweak Peak tab, that **every single** peak is red.

**ALSO** verify that the peak intensity threshold is whatever you had put on the first screen,

Change peak function to Gaussian.

Verify at least **some** of the peaks are not red.

Run diffcal.

Open the _PDCal_diag_X workspace groups, which should contain the `_fitparam` tables.  Compare the peak centers of this, to the peak centers in the `fit_peaks_diag_49525_2_fitted_params_X` table.  Verify peak centers and chi-sq are approximately the same.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4538](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4538)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
