### PR TITLE
Added get and set functions for workspace metadata tags

### DIFF
--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -320,13 +320,14 @@ class GroceryService:
     def getWorkspaceTag(self, workspaceName: str, logname: str):
         """
         Simple wrapper to get a workspace metadata tag, for the service layer.
-        Returns a tag for a given workspace
+        Returns a tag for a given workspace. Raise an error if the workspace
+        does not exist.
 
-        :param workspaceName: the name of the workspace to clone in the ADS
+        :param workspaceName: the name of the workspace containing the tag
         :type workspaceName: string
-        :param logname: the name of the resulting cloned workspace
+        :param logname: the name of the log, usually for diffcal or normalization
         :type logname: string
-        :return: string of the tag
+        :return: string of the tag, default value is "unset"
         """
         if self.workspaceDoesExist(workspaceName):
             return self.workspaceMetadataService.readMetadataTag(workspaceName, logname)
@@ -334,6 +335,18 @@ class GroceryService:
             raise RuntimeError(f"Workspace {workspaceName} does not exist")
 
     def setWorkspaceTag(self, workspaceName: str, logname: str, logvalue: str):
+        """
+        Simple wrapper to set a workspace metadata tag, for the service layer.
+        Sets a tag for a given workspace. Raise an error if the workspace
+        does not exist.
+
+        :param workspaceName: the name of the workspace containing the tag
+        :type workspaceName: string
+        :param logname: the name of the log, usually for diffcal or normalization
+        :type logname: string
+        :param logvalue: tag value to be set, must exist in the WorkspaceMetadata dao
+        :type logvalue: string
+        """
         if self.workspaceDoesExist(workspaceName):
             self.workspaceMetadataService.writeMetadataTag(workspaceName, logname, logvalue)
         else:

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -7,8 +7,12 @@ from mantid.api import AlgorithmManager, mtd
 
 from snapred.backend.dao.ingredients import GroceryListItem
 from snapred.backend.dao.state import DetectorState, GroupingMap
+from snapred.backend.dao.WorkspaceMetadata import WorkspaceMetadata
 from snapred.backend.data.LocalDataService import LocalDataService
 from snapred.backend.recipe.FetchGroceriesRecipe import FetchGroceriesRecipe
+from snapred.backend.service.WorkspaceMetadataService import WorkspaceMetadataService
+
+# from snapred.backend.recipe.algorithm.ReadWorkspaceMetadata import ReadWorkspaceMetadata
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Singleton import Singleton
 from snapred.meta.mantid.WorkspaceNameGenerator import NameBuilder, WorkspaceName
@@ -30,6 +34,7 @@ class GroceryService:
 
     def __init__(self, dataService: LocalDataService = None):
         self.dataService = self._defaultClass(dataService, LocalDataService)
+        self.workspaceMetadataService = WorkspaceMetadataService()
 
         # _loadedRuns caches a count of the number of copies made from the neutron-data workspace
         #   corresponding to a given (runNumber, isLiteMode) key:
@@ -311,6 +316,28 @@ class GroceryService:
         else:
             ws = None
         return ws
+
+    def getWorkspaceTag(self, workspaceName: str, logname: str):
+        """
+        Simple wrapper to get a workspace metadata tag, for the service layer.
+        Returns a tag for a given workspace
+
+        :param workspaceName: the name of the workspace to clone in the ADS
+        :type workspaceName: string
+        :param logname: the name of the resulting cloned workspace
+        :type logname: string
+        :return: string of the tag
+        """
+        if self.workspaceDoesExist(workspaceName):
+            return self.workspaceMetadataService.readMetadataTag(workspaceName, logname)
+        else:
+            raise RuntimeError(f"Workspace {workspaceName} does not exist")
+
+    def setWorkspaceTag(self, workspaceName: str, logname: str, logvalue: str):
+        if self.workspaceDoesExist(workspaceName):
+            self.workspaceMetadataService.writeMetadataTag(workspaceName, logname, logvalue)
+        else:
+            raise RuntimeError(f"Workspace {workspaceName} does not exist")
 
     ## FETCH METHODS
     """


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->
Get and set functions for workspace metadata tags are added to the GroceryService so you can get and set tags from a GroceryService instance, as opposed to manually making an instance of the WorkspaceMetadataService.
## Explanation of work

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->
The get and set functions are essentially wrappers for their WorkspaceMetadataService counterparts. There is also a check to make sure the workspace exists before performing the get or set.
## To test

### Dev testing

<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->
Make sure unit tests pass.
### CIS testing

None

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4808](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4808)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
