### PR TITLE
Create WorkspaceMetadata object

### DIFF
--- a/src/snapred/backend/dao/WorkspaceMetadata.py
+++ b/src/snapred/backend/dao/WorkspaceMetadata.py
@@ -19,7 +19,7 @@ diffcal_metadata_state_list = list(get_args(DIFFCAL_METADATA_STATE))
 NORMCAL_METADATA_STATE = Literal[
     "unset",  # the default condition before any settings
     "exists",  # the state exists and the corresponding .h5 file located
-    "alternate",  # the user supplied an alternate .h5 that they believe in usable
+    "alternate",  # the user supplied an alternate .h5 that they believe is usable
     "none",  # proceed without applying any normalization
     "fake",  # proceed by creating a "fake vanadium"
 ]

--- a/src/snapred/backend/dao/WorkspaceMetadata.py
+++ b/src/snapred/backend/dao/WorkspaceMetadata.py
@@ -1,0 +1,33 @@
+from typing import Literal, get_args
+
+from pydantic import BaseModel
+
+# possible states for diffraction calibration
+
+DIFFCAL_METADATA_STATE = Literal[
+    "unset",  # the default condition before any settings
+    "exists",  # the state exists and the corresponding .h5 file located
+    "alternate",  # the user supplied an alternate .h5 that they believe is usable.
+    "none",  # proceed using the defaul (IDF) geometry.
+]
+
+diffcal_metadata_state_list = list(get_args(DIFFCAL_METADATA_STATE))
+
+
+# possible states for normalization
+
+NORMCAL_METADATA_STATE = Literal[
+    "unset",  # the default condition before any settings
+    "exists",  # the state exists and the corresponding .h5 file located
+    "none",  # proceed without applying any normalization
+    "fake",  # proceed by creating a "fake vanadium"
+]
+
+normcal_metadata_state_list = list(get_args(NORMCAL_METADATA_STATE))
+
+
+class WorkspaceMetadata(BaseModel):
+    """Class to hold tags related to a workspace"""
+
+    diffcalState: DIFFCAL_METADATA_STATE = "unset"
+    normalizationState: NORMCAL_METADATA_STATE = "unset"

--- a/src/snapred/backend/dao/WorkspaceMetadata.py
+++ b/src/snapred/backend/dao/WorkspaceMetadata.py
@@ -19,6 +19,7 @@ diffcal_metadata_state_list = list(get_args(DIFFCAL_METADATA_STATE))
 NORMCAL_METADATA_STATE = Literal[
     "unset",  # the default condition before any settings
     "exists",  # the state exists and the corresponding .h5 file located
+    "alternate",  # the user supplied an alternate .h5 that they believe in usable
     "none",  # proceed without applying any normalization
     "fake",  # proceed by creating a "fake vanadium"
 ]

--- a/tests/unit/backend/dao/test_WorkspaceMetadata.py
+++ b/tests/unit/backend/dao/test_WorkspaceMetadata.py
@@ -1,0 +1,43 @@
+import pytest
+from pydantic.error_wrappers import ValidationError
+from snapred.backend.dao.WorkspaceMetadata import (
+    WorkspaceMetadata,
+    diffcal_metadata_state_list,
+    normcal_metadata_state_list,
+)
+
+
+def test_literal_bad_diffcal():
+    # test failure when adding bad value to diffraction calibration state
+    bad = "not in list"
+    assert bad not in diffcal_metadata_state_list
+    with pytest.raises(ValidationError) as e:
+        WorkspaceMetadata(diffcalState=bad)
+    assert "diffcalState" in str(e.value)
+
+
+def test_literal_bad_normcal():
+    # test failure when adding bad value to normaliztion state
+    bad = "not in list"
+    assert bad not in normcal_metadata_state_list
+    with pytest.raises(ValidationError) as e:
+        WorkspaceMetadata(normalizationState=bad)
+    assert "normalizationState" in str(e.value)
+
+
+def test_literal_good_diffcal():
+    for good in diffcal_metadata_state_list:
+        try:
+            x = WorkspaceMetadata(diffcalState=good)
+            assert x.normalizationState == normcal_metadata_state_list[0]
+        except ValidationError:
+            pytest.fail(f"Unexpected `ValidationError` setting diffcalState to {good}")
+
+
+def test_literal_good_normcal():
+    for good in normcal_metadata_state_list:
+        try:
+            x = WorkspaceMetadata(normalizationState=good)
+            assert x.diffcalState == diffcal_metadata_state_list[0]
+        except ValidationError:
+            pytest.fail(f"Unexpected `ValidationError` setting normalizationState to {good}")


### PR DESCRIPTION
## Description of work

This is for EWM 4808, which will add metadata tags to workspaces to indicate how the calibration process was handled.  The goal is to add these as logs.

The first step in adding these is to create a DAO for holding the needed values.  Later work will implement algorithm and service methods for handling this data.

## Explanation of work

Creates a simple DAO.

The literals ensure the values may be set only to one of a set of values.

The list of literals can be accessed by other code by importing the list, as seen in the test.

## To test

### Dev testing

1. Be Michael.
2. Make sure the values here are the ones desired.

### CIS testing

1. Be Malcolm.
2. Make sure the values here are the ones desired, namely:

- diffraction calibration states:
  - unset, this is a default value for internal use
  - none, meaning the user elected to use internal geometey
  - exists, SNAPRed found it
  - alternative, user elected to use some other diffcal file
- normalization states:
  - unset, this is a default value for internal use
  - none, meaning the user elected to not normalize
  - exists, SNAPRed found it
  - fake, the user elected to create a fake vanadium file

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4808](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4808)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
