### PR TITLE
Write metadata algo with individual logs

### DIFF
--- a/src/snapred/backend/dao/WorkspaceMetadata.py
+++ b/src/snapred/backend/dao/WorkspaceMetadata.py
@@ -1,6 +1,6 @@
 from typing import Literal, get_args
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Extra
 
 # possible states for diffraction calibration
 
@@ -29,7 +29,7 @@ NORMCAL_METADATA_STATE = Literal[
 normcal_metadata_state_list = list(get_args(NORMCAL_METADATA_STATE))
 
 
-class WorkspaceMetadata(BaseModel):
+class WorkspaceMetadata(BaseModel, extra=Extra.forbid):
     """Class to hold tags related to a workspace"""
 
     diffcalState: DIFFCAL_METADATA_STATE = UNSET

--- a/src/snapred/backend/recipe/algorithm/WriteWorkspaceMetadata.py
+++ b/src/snapred/backend/recipe/algorithm/WriteWorkspaceMetadata.py
@@ -7,7 +7,8 @@ from mantid.api import (
     PropertyMode,
     PythonAlgorithm,
 )
-from mantid.kernel import Direction
+from mantid.kernel import Direction, StringArrayProperty
+from pydantic import ValidationError
 
 from snapred.backend.dao.WorkspaceMetadata import UNSET, WorkspaceMetadata
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
@@ -24,7 +25,10 @@ class WriteWorkspaceMetadata(PythonAlgorithm):
             MatrixWorkspaceProperty("Workspace", "", Direction.Input, PropertyMode.Mandatory),
             doc="Workspace to contain the logs",
         )
-        self.declareProperty("WorkspaceMetadata", defaultValue="", direction=Direction.Input)
+        self.declareProperty("WorkspaceMetadata", defaultValue="{}", direction=Direction.Input)
+        # writing individual logs without an object
+        self.declareProperty(StringArrayProperty("MetadataLogNames", values=[], direction=Direction.Input))
+        self.declareProperty(StringArrayProperty("MetadataLogValues", values=[], direction=Direction.Input))
         self.setRethrows(True)
         self.mantidSnapper = MantidSnapper(self, __name__)
 
@@ -38,11 +42,21 @@ class WriteWorkspaceMetadata(PythonAlgorithm):
         # NOTE the read algo validates the properties for us
         prevMetadata = json.loads(prevMetadata.get())
 
+        # create an object from the input string logs
+        stringLogNames = self.getProperty("MetadataLogNames").value
+        stringLogValues = self.getProperty("MetadataLogValues").value
+        stringMetadata = WorkspaceMetadata.parse_obj(dict(zip(stringLogNames, stringLogValues)))
+
         # if the input WorkspaceMetadata has unset values, set them from the logs
         properties = list(WorkspaceMetadata.schema()["properties"].keys())
         for prop in properties:
             if getattr(ingredients, prop) == UNSET:
                 setattr(ingredients, prop, prevMetadata[prop])
+
+        # in the input WorkspaceMetadata has unset values, set them from the inputs
+        for prop in properties:
+            if getattr(ingredients, prop) == UNSET:
+                setattr(ingredients, prop, getattr(stringMetadata, prop))
 
         self.metadataNames = [f"SNAPRed_{prop}" for prop in properties]
         self.metadataValues = [getattr(ingredients, prop) for prop in properties]
@@ -51,6 +65,29 @@ class WriteWorkspaceMetadata(PythonAlgorithm):
         self.workspace = self.getPropertyValue("Workspace")
 
     def validateInputs(self) -> Dict[str, str]:
+        userSetDAO = not self.getProperty("WorkspaceMetadata").isDefault
+        userSetList = not self.getProperty("MetadataLogNames").isDefault
+        if not (userSetDAO ^ userSetList):
+            msg = "You may set logs EITHER through object or as lists"
+            return {"WorkspaceMetadata": msg, "MetadataLogNames": msg}
+        elif userSetDAO:
+            try:
+                WorkspaceMetadata.parse_raw(self.getPropertyValue("WorkspaceMetadata"))
+            except ValidationError as e:
+                msg = f"Invalid WorkspaceMetadata object detected: {str(e)}"
+                return {"WorkspaceMetadata": msg}
+        elif userSetList:
+            props = self.getProperty("MetadataLogNames").value
+            vals = self.getProperty("MetadataLogValues").value
+            if len(props) != len(vals):
+                msg = f"Properties and values do not match in size: {props} vs {vals}"
+                return {"MetadataLogNames": msg, "MetadataLogValues": msg}
+            obj_dict = dict(zip(props, vals))
+            try:
+                WorkspaceMetadata.parse_obj(obj_dict)
+            except ValidationError:
+                msg = f"Invalid metadata names or values: {obj_dict}"
+                return {"MetadataLogNames": msg, "MetadataLogValues": msg}
         return {}
 
     def PyExec(self):

--- a/tests/unit/backend/dao/test_WorkspaceMetadata.py
+++ b/tests/unit/backend/dao/test_WorkspaceMetadata.py
@@ -42,3 +42,9 @@ def test_literal_good_normcal():
             assert x.diffcalState == UNSET
         except ValidationError:
             pytest.fail(f"Unexpected `ValidationError` setting normalizationState to {good}")
+
+
+def test_exact_forbid():
+    with pytest.raises(ValidationError) as e:
+        WorkspaceMetadata(fancyPartyChips="uwu")
+    assert "extra" in str(e)

--- a/tests/unit/backend/recipe/algorithm/test_ReadWorkspaceMetadata.py
+++ b/tests/unit/backend/recipe/algorithm/test_ReadWorkspaceMetadata.py
@@ -11,7 +11,7 @@ import pytest
 
 # mantid imports
 from mantid.simpleapi import AddSampleLog, AddSampleLogMultiple, CreateSingleValuedWorkspace, mtd
-from pydantic import BaseModel
+from pydantic import BaseModel, Extra
 
 # the algorithm to test
 from snapred.backend.dao.WorkspaceMetadata import UNSET
@@ -23,7 +23,7 @@ thisAlgorithm = "snapred.backend.recipe.algorithm.ReadWorkspaceMetadata."
 
 # this mocks out the original workspace metadata class
 # to ensure the algorithm is as generic as possible in case of later extension
-class WorkspaceMetadata(BaseModel):
+class WorkspaceMetadata(BaseModel, extra=Extra.forbid):
     fruit: Literal[UNSET, "apple", "pear", "orange"] = UNSET
     veggie: Literal[UNSET, "broccoli", "cauliflower"] = UNSET
     bread: Literal[UNSET, "sourdough", "pumpernickel"] = UNSET
@@ -181,8 +181,8 @@ class TestReadWorkspaceMetadata(unittest.TestCase):
 
         # verify the logs exist on the workspace
         run = mtd[wsname].getRun()
-        for prop in properties:
-            assert run.getLogData(prop).value == "newt"
+        for value, prop in zip(values, properties):
+            assert value == run.getLogData(prop).value
 
         # now run the algorithm to read the logs
         algo = ReadWorkspaceMetadata()


### PR DESCRIPTION
## Description of work

For EWM 4808.

The description called for a way to write individual logs.  This adds additional properties to the write algorithm to allow for that.

I had implemented a similar improvement for the read algo.  However, this lead to two outputs, which confused things in MantidSnapper.  After discussion, it was determined these both need to be Recipes and not Algorithms.  This is here just for temporary use.

## Explanation of work

Added two StringArrayPropety's to WriteWorkspaceMetadata.

The first list contains the metadata tag names, the second list the values to write.

Added validation to make sure this doesn't collide with using a WorkspaceMetadata DAO.

## To test

### Dev testing

<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing

<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

``` python
# replace with your test script below
```

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
