### PR TITLE
Cache IPTS result to avoid calls to `GetIPTS` and OnCat

### DIFF
--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -154,7 +154,6 @@ class LocalDataService:
 
     def getIPTS(self, runNumber: str, instrumentName: str = Config["instrument.name"]) -> str:
         key = (runNumber, instrumentName)
-        print(key)
         if key not in self.iptsCache:
             self.iptsCache[key] = GetIPTS(RunNumber=int(runNumber), Instrument=instrumentName)
         return str(self.iptsCache[key])

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -69,7 +69,7 @@ def _createFileNotFoundError(msg, filename):
 @Singleton
 class LocalDataService:
     reductionParameterCache: Dict[str, Any] = {}
-    iptsCache: Dict[str, Any] = {}
+    iptsCache: Dict[Tuple[str, str], Any] = {}
     stateIdCache: Dict[str, ObjectSHA] = {}
     instrumentConfig: "InstrumentConfig"
     verifyPaths: bool = True
@@ -153,8 +153,11 @@ class LocalDataService:
         )
 
     def getIPTS(self, runNumber: str, instrumentName: str = Config["instrument.name"]) -> str:
-        ipts = GetIPTS(runNumber, instrumentName)
-        return str(ipts)
+        key = (runNumber, instrumentName)
+        print(key)
+        if key not in self.iptsCache:
+            self.iptsCache[key] = GetIPTS(RunNumber=int(runNumber), Instrument=instrumentName)
+        return str(self.iptsCache[key])
 
     def workspaceIsInstance(self, wsName: str, wsType: Any) -> bool:
         # Is the workspace an instance of the specified type.
@@ -890,7 +893,7 @@ class LocalDataService:
 
         # first make sure the run number has a valid IPTS
         try:
-            GetIPTS(runId, Config["instrument.name"])
+            self.getIPTS(runId)
         # if no IPTS found, return false
         except RuntimeError:
             return False

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -447,6 +447,7 @@ def test_calibrationFileExists_bad_ipts(GetIPTS):
     with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tmpDir:
         assert Path(tmpDir).exists()
         localDataService = LocalDataService()
+        localDataService.iptsCache = {}  # clear the ipts cache
         runNumber = "654321"
         assert not localDataService.checkCalibrationFileExists(runNumber)
 

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -482,6 +482,36 @@ def test_getIPTS(mockGetIPTS):
     )
 
 
+# NOTE this test calls GetIPTS directly with no mocks
+# this is intentional, to ensure it is being called correctly
+def test_getIPTS_cache():
+    from mantid.kernel import amend_config
+
+    localDataService = LocalDataService()
+    localDataService.iptsCache = {}
+    # test data
+    instrument = "SNAP"
+    runNumber = "123"
+    key = (runNumber, instrument)
+    correctIPTS = Resource.getPath("inputs/testInstrument/IPTS-456/")
+
+    # direct GetIPTS to look in the exact folder where it should look
+    # it is very stupid, so if you don't tell it exactly then it won't look there
+    with amend_config(data_dir=correctIPTS):
+        res = localDataService.getIPTS(*key)
+        assert res == correctIPTS
+
+        # ensure it is in the cache
+        assert (runNumber, instrument) in localDataService.iptsCache
+        assert localDataService.iptsCache[key] == correctIPTS
+
+        # call again and make sure the cache is being returned
+        localDataService.GetIPTS = mock.Mock()
+        res = localDataService.getIPTS(*key)
+        assert localDataService.GetIPTS.not_called
+        assert res == correctIPTS
+
+
 def test_workspaceIsInstance():
     localDataService = LocalDataService()
     # Create a sample workspace.


### PR DESCRIPTION
## Description of work

During our review, it was pointed out SNAPRed is pinging the OnCat server hundreds of times.

This is an unintended result of calling GetIPTS to construct filenames for neutron data.

This can be reduced by caching the IPTS results inside the LocalDataService.  Since this is the single point of contact with GetIPTS for the entire system (or should be), this should apply globally.

Caching should reduce the number of times calls to GetIPTS and therefore OnCat get made.

## Explanation of work

Very simple, added a dictionary cache of IPTS results to LocalDataService.  Whenever the `getIPTS` method is called, it first checks if the (run, instrument) pair is in the cache, and if not then and only then it calls `GetIPTS`.  Otherwise it just returns the cached value.

## To test

### Dev testing

The added unit test should be convincing.  Note this is calling `GetIPTS` directly, not any mock.

### CIS testing

Try the below script, turning off your internet between the first two calls.  That should demonstrate that it does not call OnCat after the value is cached.

``` python
import os
from mantid.kernel import amend_config
from snapred.backend.data.LocalDataService import LocalDataService

lds = LocalDataService()
lds.iptsCache = {}
correctPath = os.path.expanduser("~/SNAPRed/tests/resources/inputs/testInstrument/IPTS-456/")

new_config = {"data_dir": correctPath}
with amend_config(**new_config):
    assert correctPath == lds.getIPTS("123", "SNAP")

## PAUSE HERE AND TURN OFF YOUR INTERNET
## Then run the below while it can't send a GET to OnCat
assert False

with amend_config(**new_config):
    assert correctPath == lds.getIPTS("123", "SNAP")
assert True
```

The test would be more convincing if I didn't have to point directly at  the IPTS file to make it work.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
