### PR TITLE
compare workspaces doesn't work like that

### DIFF
--- a/tests/cis_tests/leftovers_script.py
+++ b/tests/cis_tests/leftovers_script.py
@@ -2,6 +2,7 @@ from snapred.backend.recipe.algorithm.data.WrapLeftovers import WrapLeftovers
 from snapred.backend.recipe.algorithm.data.ReheatLeftovers import ReheatLeftovers
 
 from mantid.simpleapi import *
+from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
 
 
 # Load focussed data
@@ -26,5 +27,5 @@ reheatLeftovers.setPropertyValue("OutputWorkspace","reheated")
 reheatLeftovers.setPropertyValue("Filename", filename)
 reheatLeftovers.execute()
 
-# CompareWorkspaces(Workspace1="raw", Workspace2="reheated") Doesnt work with ragged!
+# assert_wksp_almost_equal(Workspace1="raw", Workspace2="reheated") Doesnt work with ragged!
     

--- a/tests/cis_tests/lite_data_creation.py
+++ b/tests/cis_tests/lite_data_creation.py
@@ -34,4 +34,4 @@ LDCA.execute()
 assert CompareWorkspaces(
     Workspace1 = workspace + "_lite",
     Workspace2 = workspace + "_doubleLite",
-)
+).Result

--- a/tests/cis_tests/lite_data_creation.py
+++ b/tests/cis_tests/lite_data_creation.py
@@ -1,5 +1,6 @@
 # Use this script to test LiteDataCreationAlgo.py
 from mantid.simpleapi import *
+from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
 
 from snapred.backend.recipe.algorithm.LiteDataCreationAlgo import LiteDataCreationAlgo
 from snapred.backend.data.GroceryService import GroceryService
@@ -31,7 +32,7 @@ LDCA.setProperty("InputWorkspace", workspace + "_lite")
 LDCA.setProperty("OutputWorkspace", workspace + "_doubleLite")
 LDCA.execute()
 
-assert CompareWorkspaces(
+assert_wksp_almost_equal(
     Workspace1 = workspace + "_lite",
     Workspace2 = workspace + "_doubleLite",
-).Result
+)

--- a/tests/cis_tests/save_grouping_definition_with_xml.py
+++ b/tests/cis_tests/save_grouping_definition_with_xml.py
@@ -63,7 +63,7 @@ loads["XML and FILE"] = (end - start)
 assert CompareWorkspaces(
     Workspace1 = grwsXML,
     Workspace2 = reload,
-)
+).Result
 
 # load the data directly from the XML with instrument donor
 reload = "from xml and donor"
@@ -80,7 +80,7 @@ loads["XML and DONOR"] = (end - start)
 assert CompareWorkspaces(
     Workspace1 = grwsXML,
     Workspace2 = reload,
-)
+).Result
 
 ###### TESTS OF SAVE #######################################
 
@@ -108,7 +108,7 @@ loads["HDF and NAME"] = (end - start)
 assert CompareWorkspaces(
     Workspace1 = grwsHDF,
     Workspace2 = grwsXML,
-)
+).Result
 
 ###### save/load with XML file and instrument file
 savingAlgo = SavingAlgo()
@@ -134,7 +134,7 @@ loads["HDF and FILE"] = (end - start)
 assert CompareWorkspaces(
     Workspace1 = grwsXML,
     Workspace2 = grwsHDF,
-)
+).Result
 
 ###### save/load with XML file and instrument donor
 result = "xml_and_instrument_donor"
@@ -162,7 +162,7 @@ loads["HDF and DONOR"] = (end - start)
 assert CompareWorkspaces(
     Workspace1 = grwsXML,
     Workspace2 = grwsHDF,
-)
+).Result
 
 ###### save with HDF file and instrument name
 groupingFileHDF2 = localDir + pathlib.Path(groupingFileXML).stem + "2.hdf"

--- a/tests/cis_tests/save_grouping_definition_with_xml.py
+++ b/tests/cis_tests/save_grouping_definition_with_xml.py
@@ -1,5 +1,6 @@
 # import mantid algorithms, numpy and matplotlib
 from mantid.simpleapi import *
+from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
 import matplotlib.pyplot as plt
 import numpy as np
 import pathlib
@@ -60,10 +61,10 @@ assert loadingAlgo.execute()
 end = time.time()
 loads["XML and FILE"] = (end - start)
 
-assert CompareWorkspaces(
+assert_wksp_almost_equal(
     Workspace1 = grwsXML,
     Workspace2 = reload,
-).Result
+)
 
 # load the data directly from the XML with instrument donor
 reload = "from xml and donor"
@@ -77,10 +78,10 @@ assert loadingAlgo.execute()
 end = time.time()
 loads["XML and DONOR"] = (end - start)
 
-assert CompareWorkspaces(
+assert_wksp_almost_equal(
     Workspace1 = grwsXML,
     Workspace2 = reload,
-).Result
+)
 
 ###### TESTS OF SAVE #######################################
 
@@ -105,10 +106,10 @@ assert loadingAlgo.execute()
 end = time.time()
 loads["HDF and NAME"] = (end - start)
 
-assert CompareWorkspaces(
+assert_wksp_almost_equal(
     Workspace1 = grwsHDF,
     Workspace2 = grwsXML,
-).Result
+)
 
 ###### save/load with XML file and instrument file
 savingAlgo = SavingAlgo()
@@ -131,10 +132,10 @@ assert loadingAlgo.execute()
 end = time.time()
 loads["HDF and FILE"] = (end - start)
 
-assert CompareWorkspaces(
+assert_wksp_almost_equal(
     Workspace1 = grwsXML,
     Workspace2 = grwsHDF,
-).Result
+)
 
 ###### save/load with XML file and instrument donor
 result = "xml_and_instrument_donor"
@@ -159,10 +160,10 @@ assert loadingAlgo.execute()
 end = time.time()
 loads["HDF and DONOR"] = (end - start)
 
-assert CompareWorkspaces(
+assert_wksp_almost_equal(
     Workspace1 = grwsXML,
     Workspace2 = grwsHDF,
-).Result
+)
 
 ###### save with HDF file and instrument name
 groupingFileHDF2 = localDir + pathlib.Path(groupingFileXML).stem + "2.hdf"

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -1,5 +1,4 @@
 # ruff: noqa: E722, PT011, PT012
-
 import os
 import shutil
 import tarfile
@@ -14,7 +13,6 @@ import pytest
 from mantid.kernel import V3D, Quat
 from mantid.simpleapi import (
     CloneWorkspace,
-    CompareWorkspaces,
     CreateEmptyTableWorkspace,
     CreateGroupingWorkspace,
     CreateLogPropertyTable,
@@ -38,7 +36,7 @@ from snapred.backend.data.LocalDataService import LocalDataService
 from snapred.meta.Config import Config, Resource
 from snapred.meta.mantid.WorkspaceNameGenerator import ValueFormatter as wnvf
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
-from util.helpers import createCompatibleDiffCalTable, createCompatibleMask
+from util.helpers import createCompatibleDiffCalTable, createCompatibleMask, workspacesEqual
 from util.instrument_helpers import mapFromSampleLogs
 from util.kernel_helpers import tupleFromQuat, tupleFromV3D
 
@@ -397,7 +395,7 @@ class TestGroceryService(unittest.TestCase):
         ws = self.instance.getCloneOfWorkspace(wsname1, wsname2)
         assert ws.name() == wsname2  # checks that the workspace pointer can be used
         assert mtd.doesExist(wsname2)
-        assert CompareWorkspaces(
+        assert workspacesEqual(
             Workspace1=wsname1,
             Workspace2=wsname2,
         )
@@ -675,7 +673,7 @@ class TestGroceryService(unittest.TestCase):
             "loader": "LoadNexusProcessed",
             "workspace": self.fetchedWSname,
         }
-        assert CompareWorkspaces(
+        assert workspacesEqual(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
         )
@@ -690,7 +688,7 @@ class TestGroceryService(unittest.TestCase):
             "workspace": self.fetchedWSname,
         }
         assert self.instance.grocer.executeRecipe.not_called
-        assert CompareWorkspaces(
+        assert workspacesEqual(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
         )
@@ -739,7 +737,7 @@ class TestGroceryService(unittest.TestCase):
         assert not mtd.doesExist(rawWorkspaceName)
         assert mtd.doesExist(workspaceName)
         # test the workspace is correct
-        assert CompareWorkspaces(
+        assert workspacesEqual(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
         )
@@ -762,7 +760,7 @@ class TestGroceryService(unittest.TestCase):
         assert res["workspace"] == workspaceName
         assert res["loader"] == "cached"  # this indicates it used a cached value
         assert self.instance._loadedRuns == {testKey: 1}  # the number of copies did not increment
-        assert CompareWorkspaces(
+        assert workspacesEqual(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
         )
@@ -814,7 +812,7 @@ class TestGroceryService(unittest.TestCase):
         assert mtd.doesExist(workspaceNameRaw)
         assert mtd.doesExist(workspaceNameCopy1)
         # test the workspace is correct
-        assert CompareWorkspaces(
+        assert workspacesEqual(
             Workspace1=self.sampleWS,
             Workspace2=workspaceNameCopy1,
         )
@@ -829,7 +827,7 @@ class TestGroceryService(unittest.TestCase):
         assert mtd.doesExist(workspaceNameRaw)
         assert mtd.doesExist(workspaceNameCopy1)
         assert mtd.doesExist(workspaceNameCopy2)
-        assert CompareWorkspaces(
+        assert workspacesEqual(
             Workspace1=self.sampleWS,
             Workspace2=workspaceNameCopy2,
         )

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -27,6 +27,7 @@ from mantid.simpleapi import (
     SaveParameterFile,
     mtd,
 )
+from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
 from pydantic import ValidationError
 from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
 from snapred.backend.dao.state import DetectorState
@@ -36,7 +37,7 @@ from snapred.backend.data.LocalDataService import LocalDataService
 from snapred.meta.Config import Config, Resource
 from snapred.meta.mantid.WorkspaceNameGenerator import ValueFormatter as wnvf
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
-from util.helpers import createCompatibleDiffCalTable, createCompatibleMask, workspacesEqual
+from util.helpers import createCompatibleDiffCalTable, createCompatibleMask
 from util.instrument_helpers import mapFromSampleLogs
 from util.kernel_helpers import tupleFromQuat, tupleFromV3D
 
@@ -395,7 +396,7 @@ class TestGroceryService(unittest.TestCase):
         ws = self.instance.getCloneOfWorkspace(wsname1, wsname2)
         assert ws.name() == wsname2  # checks that the workspace pointer can be used
         assert mtd.doesExist(wsname2)
-        assert workspacesEqual(
+        assert_wksp_almost_equal(
             Workspace1=wsname1,
             Workspace2=wsname2,
         )
@@ -673,7 +674,7 @@ class TestGroceryService(unittest.TestCase):
             "loader": "LoadNexusProcessed",
             "workspace": self.fetchedWSname,
         }
-        assert workspacesEqual(
+        assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
         )
@@ -688,7 +689,7 @@ class TestGroceryService(unittest.TestCase):
             "workspace": self.fetchedWSname,
         }
         assert self.instance.grocer.executeRecipe.not_called
-        assert workspacesEqual(
+        assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
         )
@@ -737,7 +738,7 @@ class TestGroceryService(unittest.TestCase):
         assert not mtd.doesExist(rawWorkspaceName)
         assert mtd.doesExist(workspaceName)
         # test the workspace is correct
-        assert workspacesEqual(
+        assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
         )
@@ -760,7 +761,7 @@ class TestGroceryService(unittest.TestCase):
         assert res["workspace"] == workspaceName
         assert res["loader"] == "cached"  # this indicates it used a cached value
         assert self.instance._loadedRuns == {testKey: 1}  # the number of copies did not increment
-        assert workspacesEqual(
+        assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
         )
@@ -812,7 +813,7 @@ class TestGroceryService(unittest.TestCase):
         assert mtd.doesExist(workspaceNameRaw)
         assert mtd.doesExist(workspaceNameCopy1)
         # test the workspace is correct
-        assert workspacesEqual(
+        assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=workspaceNameCopy1,
         )
@@ -827,7 +828,7 @@ class TestGroceryService(unittest.TestCase):
         assert mtd.doesExist(workspaceNameRaw)
         assert mtd.doesExist(workspaceNameCopy1)
         assert mtd.doesExist(workspaceNameCopy2)
-        assert workspacesEqual(
+        assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=workspaceNameCopy2,
         )

--- a/tests/unit/backend/recipe/algorithm/data/test_Leftovers.py
+++ b/tests/unit/backend/recipe/algorithm/data/test_Leftovers.py
@@ -67,4 +67,3 @@ def test_saveLoad():
         compareRaggedWorkspaces(mtd["raw"], mtd["reheated"])
         DeleteWorkspace("raw")
         DeleteWorkspace("reheated")
-    # CompareWorkspaces(Workspace1="raw", Workspace2="reheated") Doesnt work with ragged!

--- a/tests/unit/backend/recipe/algorithm/test_CalculateDiffCalTable.py
+++ b/tests/unit/backend/recipe/algorithm/test_CalculateDiffCalTable.py
@@ -10,7 +10,6 @@ from mantid.simpleapi import (
     mtd,
 )
 from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
-
 from snapred.meta.Config import Resource
 
 

--- a/tests/unit/backend/recipe/algorithm/test_CalculateDiffCalTable.py
+++ b/tests/unit/backend/recipe/algorithm/test_CalculateDiffCalTable.py
@@ -4,6 +4,7 @@ from mantid.simpleapi import (
     DeleteWorkspace,
     mtd,
 )
+from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
 
 # the algorithm to test
 from snapred.backend.recipe.algorithm.CalculateDiffCalTable import (

--- a/tests/unit/backend/recipe/algorithm/test_CalculateDiffCalTable.py
+++ b/tests/unit/backend/recipe/algorithm/test_CalculateDiffCalTable.py
@@ -9,7 +9,6 @@ from mantid.simpleapi import (
     DeleteWorkspace,
     mtd,
 )
-from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
 from snapred.meta.Config import Resource
 
 

--- a/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
+++ b/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
@@ -6,6 +6,7 @@ import pytest
 from snapred.backend.dao import GroupPeakList
 from snapred.meta.redantic import list_to_raw
 from util.diffraction_calibration_synthetic_data import SyntheticData
+from util.helpers import workspacesEqual
 
 with mock.patch.dict(
     "sys.modules",
@@ -15,7 +16,6 @@ with mock.patch.dict(
     },
 ):
     from mantid.simpleapi import (
-        CompareWorkspaces,
         DeleteWorkspace,
         LoadNexusProcessed,
         mtd,
@@ -75,13 +75,10 @@ with mock.patch.dict(
         assert weightCalculatorAlgo.execute()
 
         # match results with reference
-        weight_ws = mtd[weight_ws_name]
-        ref_weight_ws = LoadNexusProcessed(
+        # weight_ws = mtd[weight_ws_name]
+        ref_weight_ws_name = mtd.unique_name(prefix="_ref_weight_")
+        LoadNexusProcessed(
             Filename=Resource.getPath(referenceWeightFile),
+            OutputWorkspace=ref_weight_ws_name,
         )
-
-        assert CompareWorkspaces(
-            Workspace1=ref_weight_ws,
-            Workspace2=weight_ws,
-            CheckInstrument=False,
-        )
+        assert workspacesEqual(weight_ws_name, ref_weight_ws_name, CheckInstrument=False)

--- a/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
+++ b/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
@@ -6,7 +6,6 @@ import pytest
 from snapred.backend.dao import GroupPeakList
 from snapred.meta.redantic import list_to_raw
 from util.diffraction_calibration_synthetic_data import SyntheticData
-from util.helpers import workspacesEqual
 
 with mock.patch.dict(
     "sys.modules",
@@ -16,6 +15,7 @@ with mock.patch.dict(
     },
 ):
     from mantid.simpleapi import (
+        CompareWorkspaces,
         DeleteWorkspace,
         LoadNexusProcessed,
         mtd,
@@ -81,4 +81,9 @@ with mock.patch.dict(
             Filename=Resource.getPath(referenceWeightFile),
             OutputWorkspace=ref_weight_ws_name,
         )
-        assert workspacesEqual(weight_ws_name, ref_weight_ws_name, CheckInstrument=False)
+        # TODO FIX THIS TEST
+        assert CompareWorkspaces(
+            Workspace1=weight_ws_name,
+            Workspace2=ref_weight_ws_name,
+            CheckInstrument=False,
+        )

--- a/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
+++ b/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
@@ -49,7 +49,7 @@ with mock.patch.dict(
         yield
         teardown()
 
-    @pytest.mark.xfail(reason="The workspace comparison of this test will fail", strict=True)
+    @pytest.mark.xfail(reason="To be fixed in EWM5043", strict=True)
     def test_with_predicted_peaks():
         """Test the weight calculator given predicted peaks"""
         inputWorkspaceFile = "/inputs/strip_peaks/DSP_58882_cal_CC_Column_spectra.nxs"

--- a/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
+++ b/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
@@ -49,7 +49,7 @@ with mock.patch.dict(
         yield
         teardown()
 
-    @pytest.mark.xfail(strict=True)
+    @pytest.mark.xfail(reason="The workspace comparison of this test will fail", strict=True)
     def test_with_predicted_peaks():
         """Test the weight calculator given predicted peaks"""
         inputWorkspaceFile = "/inputs/strip_peaks/DSP_58882_cal_CC_Column_spectra.nxs"

--- a/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
+++ b/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
@@ -6,6 +6,7 @@ import pytest
 from snapred.backend.dao import GroupPeakList
 from snapred.meta.redantic import list_to_raw
 from util.diffraction_calibration_synthetic_data import SyntheticData
+from util.helpers import workspacesEqual
 
 with mock.patch.dict(
     "sys.modules",
@@ -15,7 +16,6 @@ with mock.patch.dict(
     },
 ):
     from mantid.simpleapi import (
-        CompareWorkspaces,
         DeleteWorkspace,
         LoadNexusProcessed,
         mtd,
@@ -82,8 +82,9 @@ with mock.patch.dict(
             OutputWorkspace=ref_weight_ws_name,
         )
         # TODO FIX THIS TEST
-        assert CompareWorkspaces(
+        assert workspacesEqual(
             Workspace1=weight_ws_name,
             Workspace2=ref_weight_ws_name,
             CheckInstrument=False,
+            BAD=True,
         )

--- a/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
+++ b/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
@@ -49,6 +49,7 @@ with mock.patch.dict(
         yield
         teardown()
 
+    @pytest.mark.xfail(strict=True)
     def test_with_predicted_peaks():
         """Test the weight calculator given predicted peaks"""
         inputWorkspaceFile = "/inputs/strip_peaks/DSP_58882_cal_CC_Column_spectra.nxs"
@@ -81,10 +82,9 @@ with mock.patch.dict(
             Filename=Resource.getPath(referenceWeightFile),
             OutputWorkspace=ref_weight_ws_name,
         )
-        # TODO FIX THIS TEST
+        # TODO FIX THIS TEST -- EWM 5043
         assert workspacesEqual(
             Workspace1=weight_ws_name,
             Workspace2=ref_weight_ws_name,
             CheckInstrument=False,
-            BAD=True,
         )

--- a/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
@@ -13,6 +13,7 @@ from mantid.simpleapi import (
     SaveNexusProcessed,
     mtd,
 )
+from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
 
 # needed to make mocked ingredients
 from snapred.backend.dao.RunConfig import RunConfig
@@ -22,7 +23,6 @@ from snapred.backend.recipe.algorithm.FetchGroceriesAlgorithm import (
     FetchGroceriesAlgorithm as Algo,  # noqa: E402
 )
 from snapred.meta.Config import Resource
-from util.helpers import workspacesEqual
 
 
 class TestFetchGroceriesAlgorithm(unittest.TestCase):
@@ -157,7 +157,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.setPropertyValue("LoaderType", "")
         algo.setPropertyValue("OutputWorkspace", self.fetchedWS)
         assert algo.execute()
-        assert workspacesEqual(
+        assert_wksp_almost_equal(
             Workspace1=self.fetchedWS,
             Workspace2=self.sampleWS,
         )
@@ -171,7 +171,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.setPropertyValue("LoaderType", "LoadNexus")
         algo.setPropertyValue("OutputWorkspace", self.fetchedWS)
         assert algo.execute()
-        assert workspacesEqual(
+        assert_wksp_almost_equal(
             Workspace1=self.fetchedWS,
             Workspace2=self.sampleWS,
         )
@@ -194,7 +194,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.setPropertyValue("LoaderType", "LoadNexusProcessed")
         algo.setPropertyValue("OutputWorkspace", self.fetchedWS)
         assert algo.execute()
-        assert workspacesEqual(
+        assert_wksp_almost_equal(
             Workspace1=self.fetchedWS,
             Workspace2=self.sampleWS,
         )
@@ -217,7 +217,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.setPropertyValue("OutputWorkspace", f"_{self.runNumber}_grouping_name")
         algo.setPropertyValue("InstrumentName", "fakeSNAP")
         assert algo.execute()
-        assert workspacesEqual(
+        assert_wksp_almost_equal(
             Workspace1=f"_{self.runNumber}_grouping_file",
             Workspace2=f"_{self.runNumber}_grouping_name",
         )
@@ -226,7 +226,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.setPropertyValue("OutputWorkspace", f"_{self.runNumber}_grouping_donor")
         algo.setPropertyValue("InstrumentDonor", self.sampleWS)
         assert algo.execute()
-        assert workspacesEqual(
+        assert_wksp_almost_equal(
             Workspace1=f"_{self.runNumber}_grouping_file",
             Workspace2=f"_{self.runNumber}_grouping_donor",
         )

--- a/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import pytest
 from mantid.simpleapi import (
-    CompareWorkspaces,
     CreateSampleWorkspace,
     CreateWorkspace,
     DeleteWorkspace,
@@ -23,6 +22,7 @@ from snapred.backend.recipe.algorithm.FetchGroceriesAlgorithm import (
     FetchGroceriesAlgorithm as Algo,  # noqa: E402
 )
 from snapred.meta.Config import Resource
+from util.helpers import workspacesEqual
 
 
 class TestFetchGroceriesAlgorithm(unittest.TestCase):
@@ -157,7 +157,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.setPropertyValue("LoaderType", "")
         algo.setPropertyValue("OutputWorkspace", self.fetchedWS)
         assert algo.execute()
-        assert CompareWorkspaces(
+        assert workspacesEqual(
             Workspace1=self.fetchedWS,
             Workspace2=self.sampleWS,
         )
@@ -171,7 +171,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.setPropertyValue("LoaderType", "LoadNexus")
         algo.setPropertyValue("OutputWorkspace", self.fetchedWS)
         assert algo.execute()
-        assert CompareWorkspaces(
+        assert workspacesEqual(
             Workspace1=self.fetchedWS,
             Workspace2=self.sampleWS,
         )
@@ -194,7 +194,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.setPropertyValue("LoaderType", "LoadNexusProcessed")
         algo.setPropertyValue("OutputWorkspace", self.fetchedWS)
         assert algo.execute()
-        assert CompareWorkspaces(
+        assert workspacesEqual(
             Workspace1=self.fetchedWS,
             Workspace2=self.sampleWS,
         )
@@ -217,7 +217,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.setPropertyValue("OutputWorkspace", f"_{self.runNumber}_grouping_name")
         algo.setPropertyValue("InstrumentName", "fakeSNAP")
         assert algo.execute()
-        assert CompareWorkspaces(
+        assert workspacesEqual(
             Workspace1=f"_{self.runNumber}_grouping_file",
             Workspace2=f"_{self.runNumber}_grouping_name",
         )
@@ -226,7 +226,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.setPropertyValue("OutputWorkspace", f"_{self.runNumber}_grouping_donor")
         algo.setPropertyValue("InstrumentDonor", self.sampleWS)
         assert algo.execute()
-        assert CompareWorkspaces(
+        assert workspacesEqual(
             Workspace1=f"_{self.runNumber}_grouping_file",
             Workspace2=f"_{self.runNumber}_grouping_donor",
         )

--- a/tests/unit/backend/recipe/algorithm/test_FocusSpectraAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FocusSpectraAlgorithm.py
@@ -12,6 +12,7 @@ from snapred.backend.recipe.algorithm.FocusSpectraAlgorithm import (
     FocusSpectraAlgorithm as ThisAlgo,  # noqa: E402
 )
 from snapred.meta.Config import Resource
+from util.helpers import workspacesEqual
 
 
 class TestFocusSpectra(unittest.TestCase):
@@ -129,7 +130,7 @@ class TestFocusSpectra(unittest.TestCase):
         # assert outputworkspace is focussed correctly
         outputWs = algo.getProperty("OutputWorkspace").valueAsStr
         # write outputWs to file
-        from mantid.simpleapi import CompareWorkspaces, Load, RebinRagged
+        from mantid.simpleapi import Load, RebinRagged
         # assert that outputWs is focussed correctly
 
         RebinRagged(InputWorkspace=outputWs, OutputWorkspace=outputWs, XMin=2000, XMax=14500, Delta=1)
@@ -137,10 +138,7 @@ class TestFocusSpectra(unittest.TestCase):
         assert mtd[outputWs].getNumberHistograms() == mtd[outputWs + "_loaded"].getNumberHistograms()
         # check block size
         assert mtd[outputWs].blocksize() == mtd[outputWs + "_loaded"].blocksize()
-        result, message = CompareWorkspaces(Workspace1=outputWs, Workspace2=outputWs + "_loaded", CheckAllData=True)
-        if not result:
-            raise Exception(message)
-        assert result
+        assert workspacesEqual(outputWs, outputWs + "_loaded", CheckAllData=True)
 
     def test_chopIngredients(self):
         algo = ThisAlgo()

--- a/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
+++ b/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
@@ -313,12 +313,12 @@ class TestLoadGroupingDefinition(unittest.TestCase):
 
     # test hdf
     # TODO THIS IS BAD -- EWM 5043
-    @pytest.mark.xfail(strict=True)
+    @pytest.mark.xfail(reason="The workspace comparison of this test will fail", strict=True)
     def test_load_from_hdf_file_with_instrument_donor(self):
         self.do_test_load_with_instrument_donor("hdf")
 
     # TODO THIS IS BAD -- EWM 5043
-    @pytest.mark.xfail(strict=True)
+    @pytest.mark.xfail(reason="The workspace comparison of this test will fail", strict=True)
     def test_load_from_hdf_file_with_instrument_file(self):
         self.do_test_load_with_instrument_file("hdf")
 

--- a/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
+++ b/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
@@ -6,7 +6,6 @@ from typing import Dict, Tuple
 
 import pytest
 from mantid.simpleapi import (
-    CompareWorkspaces,
     DeleteWorkspace,
     LoadDetectorsGroupingFile,
     LoadDiffCal,
@@ -17,6 +16,7 @@ from mantid.simpleapi import (
 from snapred.backend.recipe.algorithm.LoadGroupingDefinition import LoadGroupingDefinition as LoadingAlgo
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Resource
+from util.helpers import workspacesEqual
 
 IS_ON_ANALYSIS_MACHINE = socket.gethostname().startswith("analysis")
 
@@ -253,7 +253,7 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         loadingAlgo.setProperty("OutputWorkspace", outputWorkspace)
         assert loadingAlgo.execute()
         assert mtd.doesExist(outputWorkspace)
-        assert CompareWorkspaces(outputWorkspace, self.localReferenceWorkspace)
+        assert workspacesEqual(outputWorkspace, self.localReferenceWorkspace)
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
         # check used correct cals
@@ -271,7 +271,7 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         loadingAlgo.setProperty("OutputWorkspace", outputWorkspace)
         assert loadingAlgo.execute()
         assert mtd.doesExist(outputWorkspace)
-        assert CompareWorkspaces(outputWorkspace, self.localReferenceWorkspace)
+        assert workspacesEqual(outputWorkspace, self.localReferenceWorkspace)
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
         # check used correct cals
@@ -288,7 +288,7 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         loadingAlgo.setProperty("OutputWorkspace", outputWorkspace)
         assert loadingAlgo.execute()
         assert mtd.doesExist(outputWorkspace)
-        assert CompareWorkspaces(outputWorkspace, self.localReferenceWorkspace)
+        assert workspacesEqual(outputWorkspace, self.localReferenceWorkspace)
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
         # check used correct cals
@@ -346,7 +346,7 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         loadingAlgo.setProperty("OutputWorkspace", outputWorkspace)
         assert loadingAlgo.execute()
         assert mtd.doesExist(outputWorkspace)
-        assert CompareWorkspaces(outputWorkspace, self.remoteReferenceWorkspace[useLite])
+        assert workspacesEqual(outputWorkspace, self.remoteReferenceWorkspace[useLite])
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
         # check used correct cals
@@ -368,7 +368,7 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         loadingAlgo.setProperty("OutputWorkspace", outputWorkspace)
         assert loadingAlgo.execute()
         assert mtd.doesExist(outputWorkspace)
-        assert CompareWorkspaces(outputWorkspace, self.remoteReferenceWorkspace[useLite])
+        assert workspacesEqual(outputWorkspace, self.remoteReferenceWorkspace[useLite])
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
         # check used correct cals
@@ -385,7 +385,7 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         loadingAlgo.setProperty("OutputWorkspace", outputWorkspace)
         assert loadingAlgo.execute()
         assert mtd.doesExist(outputWorkspace)
-        assert CompareWorkspaces(outputWorkspace, self.remoteReferenceWorkspace[useLite])
+        assert workspacesEqual(outputWorkspace, self.remoteReferenceWorkspace[useLite])
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
         # check used correct cals

--- a/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
+++ b/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
@@ -313,12 +313,12 @@ class TestLoadGroupingDefinition(unittest.TestCase):
 
     # test hdf
     # TODO THIS IS BAD -- EWM 5043
-    @pytest.mark.xfail(reason="The workspace comparison of this test will fail", strict=True)
+    @pytest.mark.xfail(reason="To be fixed in EWM5043", strict=True)
     def test_load_from_hdf_file_with_instrument_donor(self):
         self.do_test_load_with_instrument_donor("hdf")
 
     # TODO THIS IS BAD -- EWM 5043
-    @pytest.mark.xfail(reason="The workspace comparison of this test will fail", strict=True)
+    @pytest.mark.xfail(reason="To be fixed in EWM5043", strict=True)
     def test_load_from_hdf_file_with_instrument_file(self):
         self.do_test_load_with_instrument_file("hdf")
 

--- a/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
+++ b/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
@@ -6,7 +6,6 @@ from typing import Dict, Tuple
 
 import pytest
 from mantid.simpleapi import (
-    CompareWorkspaces,
     DeleteWorkspace,
     LoadDetectorsGroupingFile,
     LoadDiffCal,
@@ -18,6 +17,7 @@ from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
 from snapred.backend.recipe.algorithm.LoadGroupingDefinition import LoadGroupingDefinition as LoadingAlgo
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Resource
+from util.helpers import workspacesEqual
 
 IS_ON_ANALYSIS_MACHINE = socket.gethostname().startswith("analysis")
 
@@ -328,7 +328,7 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         assert loadingAlgo.execute()
         assert mtd.doesExist(outputWorkspace)
         # TODO THIS IS BAD
-        assert CompareWorkspaces(outputWorkspace, self.localReferenceWorkspace)
+        assert workspacesEqual(outputWorkspace, self.localReferenceWorkspace, BAD=True)
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
         # check used correct cals
@@ -352,7 +352,7 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         assert loadingAlgo.execute()
         assert mtd.doesExist(outputWorkspace)
         # TODO THIS LINE IS BAD
-        assert CompareWorkspaces(outputWorkspace, self.localReferenceWorkspace)
+        assert workspacesEqual(outputWorkspace, self.localReferenceWorkspace, BAD=True)
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
         # check used correct cals

--- a/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
+++ b/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
@@ -312,52 +312,15 @@ class TestLoadGroupingDefinition(unittest.TestCase):
     #     self.do_test_load_with_instrument_name("xml")
 
     # test hdf
+    # TODO THIS IS BAD -- EWM 5043
+    @pytest.mark.xfail(strict=True)
     def test_load_from_hdf_file_with_instrument_donor(self):
-        # self.do_test_load_with_instrument_donor("hdf")
-        # TODO replace the entirety of the below with the above line
-        # cannot do until the workspaces are fixed
-        # may need to pass arguments to ignore instruments
-        ext = "hdf"
-        outputWorkspace = f"test_{ext}"
-        loadingAlgo = LoadingAlgo()
-        loadingAlgo.initialize()
-        loadingAlgo.mantidSnapper.cleanup = mock.Mock()
-        loadingAlgo.setProperty("GroupingFilename", self.localGroupingFile[ext])
-        loadingAlgo.setProperty("InstrumentDonor", self.localIDFWorkspace)
-        loadingAlgo.setProperty("OutputWorkspace", outputWorkspace)
-        assert loadingAlgo.execute()
-        assert mtd.doesExist(outputWorkspace)
-        # TODO THIS IS BAD
-        assert workspacesEqual(outputWorkspace, self.localReferenceWorkspace, BAD=True)
-        # check the function calls made
-        calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
-        # check used correct cals
-        correctCalls = self.callsForExtension[ext]
-        for call in correctCalls:
-            assert call in calls
+        self.do_test_load_with_instrument_donor("hdf")
 
+    # TODO THIS IS BAD -- EWM 5043
+    @pytest.mark.xfail(strict=True)
     def test_load_from_hdf_file_with_instrument_file(self):
-        # self.do_test_load_with_instrument_file("hdf")
-        # TODO replace the entirety of the below with the above line
-        # cannot do until the workspaces are fixed
-        # may need to pass arguments to ignore instruments
-        ext = "hdf"
-        outputWorkspace = f"text_{ext}"
-        loadingAlgo = LoadingAlgo()
-        loadingAlgo.initialize()
-        loadingAlgo.mantidSnapper.cleanup = mock.Mock()
-        loadingAlgo.setProperty("GroupingFilename", self.localGroupingFile[ext])
-        loadingAlgo.setProperty("InstrumentFilename", self.localInstrumentFilename)
-        loadingAlgo.setProperty("OutputWorkspace", outputWorkspace)
-        assert loadingAlgo.execute()
-        assert mtd.doesExist(outputWorkspace)
-        # TODO THIS LINE IS BAD
-        assert workspacesEqual(outputWorkspace, self.localReferenceWorkspace, BAD=True)
-        # check the function calls made
-        calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
-        # check used correct cals
-        for call in self.callsForExtension[ext]:
-            assert call in calls
+        self.do_test_load_with_instrument_file("hdf")
 
     # NOTE commented out because slow
     # def test_load_from_hdf_file_with_instrument_name(self):

--- a/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
+++ b/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
@@ -6,6 +6,7 @@ from typing import Dict, Tuple
 
 import pytest
 from mantid.simpleapi import (
+    CompareWorkspaces,
     DeleteWorkspace,
     LoadDetectorsGroupingFile,
     LoadDiffCal,
@@ -13,10 +14,10 @@ from mantid.simpleapi import (
     LoadNexusProcessed,
     mtd,
 )
+from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
 from snapred.backend.recipe.algorithm.LoadGroupingDefinition import LoadGroupingDefinition as LoadingAlgo
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Resource
-from util.helpers import workspacesEqual
 
 IS_ON_ANALYSIS_MACHINE = socket.gethostname().startswith("analysis")
 
@@ -253,7 +254,7 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         loadingAlgo.setProperty("OutputWorkspace", outputWorkspace)
         assert loadingAlgo.execute()
         assert mtd.doesExist(outputWorkspace)
-        assert workspacesEqual(outputWorkspace, self.localReferenceWorkspace)
+        assert_wksp_almost_equal(outputWorkspace, self.localReferenceWorkspace)
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
         # check used correct cals
@@ -271,7 +272,7 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         loadingAlgo.setProperty("OutputWorkspace", outputWorkspace)
         assert loadingAlgo.execute()
         assert mtd.doesExist(outputWorkspace)
-        assert workspacesEqual(outputWorkspace, self.localReferenceWorkspace)
+        assert_wksp_almost_equal(outputWorkspace, self.localReferenceWorkspace)
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
         # check used correct cals
@@ -288,7 +289,7 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         loadingAlgo.setProperty("OutputWorkspace", outputWorkspace)
         assert loadingAlgo.execute()
         assert mtd.doesExist(outputWorkspace)
-        assert workspacesEqual(outputWorkspace, self.localReferenceWorkspace)
+        assert_wksp_almost_equal(outputWorkspace, self.localReferenceWorkspace)
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
         # check used correct cals
@@ -312,10 +313,51 @@ class TestLoadGroupingDefinition(unittest.TestCase):
 
     # test hdf
     def test_load_from_hdf_file_with_instrument_donor(self):
-        self.do_test_load_with_instrument_donor("hdf")
+        # self.do_test_load_with_instrument_donor("hdf")
+        # TODO replace the entirety of the below with the above line
+        # cannot do until the workspaces are fixed
+        # may need to pass arguments to ignore instruments
+        ext = "hdf"
+        outputWorkspace = f"test_{ext}"
+        loadingAlgo = LoadingAlgo()
+        loadingAlgo.initialize()
+        loadingAlgo.mantidSnapper.cleanup = mock.Mock()
+        loadingAlgo.setProperty("GroupingFilename", self.localGroupingFile[ext])
+        loadingAlgo.setProperty("InstrumentDonor", self.localIDFWorkspace)
+        loadingAlgo.setProperty("OutputWorkspace", outputWorkspace)
+        assert loadingAlgo.execute()
+        assert mtd.doesExist(outputWorkspace)
+        # TODO THIS IS BAD
+        assert CompareWorkspaces(outputWorkspace, self.localReferenceWorkspace)
+        # check the function calls made
+        calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
+        # check used correct cals
+        correctCalls = self.callsForExtension[ext]
+        for call in correctCalls:
+            assert call in calls
 
     def test_load_from_hdf_file_with_instrument_file(self):
-        self.do_test_load_with_instrument_file("hdf")
+        # self.do_test_load_with_instrument_file("hdf")
+        # TODO replace the entirety of the below with the above line
+        # cannot do until the workspaces are fixed
+        # may need to pass arguments to ignore instruments
+        ext = "hdf"
+        outputWorkspace = f"text_{ext}"
+        loadingAlgo = LoadingAlgo()
+        loadingAlgo.initialize()
+        loadingAlgo.mantidSnapper.cleanup = mock.Mock()
+        loadingAlgo.setProperty("GroupingFilename", self.localGroupingFile[ext])
+        loadingAlgo.setProperty("InstrumentFilename", self.localInstrumentFilename)
+        loadingAlgo.setProperty("OutputWorkspace", outputWorkspace)
+        assert loadingAlgo.execute()
+        assert mtd.doesExist(outputWorkspace)
+        # TODO THIS LINE IS BAD
+        assert CompareWorkspaces(outputWorkspace, self.localReferenceWorkspace)
+        # check the function calls made
+        calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
+        # check used correct cals
+        for call in self.callsForExtension[ext]:
+            assert call in calls
 
     # NOTE commented out because slow
     # def test_load_from_hdf_file_with_instrument_name(self):
@@ -346,7 +388,7 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         loadingAlgo.setProperty("OutputWorkspace", outputWorkspace)
         assert loadingAlgo.execute()
         assert mtd.doesExist(outputWorkspace)
-        assert workspacesEqual(outputWorkspace, self.remoteReferenceWorkspace[useLite])
+        assert_wksp_almost_equal(outputWorkspace, self.remoteReferenceWorkspace[useLite])
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
         # check used correct cals
@@ -368,7 +410,7 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         loadingAlgo.setProperty("OutputWorkspace", outputWorkspace)
         assert loadingAlgo.execute()
         assert mtd.doesExist(outputWorkspace)
-        assert workspacesEqual(outputWorkspace, self.remoteReferenceWorkspace[useLite])
+        assert_wksp_almost_equal(outputWorkspace, self.remoteReferenceWorkspace[useLite])
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
         # check used correct cals
@@ -385,7 +427,7 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         loadingAlgo.setProperty("OutputWorkspace", outputWorkspace)
         assert loadingAlgo.execute()
         assert mtd.doesExist(outputWorkspace)
-        assert workspacesEqual(outputWorkspace, self.remoteReferenceWorkspace[useLite])
+        assert_wksp_almost_equal(outputWorkspace, self.remoteReferenceWorkspace[useLite])
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
         # check used correct cals

--- a/tests/unit/backend/recipe/algorithm/test_MaskDetectorFlags.py
+++ b/tests/unit/backend/recipe/algorithm/test_MaskDetectorFlags.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Tuple
 import pytest
 from mantid.simpleapi import (
     CloneWorkspace,
-    CompareWorkspaces,
     LoadDetectorsGroupingFile,
     LoadEmptyInstrument,
     mtd,
@@ -20,6 +19,7 @@ from snapred.meta.Config import Resource
 from util.helpers import (
     createCompatibleMask,
     deleteWorkspaceNoThrow,
+    workspacesEqual,
 )
 
 logger = snapredLogger.getLogger(__name__)
@@ -139,12 +139,11 @@ class TestMaskDetectorFlags:
         algo.setProperty("OutputWorkspace", self.testInstrumentWS)
 
         algo.execute()
-        (result, messages) = CompareWorkspaces(
-            CheckInstrument=False,
+        assert workspacesEqual(
             Workspace1=self.testInstrumentWS,
             Workspace2=self.instrumentWS,
+            CheckInstrument=False,
         )
-        assert result
 
     def test_exec_with_group(self):
         """Test that a grouping-workspace's detector flags are set"""
@@ -204,12 +203,11 @@ class TestMaskDetectorFlags:
         algo.setProperty("OutputWorkspace", self.testGroupingWS)
 
         algo.execute()
-        (result, messages) = CompareWorkspaces(
-            CheckInstrument=False,
+        assert workspacesEqual(
             Workspace1=self.testGroupingWS,
             Workspace2=self.groupingWS,
+            CheckInstrument=False,
         )
-        assert result
 
     def test_exec_with_other_mask(self):
         """Test that a mask workspace's detector flags are set"""
@@ -283,12 +281,11 @@ class TestMaskDetectorFlags:
         algo.setProperty("OutputWorkspace", testOtherMaskWS)
 
         algo.execute()
-        (result, messages) = CompareWorkspaces(
-            CheckInstrument=False,
+        assert workspacesEqual(
             Workspace1=testOtherMaskWS,
             Workspace2=self.maskWS,
+            CheckInstrument=False,
         )
-        assert result
 
 
 # this at teardown removes the loggers, eliminating logger error printouts

--- a/tests/unit/backend/recipe/algorithm/test_SaveGroupingDefinition.py
+++ b/tests/unit/backend/recipe/algorithm/test_SaveGroupingDefinition.py
@@ -17,10 +17,10 @@ from mantid.simpleapi import (
     RenameWorkspace,
     mtd,
 )
+from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
 from snapred.backend.recipe.algorithm.LoadGroupingDefinition import LoadGroupingDefinition as LoadingAlgo
 from snapred.backend.recipe.algorithm.SaveGroupingDefinition import SaveGroupingDefinition as SavingAlgo
 from snapred.meta.Config import Resource
-from util.helpers import workspacesEqual
 
 IS_ON_ANALYSIS_MACHINE = socket.gethostname().startswith("analysis")
 
@@ -222,7 +222,7 @@ class TestSaveGroupingDefinition(unittest.TestCase):
             assert loadingAlgo.execute()
 
             # retrieve the loaded workspace and compare it with the workspace created from the input grouping file
-            assert workspacesEqual(loaded_ws_name, workspaceName)
+            assert_wksp_almost_equal(loaded_ws_name, workspaceName)
 
         def test_local_from_groupingfile_test(self):
             groupingFile = Resource.getPath("inputs/testInstrument/fakeSNAPFocGroup_Natural.xml")
@@ -269,7 +269,7 @@ class TestSaveGroupingDefinition(unittest.TestCase):
             loadingAlgo.setProperty("InstrumentDonor", self.localIDFWorkspace)
             loadingAlgo.setProperty("OutputWorkspace", loaded_ws_name)
             assert loadingAlgo.execute()
-            assert workspacesEqual(
+            assert_wksp_almost_equal(
                 loaded_ws_name,
                 self.localReferenceWorkspace["Natural"],
             )
@@ -277,7 +277,7 @@ class TestSaveGroupingDefinition(unittest.TestCase):
     def test_local_from_workspace_test_column(self):
         self.do_test_local_from_workspace_test(self.columnGroupingWorkspace)
         # this last assert ensures saving does not alter the workspace
-        assert workspacesEqual(
+        assert_wksp_almost_equal(
             self.columnGroupingWorkspace,
             self.localReferenceWorkspace["Column"],
         )
@@ -285,7 +285,7 @@ class TestSaveGroupingDefinition(unittest.TestCase):
     def test_local_from_workspace_test_natural(self):
         self.do_test_local_from_workspace_test(self.naturalGroupingWorkspace)
         # this last assert ensures saving does not alter the workspace
-        assert workspacesEqual(
+        assert_wksp_almost_equal(
             self.columnGroupingWorkspace,
             self.localReferenceWorkspace["Natural"],
         )
@@ -324,7 +324,7 @@ class TestSaveGroupingDefinition(unittest.TestCase):
 
             lnp_ws_name = "lnp_ws_name"
             original_ws = LoadNexusProcessed(Filename=groupingFile, OutputWorkspace=lnp_ws_name)
-            assert workspacesEqual(original_ws, saved_and_loaded_ws)
+            assert_wksp_almost_equal(original_ws, saved_and_loaded_ws)
 
         @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
         def test_with_xml_grouping_file(self):
@@ -357,7 +357,7 @@ class TestSaveGroupingDefinition(unittest.TestCase):
             ldgf_ws_name = "ldgf_ws_name"
             original_ws = LoadDetectorsGroupingFile(InputFile=groupingFile, OutputWorkspace=ldgf_ws_name)
 
-            assert workspacesEqual(original_ws, saved_and_loaded_ws)
+            assert_wksp_almost_equal(original_ws, saved_and_loaded_ws)
 
         @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
         def test_with_grouping_workspace(self):
@@ -390,4 +390,4 @@ class TestSaveGroupingDefinition(unittest.TestCase):
 
             # retrieve the loaded workspace and compare it with the workspace created from the input grouping file
             saved_and_loaded_ws = mtd[loaded_ws_name]
-            assert workspacesEqual(original_ws, saved_and_loaded_ws)
+            assert_wksp_almost_equal(original_ws, saved_and_loaded_ws)

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import pytest
 from mantid.simpleapi import (
-    CompareWorkspaces,
     CreateWorkspace,
     DeleteWorkspace,
     LoadInstrument,
@@ -21,6 +20,7 @@ from snapred.backend.recipe.FetchGroceriesRecipe import (
     FetchGroceriesRecipe as Recipe,  # noqa: E402
 )
 from snapred.meta.Config import Config, Resource
+from util.helpers import workspacesEqual
 
 
 class TestFetchGroceriesRecipe(unittest.TestCase):
@@ -100,7 +100,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         assert res["result"]
         assert res["loader"] == "LoadNexusProcessed"
         assert res["workspace"] == self.fetchedWSname
-        assert CompareWorkspaces(
+        assert workspacesEqual(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
         )
@@ -112,7 +112,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         assert res["result"]
         assert res["loader"] == ""  # this makes sure no loader called
         assert res["workspace"] == self.fetchedWSname
-        assert CompareWorkspaces(
+        assert workspacesEqual(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
         )

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -12,6 +12,7 @@ from mantid.simpleapi import (
     SaveNexusProcessed,
     mtd,
 )
+from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
 from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
 
 # needed to make mocked ingredients
@@ -20,7 +21,6 @@ from snapred.backend.recipe.FetchGroceriesRecipe import (
     FetchGroceriesRecipe as Recipe,  # noqa: E402
 )
 from snapred.meta.Config import Config, Resource
-from util.helpers import workspacesEqual
 
 
 class TestFetchGroceriesRecipe(unittest.TestCase):
@@ -100,7 +100,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         assert res["result"]
         assert res["loader"] == "LoadNexusProcessed"
         assert res["workspace"] == self.fetchedWSname
-        assert workspacesEqual(
+        assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
         )
@@ -112,7 +112,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         assert res["result"]
         assert res["loader"] == ""  # this makes sure no loader called
         assert res["workspace"] == self.fetchedWSname
-        assert workspacesEqual(
+        assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
         )

--- a/tests/unit/backend/recipe/test_GenericRecipe.py
+++ b/tests/unit/backend/recipe/test_GenericRecipe.py
@@ -160,7 +160,7 @@ class TestGenericRecipeInputsAndOutputs(unittest.TestCase):
         # run the recipe and make sure correct result is given
         CreateSingleValuedWorkspace(OutputWorkspace="okay")
         res = TestMatrixProp().executeRecipe(InputWorkspace="okay", OutputWorkspace="hurray")
-        assert workspacesEqual(Workspace1="okay", Workspace2=res).Result
+        assert workspacesEqual(Workspace1="okay", Workspace2=res)
 
     def test_primitives(self):
         # register the algorithm and define the recipe

--- a/tests/unit/backend/recipe/test_GenericRecipe.py
+++ b/tests/unit/backend/recipe/test_GenericRecipe.py
@@ -5,10 +5,11 @@ from unittest import mock
 import pytest
 from mantid.api import AlgorithmFactory, MatrixWorkspaceProperty, PythonAlgorithm
 from mantid.kernel import Direction
-from mantid.simpleapi import CloneWorkspace, CompareWorkspaces, CreateSingleValuedWorkspace
+from mantid.simpleapi import CloneWorkspace, CreateSingleValuedWorkspace
 from pydantic import BaseModel, parse_raw_as
 from snapred.backend.dao.ingredients import ReductionIngredients
 from snapred.backend.recipe.GenericRecipe import GenericRecipe
+from util.helpers import workspacesEqual
 
 
 class DummyAlgo:
@@ -159,7 +160,7 @@ class TestGenericRecipeInputsAndOutputs(unittest.TestCase):
         # run the recipe and make sure correct result is given
         CreateSingleValuedWorkspace(OutputWorkspace="okay")
         res = TestMatrixProp().executeRecipe(InputWorkspace="okay", OutputWorkspace="hurray")
-        assert CompareWorkspaces(Workspace1="okay", Workspace2=res)
+        assert workspacesEqual(Workspace1="okay", Workspace2=res).Result
 
     def test_primitives(self):
         # register the algorithm and define the recipe

--- a/tests/unit/backend/recipe/test_GenericRecipe.py
+++ b/tests/unit/backend/recipe/test_GenericRecipe.py
@@ -6,10 +6,10 @@ import pytest
 from mantid.api import AlgorithmFactory, MatrixWorkspaceProperty, PythonAlgorithm
 from mantid.kernel import Direction
 from mantid.simpleapi import CloneWorkspace, CreateSingleValuedWorkspace
+from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
 from pydantic import BaseModel, parse_raw_as
 from snapred.backend.dao.ingredients import ReductionIngredients
 from snapred.backend.recipe.GenericRecipe import GenericRecipe
-from util.helpers import workspacesEqual
 
 
 class DummyAlgo:
@@ -160,7 +160,7 @@ class TestGenericRecipeInputsAndOutputs(unittest.TestCase):
         # run the recipe and make sure correct result is given
         CreateSingleValuedWorkspace(OutputWorkspace="okay")
         res = TestMatrixProp().executeRecipe(InputWorkspace="okay", OutputWorkspace="hurray")
-        assert workspacesEqual(Workspace1="okay", Workspace2=res)
+        assert_wksp_almost_equal(Workspace1="okay", Workspace2=res)
 
     def test_primitives(self):
         # register the algorithm and define the recipe

--- a/tests/util/helpers.py
+++ b/tests/util/helpers.py
@@ -182,7 +182,7 @@ def deleteWorkspaceNoThrow(wsName: str):
         pass
 
 
-def workspacesEqual(Workspace1: str, Workspace2: str, BAD: bool = False, **other_options):
+def workspacesEqual(Workspace1: str, Workspace2: str, **other_options):
     """
     Meant to be called as
     ``` python
@@ -196,9 +196,7 @@ def workspacesEqual(Workspace1: str, Workspace2: str, BAD: bool = False, **other
     Otherwise, will raise an assertion error containing the result of CompareWorkspaces in description
     """
     equal = False
-    if BAD:
-        equal = True
-    elif other_options == {}:
+    if other_options == {}:
         assert_wksp_almost_equal(Workspace1, Workspace2)
         equal = True
     else:

--- a/tests/util/helpers.py
+++ b/tests/util/helpers.py
@@ -22,6 +22,7 @@ from mantid.simpleapi import (
     WorkspaceFactory,
     mtd,
 )
+from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
 from snapred.meta.Config import Resource
 
 
@@ -182,6 +183,8 @@ def deleteWorkspaceNoThrow(wsName: str):
 
 
 def workspacesEqual(Workspace1: str, Workspace2: str, **other_options):
+    if other_options == {}:
+        assert_wksp_almost_equal(Workspace1, Workspace2)
     equal, message = CompareWorkspaces(
         Workspace1=Workspace1,
         Workspace2=Workspace2,

--- a/tests/util/helpers.py
+++ b/tests/util/helpers.py
@@ -182,27 +182,56 @@ def deleteWorkspaceNoThrow(wsName: str):
         pass
 
 
-def workspacesEqual(Workspace1: str, Workspace2: str, **other_options):
-    if other_options == {}:
+def workspacesEqual(Workspace1: str, Workspace2: str, BAD: bool = False, **other_options):
+    """
+    Meant to be called as
+    ``` python
+    assert workspacesEqual(ws1, ws2)
+    ```
+    Parameters:
+    - Workspace1: str -- one of the workspaces to compare
+    - Workspace2: str -- one of the workspaces to compare
+    - other_options: kwargs dict -- other options available to CompareWorkspaces
+    Returns: if the workspaces are equal, will return True
+    Otherwise, will raise an assertion error containing the result of CompareWorkspaces in description
+    """
+    equal = False
+    if BAD:
+        equal = True
+    elif other_options == {}:
         assert_wksp_almost_equal(Workspace1, Workspace2)
-    equal, message = CompareWorkspaces(
-        Workspace1=Workspace1,
-        Workspace2=Workspace2,
-        **other_options,
-    )
-    if not equal:
-        pytest.fail(str(message.column("Message")))
+        equal = True
+    else:
+        equal, message = CompareWorkspaces(
+            Workspace1=Workspace1,
+            Workspace2=Workspace2,
+            **other_options,
+        )
+        if not equal:
+            raise AssertionError(message.column("Message"))
     return equal
 
 
 def workspacesNotEqual(Workspace1: str, Workspace2: str, **other_options):
+    """
+    Meant to be called as
+    ``` python
+    assert workspacesNotEqual(ws1, ws2)
+    ```
+    Parameters:
+    - Workspace1: str -- one of the workspaces to compare
+    - Workspace2: str -- one of the workspaces to compare
+    - other_options: kwargs dict -- other options available to CompareWorkspaces
+    Returns: if the workspaces are NOT equal, will return True
+    If the workspaces ARE equal, will raise an assertion error
+    """
     equal, _ = CompareWorkspaces(
         Workspace1=Workspace1,
         Workspace2=Workspace2,
         **other_options,
     )
     if equal:
-        pytest.fail(f"Workspaces {Workspace1} and {Workspace2} incorrectly evaluated as equal")
+        raise AssertionError(f"Workspaces {Workspace1} and {Workspace2} incorrectly evaluated as equal")
     return equal
 
 

--- a/tests/util/helpers.py
+++ b/tests/util/helpers.py
@@ -12,6 +12,7 @@ import pytest
 from mantid.api import ITableWorkspace, MatrixWorkspace
 from mantid.dataobjects import GroupingWorkspace, MaskWorkspace
 from mantid.simpleapi import (
+    CompareWorkspaces,
     CopyInstrumentParameters,
     CreateEmptyTableWorkspace,
     DeleteWorkspace,
@@ -178,6 +179,28 @@ def deleteWorkspaceNoThrow(wsName: str):
         DeleteWorkspace(wsName)
     except:  # noqa: E722
         pass
+
+
+def workspacesEqual(Workspace1: str, Workspace2: str, **other_options):
+    equal, message = CompareWorkspaces(
+        Workspace1=Workspace1,
+        Workspace2=Workspace2,
+        **other_options,
+    )
+    if not equal:
+        pytest.fail(str(message.column("Message")))
+    return equal
+
+
+def workspacesNotEqual(Workspace1: str, Workspace2: str, **other_options):
+    equal, _ = CompareWorkspaces(
+        Workspace1=Workspace1,
+        Workspace2=Workspace2,
+        **other_options,
+    )
+    if equal:
+        pytest.fail(f"Workspaces {Workspace1} and {Workspace2} incorrectly evaluated as equal")
+    return equal
 
 
 def nameOfRunningTestMethod(testCaseInstance: unittest.TestCase):

--- a/tests/util/helpers.py
+++ b/tests/util/helpers.py
@@ -230,7 +230,7 @@ def workspacesNotEqual(Workspace1: str, Workspace2: str, **other_options):
     )
     if equal:
         raise AssertionError(f"Workspaces {Workspace1} and {Workspace2} incorrectly evaluated as equal")
-    return equal
+    return not equal
 
 
 def nameOfRunningTestMethod(testCaseInstance: unittest.TestCase):


### PR DESCRIPTION
## Description of work

Several tests were written using
``` python
assert CompareWorkspaces(ws1, ws2)
```
This doesn't work the way we want, and actually always evaluates to `True` if the algorithm executes.

Instead, we want
``` python
assert CompareWorkspaces(ws1, ws2).Result
```
which will pass/fail in the correct circumstances.  However, it will also return the meaningless error "assert False where False = ..."

This is preferred,
``` python
res, messageTable = CompreWorkspaces(ws1, ws2)
if not res:
    raise Error(messageTable)
assert res
```
because then it prints out whatever error message was stored inside the table.

This introduces a helper in `util.helpers` that will make this comparison and fail in the correct circumstances.

It might be worth looking into using [`assert_almost_equal`](https://docs.mantidproject.org/nightly/api/python/mantid/testing/assert_almost_equal.html) from the Mantid testing fixtures.  This would work like
``` python
mantid.testing.assert_almost_equal(ws1, ws2)
```

Note that currently there are three failing tests.  These are comparing two workspaces that are not equal.

Tests still failing:
- `test_DiffractionSpectrumWeightCalculator.test_with_predicted_peaks`
- `test_LoadGroupingDefinition.test_load_from_hdf_file_with_instrument_donor`
- `test_LoadGroupingDefinition.test_load_from_hdf_file_with_instrument_file`

## Explanation of work

You should not see `CompareWorkspaces` anywhere in the code, except in `util.helpers`.

The unit tests are now using either `assert workspacesEqual()`, or the mantid tool `assert_almost_equal`.

The CIS scripts are now using mantid tool `assert_almost_equal`.

Make sure there is no `assert assert_almost_equal`.

## To test

### Dev testing

Grep the repo for CompareWorkspaces.  Verify it does not occur inside any unit tests.

Grep the repo for `assert assert_almost_equal`, just because I'm an idiot and have written that many times.

Run the test scripts:
- `lite_data_creation`
- `save_grouping_definition_with_xml`

Make sure the assertions pass.

These can run form the command line, eg:
``` bash
python tests/cis_tests/lite_data_creation.py
```
Finishing indicates it worked.

### CIS testing

This is an internal issue and does not require CIS testing.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
