### PR TITLE
Make `FocusGroup` mandatory in `PixelGroup`

### DIFF
--- a/src/snapred/backend/dao/state/PixelGroup.py
+++ b/src/snapred/backend/dao/state/PixelGroup.py
@@ -14,7 +14,7 @@ class PixelGroup(BaseModel):
     # allow initializtion from either dictionary or list
     pixelGroupingParameters: Union[List[PixelGroupingParameters], Dict[int, PixelGroupingParameters]] = {}
     nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]
-    focusGroup: Optional[FocusGroup]  # TODO this needs to be mandatory
+    focusGroup: FocusGroup
     timeOfFlight: BinnedValue[float]
 
     class BinningMode(IntEnum):

--- a/tests/resources/inputs/calibration/ReductionIngredients.json
+++ b/tests/resources/inputs/calibration/ReductionIngredients.json
@@ -122,6 +122,7 @@
     "overrides": null
   },
   "pixelGroup": {
+    "focusGroup": {"name": "Column", "definition": "/path/to/file/"},
     "timeOfFlight": {
       "minimum": 2350.800030332904,
       "maximum": 14104.800181997423,

--- a/tests/resources/inputs/normalization/ReductionIngredients.json
+++ b/tests/resources/inputs/normalization/ReductionIngredients.json
@@ -130,6 +130,10 @@
       "binWidth": 0.0002,
       "binningMode": -1
     },
+    "focusGroup": {
+      "name": "Column",
+      "definition": "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGrp_Column.lite.xml"
+    },
     "pixelGroupingParameters": [
       {
         "groupID": 1,

--- a/tests/resources/inputs/predict_peaks/input_fake_ingredients.json
+++ b/tests/resources/inputs/predict_peaks/input_fake_ingredients.json
@@ -69,6 +69,10 @@
       "binWidth": 0.0002771822370612031,
       "binningMode": -1
     },
+    "focusGroup": {
+      "name": "unlikely grouping",
+      "definition": "path/to/here"
+    },
     "pixelGroupingParameters": [
       {
         "groupID": 0,

--- a/tests/resources/inputs/predict_peaks/input_good_ingredients.json
+++ b/tests/resources/inputs/predict_peaks/input_good_ingredients.json
@@ -62,6 +62,10 @@
     "peakTailCoefficient": 2.0
   },
   "pixelGroup": {
+    "focusGroup": {
+      "name": "unlikely grouping",
+      "definition": "path/to/here"
+    },
     "timeOfFlight": {
       "minimum": 1959.0,
       "maximum": 14496.6,

--- a/tests/resources/inputs/reduction/fake_file.json
+++ b/tests/resources/inputs/reduction/fake_file.json
@@ -121,6 +121,10 @@
         "binWidth": 0.0002771822370612031,
         "binningMode": -1
       },
+      "focusGroup": {
+        "name": "unlikely grouping",
+        "definition": "path/to/here"
+      },
       "pixelGroupingParameters": [
         {
           "groupID": 1,

--- a/tests/resources/inputs/reduction/input_ingredients.json
+++ b/tests/resources/inputs/reduction/input_ingredients.json
@@ -129,6 +129,10 @@
         "binWidth": 0.0002699865774827431,
         "binningMode": -1
       },
+      "focusGroup": {
+        "name": "unlikely grouping",
+        "definition": "path/to/here"
+      },
       "pixelGroupingParameters": [
         {
           "groupID": 0,

--- a/tests/unit/backend/dao/test_PixelGroup.py
+++ b/tests/unit/backend/dao/test_PixelGroup.py
@@ -10,6 +10,7 @@ from mantid.simpleapi import (
 )
 from pydantic.error_wrappers import ValidationError
 from snapred.backend.dao.Limit import BinnedValue, Limit
+from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.backend.dao.state.PixelGroup import PixelGroup
 from snapred.backend.dao.state.PixelGroupingParameters import PixelGroupingParameters
 from snapred.meta.Config import Resource
@@ -50,11 +51,17 @@ class TestPixelGroup(unittest.TestCase):
             binWidth=0.03 / cls.nBinsAcrossPeakWidth,
         )
 
+        cls.focusGroup = FocusGroup(
+            name="Natural",
+            definition=Resource.getPath("inputs/testInstrument/fakeSNAPFocGroup_Natural.xml"),
+        )
+
         try:
             cls.reference = PixelGroup(
                 pixelGroupingParameters=cls.pixelGroupingParameters,
                 nBinsAcrossPeakWidth=cls.nBinsAcrossPeakWidth,
                 timeOfFlight=cls.tofParams,
+                focusGroup=cls.focusGroup,
             )
         except:
             pytest.fail("Failed to make a pixel group from a dictionary of PGPs")
@@ -67,6 +74,7 @@ class TestPixelGroup(unittest.TestCase):
                 pixelGroupingParameters=self.pixelGroupingParametersList,
                 nBinsAcrossPeakWidth=self.nBinsAcrossPeakWidth,
                 timeOfFlight=self.tofParams,
+                focusGroup=self.focusGroup,
             )
         except:
             pytest.fail("Failed to make a pixel group from a list of PGPs")
@@ -82,6 +90,7 @@ class TestPixelGroup(unittest.TestCase):
                 dRelativeResolution=self.dRelativeResolution,
                 nBinsAcrossPeakWidth=self.nBinsAcrossPeakWidth,
                 timeOfFlight=self.tofParams,
+                focusGroup=self.focusGroup,
             )
         except:
             pytest.fail("Failed to make a pixel group from base ingredients")
@@ -94,6 +103,7 @@ class TestPixelGroup(unittest.TestCase):
             pixelGroupingParameters=self.pixelGroupingParameters,
             nBinsAcrossPeakWidth=self.nBinsAcrossPeakWidth,
             timeOfFlight=self.tofParams,
+            focusGroup=self.focusGroup,
         )
         assert pg.groupIDs == self.groupIDs
 
@@ -102,6 +112,7 @@ class TestPixelGroup(unittest.TestCase):
             pixelGroupingParameters=self.pixelGroupingParameters,
             nBinsAcrossPeakWidth=self.nBinsAcrossPeakWidth,
             timeOfFlight=self.tofParams,
+            focusGroup=self.focusGroup,
         )
         assert pg.twoTheta == self.twoTheta
 
@@ -110,6 +121,7 @@ class TestPixelGroup(unittest.TestCase):
             pixelGroupingParameters=self.pixelGroupingParameters,
             nBinsAcrossPeakWidth=self.nBinsAcrossPeakWidth,
             timeOfFlight=self.tofParams,
+            focusGroup=self.focusGroup,
         )
         assert pg.dResolution == self.dResolution
 
@@ -118,6 +130,7 @@ class TestPixelGroup(unittest.TestCase):
             pixelGroupingParameters=self.pixelGroupingParameters,
             nBinsAcrossPeakWidth=self.nBinsAcrossPeakWidth,
             timeOfFlight=self.tofParams,
+            focusGroup=self.focusGroup,
         )
         assert pg.dRelativeResolution == self.dRelativeResolution
 
@@ -128,6 +141,7 @@ class TestPixelGroup(unittest.TestCase):
             pixelGroupingParameters=self.pixelGroupingParameters,
             nBinsAcrossPeakWidth=self.nBinsAcrossPeakWidth,
             timeOfFlight=self.tofParams,
+            focusGroup=self.focusGroup,
         )
         assert pg.dMax() == [dl.maximum for dl in self.dResolution]
 
@@ -136,6 +150,7 @@ class TestPixelGroup(unittest.TestCase):
             pixelGroupingParameters=self.pixelGroupingParameters,
             nBinsAcrossPeakWidth=self.nBinsAcrossPeakWidth,
             timeOfFlight=self.tofParams,
+            focusGroup=self.focusGroup,
         )
         assert pg.dMin() == [dl.minimum for dl in self.dResolution]
 
@@ -144,6 +159,7 @@ class TestPixelGroup(unittest.TestCase):
             pixelGroupingParameters=self.pixelGroupingParameters,
             nBinsAcrossPeakWidth=self.nBinsAcrossPeakWidth,
             timeOfFlight=self.tofParams,
+            focusGroup=self.focusGroup,
             binningMode=PixelGroup.BinningMode.LOG,
         )
         binWidths = pg.dBin()
@@ -156,6 +172,7 @@ class TestPixelGroup(unittest.TestCase):
             pixelGroupingParameters=self.pixelGroupingParameters,
             nBinsAcrossPeakWidth=self.nBinsAcrossPeakWidth,
             timeOfFlight=self.tofParams,
+            focusGroup=self.focusGroup,
             binningMode=PixelGroup.BinningMode.LINEAR,
         )
         binWidths = pg.dBin()

--- a/tests/unit/backend/recipe/algorithm/test_CalibrationMetricExtractionAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_CalibrationMetricExtractionAlgorithm.py
@@ -61,6 +61,7 @@ class TestCalibrationMetricExtractionAlgorithm(unittest.TestCase):
         ]
         fakePixelGroup = PixelGroup(
             pixelGroupingParameters=fakePixelGroupingParameterss,
+            focusGroup={"name": "something", "definition": "path/to/wherever"},
             timeOfFlight={"minimum": 1.0, "maximum": 10.0, "binWidth": 1, "binningMode": 1},
         )
 

--- a/tests/util/SculleryBoy.py
+++ b/tests/util/SculleryBoy.py
@@ -21,6 +21,7 @@ from snapred.backend.dao.state.CalibrantSample import (
     Geometry,
     Material,
 )
+from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.backend.dao.state.PixelGroup import PixelGroup
 from snapred.backend.recipe.GenericRecipe import DetectorPeakPredictorRecipe
 from snapred.meta.Config import Resource
@@ -60,14 +61,17 @@ class SculleryBoy:
             crystallography=self._prepCrystallography(),
         )
 
-    def prepFocusGroup(self, ingredients: FarmFreshIngredients):  # noqa ARG002
-        return mock.Mock()
+    def prepFocusGroup(self, ingredients: FarmFreshIngredients) -> FocusGroup:  # noqa ARG002
+        return FocusGroup(
+            name="Natural",
+            definition=Resource.getPath("inputs/testInstrument/fakeSNAPFocGroup_Natural.xml"),
+        )
 
     def prepPixelGroup(self, ingredients: FarmFreshIngredients):  # noqa ARG002
         return PixelGroup(
             pixelGroupingParameters=[],
             nBinsAcrossPeakWidth=7,
-            focusGroup={"name": "several", "definition": "/bread/coconut"},
+            focusGroup=self.prepFocusGroup(ingredients),
             timeOfFlight={"minimum": 0.001, "maximum": 100, "binWidth": 1, "binnindMode": -1},
             binningMode=-1,
         )

--- a/tests/util/diffraction_calibration_synthetic_data.py
+++ b/tests/util/diffraction_calibration_synthetic_data.py
@@ -52,9 +52,9 @@ class SyntheticData(object):
     # MOCK instruments and configuration files:
     fakeInstrumentFilePath = Resource.getPath("inputs/testInstrument/fakeSNAP.xml")
     fakeGroupingFilePath = Resource.getPath("inputs/testInstrument/fakeSNAPFocGroup_Natural.xml")
-    fakeInstrumentStatePath = Resource.read("inputs/diffcal/fakeInstrumentState.json")
-    fakeFocusGroupPath = Resource.read("inputs/diffcal/fakeFocusGroup.json")
-    fakePixelGroupPath = Resource.read("inputs/diffcal/fakePixelGroup.json")
+    fakeInstrumentStatePath = Resource.getPath("inputs/diffcal/fakeInstrumentState.json")
+    fakeFocusGroupPath = Resource.getPath("inputs/diffcal/fakeFocusGroup.json")
+    fakePixelGroupPath = Resource.getPath("inputs/diffcal/fakePixelGroup.json")
 
     # REAL instruments and configuration files:
     SNAPInstrumentFilePath = str(Path(mantid.__file__).parent / "instrument" / "SNAP_Definition.xml")
@@ -67,12 +67,12 @@ class SyntheticData(object):
             IPTS="",
         )
 
-        self.fakeInstrumentState = InstrumentState.parse_raw(SyntheticData.fakeInstrumentStatePath)
+        self.fakeInstrumentState = InstrumentState.parse_file(SyntheticData.fakeInstrumentStatePath)
 
-        self.fakeFocusGroup = FocusGroup.parse_raw(SyntheticData.fakeFocusGroupPath)
+        self.fakeFocusGroup = FocusGroup.parse_file(SyntheticData.fakeFocusGroupPath)
         self.fakeFocusGroup.definition = SyntheticData.fakeGroupingFilePath
 
-        self.fakePixelGroup = PixelGroup.parse_raw(SyntheticData.fakePixelGroupPath)
+        self.fakePixelGroup = PixelGroup.parse_file(SyntheticData.fakePixelGroupPath)
 
         # Place all peaks within the _minimum_ d-space range of any pixel group.
         dMin = max(self.fakePixelGroup.dMin())


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

There was a `#TODO` to make `FocusGroup` mandatory in `PixelGroup`.

This was needed to enable a different task.  It required changing some JSON files in the tests.  It was already being added by `SousChef`, which is how the rest of the program was accessing `PixelGroup`.

## Explanation of work

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

Made `FocusGroup` mandatory inside `PixelGroup`.

This mostly required changing tests to add a BS focus group.  Because it used to be optional it wasn't being by anything inside the code, so no behavior should be changed by this.

## To test

Open the GUI and make sure everything works.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

None yet

<--[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)-->

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
