### PR TITLE
Create metadata write algorithm and its test

### DIFF
--- a/src/snapred/backend/recipe/algorithm/WriteWorkspaceMetadata.py
+++ b/src/snapred/backend/recipe/algorithm/WriteWorkspaceMetadata.py
@@ -25,8 +25,6 @@ class WriteWorkspaceMetadata(PythonAlgorithm):
             doc="Workspace to contain the logs",
         )
         self.declareProperty("WorkspaceMetadata", defaultValue="", direction=Direction.Input)
-        # self.declareProperty("MetadataLogName", defaultValue=[], direction=Direction.Input) # string array property
-        # self.declareProperty("MetadataLogValue", defaultValue=[], direction=Direction.Input) # string array property
         self.setRethrows(True)
         self.mantidSnapper = MantidSnapper(self, __name__)
 

--- a/src/snapred/backend/recipe/algorithm/WriteWorkspaceMetadata.py
+++ b/src/snapred/backend/recipe/algorithm/WriteWorkspaceMetadata.py
@@ -1,0 +1,76 @@
+import json
+from typing import Dict
+
+from mantid.api import (
+    AlgorithmFactory,
+    MatrixWorkspaceProperty,
+    PropertyMode,
+    PythonAlgorithm,
+)
+from mantid.kernel import Direction
+
+from snapred.backend.dao.WorkspaceMetadata import UNSET, WorkspaceMetadata
+from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
+from snapred.backend.recipe.algorithm.ReadWorkspaceMetadata import ReadWorkspaceMetadata
+
+
+class WriteWorkspaceMetadata(PythonAlgorithm):
+    def category(self):
+        return "SNAPRed Internal"
+
+    def PyInit(self):
+        # declare properties
+        self.declareProperty(
+            MatrixWorkspaceProperty("Workspace", "", Direction.Input, PropertyMode.Mandatory),
+            doc="Workspace to contain the logs",
+        )
+        self.declareProperty("WorkspaceMetadata", defaultValue="", direction=Direction.Input)
+        # self.declareProperty("MetadataLogName", defaultValue=[], direction=Direction.Input) # string array property
+        # self.declareProperty("MetadataLogValue", defaultValue=[], direction=Direction.Input) # string array property
+        self.setRethrows(True)
+        self.mantidSnapper = MantidSnapper(self, __name__)
+
+    def chopIngredients(self, ingredients: WorkspaceMetadata):
+        # create an object to hold any previously-added metadata
+        prevMetadata = self.mantidSnapper.ReadWorkspaceMetadata(
+            "Read any previous metadata logs",
+            Workspace=self.getPropertyValue("Workspace"),
+        )
+        self.mantidSnapper.executeQueue()
+        # NOTE the read algo validates the properties for us
+        prevMetadata = json.loads(prevMetadata.get())
+
+        # if the input WorkspaceMetadata has unset values, set them from the logs
+        properties = list(WorkspaceMetadata.schema()["properties"].keys())
+        for prop in properties:
+            if getattr(ingredients, prop) == UNSET:
+                setattr(ingredients, prop, prevMetadata[prop])
+
+        self.metadataNames = [f"SNAPRed_{prop}" for prop in properties]
+        self.metadataValues = [getattr(ingredients, prop) for prop in properties]
+
+    def unbagGroceries(self):
+        self.workspace = self.getPropertyValue("Workspace")
+
+    def validateInputs(self) -> Dict[str, str]:
+        return {}
+
+    def PyExec(self):
+        self.log().notice("Set the workspace metadata logs")
+        metadata = WorkspaceMetadata.parse_raw(self.getPropertyValue("WorkspaceMetadata"))
+        self.chopIngredients(metadata)
+        self.unbagGroceries()
+
+        # NOTE if the log already exists, it will be quietly overwritten
+        self.mantidSnapper.AddSampleLogMultiple(
+            "Add the metadata tags as logs to the workspace",
+            Workspace=self.workspace,
+            LogNames=self.metadataNames,
+            LogValues=self.metadataValues,
+        )
+        self.mantidSnapper.executeQueue()
+        self.setProperty("Workspace", self.workspace)
+
+
+# Register algorithm with Mantid
+AlgorithmFactory.subscribe(WriteWorkspaceMetadata)

--- a/tests/unit/backend/recipe/algorithm/test_ReadWorkspaceMetadata.py
+++ b/tests/unit/backend/recipe/algorithm/test_ReadWorkspaceMetadata.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 # the algorithm to test
 from snapred.backend.dao.WorkspaceMetadata import UNSET
 from snapred.backend.recipe.algorithm.ReadWorkspaceMetadata import ReadWorkspaceMetadata
+from util.helpers import deleteWorkspaceNoThrow
 
 thisAlgorithm = "snapred.backend.recipe.algorithm.ReadWorkspaceMetadata."
 
@@ -29,11 +30,19 @@ class WorkspaceMetadata(BaseModel):
     dairy: Literal[UNSET, "milk", "cheese", "yogurt", "butter"] = UNSET
 
 
-# NOTE do NOT remove this mock
-# if your test fails with this mock, then fix your test instead
+# NOTE do NOT remove this patch
+# if your test fails with this patch, then fix your test instead
 @mock.patch(thisAlgorithm + "WorkspaceMetadata", WorkspaceMetadata)
 class TestReadWorkspaceMetadata(unittest.TestCase):
     properties = list(WorkspaceMetadata.schema()["properties"].keys())
+
+    def tearDown(cls) -> None:
+        """
+        Delete all workspaces created by previous tests.
+        """
+        for ws in mtd.getObjectNames():
+            deleteWorkspaceNoThrow(ws)
+        return super().tearDown()
 
     def test_read_nothing(self):
         wsname = "_test_read_ws_metadata"

--- a/tests/unit/backend/recipe/algorithm/test_WriteWorkspaceMetadata.py
+++ b/tests/unit/backend/recipe/algorithm/test_WriteWorkspaceMetadata.py
@@ -1,0 +1,198 @@
+import unittest
+from typing import Literal
+from unittest import mock
+
+import pytest
+
+# mantid imports
+from mantid.simpleapi import AddSampleLog, CreateSingleValuedWorkspace, mtd
+from pydantic import BaseModel
+
+# the algorithm to test
+from snapred.backend.dao.WorkspaceMetadata import UNSET
+from snapred.backend.recipe.algorithm.ReadWorkspaceMetadata import ReadWorkspaceMetadata
+from snapred.backend.recipe.algorithm.WriteWorkspaceMetadata import WriteWorkspaceMetadata
+
+thisAlgorithm = "snapred.backend.recipe.algorithm.WriteWorkspaceMetadata."
+readAlgorithm = "snapred.backend.recipe.algorithm.ReadWorkspaceMetadata."
+
+
+# this mocks out the original workspace metadata class
+# to ensure the algorithm is as generic as possible in case of later extension
+class WorkspaceMetadata(BaseModel):
+    fruit: Literal[UNSET, "apple", "pear", "orange"] = UNSET
+    veggie: Literal[UNSET, "broccoli", "cauliflower"] = UNSET
+    bread: Literal[UNSET, "sourdough", "pumpernickel"] = UNSET
+    dairy: Literal[UNSET, "milk", "cheese", "yogurt", "butter"] = UNSET
+
+
+# NOTE do NOT remove these mocks
+# if your test fails with this mock, then fix your test instead
+@mock.patch(thisAlgorithm + "WorkspaceMetadata", WorkspaceMetadata)
+@mock.patch(readAlgorithm + "WorkspaceMetadata", WorkspaceMetadata)
+class TestWriteWorkspaceMetadata(unittest.TestCase):
+    properties = list(WorkspaceMetadata.schema()["properties"].keys())
+
+    def test_write_metadata_direct(self):
+        """
+        This tests writing metadata by examining the workspace directly
+        rather than using the ReadWorkspaceMetadata algorithm, for peace of mind.
+        """
+        wsname = "_test_write_ws_metadata_1"
+        CreateSingleValuedWorkspace(OutputWorkspace=wsname)
+        assert wsname in mtd
+        properties = [f"SNAPRed_{prop}" for prop in self.properties]
+        values = ["apple", "broccoli", "sourdough", "cheese"]
+
+        # verify the logs do not exist on the workspace
+        run = mtd[wsname].getRun()
+        for prop in properties:
+            assert not run.hasProperty(prop)
+
+        ref = WorkspaceMetadata.parse_obj(dict(zip(self.properties, values)))
+
+        # now run the algorithm to write the logs
+        algo = WriteWorkspaceMetadata()
+        algo.initialize()
+        algo.setProperty("Workspace", wsname)
+        algo.setProperty("WorkspaceMetadata", ref.json())
+        algo.execute()
+
+        run = mtd[wsname].getRun()
+        for value, prop in zip(values, properties):
+            assert value == run.getLogData(prop).value
+
+    def test_write_metadata(self):
+        wsname = "_test_write_ws_metadata_2"
+        CreateSingleValuedWorkspace(OutputWorkspace=wsname)
+        assert wsname in mtd
+        properties = [f"SNAPRed_{prop}" for prop in self.properties]
+        values = ["apple", "broccoli", "sourdough", "cheese"]
+
+        # verify the logs do not exist on the workspace
+        run = mtd[wsname].getRun()
+        for prop in properties:
+            assert not run.hasProperty(prop)
+
+        ref = WorkspaceMetadata.parse_obj(dict(zip(self.properties, values)))
+
+        # now run the algorithm to write the logs
+        algo = WriteWorkspaceMetadata()
+        algo.initialize()
+        algo.setProperty("Workspace", wsname)
+        algo.setProperty("WorkspaceMetadata", ref.json())
+        algo.execute()
+
+        # read the metadata back
+        read = ReadWorkspaceMetadata()
+        read.initialize()
+        read.setProperty("Workspace", wsname)
+        read.execute()
+
+        # verify the metadata object exists and matches what it was set to
+        ans = WorkspaceMetadata.parse_raw(read.getPropertyValue("WorkspaceMetadata"))
+        assert ref == ans
+
+    def test_write_partial(self):
+        NUM = len(self.properties)
+        all_properties = [f"SNAPRed_{prop}" for prop in self.properties]
+        all_values = ["apple", "broccoli", "sourdough", "cheese"]
+
+        for i in range(NUM):
+            wsname = f"_test_write_ws_metadata_partial_{i}"
+            CreateSingleValuedWorkspace(OutputWorkspace=wsname)
+            assert wsname in mtd
+            # verify the logs do not exist on the workspace
+            run = mtd[wsname].getRun()
+            for prop in all_properties:
+                assert not run.hasProperty(prop)
+
+            # create a metadata object missing one value
+            properties = [self.properties[j] for j in range(NUM) if j != i]
+            values = [all_values[j] for j in range(NUM) if j != i]
+            ref = WorkspaceMetadata.parse_obj(dict(zip(properties, values)))
+
+            # now run the algorithm to write the logs
+            algo = WriteWorkspaceMetadata()
+            algo.initialize()
+            algo.setProperty("Workspace", wsname)
+            algo.setProperty("WorkspaceMetadata", ref.json())
+            algo.execute()
+
+            # read the metadata back
+            read = ReadWorkspaceMetadata()
+            read.initialize()
+            read.setProperty("Workspace", wsname)
+            read.execute()
+
+            # verify the metadata object exists and the dropped property is unset
+            ans = WorkspaceMetadata.parse_raw(read.getPropertyValue("WorkspaceMetadata"))
+            assert ref == ans
+            assert getattr(ans, self.properties[i]) == UNSET
+
+    def test_write_retain(self):
+        """
+        If the workspace has a property set, and write is called
+        with a metadata object having an unset property,
+        then retain the set property from the workspace's logs
+        """
+        NUM = len(self.properties)
+        all_properties = [f"SNAPRed_{prop}" for prop in self.properties]
+        all_values = ["apple", "broccoli", "sourdough", "cheese"]
+
+        for i in range(NUM):
+            # create a workspace with one log already there
+            wsname = f"_test_write_ws_metadata_partial_{i}"
+            CreateSingleValuedWorkspace(OutputWorkspace=wsname)
+            AddSampleLog(
+                Workspace=wsname,
+                LogName=all_properties[i],
+                LogText=all_values[i],
+            )
+            assert wsname in mtd
+            run = mtd[wsname].getRun()
+            assert run.hasProperty(all_properties[i])
+            assert run.getLogData(all_properties[i]).value == all_values[i]
+
+            # create a metadata object missing that property
+            properties = [self.properties[j] for j in range(NUM) if j != i]
+            values = [all_values[j] for j in range(NUM) if j != i]
+            ref = WorkspaceMetadata.parse_obj(dict(zip(properties, values)))
+            assert getattr(ref, self.properties[i]) == UNSET
+
+            # now run the algorithm to write the logs
+            algo = WriteWorkspaceMetadata()
+            algo.initialize()
+            algo.setProperty("Workspace", wsname)
+            algo.setProperty("WorkspaceMetadata", ref.json())
+            algo.execute()
+
+            # read the metadata back
+            read = ReadWorkspaceMetadata()
+            read.initialize()
+            read.setProperty("Workspace", wsname)
+            read.execute()
+
+            # verify the metadata object exists and has the previously set property is set
+            ans = WorkspaceMetadata.parse_raw(read.getPropertyValue("WorkspaceMetadata"))
+            for prop in properties:
+                assert getattr(ref, prop) == getattr(ans, prop)
+            assert getattr(ref, self.properties[i]) != getattr(ans, self.properties[i])
+            assert getattr(ans, self.properties[i]) != UNSET
+            # also check directly on the workspace
+            assert run.hasProperty(all_properties[i])
+            assert run.getLogData(all_properties[i]).value == all_values[i]
+
+
+# this at teardown removes the loggers, eliminating logger error printouts
+# see https://github.com/pytest-dev/pytest/issues/5502#issuecomment-647157873
+@pytest.fixture(autouse=True)
+def clear_loggers():  # noqa: PT004
+    """Remove handlers from all loggers"""
+    import logging
+
+    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
+    for logger in loggers:
+        handlers = getattr(logger, "handlers", [])
+        for handler in handlers:
+            logger.removeHandler(handler)

--- a/tests/unit/backend/recipe/algorithm/test_WriteWorkspaceMetadata.py
+++ b/tests/unit/backend/recipe/algorithm/test_WriteWorkspaceMetadata.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 from snapred.backend.dao.WorkspaceMetadata import UNSET
 from snapred.backend.recipe.algorithm.ReadWorkspaceMetadata import ReadWorkspaceMetadata
 from snapred.backend.recipe.algorithm.WriteWorkspaceMetadata import WriteWorkspaceMetadata
+from util.helpers import deleteWorkspaceNoThrow
 
 thisAlgorithm = "snapred.backend.recipe.algorithm.WriteWorkspaceMetadata."
 readAlgorithm = "snapred.backend.recipe.algorithm.ReadWorkspaceMetadata."
@@ -32,12 +33,20 @@ class WorkspaceMetadata(BaseModel):
     dairy: Literal[UNSET, "milk", "cheese", "yogurt", "butter"] = UNSET
 
 
-# NOTE do NOT remove these mocks
-# if your test fails with this mock, then fix your test instead
+# NOTE do NOT remove these patches
+# if your test fails with these patches, then fix your test instead
 @mock.patch(thisAlgorithm + "WorkspaceMetadata", WorkspaceMetadata)
 @mock.patch(readAlgorithm + "WorkspaceMetadata", WorkspaceMetadata)
 class TestWriteWorkspaceMetadata(unittest.TestCase):
     properties = list(WorkspaceMetadata.schema()["properties"].keys())
+
+    def tearDown(cls) -> None:
+        """
+        Delete all workspaces created by previous tests.
+        """
+        for ws in mtd.getObjectNames():
+            deleteWorkspaceNoThrow(ws)
+        return super().tearDown()
 
     def test_write_metadata_direct(self):
         """


### PR DESCRIPTION
## Description of work

More on metadata tags to workspaces.

This creates the algorithm that will write the metadata tags to the workspace logs.

## Explanation of work

The algorithm first checks if any tags on this workspace have been previously set.

If a tag has been set, **AND** the input tag is unset, then it retains the previous setting. Otherwise, the setting is overridden.

Per the story, it is necessary these tags persist to child workspaces created from the first.

## To test

### Dev testing

Check the unit tests, and make sure there is no functionality not covered.

Make sure there are no conditions not covered.

Try running the CIS script below.

### CIS testing

Try running the script below.

Experiment with different values.

Try invalid values and ensure it fails.

``` python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from snapred.backend.dao.WorkspaceMetadata import WorkspaceMetadata
from snapred.backend.recipe.algorithm.ReadWorkspaceMetadata import ReadWorkspaceMetadata
from snapred.backend.recipe.algorithm.WriteWorkspaceMetadata import WriteWorkspaceMetadata

#### user input ###########
diffcal_state = "exists"
normcal_state = "exists"
############################

ws = CreateWorkspace(DataX=[0,1], DataY=[2,3])

# create metadata object
metadata = WorkspaceMetadata(
    diffcalState = diffcal_state,
    normalizationState = normcal_state,
)

# add to workspace logs
algo = WriteWorkspaceMetadata()
algo.initialize()
algo.setProperty("Workspace", ws)
algo.setProperty("WorkspaceMetadata", metadata.json())
algo.execute()

## INSPECT WORKSPACE LOGS DIRECTLY
## COMPARE TO THIS JSON
print(metadata.json(indent=2))

# inspect workspace logs automatically
run = ws.getRun()
assert diffcal_state == run.getLogData("SNAPRed_diffcalState").value
assert normcal_state == run.getLogData("SNAPRed_normalizationState").value

# read the logs to create a read metadata object
read = ReadWorkspaceMetadata()
read.initialize()
read.setProperty("Workspace", ws)
read.execute()

res = WorkspaceMetadata.parse_raw(read.getPropertyValue("WorkspaceMetadata"))
assert metadata == res

# create a clone and read its logs
ws2 = CloneWorkspace(ws)
run = ws2.getRun()
assert diffcal_state == run.getLogData("SNAPRed_diffcalState").value
assert normcal_state == run.getLogData("SNAPRed_normalizationState").value

# transform the workspace and read its logs
ws3 = Power(ws2, 2)
run = ws3.getRun()
assert diffcal_state == run.getLogData("SNAPRed_diffcalState").value
assert normcal_state == run.getLogData("SNAPRed_normalizationState").value
```

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4808](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4808)
[EWM#4906](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4906)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

Related PRs:
- PR #311
- PR #313
