### PR TITLE
Fix issue in calibration index and default diffcal name

### DIFF
--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -735,7 +735,7 @@ class GroceryService:
         return data
 
     def fetchDefaultDiffCalTable(self, runNumber: str, useLiteMode: bool, version: str) -> Tuple[WorkspaceName, str]:
-        tableWorkspaceName = self._createDiffcalTableWorkspaceName("default", version)
+        tableWorkspaceName = self._createDiffcalTableWorkspaceName("default", int(version))
         self.mantidSnapper.CalculateDiffCalTable(
             "Generate the default diffcal table",
             InputWorkspace=self._fetchInstrumentDonor(runNumber, useLiteMode),

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -810,9 +810,10 @@ class LocalDataService:
         return detectorState
 
     # TODO remove the default value of useLiteMode and have that specifiable
-    def _writeDefaultDiffCalTable(self, runNumber: str, version: str, useLiteMode: bool = True):
+    def _writeDefaultDiffCalTable(self, runNumber: str, useLiteMode: bool = True):
         from snapred.backend.data.GroceryService import GroceryService
 
+        version = 1
         grocer = GroceryService()
         filename = Path(grocer._createDiffcalTableWorkspaceName("default", version) + ".h5")
         outWS = grocer.fetchDefaultDiffCalTable(runNumber, version, useLiteMode)
@@ -820,6 +821,13 @@ class LocalDataService:
         calibrationDataPath = self._constructCalibrationDataPath(runNumber, str(version))
 
         self.writeDiffCalWorkspaces(calibrationDataPath, filename, outWS)
+        calibrationIndexEntry = CalibrationIndexEntry(
+            runNumber=runNumber,
+            version=version,
+            comments="Inferred from the instrument geometry",
+            author="Generated automatically by SNAPRed",
+        )
+        self.writeCalibrationIndexEntry(calibrationIndexEntry)
 
     @ExceptionHandler(StateValidationException)
     def initializeState(self, runId: str, name: str = None):
@@ -877,7 +885,7 @@ class LocalDataService:
             self._prepareStateRoot(stateId)
 
         self.writeCalibrationState(runId, calibration)
-        self._writeDefaultDiffCalTable(runId, 1)
+        self._writeDefaultDiffCalTable(runId)
 
         return calibration
 

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -1485,7 +1485,7 @@ class TestGroceryService(unittest.TestCase):
         """
         runNumber = "123"
         useLiteMode = True
-        testVersion = "test"
+        testVersion = 17
 
         ## Create the reference table
         refTable = mtd.unique_name(prefix="_table_")

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -1287,7 +1287,7 @@ def test_writeCalibrationState_overwrite_warning(caplog):
 @mock.patch("snapred.backend.data.GroceryService.GroceryService._fetchInstrumentDonor")
 def test_writeDefaultDiffCalTable(fetchInstrumentDonor, createDiffCalTableWorkspaceName):
     runNumber = "default"
-    version = 3
+    version = 1
     # mock the grocery service to return the fake instrument to use for geometry
     idfWS = mtd.unique_name(prefix="_idf_")
     LoadEmptyInstrument(
@@ -1306,7 +1306,7 @@ def test_writeDefaultDiffCalTable(fetchInstrumentDonor, createDiffCalTableWorksp
         localDataService._constructCalibrationStatePath = mock.Mock(return_value=f"{tempdir}/")
         # run the method and ensure the file has been created in correct location
         # localDataService.writeCalibrationState(runNumber, calibration)
-        localDataService._writeDefaultDiffCalTable(runNumber, version)
+        localDataService._writeDefaultDiffCalTable(runNumber)
         assert os.path.exists(tempdir + f"/v_{wnvf.formatVersion(version, use_v_prefix=False)}/" + filename + ".h5")
         # TODO we could in theory load the file and verify its contents here
 
@@ -1414,7 +1414,7 @@ def test_initializeState():
     actual.creationDate = testCalibrationData.creationDate
 
     assert actual == testCalibrationData
-    assert localDataService._writeDefaultDiffCalTable.called_once_with("123", 1)
+    assert localDataService._writeDefaultDiffCalTable.called_once_with("123")
 
 
 @mock.patch.object(LocalDataService, "_prepareStateRoot")


### PR DESCRIPTION
## Description of work

I noticed two issues when testing something else
- the default diffcal workspace from PR #324 was not in the calibration index, so did not show up on the assess screen
- the default diffcal workspace name did not have the version in it, but had `vtrue` in it

## Explanation of work

Added lines to include the default diffcal workspace in the calibration index after it is written.

Added a cast to the grocery service method to make sure the version is being interpreted as an int.

## To test

### Dev testing

Open your dev calibration directory, delete the diffraction and normalization directories.

Launch SNAPRed to DiffCal workflow.  Input run 46680.  Select diamond and bank.

You will be prompted to initialize state.  Do so.

When state is initialized, there will be a single table workspace, which should have `v_0001` in its name.

When it is finished, you will have a directory `diffraction/v_0001` with the following files in it:
- `CalibrationParameters.json`
- `diffract_consts_default_v0001.h5`

In the `diffraction` directory, open `CalibrationIndex.json`, make sure the entry for the default diffcal file is in there.

Continue.

On tweak peak peek, set fwhm to 10, recalculate, continue.

On assessment stage, ensure the default diffcal file is showing in the drop-down list.

Save.  Make sure `v_0002` exists with all of the needed files.

Continue, run another diffcal workflow.

On assessment screen, make sure both v0001 and v0002 are showing in the dropdown.

### CIS testing

This is an internal issue and does not require CIS testing

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
