### PR TITLE
I guess it was failing to save the raw

### DIFF
--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -493,8 +493,14 @@ class LocalDataService:
         """
         normalizationDataPath = Path(self._constructNormalizationCalibrationDataPath(record.runNumber, record.version))
         for workspace in record.workspaceNames:
-            filename = Path(workspace + "_" + wnvf.formatVersion(record.version) + ".tar")
-            self.writeRaggedWorkspace(normalizationDataPath, filename, workspace)
+            filename = workspace + "_" + wnvf.formatVersion(record.version)
+            ws = mtd[workspace]
+            if ws.isRaggedWorkspace():
+                filename = Path(filename + ".tar")
+                self.writeRaggedWorkspace(normalizationDataPath, filename, workspace)
+            else:
+                filename = Path(filename + ".nxs")
+                self.writeWorkspace(normalizationDataPath, filename, workspace)
         return record
 
     def readCalibrationRecord(self, runId: str, version: str = None):

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -1042,9 +1042,7 @@ def test_writeNormalizationWorkspaces(mockConstructNormalizationCalibrationDataP
         localDataService.writeNormalizationWorkspaces(testNormalizationRecord)
 
         for wsName in testNormalizationRecord.workspaceNames:
-            filename = Path(
-                wsName + "_" + wnvf.formatVersion(version) + Config["calibration.diffraction.output.extension"]
-            )
+            filename = Path(wsName + "_" + wnvf.formatVersion(version) + ".nxs")
             assert (basePath / filename).exists()
         mtd.clear()
 


### PR DESCRIPTION
## Description of work

This accounts for nonragged workspaces in the normalization flow



## To test

Run normalization such that you can save a normalization
Observe 3 output workspace files, relevantly the tof_unfoc_058810_raw_van_corr one

runnumber 58810
bg runnumber 58813

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4579](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4579)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
