### PR TITLE
Allow user to change FWHM multipliers

### DIFF
--- a/src/snapred/backend/dao/Limit.py
+++ b/src/snapred/backend/dao/Limit.py
@@ -24,6 +24,25 @@ class Limit(GenericModel, Generic[T]):
     #     return values
 
 
+class Pair(GenericModel, Generic[T]):
+    left: T
+    right: T
+
+    def __init__(self, minimum: T = None, maximum: T = None, **kwargs):
+        if minimum is not None and maximum is not None:
+            super().__init__(left=minimum, right=maximum)
+        else:
+            super().__init__(**kwargs)
+
+    @property
+    def minimum(self) -> T:
+        return self.left
+
+    @property
+    def maximum(self) -> T:
+        return self.right
+
+
 class LimitedValue(GenericModel, Generic[T]):
     value: T
     minimum: T

--- a/src/snapred/backend/dao/request/CalibrationAssessmentRequest.py
+++ b/src/snapred/backend/dao/request/CalibrationAssessmentRequest.py
@@ -2,7 +2,7 @@ from typing import Dict, List
 
 from pydantic import BaseModel
 
-from snapred.backend.dao.Limit import Limit
+from snapred.backend.dao.Limit import Pair
 from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.meta.Config import Config
@@ -31,7 +31,4 @@ class CalibrationAssessmentRequest(BaseModel):
     nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]
     peakIntensityThreshold: float = Config["calibration.diffraction.peakIntensityThreshold"]
     peakType: ALLOWED_PEAK_TYPES = "Gaussian"
-    fwhmMultiplierLimit: Limit[float] = Limit(
-        minimum=Config["calibration.parameters.default.FWHMMultiplier"][0],
-        maximum=Config["calibration.parameters.default.FWHMMultiplier"][1],
-    )
+    fwhmMultipliers: Pair[float] = Pair.parse_obj(Config["calibration.parameters.default.FWHMMultiplier"])

--- a/src/snapred/backend/dao/request/CalibrationAssessmentRequest.py
+++ b/src/snapred/backend/dao/request/CalibrationAssessmentRequest.py
@@ -2,6 +2,7 @@ from typing import Dict, List
 
 from pydantic import BaseModel
 
+from snapred.backend.dao.Limit import Limit
 from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.meta.Config import Config
@@ -30,3 +31,7 @@ class CalibrationAssessmentRequest(BaseModel):
     nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]
     peakIntensityThreshold: float = Config["calibration.diffraction.peakIntensityThreshold"]
     peakType: ALLOWED_PEAK_TYPES = "Gaussian"
+    fwhmMultiplierLimit: Limit[float] = Limit(
+        minimum=Config["calibration.parameters.default.FWHMMultiplier"][0],
+        maximum=Config["calibration.parameters.default.FWHMMultiplier"][1],
+    )

--- a/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
+++ b/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from pydantic import BaseModel
 
-from snapred.backend.dao.Limit import Limit
+from snapred.backend.dao.Limit import Pair
 from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.meta.Config import Config
@@ -35,7 +35,4 @@ class DiffractionCalibrationRequest(BaseModel):
     peakIntensityThreshold: float = Config["calibration.diffraction.peakIntensityThreshold"]
     nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]
     maximumOffset: float = Config["calibration.diffraction.maximumOffset"]
-    fwhmMultiplierLimit: Limit[float] = Limit(
-        minimum=Config["calibration.parameters.default.FWHMMultiplier"][0],
-        maximum=Config["calibration.parameters.default.FWHMMultiplier"][1],
-    )
+    fwhmMultipliers: Pair[float] = Pair.parse_obj(Config["calibration.parameters.default.FWHMMultiplier"])

--- a/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
+++ b/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from pydantic import BaseModel
 
+from snapred.backend.dao.Limit import Limit
 from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.meta.Config import Config
@@ -34,3 +35,7 @@ class DiffractionCalibrationRequest(BaseModel):
     peakIntensityThreshold: float = Config["calibration.diffraction.peakIntensityThreshold"]
     nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]
     maximumOffset: float = Config["calibration.diffraction.maximumOffset"]
+    fwhmMultiplierLimit: Limit[float] = Limit(
+        minimum=Config["calibration.parameters.default.FWHMMultiplier"][0],
+        maximum=Config["calibration.parameters.default.FWHMMultiplier"][1],
+    )

--- a/src/snapred/backend/dao/request/FarmFreshIngredients.py
+++ b/src/snapred/backend/dao/request/FarmFreshIngredients.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from pydantic import BaseModel, validator
 
-from snapred.backend.dao.Limit import Limit
+from snapred.backend.dao.Limit import Limit, Pair
 from snapred.backend.dao.state import FocusGroup
 from snapred.meta.Config import Config
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
@@ -37,7 +37,4 @@ class FarmFreshIngredients(BaseModel):
         minimum=Config["constants.CrystallographicInfo.dMin"],
         maximum=Config["constants.CrystallographicInfo.dMax"],
     )
-    fwhmMultiplierLimit: Limit[float] = Limit(
-        minimum=Config["calibration.parameters.default.FWHMMultiplier"][0],
-        maximum=Config["calibration.parameters.default.FWHMMultiplier"][1],
-    )
+    fwhmMultipliers: Pair[float] = Pair.parse_obj(Config["calibration.parameters.default.FWHMMultiplier"])

--- a/src/snapred/backend/dao/request/FarmFreshIngredients.py
+++ b/src/snapred/backend/dao/request/FarmFreshIngredients.py
@@ -37,3 +37,7 @@ class FarmFreshIngredients(BaseModel):
         minimum=Config["constants.CrystallographicInfo.dMin"],
         maximum=Config["constants.CrystallographicInfo.dMax"],
     )
+    fwhmMultiplierLimit: Limit[float] = Limit(
+        minimum=Config["calibration.parameters.default.FWHMMultiplier"][0],
+        maximum=Config["calibration.parameters.default.FWHMMultiplier"][1],
+    )

--- a/src/snapred/backend/dao/request/NormalizationCalibrationRequest.py
+++ b/src/snapred/backend/dao/request/NormalizationCalibrationRequest.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 
+from snapred.backend.dao.Limit import Limit
 from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.meta.Config import Config
 
@@ -24,3 +25,7 @@ class NormalizationCalibrationRequest(BaseModel):
     crystalDMax: float = Config["constants.CrystallographicInfo.dMax"]
     peakIntensityThreshold: float = Config["constants.PeakIntensityFractionThreshold"]
     nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]
+    fwhmMultiplierLimit: Limit[float] = Limit(
+        minimum=Config["calibration.parameters.default.FWHMMultiplier"][0],
+        maximum=Config["calibration.parameters.default.FWHMMultiplier"][1],
+    )

--- a/src/snapred/backend/dao/request/NormalizationCalibrationRequest.py
+++ b/src/snapred/backend/dao/request/NormalizationCalibrationRequest.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 
-from snapred.backend.dao.Limit import Limit
+from snapred.backend.dao.Limit import Pair
 from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.meta.Config import Config
 
@@ -25,7 +25,4 @@ class NormalizationCalibrationRequest(BaseModel):
     crystalDMax: float = Config["constants.CrystallographicInfo.dMax"]
     peakIntensityThreshold: float = Config["constants.PeakIntensityFractionThreshold"]
     nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]
-    fwhmMultiplierLimit: Limit[float] = Limit(
-        minimum=Config["calibration.parameters.default.FWHMMultiplier"][0],
-        maximum=Config["calibration.parameters.default.FWHMMultiplier"][1],
-    )
+    fwhmMultipliers: Pair[float] = Pair.parse_obj(Config["calibration.parameters.default.FWHMMultiplier"])

--- a/src/snapred/backend/dao/state/InstrumentState.py
+++ b/src/snapred/backend/dao/state/InstrumentState.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, validator
 
 from snapred.backend.dao.GSASParameters import GSASParameters
 from snapred.backend.dao.InstrumentConfig import InstrumentConfig
-from snapred.backend.dao.Limit import Limit
+from snapred.backend.dao.Limit import Pair
 from snapred.backend.dao.ObjectSHA import ObjectSHA
 from snapred.backend.dao.ParticleBounds import ParticleBounds
 from snapred.backend.dao.state.DetectorState import DetectorState, GuideState
@@ -21,7 +21,7 @@ class InstrumentState(BaseModel):
     gsasParameters: GSASParameters
     particleBounds: ParticleBounds
     defaultGroupingSliceValue: float
-    fwhmMultiplierLimit: Limit[float]
+    fwhmMultipliers: Pair[float]
     peakTailCoefficient: float
 
     @property

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -17,7 +17,6 @@ from pydantic import parse_file_as
 from snapred.backend.dao import (
     GSASParameters,
     InstrumentConfig,
-    Limit,
     ObjectSHA,
     ParticleBounds,
     RunConfig,
@@ -25,6 +24,7 @@ from snapred.backend.dao import (
     StateId,
 )
 from snapred.backend.dao.calibration import Calibration, CalibrationIndexEntry, CalibrationRecord
+from snapred.backend.dao.Limit import Limit, Pair
 from snapred.backend.dao.normalization import Normalization, NormalizationIndexEntry, NormalizationRecord
 from snapred.backend.dao.state import (
     DetectorState,
@@ -810,10 +810,7 @@ class LocalDataService:
         instrumentConfig = self.readInstrumentConfig()
         # then pull static values specified by Malcolm from resources
         defaultGroupSliceValue = Config["calibration.parameters.default.groupSliceValue"]
-        fwhmMultiplier = Limit(
-            minimum=Config["calibration.parameters.default.FWHMMultiplier"][0],
-            maximum=Config["calibration.parameters.default.FWHMMultiplier"][1],
-        )
+        fwhmMultipliers = Pair.parse_obj(Config["calibration.parameters.default.FWHMMultiplier"])
         peakTailCoefficient = Config["calibration.parameters.default.peakTailCoefficient"]
         gsasParameters = GSASParameters(
             alpha=Config["calibration.parameters.default.alpha"], beta=Config["calibration.parameters.default.beta"]
@@ -837,7 +834,7 @@ class LocalDataService:
             gsasParameters=gsasParameters,
             particleBounds=particleBounds,
             defaultGroupingSliceValue=defaultGroupSliceValue,
-            fwhmMultiplierLimit=fwhmMultiplier,
+            fwhmMultipliers=fwhmMultipliers,
             peakTailCoefficient=peakTailCoefficient,
         )
 

--- a/src/snapred/backend/recipe/algorithm/DetectorPeakPredictor.py
+++ b/src/snapred/backend/recipe/algorithm/DetectorPeakPredictor.py
@@ -49,8 +49,8 @@ class DetectorPeakPredictor(PythonAlgorithm):
     def chopIngredients(self, ingredients: PeakIngredients) -> None:
         self.beta_0 = ingredients.instrumentState.gsasParameters.beta[0]
         self.beta_1 = ingredients.instrumentState.gsasParameters.beta[1]
-        self.FWHMMultiplierLeft = ingredients.instrumentState.fwhmMultiplierLimit.minimum
-        self.FWHMMultiplierRight = ingredients.instrumentState.fwhmMultiplierLimit.maximum
+        self.FWHMMultiplierLeft = ingredients.instrumentState.fwhmMultipliers.left
+        self.FWHMMultiplierRight = ingredients.instrumentState.fwhmMultipliers.right
         self.peakTailCoefficient = ingredients.instrumentState.peakTailCoefficient
         self.L = ingredients.instrumentState.instrumentConfig.L1 + ingredients.instrumentState.instrumentConfig.L2
 

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -130,6 +130,7 @@ class CalibrationService(Service):
             peakIntensityThreshold=request.peakIntensityThreshold,
             convergenceThreshold=request.convergenceThreshold,
             nBinsAcrossPeakWidth=request.nBinsAcrossPeakWidth,
+            fwhmMultiplierLimit=request.fwhmMultiplierLimit,
         )
         return self.sousChef.prepDiffractionCalibrationIngredients(farmFresh)
 

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -345,6 +345,7 @@ class CalibrationService(Service):
             focusGroup=request.focusGroup,
             cifPath=cifPath,
             calibrantSamplePath=request.calibrantSamplePath,
+            fwhmMultiplierLimit=request.fwhmMultiplierLimit,
         )
         pixelGroup = self.sousChef.prepPixelGroup(farmFresh)
         detectorPeaks = self.sousChef.prepDetectorPeaks(farmFresh)
@@ -359,7 +360,7 @@ class CalibrationService(Service):
         record = CalibrationRecord(
             runNumber=request.run.runNumber,
             crystalInfo=self.sousChef.prepCrystallographicInfo(farmFresh),
-            calibrationFittingIngredients=self.sousChef.prepCalibration(request.run.runNumber),
+            calibrationFittingIngredients=self.sousChef.prepCalibration(farmFresh),
             pixelGroups=[pixelGroup],
             focusGroupCalibrationMetrics=metrics,
             workspaces=request.workspaces,

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -130,7 +130,7 @@ class CalibrationService(Service):
             peakIntensityThreshold=request.peakIntensityThreshold,
             convergenceThreshold=request.convergenceThreshold,
             nBinsAcrossPeakWidth=request.nBinsAcrossPeakWidth,
-            fwhmMultiplierLimit=request.fwhmMultiplierLimit,
+            fwhmMultipliers=request.fwhmMultipliers,
         )
         return self.sousChef.prepDiffractionCalibrationIngredients(farmFresh)
 
@@ -345,7 +345,7 @@ class CalibrationService(Service):
             focusGroup=request.focusGroup,
             cifPath=cifPath,
             calibrantSamplePath=request.calibrantSamplePath,
-            fwhmMultiplierLimit=request.fwhmMultiplierLimit,
+            fwhmMultipliers=request.fwhmMultipliers,
         )
         pixelGroup = self.sousChef.prepPixelGroup(farmFresh)
         detectorPeaks = self.sousChef.prepDetectorPeaks(farmFresh)

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -155,7 +155,14 @@ class NormalizationService(Service):
 
     @FromString
     def normalizationAssessment(self, request: NormalizationCalibrationRequest):
-        calibration = self.dataFactoryService.getCalibrationState(request.runNumber)
+        farmFresh = FarmFreshIngredients(
+            runNumber=request.runNumber,
+            focusGroup=request.focusGroup,
+            useLiteMode=request.useLiteMode,
+            calibrantSamplePath=request.calibrantSamplePath,
+            fwhmMultiplierLimit=request.fwhmMultiplierLimit,
+        )
+        calibration = self.sousChef.prepCalibration(farmFresh)
         record = NormalizationRecord(
             runNumber=request.runNumber,
             backgroundRunNumber=request.backgroundRunNumber,

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -160,7 +160,7 @@ class NormalizationService(Service):
             focusGroup=request.focusGroup,
             useLiteMode=request.useLiteMode,
             calibrantSamplePath=request.calibrantSamplePath,
-            fwhmMultiplierLimit=request.fwhmMultiplierLimit,
+            fwhmMultipliers=request.fwhmMultipliers,
         )
         calibration = self.sousChef.prepCalibration(farmFresh)
         record = NormalizationRecord(

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -58,7 +58,7 @@ class SousChef(Service):
 
     def prepCalibration(self, ingredients: FarmFreshIngredients) -> Calibration:
         calibration = self.dataFactoryService.getCalibrationState(ingredients.runNumber)
-        calibration.instrumentState.fwhmMultiplierLimit = ingredients.fwhmMultiplierLimit
+        calibration.instrumentState.fwhmMultipliers = ingredients.fwhmMultipliers
         return calibration
 
     def prepInstrumentState(self, ingredients: FarmFreshIngredients) -> InstrumentState:
@@ -133,8 +133,8 @@ class SousChef(Service):
             ingredients.focusGroup.name,
             ingredients.crystalDBounds.minimum,
             ingredients.crystalDBounds.maximum,
-            ingredients.fwhmMultiplierLimit.minimum,
-            ingredients.fwhmMultiplierLimit.maximum,
+            ingredients.fwhmMultipliers.left,
+            ingredients.fwhmMultipliers.right,
             ingredients.peakIntensityThreshold,
             purgePeaks,
         )

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -56,11 +56,13 @@ class SousChef(Service):
     def name():
         return "souschef"
 
-    def prepCalibration(self, runNumber: str) -> Calibration:
-        return self.dataFactoryService.getCalibrationState(runNumber)
+    def prepCalibration(self, ingredients: FarmFreshIngredients) -> Calibration:
+        calibration = self.dataFactoryService.getCalibrationState(ingredients.runNumber)
+        calibration.instrumentState.fwhmMultiplierLimit = ingredients.fwhmMultiplierLimit
+        return calibration
 
-    def prepInstrumentState(self, runNumber: str) -> InstrumentState:
-        return self.prepCalibration(runNumber).instrumentState
+    def prepInstrumentState(self, ingredients: FarmFreshIngredients) -> InstrumentState:
+        return self.prepCalibration(ingredients).instrumentState
 
     def prepRunConfig(self, runNumber: str) -> RunConfig:
         return self.dataFactoryService.getRunConfig(runNumber)
@@ -80,7 +82,7 @@ class SousChef(Service):
         key = (ingredients.runNumber, ingredients.useLiteMode, groupingSchema)
         if key not in self._pixelGroupCache:
             focusGroup = self.prepFocusGroup(ingredients)
-            instrumentState = self.prepInstrumentState(ingredients.runNumber)
+            instrumentState = self.prepInstrumentState(ingredients)
             pixelIngredients = PixelGroupingIngredients(
                 instrumentState=instrumentState,
                 nBinsAcrossPeakWidth=ingredients.nBinsAcrossPeakWidth,
@@ -117,7 +119,7 @@ class SousChef(Service):
     def prepPeakIngredients(self, ingredients: FarmFreshIngredients) -> PeakIngredients:
         return PeakIngredients(
             crystalInfo=self.prepCrystallographicInfo(ingredients),
-            instrumentState=self.prepInstrumentState(ingredients.runNumber),
+            instrumentState=self.prepInstrumentState(ingredients),
             pixelGroup=self.prepPixelGroup(ingredients),
             peakIntensityThreshold=ingredients.peakIntensityThreshold,
         )
@@ -131,6 +133,8 @@ class SousChef(Service):
             ingredients.focusGroup.name,
             ingredients.crystalDBounds.minimum,
             ingredients.crystalDBounds.maximum,
+            ingredients.fwhmMultiplierLimit.minimum,
+            ingredients.fwhmMultiplierLimit.maximum,
             ingredients.peakIntensityThreshold,
             purgePeaks,
         )

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -78,9 +78,7 @@ calibration:
       beta:
         - 0.02
         - 0.05
-      FWHMMultiplier:
-        - 2.0
-        - 2.0
+      FWHMMultiplier: {left: 2.0, right: 2.0}
       peakTailCoefficient: 2.0
       smoothing: 0.5
   fitting:

--- a/src/snapred/resources/default/request/fitMultiplePeaks/fitMultiplePeaks/payload.json
+++ b/src/snapred/resources/default/request/fitMultiplePeaks/fitMultiplePeaks/payload.json
@@ -55,7 +55,7 @@
       }
     },
     "defaultGroupingSliceValue": 5.0,
-    "fwhmMultiplierLimit": {
+    "fwhmMultipliers": {
       "minimum": 1.5,
       "maximum": 1.5
     },

--- a/src/snapred/resources/default/request/vanadiumReduction/vanadiumReduction/payload.json
+++ b/src/snapred/resources/default/request/vanadiumReduction/vanadiumReduction/payload.json
@@ -59,7 +59,7 @@
                 }
             },
             "defaultGroupingSliceValue": 5,
-            "fwhmMultiplierLimit": {
+            "fwhmMultipliers": {
                 "minimum": 1.5,
                 "maximum": 1.5
             },

--- a/src/snapred/resources/input_parameters.json
+++ b/src/snapred/resources/input_parameters.json
@@ -55,7 +55,7 @@
         }
       },
       "defaultGroupingSliceValue": 5,
-      "fwhmMultiplierLimit": {
+      "fwhmMultipliers": {
         "minimum": 1.5,
         "maximum": 1.5
       }

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -306,6 +306,7 @@ class DiffCalWorkflow(WorkflowImplementer):
             nBinsAcrossPeakWidth=self.nBinsAcrossPeakWidth,
             useLiteMode=self.useLiteMode,
             calibrantSamplePath=self.calibrantSamplePath,
+            fwhmMultiplierLimit=self.prevFWHM,
         )
 
         response = self.request(path="calibration/assessment", payload=payload.json())

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -86,6 +86,8 @@ class DiffCalWorkflow(WorkflowImplementer):
         self._requestView.runNumberField.editingFinished.connect(self._populateGroupingDropdown)
         self._tweakPeakView.signalValueChanged.connect(self.onValueChange)
 
+        self.prevFWHM = DiffCalTweakPeakView.FWHM
+
         # 1. input run number and other basic parameters
         # 2. display peak graphs, allow adjustments to view
         # 3. perform diffraction calibration after user approves peaks then move on
@@ -167,6 +169,7 @@ class DiffCalWorkflow(WorkflowImplementer):
             peakIntensityThreshold=self.peakThreshold,
             convergenceThreshold=self.convergenceThreshold,
             nBinsAcrossPeakWidth=self.nBinsAcrossPeakWidth,
+            fwhmMultipliers=self.prevFWHM,
         )
 
         self.ingredients = self.request(path="calibration/ingredients", payload=payload.json()).data
@@ -177,7 +180,7 @@ class DiffCalWorkflow(WorkflowImplementer):
         self.prevDMin = payload.crystalDMin
         self.prevDMax = payload.crystalDMax
         self.prevThreshold = payload.peakIntensityThreshold
-        self.prevFWHM = payload.fwhmMultiplierLimit
+        self.prevFWHM = payload.fwhmMultipliers  # NOTE set in __init__ to defaults
         self.prevGroupingIndex = view.groupingFileDropdown.currentIndex()
         self.fitPeaksDiagnostic = f"fit_peak_diag_{self.runNumber}_{self.prevGroupingIndex}"
 
@@ -241,7 +244,7 @@ class DiffCalWorkflow(WorkflowImplementer):
             crystalDMin=dMin,
             crystalDMax=dMax,
             peakIntensityThreshold=peakThreshold,
-            fwhmMultiplierLimit=fwhm,
+            fwhmMultipliers=fwhm,
         )
         response = self.request(path="calibration/ingredients", payload=payload.json())
         self.ingredients = response.data
@@ -290,7 +293,7 @@ class DiffCalWorkflow(WorkflowImplementer):
             peakIntensityThreshold=self.prevThreshold,
             convergenceThreshold=self.convergenceThreshold,
             nBinsAcrossPeakWidth=self.nBinsAcrossPeakWidth,
-            fwhmMultiplierLimit=self.prevFWHM,
+            fwhmMultipliers=self.prevFWHM,
         )
 
         response = self.request(path="calibration/diffraction", payload=payload.json())
@@ -306,7 +309,7 @@ class DiffCalWorkflow(WorkflowImplementer):
             nBinsAcrossPeakWidth=self.nBinsAcrossPeakWidth,
             useLiteMode=self.useLiteMode,
             calibrantSamplePath=self.calibrantSamplePath,
-            fwhmMultiplierLimit=self.prevFWHM,
+            fwhmMultipliers=self.prevFWHM,
         )
 
         response = self.request(path="calibration/assessment", payload=payload.json())

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -80,9 +80,7 @@ calibration:
       beta:
         - 1
         - 2
-      FWHMMultiplier:
-        - -2
-        - 2
+      FWHMMultiplier: {left: 2.0, right: 2.0}
       peakTailCoefficient: 2.0
       smoothing: 0.5
   fitting:

--- a/tests/resources/inputs/calibration/CalibrationParameters.json
+++ b/tests/resources/inputs/calibration/CalibrationParameters.json
@@ -55,8 +55,8 @@
       }
     },
     "defaultGroupingSliceValue": 5,
-    "fwhmMultiplierLimit": {
-      "minimum": -2,
+    "fwhmMultipliers": {
+      "minimum": 2,
       "maximum": 2
     },
     "peakTailCoefficient": 2.0

--- a/tests/resources/inputs/calibration/CalibrationRecord_v0001.json
+++ b/tests/resources/inputs/calibration/CalibrationRecord_v0001.json
@@ -442,7 +442,7 @@
           }
         },
         "defaultGroupingSliceValue": 5,
-        "fwhmMultiplierLimit": {
+        "fwhmMultipliers": {
           "minimum": 1.3,
           "maximum": 1.3
         }

--- a/tests/resources/inputs/calibration/CalibrationRecord_v0002.json
+++ b/tests/resources/inputs/calibration/CalibrationRecord_v0002.json
@@ -442,7 +442,7 @@
           }
         },
         "defaultGroupingSliceValue": 5,
-        "fwhmMultiplierLimit": {
+        "fwhmMultipliers": {
           "minimum": 1.3,
           "maximum": 1.3
         }

--- a/tests/resources/inputs/calibration/ReductionIngredients.json
+++ b/tests/resources/inputs/calibration/ReductionIngredients.json
@@ -89,7 +89,7 @@
             }
           },
           "defaultGroupingSliceValue": 5,
-          "fwhmMultiplierLimit": {
+          "fwhmMultipliers": {
             "minimum": 2,
             "maximum": 2
           },

--- a/tests/resources/inputs/calibration/sampleInstrumentState.json
+++ b/tests/resources/inputs/calibration/sampleInstrumentState.json
@@ -55,7 +55,7 @@
     }
   },
   "defaultGroupingSliceValue": 5,
-  "fwhmMultiplierLimit": {
+  "fwhmMultipliers": {
     "minimum": -2,
     "maximum": 2
   }

--- a/tests/resources/inputs/diffcal/fakeInstrumentState.json
+++ b/tests/resources/inputs/diffcal/fakeInstrumentState.json
@@ -105,7 +105,7 @@
    ]
   },
   "defaultGroupingSliceValue": 5,
-  "fwhmMultiplierLimit": {
+  "fwhmMultipliers": {
     "minimum": 1,
     "maximum": 2
   }

--- a/tests/resources/inputs/normalization/NormalizationParameters.json
+++ b/tests/resources/inputs/normalization/NormalizationParameters.json
@@ -55,7 +55,7 @@
         }
       },
       "defaultGroupingSliceValue": 5,
-      "fwhmMultiplierLimit": {
+      "fwhmMultipliers": {
         "minimum": -2,
         "maximum": 2
       },

--- a/tests/resources/inputs/normalization/NormalizationRecord.json
+++ b/tests/resources/inputs/normalization/NormalizationRecord.json
@@ -60,7 +60,7 @@
               }
             },
             "defaultGroupingSliceValue": 5,
-            "fwhmMultiplierLimit": {
+            "fwhmMultipliers": {
               "minimum": 1.3,
               "maximum": 1.3
             }

--- a/tests/resources/inputs/normalization/ReductionIngredients.json
+++ b/tests/resources/inputs/normalization/ReductionIngredients.json
@@ -89,7 +89,7 @@
             }
           },
           "defaultGroupingSliceValue": 5,
-          "fwhmMultiplierLimit": {
+          "fwhmMultipliers": {
             "minimum": 2,
             "maximum": 2
           },

--- a/tests/resources/inputs/pixel_grouping/CalibrationParameters.json
+++ b/tests/resources/inputs/pixel_grouping/CalibrationParameters.json
@@ -37,7 +37,7 @@
       "tof": {"minimum": 2742.6, "maximum": 13713.0}
     },
     "defaultGroupingSliceValue": 5.0,
-    "fwhmMultiplierLimit": {"minimum": 1.3, "maximum": 1.3},
+    "fwhmMultipliers": {"left": 1.3, "right": 1.3},
     "peakTailCoefficient" : 2.0
   },
   "seedRun": 57514,

--- a/tests/resources/inputs/predict_peaks/input_fake_ingredients.json
+++ b/tests/resources/inputs/predict_peaks/input_fake_ingredients.json
@@ -55,7 +55,7 @@
       }
     },
     "defaultGroupingSliceValue": 5,
-    "fwhmMultiplierLimit": {
+    "fwhmMultipliers": {
       "minimum": 1.5,
       "maximum": 1.5
     },

--- a/tests/resources/inputs/predict_peaks/input_good_ingredients.json
+++ b/tests/resources/inputs/predict_peaks/input_good_ingredients.json
@@ -55,7 +55,7 @@
       }
     },
     "defaultGroupingSliceValue": 5,
-    "fwhmMultiplierLimit": {
+    "fwhmMultipliers": {
       "minimum": 1.5,
       "maximum": 1.5
     },

--- a/tests/resources/inputs/purge_peaks/input_ingredients.json
+++ b/tests/resources/inputs/purge_peaks/input_ingredients.json
@@ -90,7 +90,7 @@
             }
           },
           "defaultGroupingSliceValue": 5,
-          "fwhmMultiplierLimit": {
+          "fwhmMultipliers": {
             "minimum": 2,
             "maximum": 2
           },

--- a/tests/resources/inputs/purge_peaks/input_parameters.json
+++ b/tests/resources/inputs/purge_peaks/input_parameters.json
@@ -55,7 +55,7 @@
         }
       },
       "defaultGroupingSliceValue": 5,
-      "fwhmMultiplierLimit": {
+      "fwhmMultipliers": {
         "minimum": 1.5,
         "maximum": 1.5
       },

--- a/tests/resources/inputs/reduction/fake_file.json
+++ b/tests/resources/inputs/reduction/fake_file.json
@@ -90,7 +90,7 @@
               }
             },
             "defaultGroupingSliceValue": 5,
-            "fwhmMultiplierLimit": {
+            "fwhmMultipliers": {
               "minimum": 2,
               "maximum": 2
             },

--- a/tests/resources/inputs/reduction/input_ingredients.json
+++ b/tests/resources/inputs/reduction/input_ingredients.json
@@ -90,7 +90,7 @@
               }
             },
             "defaultGroupingSliceValue": 5,
-            "fwhmMultiplierLimit": {
+            "fwhmMultipliers": {
               "minimum": 2,
               "maximum": 2
             },

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -61,9 +61,8 @@ def _capture_logging(monkeypatch):
 
 
 fakeInstrumentFilePath = Resource.getPath("inputs/testInstrument/fakeSNAP.xml")
-reductionIngredients = None
-with Resource.open("inputs/calibration/ReductionIngredients.json", "r") as file:
-    reductionIngredients = parse_raw_as(ReductionIngredients, file.read())
+reductionIngredientsPath = Resource.getPath("inputs/calibration/ReductionIngredients.json")
+reductionIngredients = ReductionIngredients.parse_file(reductionIngredientsPath)
 
 
 def test_fileExists_yes():

--- a/tests/unit/backend/recipe/algorithm/test_DetectorPeakPredictor.py
+++ b/tests/unit/backend/recipe/algorithm/test_DetectorPeakPredictor.py
@@ -56,8 +56,8 @@ with mock.patch.dict(
         # check various properties copied over
         assert algo.beta_0 == ingredients.instrumentState.gsasParameters.beta[0]
         assert algo.beta_1 == ingredients.instrumentState.gsasParameters.beta[1]
-        assert algo.FWHMMultiplierLeft == ingredients.instrumentState.fwhmMultiplierLimit.minimum
-        assert algo.FWHMMultiplierRight == ingredients.instrumentState.fwhmMultiplierLimit.maximum
+        assert algo.FWHMMultiplierLeft == ingredients.instrumentState.fwhmMultipliers.left
+        assert algo.FWHMMultiplierRight == ingredients.instrumentState.fwhmMultipliers.right
         assert algo.peakTailCoefficient == ingredients.instrumentState.peakTailCoefficient
         assert (
             algo.L == ingredients.instrumentState.instrumentConfig.L1 + ingredients.instrumentState.instrumentConfig.L2

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -188,28 +188,21 @@ class TestNormalizationService(unittest.TestCase):
             Ingredients=self.instance.sousChef.prepDetectorPeaks({}),
         )
 
-    @patch(thisService + "DataFactoryService")
     @patch(
         thisService + "NormalizationRecord",
         return_value=MagicMock(mockId="mock_normalization_record"),
     )
     def test_normalizationAssessment(
         self,
-        mockNormalizationRecord,
-        mockDataFactoryService,
+        NormalizationRecord,
     ):
-        mockNormalization = MagicMock()
-        mockDataFactoryService = mockDataFactoryService.return_value
-        mockDataFactoryService.getCalibrationState.return_value = mockNormalization
-
         self.instance = NormalizationService()
-        self.instance.dataFactoryService.getNormalizationRecord = MagicMock(return_value=mockNormalizationRecord)
+        self.instance.sousChef = SculleryBoy()
+        self.instance.dataFactoryService.getNormalizationRecord = MagicMock(return_value=MagicMock())
 
         result = self.instance.normalizationAssessment(self.request)
 
-        mockDataFactoryService.getCalibrationState.assert_called_once_with(self.request.runNumber)
-        expected_record_mockId = "mock_normalization_record"
-        assert result.mockId == expected_record_mockId
+        assert result.mockId == NormalizationRecord.return_value.mockId
 
     @patch(thisService + "FarmFreshIngredients")
     @patch(thisService + "RawVanadiumCorrectionRecipe")

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -67,27 +67,22 @@ class TestSousChef(unittest.TestCase):
 
         assert self.instance.dataFactoryService.getCalibrationState.called_once_with(self.ingredients)
         assert res == self.instance.dataFactoryService.getCalibrationState.return_value
-        assert (
-            res.instrumentState.fwhmMultiplierLimit.minimum
-            == Config["calibration.parameters.default.FWHMMultiplier"][0]
-        )
-        assert (
-            res.instrumentState.fwhmMultiplierLimit.maximum
-            == Config["calibration.parameters.default.FWHMMultiplier"][1]
-        )
+        assert res.instrumentState.fwhmMultipliers.dict() == Config["calibration.parameters.default.FWHMMultiplier"]
 
     def test_prepCalibration_userFWHM(self):
         mockCalibration = mock.Mock()
         self.instance.dataFactoryService.getCalibrationState = mock.Mock(return_value=mockCalibration)
-        self.ingredients.fwhmMultiplierLimit = mock.Mock(minimum=100, maximum=100)
+        fakeLeft = 116
+        fakeRight = 17
+        self.ingredients.fwhmMultipliers = mock.Mock(left=fakeLeft, right=fakeRight)
 
         res = self.instance.prepCalibration(self.ingredients)
 
         assert self.instance.dataFactoryService.getCalibrationState.called_once_with(self.ingredients)
         assert res == self.instance.dataFactoryService.getCalibrationState.return_value
-        assert res.instrumentState.fwhmMultiplierLimit == self.ingredients.fwhmMultiplierLimit
-        assert res.instrumentState.fwhmMultiplierLimit.minimum == 100
-        assert res.instrumentState.fwhmMultiplierLimit.maximum == 100
+        assert res.instrumentState.fwhmMultipliers == self.ingredients.fwhmMultipliers
+        assert res.instrumentState.fwhmMultipliers.left == fakeLeft
+        assert res.instrumentState.fwhmMultipliers.right == fakeRight
 
     def test_prepInstrumentState(self):
         runNumber = "123"
@@ -243,8 +238,8 @@ class TestSousChef(unittest.TestCase):
             self.ingredients.focusGroup.name,
             self.ingredients.crystalDBounds.minimum,
             self.ingredients.crystalDBounds.maximum,
-            self.ingredients.fwhmMultiplierLimit.minimum,
-            self.ingredients.fwhmMultiplierLimit.maximum,
+            self.ingredients.fwhmMultipliers.left,
+            self.ingredients.fwhmMultipliers.right,
             self.ingredients.peakIntensityThreshold,
             False,
         )
@@ -278,8 +273,8 @@ class TestSousChef(unittest.TestCase):
             self.ingredients.focusGroup.name,
             self.ingredients.crystalDBounds.minimum,
             self.ingredients.crystalDBounds.maximum,
-            self.ingredients.fwhmMultiplierLimit.minimum,
-            self.ingredients.fwhmMultiplierLimit.maximum,
+            self.ingredients.fwhmMultipliers.left,
+            self.ingredients.fwhmMultipliers.right,
             self.ingredients.peakIntensityThreshold,
             True,
         )
@@ -304,8 +299,8 @@ class TestSousChef(unittest.TestCase):
             self.ingredients.focusGroup.name,
             self.ingredients.crystalDBounds.minimum,
             self.ingredients.crystalDBounds.maximum,
-            self.ingredients.fwhmMultiplierLimit.minimum,
-            self.ingredients.fwhmMultiplierLimit.maximum,
+            self.ingredients.fwhmMultipliers.left,
+            self.ingredients.fwhmMultipliers.right,
             self.ingredients.peakIntensityThreshold,
             True,
         )

--- a/tests/util/SculleryBoy.py
+++ b/tests/util/SculleryBoy.py
@@ -37,10 +37,15 @@ class SculleryBoy:
     def __init__(self):
         pass
 
-    def prepCalibration(self, runNumber: str):  # noqa ARG002
-        return {mock.Mock()}
+    def prepCalibration(self, ingredients: FarmFreshIngredients):  # noqa ARG002
+        return {
+            "instumentState": mock.Mock(),
+            "seedRun": mock.Mock(),
+            "creationDate": mock.Mock(),
+            "name": "mocked calibration",
+        }
 
-    def prepInstrumentState(self, runNumber: str):  # noqa ARG002
+    def prepInstrumentState(self, ingredients: FarmFreshIngredients):  # noqa ARG002
         return mock.Mock()
 
     def prepRunConfig(self, runNumber: str) -> RunConfig:


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing

Run GUI with 46680 and **Bank**.

On the tweak peak view, change the FWHM Right multiplier to 8.  Recalculate.  Make sure the peak is now selected blue.

Because this is using signals, change all kinds of things and recalculate.  Change groupings multiple times, change dMin/dMax multiple times, change peak threshold, etc., to make sure nothing accidentally broke.

When done, click to continue.  You will get a **warning**, but just continue anyway.

When done, save.  

After saving, go to your local folder (because you're running this in your local dev copy of Calibration) and open `CalibrationRecord.json`, and scroll down to "calibrationFittingIngredients":"instrumentState":"fwhmMultiplierLimit", and confirm these values are the ones you set on the tweak peak peek (should be 2.0 and 8.0).

Open `CalibrationParameters.json` and scroll down to "instrumentState":"fwhmMultiplierLimit" and scroll down and verify same values.

### CIS testing

Find the runs which generated this problem.

Adjust the FWHM until you get good peak fits, and verify that the diffcal process executes with good, tightly-fitting peaks.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4556](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4556)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
