### PR TITLE
add the isLite flag to calib/norm records

### DIFF
--- a/src/snapred/backend/dao/calibration/CalibrationRecord.py
+++ b/src/snapred/backend/dao/calibration/CalibrationRecord.py
@@ -25,6 +25,7 @@ class CalibrationRecord(BaseModel):
 
     runNumber: str
     crystalInfo: CrystallographicInfo
+    isLite: bool
     calibrationFittingIngredients: Calibration
     pixelGroups: Optional[List[PixelGroup]]  # TODO: really shouldn't be optional, will be when sns data fixed
     focusGroupCalibrationMetrics: FocusGroupMetric

--- a/src/snapred/backend/dao/normalization/NormalizationRecord.py
+++ b/src/snapred/backend/dao/normalization/NormalizationRecord.py
@@ -16,6 +16,7 @@ class NormalizationRecord(BaseModel):
     """
 
     runNumber: str
+    isLite: bool
     backgroundRunNumber: str
     smoothingParameter: float
     calibration: Calibration

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -365,6 +365,7 @@ class CalibrationService(Service):
 
         record = CalibrationRecord(
             runNumber=request.run.runNumber,
+            isLite=request.useLiteMode,
             crystalInfo=self.sousChef.prepCrystallographicInfo(farmFresh),
             calibrationFittingIngredients=self.sousChef.prepCalibration(farmFresh),
             pixelGroups=[pixelGroup],

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -165,6 +165,7 @@ class NormalizationService(Service):
         calibration = self.sousChef.prepCalibration(farmFresh)
         record = NormalizationRecord(
             runNumber=request.runNumber,
+            isLite=request.useLiteMode,
             backgroundRunNumber=request.backgroundRunNumber,
             smoothingParameter=request.smoothingParameter,
             calibration=calibration,

--- a/tests/resources/inputs/calibration/CalibrationRecord_v0001.json
+++ b/tests/resources/inputs/calibration/CalibrationRecord_v0001.json
@@ -1,5 +1,6 @@
 {
   "runNumber": 57514,
+  "isLite": true,
   "crystalInfo": {
     "peaks": [
         {

--- a/tests/resources/inputs/calibration/CalibrationRecord_v0002.json
+++ b/tests/resources/inputs/calibration/CalibrationRecord_v0002.json
@@ -1,5 +1,6 @@
 {
   "runNumber": 57514,
+  "isLite": true,
   "crystalInfo": {
     "peaks": [
         {

--- a/tests/resources/inputs/normalization/NormalizationRecord.json
+++ b/tests/resources/inputs/normalization/NormalizationRecord.json
@@ -1,5 +1,6 @@
 {
     "runNumber": 57514,
+    "isLite": true,
     "backgroundRunNumber": 58813,
     "smoothingParameter": 0.5,
     "calibration":{


### PR DESCRIPTION
## Description of work

This adds the isLite flag to calibration and normalization records

## To test

if you would like to regression test the ui, try the following for calib:
```
Run Number: 46581
Convergence Threshold: 0.1
Peak Intensity Threshold: 0.0001
Bins Across Peak Width: 10
Sample: Any
Grouping File: Any
Peak Function: Any

dmin: 1.1
```

for normalization any will work really but heres one I copy pasted from another pr:
```
   run = 58813
background = 58813
sample = silicon
```

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4770](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4770)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
