### PR TITLE
Added recipe and tests for Reduction Group Processing

### DIFF
--- a/src/snapred/backend/dao/state/FocusParams.py
+++ b/src/snapred/backend/dao/state/FocusParams.py
@@ -1,0 +1,10 @@
+from typing import List
+
+from pydantic import BaseModel
+
+
+class FocusParams(BaseModel):
+    # TODO: To be reevaluated for EWM 4798
+    L2: List[float]
+    Polar: List[float]
+    Azimuthal: List[float]

--- a/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
+++ b/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
@@ -1,0 +1,108 @@
+from typing import Any, Dict, List, Tuple
+
+from snapred.backend.log.logger import snapredLogger
+from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
+from snapred.backend.recipe.algorithm.Utensils import Utensils
+from snapred.meta.decorators.Singleton import Singleton
+
+logger = snapredLogger.getLogger(__name__)
+
+Pallet = Tuple[Dict[str, str]]
+
+
+@Singleton
+class ReductionGroupProcessingRecipe:
+    def __init__(self, utensils: Utensils = None):
+        """
+        Sets up the recipe with the necessary utensils.
+        """
+        # NOTE: workaround, we just add an empty host algorithm.
+        if utensils is None:
+            utensils = Utensils()
+            utensils.PyInit()
+        self.mantidSnapper = utensils.mantidSnapper
+
+    def unbagGroceries(self, groceries: Dict[str, Any]):
+        self.rawInput = groceries["inputWorkspace"]
+        self.outputWS = groceries["outputWorkspace"]
+        self.geometryOutputWS = groceries["geometryOutputWorkspace"]
+        self.diffFocOutputWS = groceries["diffFocOutputWorkspace"]
+        self.groupingWS = groceries["groupingWorkspace"]
+
+    def queueAlgos(self):
+        """
+        Queues up the procesing algorithms for the recipe.
+        Requires: unbagged groceries.
+        """
+        # TODO: This is all subject to change based on EWM 4798
+        # if self.rawInput is not None:
+        #     logger.info("Processing Reduction Group...")
+        #     estimateGeometryAlgo = EstimateFocusedInstrumentGeometry()
+        #     estimateGeometryAlgo.initialize()
+        #     estimateGeometryAlgo.setProperty("GroupingWorkspace", self.groupingWS)
+        #     estimateGeometryAlgo.setProperty("OutputWorkspace", self.geometryOutputWS)
+        #     try:
+        #         estimateGeometryAlgo.execute()
+        #         data["focusParams"] = estimateGeometryAlgo.getPropertyValue("FocusParams")
+        #     except RuntimeError as e:
+        #         errorString = str(e)
+        #         raise RuntimeError(errorString) from e
+        # else:
+        #     raise NotImplementedError
+
+        # self.mantidSnapper.EditInstrumentGeometry(
+        #     "Editing Instrument Geometry...",
+        #         Workspace=self.geometryOutputWS,
+        #         L2=data["focusParams"].L2,
+        #         Polar=data["focusParams"].Polar,
+        #         Azimuthal=data["focusParams"].Azimuthal,
+        # )
+
+        self.mantidSnapper.DiffractionFocussing(
+            "Applying Diffraction Focussing...",
+            InputWorkspace=self.geometryOutputWS,
+            GroupingWorkspace=self.groupingWS,
+            OutputWorkspace=self.diffFocOutputWS,
+        )
+
+        self.mantidSnapper.NormaliseByCurrent(
+            "Normalizing Current ...",
+            InputWorkspace=self.diffFocOutputWS,
+            OutputWorkspace=self.outputWS,
+        )
+
+    def prep(self, groceries: Dict[str, str]):
+        """
+        Convinience method to prepare the recipe for execution.
+        """
+        self.unbagGroceries(groceries)
+        self.queueAlgos()
+
+    def execute(self):
+        """
+        Final step in a recipe, executes the queued algorithms.
+        Requires: queued algorithms.
+        """
+        self.mantidSnapper.executeQueue()
+
+    def cook(self, groceries: Dict[str, str]) -> Dict[str, Any]:
+        """
+        Main interface method for the recipe.
+        Given the ingredients and groceries, it prepares, executes and returns the final workspace.
+        """
+        self.prep(groceries)
+        self.execute()
+        return self.outputWS
+
+    def cater(self, shipment: List[Pallet]) -> List[Dict[str, Any]]:
+        """
+        A secondary interface method for the recipe.
+        It is a batched version of cook.
+        Given a shipment of ingredients and groceries, it prepares, executes and returns the final workspaces.
+        """
+        output = []
+        for grocery in shipment:
+            self.prep(grocery)
+            output.append(self.outputWS)
+        self.execute()
+        return output

--- a/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
+++ b/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
@@ -73,7 +73,7 @@ class ReductionGroupProcessingRecipe:
 
     def prep(self, groceries: Dict[str, str]):
         """
-        Convinience method to prepare the recipe for execution.
+        Convenience method to prepare the recipe for execution.
         """
         self.unbagGroceries(groceries)
         self.queueAlgos()

--- a/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
+++ b/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
@@ -26,6 +26,7 @@ class ReductionGroupProcessingRecipe:
         self.rawInput = groceries["inputWorkspace"]
         self.outputWS = groceries["outputWorkspace"]
         self.geometryOutputWS = groceries["geometryOutputWorkspace"]
+        self.diffFocOutputWS = groceries["diffFocOutputWorkspace"]
         self.groupingWS = groceries["groupingWorkspace"]
 
     def queueAlgos(self):
@@ -61,6 +62,12 @@ class ReductionGroupProcessingRecipe:
             "Applying Diffraction Focussing...",
             InputWorkspace=self.geometryOutputWS,
             GroupingWorkspace=self.groupingWS,
+            OutputWorkspace=self.diffFocOutputWS,
+        )
+
+        self.mantidSnapper.NormaliseByCurrent(
+            "Normalizing Current ...",
+            InputWorkspace=self.diffFocOutputWS,
             OutputWorkspace=self.outputWS,
         )
 

--- a/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
+++ b/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
@@ -26,7 +26,6 @@ class ReductionGroupProcessingRecipe:
         self.rawInput = groceries["inputWorkspace"]
         self.outputWS = groceries["outputWorkspace"]
         self.geometryOutputWS = groceries["geometryOutputWorkspace"]
-        self.diffFocOutputWS = groceries["diffFocOutputWorkspace"]
         self.groupingWS = groceries["groupingWorkspace"]
 
     def queueAlgos(self):
@@ -62,12 +61,6 @@ class ReductionGroupProcessingRecipe:
             "Applying Diffraction Focussing...",
             InputWorkspace=self.geometryOutputWS,
             GroupingWorkspace=self.groupingWS,
-            OutputWorkspace=self.diffFocOutputWS,
-        )
-
-        self.mantidSnapper.NormaliseByCurrent(
-            "Normalizing Current ...",
-            InputWorkspace=self.diffFocOutputWS,
             OutputWorkspace=self.outputWS,
         )
 

--- a/src/snapred/backend/recipe/algorithm/RawVanadiumCorrectionAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/RawVanadiumCorrectionAlgorithm.py
@@ -84,6 +84,12 @@ class RawVanadiumCorrectionAlgorithm(PythonAlgorithm):
             BinningMode="Logarithmic",
         )
 
+        self.mantidSnapper.NormaliseByCurrent(
+            "Normalize by current",
+            InputWorkspace=outputWS,
+            OutputWorkspace=outputWS,
+        )
+
         self.mantidSnapper.MakeDirtyDish(
             "make a copy of data after chop",
             InputWorkspace=outputWS,

--- a/src/snapred/backend/recipe/algorithm/RawVanadiumCorrectionAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/RawVanadiumCorrectionAlgorithm.py
@@ -84,12 +84,6 @@ class RawVanadiumCorrectionAlgorithm(PythonAlgorithm):
             BinningMode="Logarithmic",
         )
 
-        self.mantidSnapper.NormaliseByCurrent(
-            "Normalize by current",
-            InputWorkspace=outputWS,
-            OutputWorkspace=outputWS,
-        )
-
         self.mantidSnapper.MakeDirtyDish(
             "make a copy of data after chop",
             InputWorkspace=outputWS,

--- a/src/snapred/backend/recipe/algorithm/RawVanadiumCorrectionAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/RawVanadiumCorrectionAlgorithm.py
@@ -6,7 +6,6 @@ from mantid.api import (
     MatrixWorkspaceProperty,
     PropertyMode,
     PythonAlgorithm,
-    mtd,
 )
 from mantid.kernel import Direction, StringMandatoryValidator
 
@@ -119,8 +118,8 @@ class RawVanadiumCorrectionAlgorithm(PythonAlgorithm):
         self.chopNeutronData(self.inputVanadiumWS, self.outputVanadiumWS)
         self.chopNeutronData(self.inputBackgroundWS, self.outputBackgroundWS)
 
-        pcV = mtd[self.outputVanadiumWS].run().getProtonCharge()
-        pcB = mtd[self.outputBackgroundWS].run().getProtonCharge()
+        pcV = self.mantidSnapper.mtd[self.outputVanadiumWS].run().getProtonCharge()
+        pcB = self.mantidSnapper.mtd[self.outputBackgroundWS].run().getProtonCharge()
         protonCharge = pcV / pcB
 
         self.mantidSnapper.Scale(

--- a/tests/unit/backend/recipe/algorithm/test_RawVanadiumCorrection.py
+++ b/tests/unit/backend/recipe/algorithm/test_RawVanadiumCorrection.py
@@ -185,7 +185,7 @@ class TestRawVanadiumCorrection(unittest.TestCase):
         for x, y in zip(dataX, dataY):
             if x >= algo.TOFPars[0] and x <= algo.TOFPars[2]:
                 dataXnorm.append(x)
-                dataYnorm.append(y)
+                dataYnorm.append(y / self.sample_proton_charge)
 
         dataXrebin = [sum(dataXnorm) / len(dataXnorm)]
         dataYrebin = [sum(dataYnorm[:-1])]

--- a/tests/unit/backend/recipe/algorithm/test_RawVanadiumCorrection.py
+++ b/tests/unit/backend/recipe/algorithm/test_RawVanadiumCorrection.py
@@ -185,7 +185,7 @@ class TestRawVanadiumCorrection(unittest.TestCase):
         for x, y in zip(dataX, dataY):
             if x >= algo.TOFPars[0] and x <= algo.TOFPars[2]:
                 dataXnorm.append(x)
-                dataYnorm.append(y / self.sample_proton_charge)
+                dataYnorm.append(y)
 
         dataXrebin = [sum(dataXnorm) / len(dataXnorm)]
         dataYrebin = [sum(dataYnorm[:-1])]
@@ -203,7 +203,7 @@ class TestRawVanadiumCorrection(unittest.TestCase):
         algo.setProperty("InputWorkspace", self.sampleWS)
         algo.setProperty("BackgroundWorkspace", self.backgroundWS)
         algo.setProperty("Ingredients", self.ingredients.json())
-        algo.setProperty("OutputWorkspace", "_test_workspace_rar_vanadium")
+        algo.setProperty("OutputWorkspace", "_test_workspace_raw_vanadium")
         assert algo.execute()
 
 

--- a/tests/unit/backend/recipe/algorithm/test_RawVanadiumCorrection.py
+++ b/tests/unit/backend/recipe/algorithm/test_RawVanadiumCorrection.py
@@ -185,7 +185,7 @@ class TestRawVanadiumCorrection(unittest.TestCase):
         for x, y in zip(dataX, dataY):
             if x >= algo.TOFPars[0] and x <= algo.TOFPars[2]:
                 dataXnorm.append(x)
-                dataYnorm.append(y / self.sample_proton_charge)
+                dataYnorm.append(y)
 
         dataXrebin = [sum(dataXnorm) / len(dataXnorm)]
         dataYrebin = [sum(dataYnorm[:-1])]

--- a/tests/unit/backend/recipe/test_ReductionGroupProcessingRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionGroupProcessingRecipe.py
@@ -22,12 +22,14 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
             "inputWorkspace": "input",
             "outputWorkspace": "output",
             "geometryOutputWorkspace": "geoWS",
+            "diffFocOutputWorkspace": "diffFocWS",
             "groupingWorkspace": "groupingWS",
         }
         recipe.unbagGroceries(groceries)
         assert recipe.rawInput == groceries["inputWorkspace"]
         assert recipe.outputWS == groceries["outputWorkspace"]
         assert recipe.geometryOutputWS == groceries["geometryOutputWorkspace"]
+        assert recipe.diffFocOutputWS == groceries["diffFocOutputWorkspace"]
         assert recipe.groupingWS == groceries["groupingWorkspace"]
 
     def test_queueAlgos(self):
@@ -36,6 +38,7 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
             "inputWorkspace": "input",
             "outputWorkspace": "output",
             "geometryOutputWorkspace": "geoWS",
+            "diffFocOutputWorkspace": "diffFocWS",
             "groupingWorkspace": "groupingWS",
         }
         recipe.prep(groceries)
@@ -43,12 +46,17 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
 
         queuedAlgos = recipe.mantidSnapper._algorithmQueue
         diffFoc = queuedAlgos[0]
+        normCurr = queuedAlgos[1]
 
         assert diffFoc[0] == "DiffractionFocussing"
+        assert normCurr[0] == "NormaliseByCurrent"
         assert diffFoc[1] == "Applying Diffraction Focussing..."
+        assert normCurr[1] == "Normalizing Current ..."
         assert diffFoc[2]["InputWorkspace"] == groceries["geometryOutputWorkspace"]
         assert diffFoc[2]["GroupingWorkspace"] == groceries["groupingWorkspace"]
-        assert diffFoc[2]["OutputWorkspace"] == groceries["outputWorkspace"]
+        assert diffFoc[2]["OutputWorkspace"] == groceries["diffFocOutputWorkspace"]
+        assert normCurr[2]["InputWorkspace"] == groceries["diffFocOutputWorkspace"]
+        assert normCurr[2]["OutputWorkspace"] == groceries["outputWorkspace"]
 
     def test_cook(self):
         untensils = Utensils()
@@ -59,6 +67,7 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
             "inputWorkspace": "input",
             "outputWorkspace": "output",
             "geometryOutputWorkspace": "geoWS",
+            "diffFocOutputWorkspace": "diffFocWS",
             "groupingWorkspace": "groupingWS",
         }
 
@@ -67,11 +76,13 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
         assert recipe.rawInput == groceries["inputWorkspace"]
         assert recipe.outputWS == groceries["outputWorkspace"]
         assert recipe.geometryOutputWS == groceries["geometryOutputWorkspace"]
+        assert recipe.diffFocOutputWS == groceries["diffFocOutputWorkspace"]
         assert recipe.groupingWS == groceries["groupingWorkspace"]
         assert output == groceries["outputWorkspace"]
 
         assert mockSnapper.executeQueue.called
         assert mockSnapper.DiffractionFocussing.called
+        assert mockSnapper.NormaliseByCurrent.called
 
     def test_cater(self):
         untensils = Utensils()
@@ -82,6 +93,7 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
             "inputWorkspace": "input",
             "outputWorkspace": "output",
             "geometryOutputWorkspace": "geoWS",
+            "diffFocOutputWorkspace": "diffFocWS",
             "groupingWorkspace": "groupingWS",
         }
 
@@ -90,8 +102,10 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
         assert recipe.rawInput == groceries["inputWorkspace"]
         assert recipe.outputWS == groceries["outputWorkspace"]
         assert recipe.geometryOutputWS == groceries["geometryOutputWorkspace"]
+        assert recipe.diffFocOutputWS == groceries["diffFocOutputWorkspace"]
         assert recipe.groupingWS == groceries["groupingWorkspace"]
         assert output[0] == groceries["outputWorkspace"]
 
         assert mockSnapper.executeQueue.called
         assert mockSnapper.DiffractionFocussing.called
+        assert mockSnapper.NormaliseByCurrent.called

--- a/tests/unit/backend/recipe/test_ReductionGroupProcessingRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionGroupProcessingRecipe.py
@@ -1,0 +1,111 @@
+import unittest
+
+import pytest
+from snapred.backend.recipe.ReductionGroupProcessingRecipe import ReductionGroupProcessingRecipe, Utensils
+
+
+# TODO: Add/update tests when EWM 4798 is complete
+class ReductionGroupProcessingRecipeTest(unittest.TestCase):
+    def test_init(self):
+        ReductionGroupProcessingRecipe()
+
+    def test_init_reuseUtensils(self):
+        utensils = Utensils()
+        utensils.PyInit()
+        recipe = ReductionGroupProcessingRecipe(utensils=utensils)
+        assert recipe.mantidSnapper == utensils.mantidSnapper
+
+    def test_unbagGroceries(self):
+        recipe = ReductionGroupProcessingRecipe()
+
+        groceries = {
+            "inputWorkspace": "input",
+            "outputWorkspace": "output",
+            "geometryOutputWorkspace": "geoWS",
+            "diffFocOutputWorkspace": "diffFocWS",
+            "groupingWorkspace": "groupingWS",
+        }
+        recipe.unbagGroceries(groceries)
+        assert recipe.rawInput == groceries["inputWorkspace"]
+        assert recipe.outputWS == groceries["outputWorkspace"]
+        assert recipe.geometryOutputWS == groceries["geometryOutputWorkspace"]
+        assert recipe.diffFocOutputWS == groceries["diffFocOutputWorkspace"]
+        assert recipe.groupingWS == groceries["groupingWorkspace"]
+
+    def test_queueAlgos(self):
+        recipe = ReductionGroupProcessingRecipe()
+        groceries = {
+            "inputWorkspace": "input",
+            "outputWorkspace": "output",
+            "geometryOutputWorkspace": "geoWS",
+            "diffFocOutputWorkspace": "diffFocWS",
+            "groupingWorkspace": "groupingWS",
+        }
+        recipe.prep(groceries)
+        recipe.queueAlgos()
+
+        queuedAlgos = recipe.mantidSnapper._algorithmQueue
+        diffFoc = queuedAlgos[0]
+        normCurr = queuedAlgos[1]
+
+        assert diffFoc[0] == "DiffractionFocussing"
+        assert normCurr[0] == "NormaliseByCurrent"
+        assert diffFoc[1] == "Applying Diffraction Focussing..."
+        assert normCurr[1] == "Normalizing Current ..."
+        assert diffFoc[2]["InputWorkspace"] == groceries["geometryOutputWorkspace"]
+        assert diffFoc[2]["GroupingWorkspace"] == groceries["groupingWorkspace"]
+        assert diffFoc[2]["OutputWorkspace"] == groceries["diffFocOutputWorkspace"]
+        assert normCurr[2]["InputWorkspace"] == groceries["diffFocOutputWorkspace"]
+        assert normCurr[2]["OutputWorkspace"] == groceries["outputWorkspace"]
+
+    def test_cook(self):
+        untensils = Utensils()
+        mockSnapper = unittest.mock.Mock()
+        untensils.mantidSnapper = mockSnapper
+        recipe = ReductionGroupProcessingRecipe(utensils=untensils)
+        groceries = {
+            "inputWorkspace": "input",
+            "outputWorkspace": "output",
+            "geometryOutputWorkspace": "geoWS",
+            "diffFocOutputWorkspace": "diffFocWS",
+            "groupingWorkspace": "groupingWS",
+        }
+
+        output = recipe.cook(groceries)
+
+        assert recipe.rawInput == groceries["inputWorkspace"]
+        assert recipe.outputWS == groceries["outputWorkspace"]
+        assert recipe.geometryOutputWS == groceries["geometryOutputWorkspace"]
+        assert recipe.diffFocOutputWS == groceries["diffFocOutputWorkspace"]
+        assert recipe.groupingWS == groceries["groupingWorkspace"]
+        assert output == groceries["outputWorkspace"]
+
+        assert mockSnapper.executeQueue.called
+        assert mockSnapper.DiffractionFocussing.called
+        assert mockSnapper.NormaliseByCurrent.called
+
+    def test_cater(self):
+        untensils = Utensils()
+        mockSnapper = unittest.mock.Mock()
+        untensils.mantidSnapper = mockSnapper
+        recipe = ReductionGroupProcessingRecipe(utensils=untensils)
+        groceries = {
+            "inputWorkspace": "input",
+            "outputWorkspace": "output",
+            "geometryOutputWorkspace": "geoWS",
+            "diffFocOutputWorkspace": "diffFocWS",
+            "groupingWorkspace": "groupingWS",
+        }
+
+        output = recipe.cater([(groceries)])
+
+        assert recipe.rawInput == groceries["inputWorkspace"]
+        assert recipe.outputWS == groceries["outputWorkspace"]
+        assert recipe.geometryOutputWS == groceries["geometryOutputWorkspace"]
+        assert recipe.diffFocOutputWS == groceries["diffFocOutputWorkspace"]
+        assert recipe.groupingWS == groceries["groupingWorkspace"]
+        assert output[0] == groceries["outputWorkspace"]
+
+        assert mockSnapper.executeQueue.called
+        assert mockSnapper.DiffractionFocussing.called
+        assert mockSnapper.NormaliseByCurrent.called

--- a/tests/unit/backend/recipe/test_ReductionGroupProcessingRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionGroupProcessingRecipe.py
@@ -22,14 +22,12 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
             "inputWorkspace": "input",
             "outputWorkspace": "output",
             "geometryOutputWorkspace": "geoWS",
-            "diffFocOutputWorkspace": "diffFocWS",
             "groupingWorkspace": "groupingWS",
         }
         recipe.unbagGroceries(groceries)
         assert recipe.rawInput == groceries["inputWorkspace"]
         assert recipe.outputWS == groceries["outputWorkspace"]
         assert recipe.geometryOutputWS == groceries["geometryOutputWorkspace"]
-        assert recipe.diffFocOutputWS == groceries["diffFocOutputWorkspace"]
         assert recipe.groupingWS == groceries["groupingWorkspace"]
 
     def test_queueAlgos(self):
@@ -38,7 +36,6 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
             "inputWorkspace": "input",
             "outputWorkspace": "output",
             "geometryOutputWorkspace": "geoWS",
-            "diffFocOutputWorkspace": "diffFocWS",
             "groupingWorkspace": "groupingWS",
         }
         recipe.prep(groceries)
@@ -46,17 +43,12 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
 
         queuedAlgos = recipe.mantidSnapper._algorithmQueue
         diffFoc = queuedAlgos[0]
-        normCurr = queuedAlgos[1]
 
         assert diffFoc[0] == "DiffractionFocussing"
-        assert normCurr[0] == "NormaliseByCurrent"
         assert diffFoc[1] == "Applying Diffraction Focussing..."
-        assert normCurr[1] == "Normalizing Current ..."
         assert diffFoc[2]["InputWorkspace"] == groceries["geometryOutputWorkspace"]
         assert diffFoc[2]["GroupingWorkspace"] == groceries["groupingWorkspace"]
-        assert diffFoc[2]["OutputWorkspace"] == groceries["diffFocOutputWorkspace"]
-        assert normCurr[2]["InputWorkspace"] == groceries["diffFocOutputWorkspace"]
-        assert normCurr[2]["OutputWorkspace"] == groceries["outputWorkspace"]
+        assert diffFoc[2]["OutputWorkspace"] == groceries["outputWorkspace"]
 
     def test_cook(self):
         untensils = Utensils()
@@ -67,7 +59,6 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
             "inputWorkspace": "input",
             "outputWorkspace": "output",
             "geometryOutputWorkspace": "geoWS",
-            "diffFocOutputWorkspace": "diffFocWS",
             "groupingWorkspace": "groupingWS",
         }
 
@@ -76,13 +67,11 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
         assert recipe.rawInput == groceries["inputWorkspace"]
         assert recipe.outputWS == groceries["outputWorkspace"]
         assert recipe.geometryOutputWS == groceries["geometryOutputWorkspace"]
-        assert recipe.diffFocOutputWS == groceries["diffFocOutputWorkspace"]
         assert recipe.groupingWS == groceries["groupingWorkspace"]
         assert output == groceries["outputWorkspace"]
 
         assert mockSnapper.executeQueue.called
         assert mockSnapper.DiffractionFocussing.called
-        assert mockSnapper.NormaliseByCurrent.called
 
     def test_cater(self):
         untensils = Utensils()
@@ -93,7 +82,6 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
             "inputWorkspace": "input",
             "outputWorkspace": "output",
             "geometryOutputWorkspace": "geoWS",
-            "diffFocOutputWorkspace": "diffFocWS",
             "groupingWorkspace": "groupingWS",
         }
 
@@ -102,10 +90,8 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
         assert recipe.rawInput == groceries["inputWorkspace"]
         assert recipe.outputWS == groceries["outputWorkspace"]
         assert recipe.geometryOutputWS == groceries["geometryOutputWorkspace"]
-        assert recipe.diffFocOutputWS == groceries["diffFocOutputWorkspace"]
         assert recipe.groupingWS == groceries["groupingWorkspace"]
         assert output[0] == groceries["outputWorkspace"]
 
         assert mockSnapper.executeQueue.called
         assert mockSnapper.DiffractionFocussing.called
-        assert mockSnapper.NormaliseByCurrent.called


### PR DESCRIPTION
## Description of work

This implements the recipe for reduction group processing

## Explanation of work

The recipe and test is implemented very similar to how Apply Normalization is implemented. We call DiffractionFocussing and then NormaliseByCurrent. There are other steps to be added when EWM 4798 is completed. FocusParams is to be used when 4798 is done.

## To test

### Dev testing

Make sure unit tests pass.

### CIS testing

None

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4793)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
