### PR TITLE
add better exception handling for when recalc fails

### DIFF
--- a/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
@@ -145,9 +145,15 @@ class PurgeOverlappingPeaksAlgorithm(PythonAlgorithm):
                 peaks=outputPeakList,
                 maxfwhm=groupPeakList.maxfwhm,
             )
-            outputPeaks.append(outputGroupPeakList)
+            if len(outputGroupPeakList.peaks) > 0:
+                outputPeaks.append(outputGroupPeakList)
         outputPeaks = self.filterPeaksOnIntensity(outputPeaks)
         outputPeaks = self.filterPeaksOnDRange(outputPeaks)
+            
+
+        if len(outputPeaks) == 0:
+            raise RuntimeError("All Peaks were Purged!  Please adjust your parameters!\n\n\n")
+
         self.setProperty("OutputPeakMap", list_to_raw(outputPeaks))
 
         return outputPeaks

--- a/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
@@ -149,7 +149,6 @@ class PurgeOverlappingPeaksAlgorithm(PythonAlgorithm):
                 outputPeaks.append(outputGroupPeakList)
         outputPeaks = self.filterPeaksOnIntensity(outputPeaks)
         outputPeaks = self.filterPeaksOnDRange(outputPeaks)
-            
 
         if len(outputPeaks) == 0:
             raise RuntimeError("All Peaks were Purged!  Please adjust your parameters!\n\n\n")

--- a/src/snapred/meta/decorators/ExceptionToErrLog.py
+++ b/src/snapred/meta/decorators/ExceptionToErrLog.py
@@ -1,0 +1,21 @@
+import functools
+from typing import Any, Callable, Optional, Type
+
+from snapred.backend.error.RecoverableException import RecoverableException
+from snapred.backend.log.logger import snapredLogger
+
+logger = snapredLogger.getLogger(__name__)
+
+
+def ExceptionToErrLog(func: Callable[..., Any]):
+    @functools.wraps(func)
+    def inner(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:  # noqa BLE001
+            import traceback
+
+            logger.error(e)
+            traceback.print_exc()
+
+    return inner

--- a/src/snapred/ui/handler/SNAPResponseHandler.py
+++ b/src/snapred/ui/handler/SNAPResponseHandler.py
@@ -1,3 +1,5 @@
+import threading
+
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QMessageBox, QWidget
 
@@ -26,9 +28,12 @@ class SNAPResponseHandler(QWidget):
         # if errors, do nothing here (program will halt)
         # if a continue warning was raised, receive what user selected
         # if the user selected to continue anyway, then emit the signal to continue anyway
-        userSelectedContinueAnyway = SNAPResponseHandler._handleComplications(result.code, result.message, self)
-        if userSelectedContinueAnyway:
-            self.continueAnyway.emit()
+        if isinstance(threading.current_thread(), threading._MainThread):
+            userSelectedContinueAnyway = SNAPResponseHandler._handleComplications(result.code, result.message, self)
+            if userSelectedContinueAnyway:
+                self.continueAnyway.emit()
+        else:
+            self.rethrow()
 
     def _isErrorCode(code):
         return code >= ResponseCode.ERROR

--- a/src/snapred/ui/workflow/WorkflowImplementer.py
+++ b/src/snapred/ui/workflow/WorkflowImplementer.py
@@ -72,6 +72,7 @@ class WorkflowImplementer:
         return form.verify()
 
     def _handleComplications(self, result):
+        self.responseHandler.handle(result)
         self.responseHandler.rethrow(result)
 
     @property


### PR DESCRIPTION
## Description of work

Exception handling for recalc and other signals do not take into account a failure state.
This is a temp solution to combat that.
Also, toss an exception if no peaks are left after purging, to prevent recalc from getting into a weird state where it trys to delete workspaces that dont exist?

## Explanation of 

I wrapped a bunch of code in try/excepts that really should have been spinning up threads with fail and cleanup conditions.

## To test

Convergence: .1
Bins: 7
![image](https://github.com/neutrons/SNAPRed/assets/68125095/2757f0d8-f0d9-4607-827f-de9d46c5ed1a)

These params on recalc should net an exception, but it should now fail gracefully instead of below:
![image](https://github.com/neutrons/SNAPRed/assets/68125095/51a8d4b8-26d8-4272-a037-85a47d84d72f)


and you should be able to recalc again.
