### PR TITLE
Create metadata read algorithm and its test

### DIFF
--- a/src/snapred/backend/dao/WorkspaceMetadata.py
+++ b/src/snapred/backend/dao/WorkspaceMetadata.py
@@ -4,8 +4,10 @@ from pydantic import BaseModel
 
 # possible states for diffraction calibration
 
+UNSET: str = "unset"
+
 DIFFCAL_METADATA_STATE = Literal[
-    "unset",  # the default condition before any settings
+    UNSET,  # the default condition before any settings
     "exists",  # the state exists and the corresponding .h5 file located
     "alternate",  # the user supplied an alternate .h5 that they believe is usable.
     "none",  # proceed using the defaul (IDF) geometry.
@@ -17,7 +19,7 @@ diffcal_metadata_state_list = list(get_args(DIFFCAL_METADATA_STATE))
 # possible states for normalization
 
 NORMCAL_METADATA_STATE = Literal[
-    "unset",  # the default condition before any settings
+    UNSET,  # the default condition before any settings
     "exists",  # the state exists and the corresponding .h5 file located
     "alternate",  # the user supplied an alternate .h5 that they believe is usable
     "none",  # proceed without applying any normalization
@@ -30,5 +32,5 @@ normcal_metadata_state_list = list(get_args(NORMCAL_METADATA_STATE))
 class WorkspaceMetadata(BaseModel):
     """Class to hold tags related to a workspace"""
 
-    diffcalState: DIFFCAL_METADATA_STATE = "unset"
-    normalizationState: NORMCAL_METADATA_STATE = "unset"
+    diffcalState: DIFFCAL_METADATA_STATE = UNSET
+    normalizationState: NORMCAL_METADATA_STATE = UNSET

--- a/src/snapred/backend/recipe/algorithm/ReadWorkspaceMetadata.py
+++ b/src/snapred/backend/recipe/algorithm/ReadWorkspaceMetadata.py
@@ -1,4 +1,11 @@
-from mantid.api import AlgorithmFactory, PythonAlgorithm
+from typing import Dict
+
+from mantid.api import (
+    AlgorithmFactory,
+    MatrixWorkspaceProperty,
+    PropertyMode,
+    PythonAlgorithm,
+)
 from mantid.kernel import Direction
 
 from snapred.backend.dao.WorkspaceMetadata import WorkspaceMetadata
@@ -11,7 +18,10 @@ class ReadWorkspaceMetadata(PythonAlgorithm):
 
     def PyInit(self):
         # declare properties
-        self.declareProperty("Workspace", defaultValue="", direction=Direction.Input)
+        self.declareProperty(
+            MatrixWorkspaceProperty("Workspace", "", Direction.Input, PropertyMode.Mandatory),
+            doc="Workspace containing the logs",
+        )
         self.declareProperty("WorkspaceMetadata", defaultValue="", direction=Direction.Output)
         self.setRethrows(True)
         self.mantidSnapper = MantidSnapper(self, __name__)
@@ -21,6 +31,9 @@ class ReadWorkspaceMetadata(PythonAlgorithm):
 
     def unbagGroceries(self):
         self.workspace = self.getPropertyValue("Workspace")
+
+    def validateInputs(self) -> Dict[str, str]:
+        return {}
 
     def PyExec(self):
         self.log().notice("Fetch the workspace metadata logs")

--- a/src/snapred/backend/recipe/algorithm/ReadWorkspaceMetadata.py
+++ b/src/snapred/backend/recipe/algorithm/ReadWorkspaceMetadata.py
@@ -1,0 +1,39 @@
+from mantid.api import AlgorithmFactory, PythonAlgorithm
+from mantid.kernel import Direction
+
+from snapred.backend.dao.WorkspaceMetadata import WorkspaceMetadata
+from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
+
+
+class ReadWorkspaceMetadata(PythonAlgorithm):
+    def category(self):
+        return "SNAPRed Internal"
+
+    def PyInit(self):
+        # declare properties
+        self.declareProperty("Workspace", defaultValue="", direction=Direction.Input)
+        self.declareProperty("WorkspaceMetadata", defaultValue="", direction=Direction.Output)
+        self.setRethrows(True)
+        self.mantidSnapper = MantidSnapper(self, __name__)
+
+    def chopIngredients(self, ingredients):
+        pass
+
+    def unbagGroceries(self):
+        self.workspace = self.getPropertyValue("Workspace")
+
+    def PyExec(self):
+        self.log().notice("Fetch the workspace metadata logs")
+        self.unbagGroceries()
+
+        properties = list(WorkspaceMetadata.schema()["properties"].keys())
+        metadata = WorkspaceMetadata()
+        run = self.mantidSnapper.mtd[self.workspace].getRun()  # NOTE this is a mantid object that holds logs
+        for prop in properties:
+            if run.hasProperty(f"SNAPRed_{prop}"):
+                setattr(metadata, prop, run.getLogData(f"SNAPRed_{prop}").value)
+        self.setPropertyValue("WorkspaceMetadata", metadata.json())
+
+
+# Register algorithm with Mantid
+AlgorithmFactory.subscribe(ReadWorkspaceMetadata)

--- a/src/snapred/backend/recipe/algorithm/ReadWorkspaceMetadata.py
+++ b/src/snapred/backend/recipe/algorithm/ReadWorkspaceMetadata.py
@@ -27,11 +27,12 @@ class ReadWorkspaceMetadata(PythonAlgorithm):
         self.unbagGroceries()
 
         properties = list(WorkspaceMetadata.schema()["properties"].keys())
-        metadata = WorkspaceMetadata()
+        metadata = {}
         run = self.mantidSnapper.mtd[self.workspace].getRun()  # NOTE this is a mantid object that holds logs
         for prop in properties:
             if run.hasProperty(f"SNAPRed_{prop}"):
-                setattr(metadata, prop, run.getLogData(f"SNAPRed_{prop}").value)
+                metadata[prop] = run.getLogData(f"SNAPRed_{prop}").value
+        metadata = WorkspaceMetadata.parse_obj(metadata)
         self.setPropertyValue("WorkspaceMetadata", metadata.json())
 
 

--- a/tests/unit/backend/dao/test_WorkspaceMetadata.py
+++ b/tests/unit/backend/dao/test_WorkspaceMetadata.py
@@ -1,6 +1,7 @@
 import pytest
 from pydantic.error_wrappers import ValidationError
 from snapred.backend.dao.WorkspaceMetadata import (
+    UNSET,
     WorkspaceMetadata,
     diffcal_metadata_state_list,
     normcal_metadata_state_list,
@@ -29,7 +30,7 @@ def test_literal_good_diffcal():
     for good in diffcal_metadata_state_list:
         try:
             x = WorkspaceMetadata(diffcalState=good)
-            assert x.normalizationState == normcal_metadata_state_list[0]
+            assert x.normalizationState == UNSET
         except ValidationError:
             pytest.fail(f"Unexpected `ValidationError` setting diffcalState to {good}")
 
@@ -38,6 +39,6 @@ def test_literal_good_normcal():
     for good in normcal_metadata_state_list:
         try:
             x = WorkspaceMetadata(normalizationState=good)
-            assert x.diffcalState == diffcal_metadata_state_list[0]
+            assert x.diffcalState == UNSET
         except ValidationError:
             pytest.fail(f"Unexpected `ValidationError` setting normalizationState to {good}")

--- a/tests/unit/backend/recipe/algorithm/test_ReadWorkspaceMetadata.py
+++ b/tests/unit/backend/recipe/algorithm/test_ReadWorkspaceMetadata.py
@@ -1,0 +1,113 @@
+"""
+NOTE DO NOT use WriteWorkspaceMetadata in these tests
+because that algorithm depends on ReadWorkspaceMetadata
+"""
+
+import unittest
+from typing import Literal
+from unittest import mock
+
+import pytest
+
+# mantid imports
+from mantid.simpleapi import AddSampleLog, AddSampleLogMultiple, CreateSingleValuedWorkspace, mtd
+from pydantic import BaseModel
+
+# the algorithm to test
+from snapred.backend.dao.WorkspaceMetadata import UNSET
+from snapred.backend.recipe.algorithm.ReadWorkspaceMetadata import ReadWorkspaceMetadata
+
+thisAlgorithm = "snapred.backend.recipe.algorithm.ReadWorkspaceMetadata."
+
+
+# this mocks out the original workspace metadata class
+# to ensure the algorithm is as generic as possible in case of later extension
+class MockWorkspaceMetadata(BaseModel):
+    fruit: Literal[UNSET, "apple", "pear", "orange"] = UNSET
+    veggie: Literal[UNSET, "broccoli", "cauliflower"] = UNSET
+    bread: Literal[UNSET, "sourdough", "pumpernickel"] = UNSET
+    dairy: Literal[UNSET, "milk", "cheese", "yogurt", "butter"] = UNSET
+
+
+class TestReadWorkspaceMetadata(unittest.TestCase):
+    properties = list(MockWorkspaceMetadata.schema()["properties"].keys())
+
+    @mock.patch(thisAlgorithm + "WorkspaceMetadata", MockWorkspaceMetadata)
+    def test_read_properties(self):
+        wsname = "_test_read_ws_metadata"
+        CreateSingleValuedWorkspace(OutputWorkspace=wsname)
+        assert wsname in mtd
+        properties = [f"SNAPRed_{prop}" for prop in self.properties]
+        values = ["apple", "broccoli", "sourdough", "cheese"]
+
+        # add the logs to the workspace
+        AddSampleLogMultiple(
+            Workspace=wsname,
+            LogNames=properties,
+            LogValues=values,
+        )
+        # verify the logs exist on the workspace
+        run = mtd[wsname].getRun()
+        for prop in properties:
+            assert run.hasProperty(prop)
+
+        # now run the algorithm to read the logs and verify the correct object created
+        algo = ReadWorkspaceMetadata()
+        algo.initialize()
+        algo.setProperty("Workspace", wsname)
+        algo.execute()
+
+        # verify each property is set to appropriate value
+        metadata = MockWorkspaceMetadata.parse_raw(algo.getPropertyValue("WorkspaceMetadata"))
+        for value, prop in zip(values, self.properties):
+            assert value == getattr(metadata, prop)
+
+        # verify it equals the correct object
+        dictionary = dict(zip(self.properties, values))
+        ref = MockWorkspaceMetadata.parse_obj(dictionary)
+        assert ref == metadata
+
+    @mock.patch(thisAlgorithm + "WorkspaceMetadata", MockWorkspaceMetadata)
+    def test_read_unset(self):
+        wsname = "_test_read_ws_metadata_unset"
+        CreateSingleValuedWorkspace(OutputWorkspace=wsname)
+        assert wsname in mtd
+        properties = [f"SNAPRed_{prop}" for prop in self.properties]
+        values = [UNSET for prop in properties]
+
+        # create all the logs in an unset state
+        # add the logs to the workspace
+        AddSampleLogMultiple(
+            Workspace=wsname,
+            LogNames=properties,
+            LogValues=values,
+        )
+
+        # verify the logs exist on the workspace
+        run = mtd[wsname].getRun()
+        for prop in properties:
+            assert run.getLogData(prop).value == UNSET
+
+        # now run the algorithm to read the logs and verify the correct object created
+        algo = ReadWorkspaceMetadata()
+        algo.initialize()
+        algo.setProperty("Workspace", wsname)
+        algo.execute()
+        metadata = MockWorkspaceMetadata.parse_raw(algo.getPropertyValue("WorkspaceMetadata"))
+
+        # ensure it is equal to an object with all fields unset
+        assert metadata == MockWorkspaceMetadata()
+
+
+# this at teardown removes the loggers, eliminating logger error printouts
+# see https://github.com/pytest-dev/pytest/issues/5502#issuecomment-647157873
+@pytest.fixture(autouse=True)
+def clear_loggers():  # noqa: PT004
+    """Remove handlers from all loggers"""
+    import logging
+
+    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
+    for logger in loggers:
+        handlers = getattr(logger, "handlers", [])
+        for handler in handlers:
+            logger.removeHandler(handler)

--- a/tests/unit/backend/recipe/algorithm/test_ReadWorkspaceMetadata.py
+++ b/tests/unit/backend/recipe/algorithm/test_ReadWorkspaceMetadata.py
@@ -22,7 +22,7 @@ thisAlgorithm = "snapred.backend.recipe.algorithm.ReadWorkspaceMetadata."
 
 # this mocks out the original workspace metadata class
 # to ensure the algorithm is as generic as possible in case of later extension
-class MockWorkspaceMetadata(BaseModel):
+class WorkspaceMetadata(BaseModel):
     fruit: Literal[UNSET, "apple", "pear", "orange"] = UNSET
     veggie: Literal[UNSET, "broccoli", "cauliflower"] = UNSET
     bread: Literal[UNSET, "sourdough", "pumpernickel"] = UNSET
@@ -31,9 +31,9 @@ class MockWorkspaceMetadata(BaseModel):
 
 # NOTE do NOT remove this mock
 # if your test fails with this mock, then fix your test instead
-@mock.patch(thisAlgorithm + "WorkspaceMetadata", MockWorkspaceMetadata)
+@mock.patch(thisAlgorithm + "WorkspaceMetadata", WorkspaceMetadata)
 class TestReadWorkspaceMetadata(unittest.TestCase):
-    properties = list(MockWorkspaceMetadata.schema()["properties"].keys())
+    properties = list(WorkspaceMetadata.schema()["properties"].keys())
 
     def test_read_nothing(self):
         wsname = "_test_read_ws_metadata"
@@ -53,8 +53,8 @@ class TestReadWorkspaceMetadata(unittest.TestCase):
         algo.execute()
 
         # verify the metadata object exists and is entirely unset
-        metadata = MockWorkspaceMetadata.parse_raw(algo.getPropertyValue("WorkspaceMetadata"))
-        ref = MockWorkspaceMetadata()
+        metadata = WorkspaceMetadata.parse_raw(algo.getPropertyValue("WorkspaceMetadata"))
+        ref = WorkspaceMetadata()
         assert ref == metadata
 
     def test_read_properties(self):
@@ -82,13 +82,13 @@ class TestReadWorkspaceMetadata(unittest.TestCase):
         algo.execute()
 
         # verify each property is set to appropriate value
-        metadata = MockWorkspaceMetadata.parse_raw(algo.getPropertyValue("WorkspaceMetadata"))
+        metadata = WorkspaceMetadata.parse_raw(algo.getPropertyValue("WorkspaceMetadata"))
         for value, prop in zip(values, self.properties):
             assert value == getattr(metadata, prop)
 
         # verify it equals the correct object
         dictionary = dict(zip(self.properties, values))
-        ref = MockWorkspaceMetadata.parse_obj(dictionary)
+        ref = WorkspaceMetadata.parse_obj(dictionary)
         assert ref == metadata
 
     def test_read_all_unset(self):
@@ -116,10 +116,10 @@ class TestReadWorkspaceMetadata(unittest.TestCase):
         algo.initialize()
         algo.setProperty("Workspace", wsname)
         algo.execute()
-        metadata = MockWorkspaceMetadata.parse_raw(algo.getPropertyValue("WorkspaceMetadata"))
+        metadata = WorkspaceMetadata.parse_raw(algo.getPropertyValue("WorkspaceMetadata"))
 
         # ensure it is equal to an object with all fields unset
-        assert metadata == MockWorkspaceMetadata()
+        assert metadata == WorkspaceMetadata()
 
     def test_read_one_unset(self):
         wsname = "_test_read_ws_metadata_unset"
@@ -148,11 +148,11 @@ class TestReadWorkspaceMetadata(unittest.TestCase):
         algo.initialize()
         algo.setProperty("Workspace", wsname)
         algo.execute()
-        metadata = MockWorkspaceMetadata.parse_raw(algo.getPropertyValue("WorkspaceMetadata"))
+        metadata = WorkspaceMetadata.parse_raw(algo.getPropertyValue("WorkspaceMetadata"))
 
         # ensure it is equal to the correct object
         dictionary = dict(zip(self.properties, values))
-        ref = MockWorkspaceMetadata.parse_obj(dictionary)
+        ref = WorkspaceMetadata.parse_obj(dictionary)
         assert metadata == ref
 
     def test_fail_invalid(self):
@@ -181,7 +181,7 @@ class TestReadWorkspaceMetadata(unittest.TestCase):
         algo.setProperty("Workspace", wsname)
         with pytest.raises(RuntimeError) as e:
             algo.execute()
-        assert "validation errors for MockWorkspaceMetadata" in str(e.value)
+        assert "validation errors for WorkspaceMetadata" in str(e.value)
 
 
 # this at teardown removes the loggers, eliminating logger error printouts


### PR DESCRIPTION
## Description of work

Part of EWM 4808.

The goal is to use metadata tags on workspaces to specify information about their calibration state.

This achieves part of this goal, by creating a SNAPRed algorithm that can read the logs when they exist.  The logs are read into a `WorkspaceMetadata` object for use within SNAPRed.

## Explanation of work

Added an `UNSET` variable to the `WorkspaceMetadata` for easier, non-magical testing against unset properties.

Created an algorithm to read logs using mantid's built=in functionality.  It will read the specific logs corresponding to `WorkspaceMetadata`, and store them in a DAO.

## To test

### Dev testing

Check the unit tests.  Is there any condition or situation I am not catching with these tests?

### CIS testing

Use the below script to verify that read logs is in fact reading logs.

Experiment with different values for the states. Valid options are:
- unset
- exists
- none
- alternate

Try using an invalid option and making sure things fail.

``` python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from snapred.backend.dao.WorkspaceMetadata import WorkspaceMetadata
from snapred.backend.recipe.algorithm.ReadWorkspaceMetadata import ReadWorkspaceMetadata

#### user input ###########
diffcal_state = "exists"
normcal_state = "exists"
############################

ws = CreateWorkspace(DataX=[0,1], DataY=[2,3])
AddSampleLogMultiple(
    Workspace=ws,
    LogNames=["SNAPRed_diffcalState", "SNAPRed_normalizationState"],
    LogValues=[diffcal_state, normcal_state],
)

run = ws.getRun()
assert diffcal_state == run.getLogData("SNAPRed_diffcalState").value
assert normcal_state == run.getLogData("SNAPRed_normalizationState").value

algo = ReadWorkspaceMetadata()
algo.initialize()
algo.setProperty("Workspace", ws)
algo.execute()

metadata = WorkspaceMetadata.parse_raw(algo.getPropertyValue("WorkspaceMetadata"))
assert diffcal_state == metadata.diffcalState
assert normcal_state == metadata.normalizationState

## INSPECT WORKSPACE LOGS DIRECTLY
## COMPARE TO THIS JSON
print(metadata.json(indent=2))

```

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4808](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4808)
[EWM#4907](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4907)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
