### PR TITLE
Fix failing Load tests

### DIFF
--- a/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
@@ -120,7 +120,6 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
                     "Loading with unspecified loader",
                     Filename=filename,
                     OutputWorkspace=outWS,
-                    LoaderName=loaderType,
                 )
             elif loaderType == "LoadGroupingDefinition":
                 for x in ["InstrumentName", "InstrumentFilename", "InstrumentDonor"]:


### PR DESCRIPTION
## Description of work

See [Mantid Issue #37236](https://github.com/mantidproject/mantid/issues/37236)

It was determined, while the issue *is* due to the recent change, the easier fix is to no longer set the `LoaderType` parameter with what we know to be a blank string.

## Explanation of work

Deletes a single line from `FetchGroceriesAlgorithm`

## To test

### Dev testing

Make sure all tests pass.  If they do, then there's no reason *not* to merge this.

### CIS testing

This is internal and doesn't require CIS testing

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

Make a story and I'll link it here

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)
