### PR TITLE
forgot to add the new version to the calibration entry

### DIFF
--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -212,6 +212,7 @@ class CalibrationService(Service):
         calibrationRecord.version = version
         calibrationRecord = self.dataExportService.exportCalibrationRecord(calibrationRecord)
         calibrationRecord = self.dataExportService.exportCalibrationWorkspaces(calibrationRecord)
+        entry.version = calibrationRecord.version
         self.saveCalibrationToIndex(entry)
 
     @FromString

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -173,6 +173,7 @@ class NormalizationService(Service):
         normalizationRecord.version = version
         normalizationRecord = self.dataExportService.exportNormalizationRecord(normalizationRecord)
         normalizationRecord = self.dataExportService.exportNormalizationWorkspaces(normalizationRecord)
+        entry.version = normalizationRecord.version
         self.saveNormalizationToIndex(entry)
 
     def saveNormalizationToIndex(self, entry: NormalizationIndexEntry):


### PR DESCRIPTION
## Description of work

Forgot to update the entry's value of version. 

## To test

Run Calibration and/or normalization and check their index, see that the correct version is populated.
Calibration: 49525
Normalization: 58813, 58810

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
