### PR TITLE
All peaks to assessment

### DIFF
--- a/docs/source/developer/architecture/backend/api/calibration/calibration_assessment_request.rst
+++ b/docs/source/developer/architecture/backend/api/calibration/calibration_assessment_request.rst
@@ -38,6 +38,6 @@ Attributes:
   for peak intensity, below which peaks will be disregarded in the analysis. This threshold is crucial for distinguishing
   significant peaks from noise, ensuring the focus is on relevant data points.
 
-- peakType (ALLOWED_PEAK_TYPES, default="Gaussian"): Defines the type of peak model to be used in the assessment, with a
+- peakFunction (ALLOWED_PEAK_TYPES, default="Gaussian"): Defines the type of peak model to be used in the assessment, with a
   default set to Gaussian. The choice of peak type influences the modeling and analysis of peak data, impacting the
   assessment outcomes.

--- a/src/snapred/backend/dao/request/CalibrationAssessmentRequest.py
+++ b/src/snapred/backend/dao/request/CalibrationAssessmentRequest.py
@@ -18,7 +18,7 @@ class CalibrationAssessmentRequest(BaseModel):
     provided through a cif file. It incorporates a run configuration, mapping various workspaces
     by their type to workspace names for analytical context, and specifies a focusGroup for targeted
     assessment. The calibrantSamplePath points to the sample data, while useLiteMode, nBinsAcrossPeakWidth,
-    peakIntensityThreshold, and peakType define the assessment's operational parameters, with defaults set
+    peakIntensityThreshold, and peakFunction define the assessment's operational parameters, with defaults set
     according to system configurations.
 
     """

--- a/src/snapred/backend/dao/request/CalibrationAssessmentRequest.py
+++ b/src/snapred/backend/dao/request/CalibrationAssessmentRequest.py
@@ -24,11 +24,14 @@ class CalibrationAssessmentRequest(BaseModel):
     """
 
     run: RunConfig
-    workspaces: Dict[WorkspaceType, List[WorkspaceName]]
+    useLiteMode: bool
     focusGroup: FocusGroup
     calibrantSamplePath: str
-    useLiteMode: bool
-    nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]
-    peakIntensityThreshold: float = Config["calibration.diffraction.peakIntensityThreshold"]
-    peakType: ALLOWED_PEAK_TYPES = "Gaussian"
+    workspaces: Dict[WorkspaceType, List[WorkspaceName]]
+    # fiddly bits
+    peakFunction: ALLOWED_PEAK_TYPES
+    crystalDMin: float
+    crystalDMax: float
+    peakIntensityThreshold: float
+    nBinsAcrossPeakWidth: int
     fwhmMultipliers: Pair[float] = Pair.parse_obj(Config["calibration.parameters.default.FWHMMultiplier"])

--- a/src/snapred/backend/recipe/algorithm/FitMultiplePeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FitMultiplePeaksAlgorithm.py
@@ -52,7 +52,7 @@ class FitMultiplePeaksAlgorithm(PythonAlgorithm):
             doc="Input list of peaks to be fit",
         )
         self.declareProperty(
-            "PeakType", "Gaussian", StringListValidator(allowed_peak_type_list), direction=Direction.Input
+            "PeakFunction", "Gaussian", StringListValidator(allowed_peak_type_list), direction=Direction.Input
         )
         self.declareProperty("OutputWorkspaceGroup", defaultValue="fitPeaksWSGroup", direction=Direction.Output)
         self.setRethrows(True)
@@ -85,7 +85,7 @@ class FitMultiplePeaksAlgorithm(PythonAlgorithm):
         mtd.addOrReplace(self.outputWorkspaceName, self.outputWorkspace)
 
     def PyExec(self):
-        peakType = self.getPropertyValue("PeakType")
+        peakFunction = self.getPropertyValue("PeakFunction")
         reducedPeakList = parse_raw_as(List[GroupPeakList], self.getPropertyValue("DetectorPeaks"))
         self.chopIngredients(reducedPeakList)
         self.unbagGroceries()
@@ -114,7 +114,7 @@ class FitMultiplePeaksAlgorithm(PythonAlgorithm):
                 "Fit Peaks...",
                 InputWorkspace="ws2fit",
                 PeakCenters=",".join(np.array(peakCenters).astype("str")),
-                PeakFunction=peakType,
+                PeakFunction=peakFunction,
                 FitWindowBoundaryList=",".join(np.array(peakLimits).astype("str")),
                 OutputWorkspace=outputNames[FitOutputEnum.PeakPosition.value],
                 OutputPeakParametersWorkspace=outputNames[FitOutputEnum.Parameters.value],

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -201,7 +201,7 @@ class CalibrationService(Service):
         return FitMultiplePeaksRecipe().executeRecipe(
             InputWorkspace=request.inputWorkspace,
             DetectorPeaks=request.detectorPeaks,
-            PeakType=request.peakFunction,
+            PeakFunction=request.peakFunction,
             OutputWorkspaceGroup=request.outputWorkspaceGroup,
         )
 

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 
 from pydantic import parse_file_as, parse_raw_as
 
-from snapred.backend.dao import RunConfig
+from snapred.backend.dao import Limit, RunConfig
 from snapred.backend.dao.calibration import (
     CalibrationIndexEntry,
     CalibrationMetric,
@@ -346,6 +346,11 @@ class CalibrationService(Service):
             focusGroup=request.focusGroup,
             cifPath=cifPath,
             calibrantSamplePath=request.calibrantSamplePath,
+            # fiddly bits
+            peakFucntion=request.peakFunction,
+            crystalDBounds=Limit(minimum=request.crystalDMin, maximum=request.crystalDMax),
+            peakIntensityThreshold=request.peakIntensityThreshold,
+            nBinsAcrossPeakWidth=request.nBinsAcrossPeakWidth,
             fwhmMultipliers=request.fwhmMultipliers,
         )
         pixelGroup = self.sousChef.prepPixelGroup(farmFresh)

--- a/src/snapred/resources/default/request/fitMultiplePeaks/fitMultiplePeaks/payload.json
+++ b/src/snapred/resources/default/request/fitMultiplePeaks/fitMultiplePeaks/payload.json
@@ -445,7 +445,7 @@
       }
     ]
   },
-  "peakType": "Gaussian",
+  "peakFunction": "Gaussian",
   "inputWorkspace": "testWS",
   "showResult": false
 }

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -300,15 +300,20 @@ class DiffCalWorkflow(WorkflowImplementer):
 
         payload = CalibrationAssessmentRequest(
             run=RunConfig(runNumber=self.runNumber),
+            useLiteMode=self.useLiteMode,
+            focusGroup=self.focusGroups[self.focusGroupPath],
+            calibrantSamplePath=self.calibrantSamplePath,
             workspaces={
                 wngt.DIFFCAL_OUTPUT: [response.data["outputDSPWorkspace"], response.data["outputTOFWorkspace"]],
                 wngt.DIFFCAL_TABLE: [response.data["calibrationTable"]],
                 wngt.DIFFCAL_MASK: [response.data["maskWorkspace"]],
             },
-            focusGroup=self.focusGroups[self.focusGroupPath],
+            # fiddly bits
+            peakFunction=self.peakFunction,
+            crystalDMin=self.prevDMin,
+            crystalDMax=self.prevDMax,
+            peakIntensityThreshold=self.prevThreshold,
             nBinsAcrossPeakWidth=self.nBinsAcrossPeakWidth,
-            useLiteMode=self.useLiteMode,
-            calibrantSamplePath=self.calibrantSamplePath,
             fwhmMultipliers=self.prevFWHM,
         )
 

--- a/tests/unit/backend/dao/test_AllowedPeaks.py
+++ b/tests/unit/backend/dao/test_AllowedPeaks.py
@@ -15,9 +15,13 @@ def test_literal_bad():
             focusGroup={"name": "nope", "definition": "nope"},
             calibrantSamplePath="nope",
             useLiteMode=False,
-            peakType=bad,
+            peakFunction=bad,
+            crystalDMin=0.0,
+            crystaldMax=10.0,
+            peakIntensityThreshold=1.0,
+            nBinsAcrossPeakWidth=10,
         )
-    assert "peakType" in str(e.value)
+    assert "peakFunction" in str(e.value)
 
 
 def test_literal_good():
@@ -29,7 +33,11 @@ def test_literal_good():
                 focusGroup={"name": "nope", "definition": "nope"},
                 calibrantSamplePath="nope",
                 useLiteMode=False,
-                peakType=good,
+                peakFunction=good,
+                crystalDMin=0.0,
+                crystalDMax=10.0,
+                peakIntensityThreshold=1.0,
+                nBinsAcrossPeakWidth=10,
             )
         except ValidationError:
             pytest.fail("unexpected `ValidationError` during test")

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -267,6 +267,11 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             useLiteMode=True,
             focusGroup={"name": fakeMetrics.focusGroupName, "definition": ""},
             calibrantSamplePath="egg/muffin/biscuit",
+            peakFunction="Gaussian",
+            crystalDMin=0,
+            crystalDMax=10,
+            peakIntensityThreshold=0,
+            nBinsAcrossPeakWidth=0,
         )
         response = self.instance.assessQuality(request)
 


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

The peaks being fit inside the calibration assessment were not the same peaks sent to the diffraction calibration recipe, nor the same viewed in the peak tweak peek viewer.

This makes sure all the correct parameters are passed forward.

In the future, it will be simpler to just pass the list of peaks forward, but that's another day.

## Explanation of work

Added more fields to `CalibrationAssessmentRequest`.  I did **not** add defaults to these, to ensure all values are being set.

Because there are no default,s several tests which did not have these values had to be updated to include values.

## To test

### Dev Testing

Open GUI, run diffcal with 46880, using Diamond and **Bank**.

You will notice when the peak-tweak peek loads, each group has **two** (2) peaks fit,  The right side will be red.

Set the following:
- dMin = 0.8
- dMax = 100
- FWHM Left = 2
- FWHM Right = 8
- Peak Intensity threshold = 0.0

Recalculate.  You should now have **five** (5) peaks in each group.

Observe the workspace group `fit_peak_diag_46680_1`, and look at tables ending in `_fitted_params_X`.  Make sure each has five rows for peaks, and the peaks have low chi-sq (<100).' 

Now continue with the four peaks.

At the end, inspect the `fitPeaksWSGroup`, and look at each `_fitted_params_X` table.  Compare to the tables under `fit_peak_diag_46680_1`, and make sure they have the same number of rows and *similar* peak centers, sigmas, and chi-squared values (won't be exact because things move during calibration).

See the below screenshot
![image](https://github.com/neutrons/SNAPRed/assets/52183986/d8de57f8-1fb9-41e5-999f-b0f29ef0d4ee)

### CIS Testing

As above, but try runs 49525, 58882, and try adjusting many more parameters.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

Related to
[EWM#4580](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4580)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
