### PR TITLE
Create reduction UI elements

### DIFF
--- a/src/snapred/ui/presenter/TestPanelPresenter.py
+++ b/src/snapred/ui/presenter/TestPanelPresenter.py
@@ -37,8 +37,7 @@ class TestPanelPresenter(object):
 
         self.view.tabWidget.addTab(self.diffractionCalibrationWidget, "Diffraction Calibration")
         self.view.tabWidget.addTab(self.calibrationNormalizationWidget, "Normalization")
-        # TODO reenable in Phase 3
-        # self.view.tabWidget.addTab(self.reductionWidget, "Reduction")
+        self.view.tabWidget.addTab(self.reductionWidget, "Reduction")
 
     def _findSchemaForPath(self, path):
         currentVal = self.apiDict

--- a/src/snapred/ui/view/BackendRequestView.py
+++ b/src/snapred/ui/view/BackendRequestView.py
@@ -5,6 +5,7 @@ from qtpy.QtWidgets import QGridLayout, QHBoxLayout, QLabel, QMessageBox, QPushB
 from snapred.backend.api.InterfaceController import InterfaceController
 from snapred.backend.dao.SNAPRequest import SNAPRequest
 from snapred.ui.threading.worker_pool import WorkerPool
+from snapred.ui.widget.LabeledCheckBox import LabeledCheckBox
 from snapred.ui.widget.LabeledField import LabeledField
 from snapred.ui.widget.SampleDropDown import SampleDropDown
 
@@ -28,8 +29,11 @@ class BackendRequestView(QWidget):
     def getField(self, key):
         return self.jsonForm.getField(key)
 
-    def _labeledField(self, label, field=None):
-        return LabeledField(label, field, self)
+    def _labeledField(self, label, field=None, multi=False):
+        return LabeledField(label, field, self, multi)
+
+    def _labeledCheckBox(self, label):
+        return LabeledCheckBox(label, self)
 
     def _sampleDropDown(self, label, items=[]):
         return SampleDropDown(label, items, self)

--- a/src/snapred/ui/view/BackendRequestView.py
+++ b/src/snapred/ui/view/BackendRequestView.py
@@ -30,7 +30,7 @@ class BackendRequestView(QWidget):
         return self.jsonForm.getField(key)
 
     def _labeledField(self, label, field=None, multi=False):
-        return LabeledField(label, field, self, multi)
+        return LabeledField(label, field, multi, self)
 
     def _labeledCheckBox(self, label):
         return LabeledCheckBox(label, self)

--- a/src/snapred/ui/view/BackendRequestView.py
+++ b/src/snapred/ui/view/BackendRequestView.py
@@ -29,8 +29,8 @@ class BackendRequestView(QWidget):
     def getField(self, key):
         return self.jsonForm.getField(key)
 
-    def _labeledField(self, label, field=None, multi=False):
-        return LabeledField(label, field, multi, self)
+    def _labeledField(self, label, field=None):
+        return LabeledField(label, field, self)
 
     def _labeledCheckBox(self, label):
         return LabeledCheckBox(label, self)

--- a/src/snapred/ui/view/ReductionView.py
+++ b/src/snapred/ui/view/ReductionView.py
@@ -1,19 +1,26 @@
+from qtpy.QtWidgets import QGridLayout, QWidget
+
 from snapred.meta.decorators.Resettable import Resettable
-from snapred.ui.view.BackendRequestView import BackendRequestView
+from snapred.ui.widget.LabeledCheckBox import LabeledCheckBox
+from snapred.ui.widget.LabeledField import LabeledField
+from snapred.ui.widget.SampleDropDown import SampleDropDown
 from snapred.ui.widget.Toggle import Toggle
 
 
 @Resettable
-class ReductionView(BackendRequestView):
-    def __init__(self, jsonForm, pixelMasks=[], parent=None):
-        super(ReductionView, self).__init__(jsonForm, "", parent=parent)
+class ReductionView(QWidget):
+    # This class will need to updated once backend implemenation is complete.
+    def __init__(self, pixelMasks=[], parent=None):
+        super().__init__(parent)
+
+        self.layout = QGridLayout()
+        self.setLayout(self.layout)
 
         # input fields
-        self.runNumberField = self._labeledField("Run Number:", jsonForm.getField("runNumber"), """multi=True""")
-        # multi argument allows acceptance of a list of run numbers like 12345, 67890, 12145, etc....
-        self.litemodeToggle = self._labeledField("Lite Mode", Toggle(parent=self, state=True))
-        self.checkbox = self._labeledCheckBox("Retain Unfocussed Data")
-        self.dropDown = self._sampleDropDown("Pixel Masks", pixelMasks)
+        self.runNumberField = LabeledField("Run Number:")
+        self.litemodeToggle = LabeledField("Lite Mode", Toggle(parent=self, state=True))
+        self.checkbox = LabeledCheckBox("Retain Unfocussed Data")
+        self.dropDown = SampleDropDown("Pixel Masks", pixelMasks)
 
         # set field properties
         self.litemodeToggle.setEnabled(False)

--- a/src/snapred/ui/widget/LabeledCheckBox.py
+++ b/src/snapred/ui/widget/LabeledCheckBox.py
@@ -1,0 +1,35 @@
+from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtWidgets import QCheckBox, QHBoxLayout, QLabel, QWidget
+
+
+class LabeledCheckBox(QWidget):
+    checkedChanged = pyqtSignal(bool)
+
+    def __init__(self, label, parent=None):
+        super(LabeledCheckBox, self).__init__(parent)
+        self.setStyleSheet("background-color: #F5E9E2;")
+
+        self._label = QLabel(label + ":", self)
+        self._checkBox = QCheckBox(self)
+
+        layout = QHBoxLayout()
+        layout.addWidget(self._label)
+        layout.addWidget(self._checkBox)
+        layout.addStretch(1)
+        layout.setContentsMargins(5, 5, 5, 5)
+        self.setLayout(layout)
+
+        self._checkBox.stateChanged.connect(self.emitCheckedState)
+
+    def emitCheckedState(self, state):
+        self.checkedChanged.emit(state == QCheckBox.Checked)
+
+    @property
+    def checkBox(self):
+        return self._checkBox
+
+    def isChecked(self):
+        return self._checkBox.isChecked()
+
+    def setChecked(self, state):
+        self._checkBox.setChecked(state)

--- a/src/snapred/ui/widget/LabeledField.py
+++ b/src/snapred/ui/widget/LabeledField.py
@@ -2,29 +2,20 @@ from qtpy.QtWidgets import QHBoxLayout, QLabel, QLineEdit, QWidget
 
 
 class LabeledField(QWidget):
-    def __init__(self, label, field=None, parent=None, multi=False):
+    def __init__(self, label, field=None, parent=None):
         super(LabeledField, self).__init__(parent)
         self.setStyleSheet("background-color: #F5E9E2;")
         layout = QHBoxLayout()
         self.setLayout(layout)
 
         self._label = QLabel(label)
-        layout.addWidget(self._label)
-
-        if multi:
-            self._field = QLineEdit(parent=self)
-            if field is not None:
-                self._field.setText(", ".join(map(str, field)))
+        if field is not None:
+            self._field = field
         else:
-            if field is None:
-                self._field = QLineEdit(parent=self)
-            elif isinstance(field, QLineEdit):
-                self._field = field
-            else:
-                self._field = QLineEdit(str(field), parent=self)
+            self._field = QLineEdit(parent=self)
 
+        layout.addWidget(self._label)
         layout.addWidget(self._field)
-
         # adjust layout size such that label has no whitespace
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
@@ -52,6 +43,9 @@ class LabeledField(QWidget):
 
     def text(self):
         return self._field.text()
+
+    def convertCommaSepartedToList(self):
+        return self.text().split(",")
 
     def setText(self, text):
         self._field.setText(text)

--- a/src/snapred/ui/widget/LabeledField.py
+++ b/src/snapred/ui/widget/LabeledField.py
@@ -2,20 +2,29 @@ from qtpy.QtWidgets import QHBoxLayout, QLabel, QLineEdit, QWidget
 
 
 class LabeledField(QWidget):
-    def __init__(self, label, field=None, parent=None):
+    def __init__(self, label, field=None, parent=None, multi=False):
         super(LabeledField, self).__init__(parent)
         self.setStyleSheet("background-color: #F5E9E2;")
         layout = QHBoxLayout()
         self.setLayout(layout)
 
         self._label = QLabel(label)
-        if field is not None:
-            self._field = field
-        else:
-            self._field = QLineEdit(parent=self)
-
         layout.addWidget(self._label)
+
+        if multi:
+            self._field = QLineEdit(parent=self)
+            if field is not None:
+                self._field.setText(", ".join(map(str, field)))
+        else:
+            if field is None:
+                self._field = QLineEdit(parent=self)
+            elif isinstance(field, QLineEdit):
+                self._field = field
+            else:
+                self._field = QLineEdit(str(field), parent=self)
+
         layout.addWidget(self._field)
+
         # adjust layout size such that label has no whitespace
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)


### PR DESCRIPTION
## Description of work
This work was the capture the integration of the agreed upon UI elements to facilitate user interaction for the future Reduction feature within SNAPRed.
<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work
There was a previous existing `ReductionView` which was modified to incorporate the list of required user interactive UI elements as specified:
1. The lite mode widget (this can be identical to the difCal/normCal element)
2. An input run number text field. [ENABLED but RESTRICTED (For the initial release, this shall be constrained to only accept a single run number at a time)]
3. A checkbox enabling retention of unfocussed data [DISABLED]
4. A drop down allowing the user to select from a list of pixel masks [DISABLED]

An attempt was made to create a signal endpoint for the checkbox along with following the current accepted UI code structure for other additions.

**NOTE:** Slight updates will be needed to this view later on once backend implementation is complete. There are no endpoints to handle form creation within the `TestPanelPresenter` and therefore ReductionView was left as an inheriting OWidget class as apposed to a `BackendRequestView` class. This would require a request call associated to a path done within L83 - L86 for DiffCal and L88 - L91 for Normalization within TestPanelPresenter.
<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing
Launch SNAPRed and view the reduction tab within the Test Panel.
<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing
None needed for now!

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM # 4775](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4775)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
