### PR TITLE
Algo No Mo'

### DIFF
--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -3,16 +3,14 @@ import os
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-from mantid.api import AlgorithmManager, mtd
+from mantid.api import mtd
 
 from snapred.backend.dao.ingredients import GroceryListItem
 from snapred.backend.dao.state import DetectorState, GroupingMap
-from snapred.backend.dao.WorkspaceMetadata import WorkspaceMetadata
 from snapred.backend.data.LocalDataService import LocalDataService
+from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.backend.recipe.FetchGroceriesRecipe import FetchGroceriesRecipe
 from snapred.backend.service.WorkspaceMetadataService import WorkspaceMetadataService
-
-# from snapred.backend.recipe.algorithm.ReadWorkspaceMetadata import ReadWorkspaceMetadata
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Singleton import Singleton
 from snapred.meta.mantid.WorkspaceNameGenerator import NameBuilder, WorkspaceName
@@ -49,6 +47,7 @@ class GroceryService:
         self._loadedInstruments: Dict[Tuple[str, bool], str] = {}
 
         self.grocer = FetchGroceriesRecipe()
+        self.mantidSnapper = MantidSnapper(None, "Utensils")
 
     def _defaultClass(self, val, clazz):
         if val is None:
@@ -273,10 +272,12 @@ class GroceryService:
         :param newName: the name to replace the workspace name in the ADS
         :type newName: WorkspaceName
         """
-        renameAlgo = AlgorithmManager.create("RenameWorkspace")
-        renameAlgo.setProperty("InputWorkspace", oldName)
-        renameAlgo.setProperty("OutputWorkspace", newName)
-        renameAlgo.execute()
+        self.mantidSnapper.RenameWorkspace(
+            f"Renaming {oldName} to {newName}",
+            InputWorkspace=oldName,
+            OutputWorkspace=newName,
+        )
+        self.mantidSnapper.executeQueue()
 
     def getWorkspaceForName(self, name: WorkspaceName):
         """
@@ -395,10 +396,12 @@ class GroceryService:
                     if useLiteMode
                     else Config["instrument.native.definition.file"]
                 )
-                loadEmptyInstrument = AlgorithmManager.create("LoadEmptyInstrument")
-                loadEmptyInstrument.setProperty("Filename", instrumentFilename)
-                loadEmptyInstrument.setProperty("OutputWorkspace", wsName)
-                loadEmptyInstrument.execute()
+                self.mantidSnapper.LoadEmptyInstrument(
+                    f"Loading instrument at {instrumentFilename} to {wsName}",
+                    Filename=instrumentFilename,
+                    OutputWorkspace=wsName,
+                )
+                self.mantidSnapper.executeQueue()
 
                 # Initialize the instrument parameters
                 # (Reserved run-numbers will use the unmodified instrument.)
@@ -435,14 +438,16 @@ class GroceryService:
         logsAdded = 0
         for paramName in ("arc", "lin"):
             for index in range(2):
-                addSampleLog = AlgorithmManager.create("AddSampleLog")
-                addSampleLog.setProperty("Workspace", wsName)
-                addSampleLog.setProperty("LogName", "det_" + paramName + str(index + 1))
-                addSampleLog.setProperty("LogText", str(getattr(detectorState, paramName)[index]))
-                addSampleLog.setProperty("LogType", "Number Series")
-                addSampleLog.setProperty("UpdateInstrumentParameters", (logsAdded >= 3))
-                addSampleLog.execute()
+                self.mantidSnapper.AddSampleLog(
+                    f"Updating parameter {paramName}{str(index + 1)}",
+                    Workspace=wsName,
+                    LogName=f"det_{paramName}{str(index + 1)}",
+                    LogText=str(getattr(detectorState, paramName)[index]),
+                    LogType="Number Series",
+                    UpdateInstrumentParameters=(logsAdded >= 3),
+                )
                 logsAdded += 1
+        self.mantidSnapper.executeQueue()
 
     def _getDetectorState(self, runNumber: str) -> DetectorState:
         """
@@ -833,9 +838,11 @@ class GroceryService:
         :param name: the name of the workspace in the ADS to be deleted.
         :type name: WorkspaceName
         """
-        deleteAlgo = AlgorithmManager.create("WashDishes")
-        deleteAlgo.setProperty("Workspace", name)
-        deleteAlgo.execute()
+        self.mantidSnapper.WashDishes(
+            f"Washing dish {name}",
+            Workspace=name,
+        )
+        self.mantidSnapper.executeQueue()
 
     # TODO: move `deleteWorkspace` methods to `DataExportService` via `LocalDataService`
     def deleteWorkspaceUnconditional(self, name: WorkspaceName):
@@ -847,9 +854,11 @@ class GroceryService:
         :type name: WorkspaceName
         """
         if self.workspaceDoesExist(name):
-            deleteAlgo = AlgorithmManager.create("DeleteWorkspace")
-            deleteAlgo.setProperty("Workspace", name)
-            deleteAlgo.execute()
+            self.mantidSnapper.DeleteWorkspace(
+                f"Deleting workspace {name}",
+                Workspace=name,
+            )
+            self.mantidSnapper.executeQueue()
         else:
             pass
 

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 import h5py
-from mantid.api import AlgorithmManager, ITableWorkspace
+from mantid.api import ITableWorkspace
 from mantid.dataobjects import MaskWorkspace
 from mantid.kernel import PhysicalConstants
 from mantid.simpleapi import GetIPTS, mtd
@@ -40,6 +40,7 @@ from snapred.backend.error.StateValidationException import StateValidationExcept
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.data.ReheatLeftovers import ReheatLeftovers
 from snapred.backend.recipe.algorithm.data.WrapLeftovers import WrapLeftovers
+from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.backend.recipe.algorithm.SaveGroupingDefinition import SaveGroupingDefinition
 from snapred.meta.Config import Config, Resource
 from snapred.meta.decorators.ExceptionHandler import ExceptionHandler
@@ -80,6 +81,7 @@ class LocalDataService:
     def __init__(self) -> None:
         self.verifyPaths = Config["localdataservice.config.verifypaths"]
         self.instrumentConfig = self.readInstrumentConfig()
+        self.mantidSnapper = MantidSnapper(None, "Utensils")
 
     def fileExists(self, path):
         return os.path.isfile(path)
@@ -965,28 +967,34 @@ class LocalDataService:
         """
         if filename.suffix != ".nxs":
             raise RuntimeError(f"[writeWorkspace]: specify filename including '.nxs' extension, not {filename}")
-        saveAlgo = AlgorithmManager.create("SaveNexus")
-        saveAlgo.setProperty("InputWorkspace", workspaceName)
-        saveAlgo.setProperty("Filename", str(path / filename))
-        saveAlgo.execute()
+        self.mantidSnapper.SaveNexus(
+            "Save a workspace with Nexus",
+            InputWorkspace=workspaceName,
+            Filename=str(path / filename),
+        )
+        self.mantidSnapper.executeQueue()
 
     def writeRaggedWorkspace(self, path: Path, filename: Path, workspaceName: WorkspaceName):
         """
         Write a ragged workspace to disk in a .tar format.
         """
-        saveAlgo = AlgorithmManager.create(WrapLeftovers.__name__)
-        saveAlgo.setProperty("InputWorkspace", workspaceName)
-        saveAlgo.setProperty("Filename", str(path / filename))
-        saveAlgo.execute()
+        self.mantidSnapper.WrapLeftovers(
+            "Store the ragged workspace",
+            InputWorkspace=workspaceName,
+            Filename=str(path / filename),
+        )
+        self.mantidSnapper.executeQueue()
 
     def readRaggedWorkspace(self, path: Path, filename: Path, workspaceName: WorkspaceName):
         """
         Read a ragged workspace from disk in a .tar format.
         """
-        loadAlgo = AlgorithmManager.create(ReheatLeftovers.__name__)
-        loadAlgo.setProperty("Filename", str(path / filename))
-        loadAlgo.setProperty("OutputWorkspace", workspaceName)
-        loadAlgo.execute()
+        self.mantidSnapper.ReheatLeftovers(
+            "Load a ragged workspace",
+            Filename=str(path / filename),
+            OutputWorkspace=workspaceName,
+        )
+        self.mantidSnapper.executeQueue()
 
     def writeGroupingWorkspace(self, path: Path, filename: Path, workspaceName: WorkspaceName):
         """
@@ -1010,9 +1018,11 @@ class LocalDataService:
             raise RuntimeError(
                 f"[writeCalibrationWorkspaces]: specify filename including '.h5' extension, not {filename}"
             )
-        saveAlgo = AlgorithmManager.create("SaveDiffCal")
-        saveAlgo.setPropertyValue("CalibrationWorkspace", tableWorkspaceName)
-        saveAlgo.setPropertyValue("MaskWorkspace", maskWorkspaceName)
-        saveAlgo.setPropertyValue("GroupingWorkspace", groupingWorkspaceName)
-        saveAlgo.setPropertyValue("Filename", str(path / filename))
-        saveAlgo.execute()
+        self.mantidSnapper.SaveDiffCal(
+            "Save a diffcal table or grouping file",
+            CalibrationWorkspace=tableWorkspaceName,
+            MaskWorkspace=maskWorkspaceName,
+            GroupingWorkspace=groupingWorkspaceName,
+            Filename=str(path / filename),
+        )
+        self.mantidSnapper.executeQueue()

--- a/src/snapred/backend/recipe/ApplyNormalizationRecipe.py
+++ b/src/snapred/backend/recipe/ApplyNormalizationRecipe.py
@@ -1,7 +1,5 @@
 from typing import Any, Dict, List, Tuple
 
-from mantid.api import AlgorithmManager
-
 from snapred.backend.dao.ingredients import ApplyNormalizationIngredients as Ingredients
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.Recipe import Recipe

--- a/src/snapred/backend/recipe/PixelGroupingParametersCalculationRecipe.py
+++ b/src/snapred/backend/recipe/PixelGroupingParametersCalculationRecipe.py
@@ -1,7 +1,6 @@
 import json
 from typing import Any, Dict, List
 
-from mantid.api import AlgorithmManager
 from pydantic import parse_raw_as
 
 from snapred.backend.dao.ingredients import PixelGroupingIngredients
@@ -11,6 +10,7 @@ from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.PixelGroupingParametersCalculationAlgorithm import (
     PixelGroupingParametersCalculationAlgorithm,
 )
+from snapred.backend.recipe.algorithm.Utensils import Utensils
 from snapred.meta.decorators.Singleton import Singleton
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
@@ -19,10 +19,11 @@ logger = snapredLogger.getLogger(__name__)
 
 @Singleton
 class PixelGroupingParametersCalculationRecipe:
-    PixelGroupingParametersCalculationAlgorithmName: str = PixelGroupingParametersCalculationAlgorithm.__name__
-
     def __init__(self):
-        pass
+        # NOTE: workaround, we just add an empty host algorithm.
+        utensils = Utensils()
+        utensils.PyInit()
+        self.mantidSnapper = utensils.mantidSnapper
 
     def executeRecipe(
         self, ingredients: PixelGroupingIngredients, groceries: Dict[str, WorkspaceName]
@@ -30,32 +31,25 @@ class PixelGroupingParametersCalculationRecipe:
         logger.info("Executing recipe for: %s" % ingredients.groupingScheme)
         data: Dict[str, Any] = {}
 
-        algo = AlgorithmManager.create(self.PixelGroupingParametersCalculationAlgorithmName)
+        res = self.mantidSnapper.PixelGroupingParametersCalculationAlgorithm(
+            "Calling algorithm",
+            Ingredients=ingredients.json(),
+            GroupingWorkspace=groceries["groupingWorkspace"],
+            MaskWorkspace=groceries.get("MaskWorkspace", ""),
+        )
+        self.mantidSnapper.executeQueue()
 
-        algo.setProperty("Ingredients", ingredients.json())
-        algo.setProperty("GroupingWorkspace", groceries["groupingWorkspace"])
+        data["result"] = True
+        pixelGroupingParams = parse_raw_as(List[PixelGroupingParameters], res)
+        data["parameters"] = pixelGroupingParams
+        data["tof"] = BinnedValue(
+            minimum=ingredients.instrumentState.particleBounds.tof.minimum,
+            maximum=ingredients.instrumentState.particleBounds.tof.maximum,
+            binWidth=min(
+                [abs(pgp.dRelativeResolution) / ingredients.nBinsAcrossPeakWidth for pgp in pixelGroupingParams]
+            ),
+            binningMode=BinnedValue.BinningMode.LOG,
+        )
 
-        # MaskWorkspace: optional argument
-        algo.setProperty("MaskWorkspace", groceries.get("maskWorkspace", ""))
-
-        try:
-            data["result"] = algo.execute()
-            # parse the algorithm output and create a list of calculated PixelGroupingParameters
-            pixelGroupingParams = parse_raw_as(
-                List[PixelGroupingParameters],
-                algo.getProperty("OutputParameters").value,
-            )
-            data["parameters"] = pixelGroupingParams
-            data["tof"] = BinnedValue(
-                minimum=ingredients.instrumentState.particleBounds.tof.minimum,
-                maximum=ingredients.instrumentState.particleBounds.tof.maximum,
-                binWidth=min(
-                    [abs(pgp.dRelativeResolution) / ingredients.nBinsAcrossPeakWidth for pgp in pixelGroupingParams]
-                ),
-                binningMode=BinnedValue.BinningMode.LOG,
-            )
-        except RuntimeError as e:
-            errorString = str(e)
-            raise Exception(errorString.split("\n")[0])
         logger.info("Finished pixel grouping parameters calculation.")
         return data

--- a/src/snapred/backend/recipe/PreprocessReductionRecipe.py
+++ b/src/snapred/backend/recipe/PreprocessReductionRecipe.py
@@ -1,7 +1,5 @@
 from typing import Any, Dict, List, Tuple
 
-from mantid.api import AlgorithmManager
-
 from snapred.backend.dao.ingredients import PreprocessReductionIngredients as Ingredients
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper

--- a/src/snapred/backend/recipe/Recipe.py
+++ b/src/snapred/backend/recipe/Recipe.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Generic, List, Tuple, TypeVar, get_args
 
-from mantid.api import AlgorithmManager
 from pydantic import BaseModel, ValidationError
 
 from snapred.backend.log.logger import snapredLogger

--- a/src/snapred/backend/recipe/WriteWorkspaceMetadata.py
+++ b/src/snapred/backend/recipe/WriteWorkspaceMetadata.py
@@ -1,8 +1,6 @@
 import json
 from typing import Any, Dict, List, Tuple
 
-from mantid.api import AlgorithmManager
-
 from snapred.backend.dao.WorkspaceMetadata import UNSET, WorkspaceMetadata
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.ReadWorkspaceMetadata import ReadWorkspaceMetadata

--- a/src/snapred/backend/recipe/algorithm/CrystallographicInfoAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/CrystallographicInfoAlgorithm.py
@@ -36,7 +36,7 @@ class CrystallographicInfoAlgorithm(PythonAlgorithm):
 
         # Load the CIF file into an empty workspace
         # use this to set the crystallography output
-        # also creat a mantid CrystalStructure object
+        # also create a mantid CrystalStructure object
         if not self.getProperty("CifPath").isDefault:
             ws = "xtal_data"
             self.mantidSnapper.CreateSingleValuedWorkspace(

--- a/tests/cis_tests/lazy_raw_vanadium.py
+++ b/tests/cis_tests/lazy_raw_vanadium.py
@@ -33,7 +33,6 @@ from snapred.backend.recipe.algorithm.RawVanadiumCorrectionAlgorithm import RawV
 from snapred.meta.Config import Config, Resource
 Config._config['cis_mode'] = True
 Resource._resourcesPath = os.path.expanduser("~/SNAPRed/tests/resources/")
-TheAlgorithmManager: str = "snapred.backend.recipe.algorithm.MantidSnapper.AlgorithmManager"
 
 class TestRawVanadiumCorrection(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -8,6 +8,7 @@ import unittest
 from pathlib import Path
 from typing import Dict, Tuple
 from unittest import mock
+from unittest.mock import ANY
 
 import pytest
 from mantid.kernel import V3D, Quat
@@ -17,7 +18,6 @@ from mantid.simpleapi import (
     CreateEmptyTableWorkspace,
     CreateGroupingWorkspace,
     CreateLogPropertyTable,
-    CreateSingleValuedWorkspace,
     CreateWorkspace,
     DeleteWorkspace,
     ExtractMask,
@@ -643,32 +643,26 @@ class TestGroceryService(unittest.TestCase):
 
     ## TEST CLEANUP METHODS
 
-    @mock.patch(ThisService + "AlgorithmManager")
-    def test_deleteWorkspace(self, mockAlgoManager):
-        wsname = "_test_ws"
+    def test_deleteWorkspace(self):
+        wsname = mtd.unique_name(prefix="_test_ws_")
         mockAlgo = mock.Mock()
-        mockAlgoManager.create.return_value = mockAlgo
+        self.instance.mantidSnapper.WashDishes = mockAlgo
+        # wash the dish
         self.instance.deleteWorkspace(wsname)
-        assert mockAlgoManager.called_once_with("WashDishes")
-        assert mockAlgo.setProperty.called_with(wsname)
-        assert mockAlgo.execute.called_once
+        assert mockAlgo.called_once_with(ANY, Workspace=wsname)
 
-    @mock.patch(ThisService + "AlgorithmManager")
-    def test_deleteWorkspaceUnconditional(self, mockAlgoManager):
-        wsname = "_test_ws"
+    def test_deleteWorkspaceUnconditional(self):
+        wsname = mtd.unique_name(prefix="_test_ws_")
         mockAlgo = mock.Mock()
-        mockAlgoManager.create.return_value = mockAlgo
+        self.instance.mantidSnapper.DeleteWorkspace = mockAlgo
         # if the workspace does not exist, then don't do anything
         self.instance.deleteWorkspaceUnconditional(wsname)
-        assert mockAlgoManager.not_called
-        assert mockAlgo.execute.not_called
+        assert mockAlgo.not_called
         # make the workspace
         self.create_dumb_workspace(wsname)
         # if the workspace does exist, then delete it
         self.instance.deleteWorkspaceUnconditional(wsname)
-        assert mockAlgoManager.called_once_with("DeleteWorkspace")
-        assert mockAlgo.setProperty.called_with(wsname)
-        assert mockAlgo.execute.called_once
+        assert mockAlgo.called_once_with(ANY, Workspace=wsname)
 
     ## TEST FETCH METHODS
 

--- a/tests/unit/backend/recipe/algorithm/test_CalibrationMetricExtractionAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_CalibrationMetricExtractionAlgorithm.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
-from mantid.api import AlgorithmManager
 from mantid.kernel import Direction
 from pydantic import parse_raw_as
 from snapred.backend.dao.calibration.CalibrationMetric import CalibrationMetric

--- a/tests/unit/backend/recipe/algorithm/test_CrystallographicInfoAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_CrystallographicInfoAlgorithm.py
@@ -20,15 +20,15 @@ with mock.patch.dict(
         fakeCIF = Resource.getPath("/inputs/crystalInfo/fake_file.cif")
         xtalAlgo = Algo()
         xtalAlgo.initialize()
-        xtalAlgo.setProperty("cifPath", fakeCIF)
-        assert fakeCIF == xtalAlgo.getProperty("cifPath").value
+        xtalAlgo.setProperty("CifPath", fakeCIF)
+        assert fakeCIF == xtalAlgo.getProperty("CifPath").value
 
     def test_failed_path():
         """Test failure of crystal ingestion algo with a bad path name"""
         fakeCIF = Resource.getPath("/inputs/crystalInfo/fake_file.cif")
         xtalAlgo = Algo()
         xtalAlgo.initialize()
-        xtalAlgo.setProperty("cifPath", fakeCIF)
+        xtalAlgo.setProperty("CifPath", fakeCIF)
         with pytest.raises(Exception):  # noqa: PT011
             xtalAlgo.execute()
 
@@ -38,13 +38,12 @@ with mock.patch.dict(
         try:
             xtalAlgo = Algo()
             xtalAlgo.initialize()
-            xtalAlgo.setProperty("cifPath", goodCIF)
+            xtalAlgo.setProperty("CifPath", goodCIF)
             xtalAlgo.setProperty("dMin", 1.0)
             xtalAlgo.setProperty("dMax", 10.0)
             xtalAlgo.execute()
-            xtalInfo = json.loads(xtalAlgo.getPropertyValue("crystalInfo"))
-            xtalStructure = json.loads(xtalAlgo.getPropertyValue("crystalStructure"))
-            print(xtalStructure)
+            xtalInfo = json.loads(xtalAlgo.getPropertyValue("CrystalInfo"))
+            xtallography = json.loads(xtalAlgo.getPropertyValue("Crystallography"))
         except Exception:  # noqa: BLE001
             pytest.fail("valid file failed to open")
         else:
@@ -52,8 +51,8 @@ with mock.patch.dict(
             assert xtalInfo["peaks"][5]["hkl"] == [4, 0, 0]
             assert xtalInfo["peaks"][0]["dSpacing"] == 3.13592994862768
             assert xtalInfo["peaks"][4]["dSpacing"] == 1.0453099828758932
-            assert xtalStructure["cifFile"] == goodCIF
-            assert xtalStructure["spaceGroup"] == "F d -3 m"
+            assert xtallography["cifFile"] == goodCIF
+            assert xtallography["spaceGroup"] == "F d -3 m"
 
     def test_from_xtal():
         """Test success of crystal ingestion algo using Crystallography object"""
@@ -62,7 +61,7 @@ with mock.patch.dict(
 
         goodCIF = Resource.getPath("/inputs/crystalInfo/example.cif")
         atom = Atom(symbol="Si", coordinates=[0.125, 0.125, 0.125], siteOccupationFactor=1.0)
-        xtal = Crystallography(
+        xtallography = Crystallography(
             cifFile=goodCIF,
             spaceGroup="F d -3 m",
             latticeParameters=[5.43159, 5.43159, 5.43159, 90.0, 90.0, 90.0],
@@ -71,12 +70,12 @@ with mock.patch.dict(
         try:
             xtalAlgo = Algo()
             xtalAlgo.initialize()
-            xtalAlgo.setProperty("crystalStructure", xtal.json())
+            xtalAlgo.setProperty("Crystallography", xtallography.json())
             xtalAlgo.setProperty("dMin", 1.0)
             xtalAlgo.setProperty("dMax", 10.0)
             xtalAlgo.execute()
-            xtalInfo = json.loads(xtalAlgo.getPropertyValue("crystalInfo"))
-            xtalStructure = json.loads(xtalAlgo.getPropertyValue("crystalStructure"))
+            xtalInfo = json.loads(xtalAlgo.getPropertyValue("CrystalInfo"))
+            xtallography2 = json.loads(xtalAlgo.getPropertyValue("Crystallography"))
         except Exception:  # noqa: BLE001
             pytest.fail("valid file failed to open")
         else:
@@ -84,5 +83,5 @@ with mock.patch.dict(
             assert xtalInfo["peaks"][5]["hkl"] == [4, 0, 0]
             assert xtalInfo["peaks"][0]["dSpacing"] == 3.13592994862768
             assert xtalInfo["peaks"][4]["dSpacing"] == 1.0453099828758932
-            assert xtalStructure["cifFile"] == goodCIF
-            assert xtalStructure["spaceGroup"] == "F d -3 m"
+            assert xtallography2["cifFile"] == goodCIF
+            assert xtallography2["spaceGroup"] == "F d -3 m"

--- a/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
@@ -24,8 +24,6 @@ from snapred.backend.recipe.algorithm.FetchGroceriesAlgorithm import (
 )
 from snapred.meta.Config import Resource
 
-TheAlgorithmManager: str = "snapred.backend.recipe.algorithm.MantidSnapper.AlgorithmManager"
-
 
 class TestFetchGroceriesAlgorithm(unittest.TestCase):
     @classmethod

--- a/tests/unit/backend/recipe/algorithm/test_RawVanadiumCorrection.py
+++ b/tests/unit/backend/recipe/algorithm/test_RawVanadiumCorrection.py
@@ -32,8 +32,6 @@ from snapred.backend.recipe.algorithm.RawVanadiumCorrectionAlgorithm import (
 from snapred.meta.Config import Resource
 from util.SculleryBoy import SculleryBoy
 
-TheAlgorithmManager: str = "snapred.backend.recipe.algorithm.MantidSnapper.AlgorithmManager"
-
 
 class TestRawVanadiumCorrection(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -22,8 +22,6 @@ from snapred.backend.recipe.FetchGroceriesRecipe import (
 )
 from snapred.meta.Config import Config, Resource
 
-TheAlgorithmManager: str = "snapred.backend.recipe.algorithm.MantidSnapper.AlgorithmManager"
-
 
 class TestFetchGroceriesRecipe(unittest.TestCase):
     @classmethod

--- a/tests/unit/backend/recipe/test_PixelGroupingParametersCalculationRecipe.py
+++ b/tests/unit/backend/recipe/test_PixelGroupingParametersCalculationRecipe.py
@@ -2,67 +2,60 @@ import json
 import unittest.mock as mock
 
 import pytest
+from snapred.backend.dao.ingredients.PixelGroupingIngredients import PixelGroupingIngredients
+from snapred.backend.dao.Limit import Limit
+from snapred.backend.dao.state.PixelGroupingParameters import PixelGroupingParameters
+from snapred.backend.recipe.PixelGroupingParametersCalculationRecipe import PixelGroupingParametersCalculationRecipe
+from snapred.meta.redantic import list_to_raw
 
-with mock.patch("mantid.api.AlgorithmManager") as MockAlgorithmManager:
-    from snapred.backend.dao.ingredients.PixelGroupingIngredients import PixelGroupingIngredients
-    from snapred.backend.dao.Limit import Limit
-    from snapred.backend.dao.state.PixelGroupingParameters import PixelGroupingParameters
-    from snapred.backend.recipe.PixelGroupingParametersCalculationRecipe import PixelGroupingParametersCalculationRecipe
-    from snapred.meta.redantic import list_to_raw
 
-    mockAlgo = mock.Mock()
-    MockAlgorithmManager.create.return_value = mockAlgo
+@mock.patch("snapred.backend.recipe.PixelGroupingParametersCalculationRecipe.BinnedValue")
+def test_execute_successful(mockBinnedValue):
+    # mock algorithm execution result and output
+    params = PixelGroupingParameters(
+        groupID=1,
+        isMasked=False,
+        twoTheta=3.14,
+        dResolution=Limit(minimum=0.1, maximum=1.0),
+        dRelativeResolution=0.01,
+    )
+    mock_output_val = [params]
+    mockAlgo = mock.Mock(return_value=list_to_raw(mock_output_val))
 
-    @mock.patch("snapred.backend.recipe.PixelGroupingParametersCalculationRecipe.BinnedValue")
-    def test_execute_successful(mockBinnedValue):
-        # mock algorithm execution result and output
-        mockAlgo.execute.return_value = "passed"
-        params = PixelGroupingParameters(
-            groupID=1,
-            isMasked=False,
-            twoTheta=3.14,
-            dResolution=Limit(minimum=0.1, maximum=1.0),
-            dRelativeResolution=0.01,
-        )
-        mock_output_val = [params]
-        mockAlgo.getProperty("OutputParameters").value = list_to_raw(mock_output_val)
+    # execute recipe with mocked input
+    recipe = PixelGroupingParametersCalculationRecipe()
+    recipe.mantidSnapper.PixelGroupingParametersCalculationAlgorithm = mockAlgo
+    ingredients = mock.Mock(json=mock.Mock(return_value="good ingredients"))
+    ingredients.nBinsAcrossPeakWidth = 7
+    groceries = {
+        "groupingWorkspace": "grouping workspace",
+        "maskWorkspace": "mask workspace",
+    }
+    data = recipe.executeRecipe(ingredients, groceries)
 
-        # execute recipe with mocked input
-        recipe = PixelGroupingParametersCalculationRecipe()
-        ingredients = mock.Mock(return_value="good ingredients")
-        ingredients.nBinsAcrossPeakWidth = 7
-        groceries = {
-            "groupingWorkspace": mock.Mock(return_value="grouping workspace"),
-            "maskWorkspace": mock.Mock(return_value="mask workspace"),
-        }
-        data = recipe.executeRecipe(ingredients, groceries)
+    assert mockAlgo.call_count == 1
+    assert isinstance(data, dict)
+    assert data["result"]
+    assert isinstance(data["parameters"], list)
+    assert data["parameters"][0] == mock_output_val[0]
+    assert data["tof"] == mockBinnedValue.return_value
 
-        assert mockAlgo.execute.called
-        assert isinstance(data, dict)
-        assert data["result"] is not None
-        assert data["result"] == "passed"
-        assert isinstance(data["parameters"], list)
-        assert data["parameters"][0] == mock_output_val[0]
-        assert data["tof"] == mockBinnedValue.return_value
 
-    def test_execute_unsuccessful():
-        mockAlgo.execute.side_effect = RuntimeError("passed")
+def test_execute_unsuccessful():
+    mockAlgo = mock.Mock(side_effect=RuntimeError("passed"))
 
-        recipe = PixelGroupingParametersCalculationRecipe()
-        ingredients = mock.Mock()
-        groceries = {
-            "groupingWorkspace": mock.Mock(return_value="grouping workspace"),
-            "maskWorkspace": mock.Mock(return_value="mask workspace"),
-        }
+    recipe = PixelGroupingParametersCalculationRecipe()
+    recipe.mantidSnapper.PixelGroupingParametersCalculationAlgorithm = mockAlgo
+    ingredients = mock.Mock()
+    groceries = {
+        "groupingWorkspace": "grouping workspace",
+        "maskWorkspace": "mask workspace",
+    }
 
-        try:
-            recipe.executeRecipe(ingredients, groceries)
-        except Exception as e:  # noqa: E722 BLE001
-            assert str(e) == "passed"  # noqa: PT017
-            assert mockAlgo.execute.called
-        else:
-            # fail if execute did not raise an exception
-            pytest.fail("Test should have raised RuntimeError, but no error raised")
+    with pytest.raises(RuntimeError) as e:
+        recipe.executeRecipe(ingredients, groceries)
+    assert str(e.value) == "passed"  # noqa: PT017
+    assert mockAlgo.call_count == 1
 
 
 # this at teardown removes the loggers, eliminating logger error printouts


### PR DESCRIPTION
## Description of work

Following a conversation during SNAPRed review.

Within `GroceryService` and `LocalDataService`, remove construction of algorithms directly through `AlgorithmManager`, and instead rely on `MantidSnapper`.

`AlgorithmManager` should only appear in two places `MantidSnapper` and its test.

## Explanation of work

`AlgorithmManager`  was only meaningfully used in the following places:
- `LocalDataService` inside some write methods
- `GroceryService` in various places
- `CrystallographicInfoRecipe` which just used it to call the related algorithm; but some minor refactoring was needed to grab both of the outputs
- `PixelGroupingParametersCalculationRecipe`, which also just calls the related algorithm

The other occurrences were stray imports or similar.

Where changed, it was changed from

``` python
algo = AlgorithmManager(BakeCake.__name__)
algo.initialize()
algo.setProperty("CakeType", cakeType)
algo.execute()
```

to call from `MantidSnapper` like so

``` python
self.mantidSnapper.BakeCake(
    f"Bake a {cakeType} cake",
    CakeType=cakeType,
) 
self.mantidSnapper.executeQueue()
```

within the `LocalDataService` and the `GroceryService`.

Inside the services, `MantidSnapper is initialized as
``` python
self.mantidSnapper = MantidSnapper(None, "Utensils")
```

## To test

### Dev testing

Do a grep test for `AlgorithmManager` occurring in the repo, and ensure it is only in `MantidSnapper`

### CIS testing

This is internal and doesn't need CIS testing

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
