### PR TITLE
Add lite/native mode folders

### DIFF
--- a/src/snapred/backend/api/InterfaceController.py
+++ b/src/snapred/backend/api/InterfaceController.py
@@ -49,8 +49,10 @@ class InterfaceController:
             self.logger.error(f"Recoverable error occurred: {str(e)}")
             payloadDict = json.loads(request.payload)
             runNumber = payloadDict["runNumber"]
+            useLiteMode = payloadDict["useLiteMode"]
             if runNumber:
                 InitializeStateHandler.runId = runNumber
+                InitializeStateHandler.useLiteMode = useLiteMode
             response = SNAPResponse(code=ResponseCode.RECOVERABLE, message="state")
 
         except Exception as e:  # noqa BLE001

--- a/src/snapred/backend/dao/calibration/CalibrationRecord.py
+++ b/src/snapred/backend/dao/calibration/CalibrationRecord.py
@@ -25,7 +25,7 @@ class CalibrationRecord(BaseModel):
 
     runNumber: str
     crystalInfo: CrystallographicInfo
-    isLite: bool
+    useLiteMode: bool
     calibrationFittingIngredients: Calibration
     pixelGroups: Optional[List[PixelGroup]]  # TODO: really shouldn't be optional, will be when sns data fixed
     focusGroupCalibrationMetrics: FocusGroupMetric

--- a/src/snapred/backend/dao/normalization/NormalizationRecord.py
+++ b/src/snapred/backend/dao/normalization/NormalizationRecord.py
@@ -16,7 +16,7 @@ class NormalizationRecord(BaseModel):
     """
 
     runNumber: str
-    isLite: bool
+    useLiteMode: bool
     backgroundRunNumber: str
     smoothingParameter: float
     calibration: Calibration

--- a/src/snapred/backend/dao/request/FocusSpectraRequest.py
+++ b/src/snapred/backend/dao/request/FocusSpectraRequest.py
@@ -7,7 +7,7 @@ from snapred.backend.dao.state.FocusGroup import FocusGroup
 
 class FocusSpectraRequest(BaseModel):
     runNumber: str
-    useLiteMode: bool = True
+    useLiteMode: bool
     focusGroup: FocusGroup
 
     inputWorkspace: str

--- a/src/snapred/backend/dao/request/HasStateRequest.py
+++ b/src/snapred/backend/dao/request/HasStateRequest.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 
 
-class InitializeStateHandler(BaseModel):
+class HasStateRequest(BaseModel):
     runId: str
     useLiteMode: bool

--- a/src/snapred/backend/dao/request/InitializeStateRequest.py
+++ b/src/snapred/backend/dao/request/InitializeStateRequest.py
@@ -4,3 +4,4 @@ from pydantic import BaseModel
 class InitializeStateRequest(BaseModel):
     runId: str
     humanReadableName: str
+    useLiteMode: bool

--- a/src/snapred/backend/dao/request/NormalizationCalibrationRequest.py
+++ b/src/snapred/backend/dao/request/NormalizationCalibrationRequest.py
@@ -17,7 +17,7 @@ class NormalizationCalibrationRequest(BaseModel):
 
     runNumber: str
     backgroundRunNumber: str
-    useLiteMode: bool = True  # TODO: Ensure this is activated in the view and workflow context.
+    useLiteMode: bool
     focusGroup: FocusGroup
     calibrantSamplePath: str
     smoothingParameter: float = Config["calibration.parameters.default.smoothing"]

--- a/src/snapred/backend/dao/request/SmoothDataExcludingPeaksRequest.py
+++ b/src/snapred/backend/dao/request/SmoothDataExcludingPeaksRequest.py
@@ -15,7 +15,7 @@ class SmoothDataExcludingPeaksRequest(BaseModel):
     """
 
     runNumber: str
-    useLiteMode: bool = True  # TODO turn this on inside the view and workflow
+    useLiteMode: bool
     focusGroup: FocusGroup
     calibrantSamplePath: str
     inputWorkspace: str

--- a/src/snapred/backend/dao/request/VanadiumCorrectionRequest.py
+++ b/src/snapred/backend/dao/request/VanadiumCorrectionRequest.py
@@ -6,7 +6,7 @@ from snapred.meta.Config import Config
 
 class VanadiumCorrectionRequest(BaseModel):
     runNumber: str
-    useLiteMode: bool = True  # TODO turn this on inside the view and workflow
+    useLiteMode: bool
     focusGroup: FocusGroup
 
     calibrantSamplePath: str

--- a/src/snapred/backend/data/DataExportService.py
+++ b/src/snapred/backend/data/DataExportService.py
@@ -59,5 +59,5 @@ class DataExportService:
         """
         return self.dataService.writeRaggedWorkspace(path, filename, workspaceName)
 
-    def initializeState(self, runId: str, name: str, useLiteMode: bool):
-        return self.dataService.initializeState(runId, name, useLiteMode)
+    def initializeState(self, runId: str, name: str):
+        return self.dataService.initializeState(runId, name)

--- a/src/snapred/backend/data/DataExportService.py
+++ b/src/snapred/backend/data/DataExportService.py
@@ -23,8 +23,8 @@ class DataExportService:
             val = clazz()
         return val
 
-    def exportCalibrationIndexEntry(self, entry: CalibrationIndexEntry):
-        self.dataService.writeCalibrationIndexEntry(entry)
+    def exportCalibrationIndexEntry(self, entry: CalibrationIndexEntry, useLiteMode: bool):
+        self.dataService.writeCalibrationIndexEntry(entry, useLiteMode)
 
     def exportCalibrationRecord(self, record: CalibrationRecord):
         return self.dataService.writeCalibrationRecord(record)
@@ -38,8 +38,8 @@ class DataExportService:
     def exportCalibrationState(self, runId: str, calibration: Calibration):
         return self.dataService.writeCalibrationState(runId, calibration)
 
-    def exportNormalizationIndexEntry(self, entry: NormalizationIndexEntry):
-        self.dataService.writeNormalizationIndexEntry(entry)
+    def exportNormalizationIndexEntry(self, entry: NormalizationIndexEntry, useLiteMode: bool):
+        self.dataService.writeNormalizationIndexEntry(entry, useLiteMode)
 
     def exportNormalizationRecord(self, record: NormalizationRecord):
         return self.dataService.writeNormalizationRecord(record)
@@ -59,5 +59,5 @@ class DataExportService:
         """
         return self.dataService.writeRaggedWorkspace(path, filename, workspaceName)
 
-    def initializeState(self, runId: str, name: str):
-        return self.dataService.initializeState(runId, name)
+    def initializeState(self, runId: str, name: str, useLiteMode: bool):
+        return self.dataService.initializeState(runId, name, useLiteMode)

--- a/src/snapred/backend/data/DataExportService.py
+++ b/src/snapred/backend/data/DataExportService.py
@@ -59,5 +59,5 @@ class DataExportService:
         """
         return self.dataService.writeRaggedWorkspace(path, filename, workspaceName)
 
-    def initializeState(self, runId: str, name: str):
-        return self.dataService.initializeState(runId, name)
+    def initializeState(self, runId: str, name: str, useLiteMode: bool):
+        return self.dataService.initializeState(runId, name, useLiteMode)

--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -63,8 +63,8 @@ class DataFactoryService:
     def getCifFilePath(self, sampleId):
         return self.lookupService.readCifFilePath(sampleId)
 
-    def getCalibrationState(self, runId):
-        return self.lookupService.readCalibrationState(runId)
+    def getCalibrationState(self, runId, useLiteMode):
+        return self.lookupService.readCalibrationState(runId, useLiteMode)
 
     def getNormalizationState(self, runId):
         return self.lookupService.readNormalizationState(runId)

--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -94,17 +94,17 @@ class DataFactoryService:
     def getCalibrationRecord(self, runId, version: str = None, useLiteMode: bool = False):
         return self.lookupService.readCalibrationRecord(runId, version, useLiteMode)
 
-    def getNormalizationRecord(self, runId):
-        return self.lookupService.readNormalizationRecord(runId)
+    def getNormalizationRecord(self, runId, useLiteMode: bool):
+        return self.lookupService.readNormalizationRecord(runId, useLiteMode)
 
     def getCalibrationIndex(self, runId: str, useLiteMode: bool):
         return self.lookupService.readCalibrationIndex(runId, useLiteMode)
 
-    def getGroupingMap(self, runId: str, useLiteMode: bool):
-        return self.lookupService.readGroupingMap(runId, useLiteMode)
+    def getGroupingMap(self, runId: str):
+        return self.lookupService.readGroupingMap(runId)
 
-    def checkCalibrationStateExists(self, runId: str, useLiteMode: bool):
-        return self.lookupService.checkCalibrationFileExists(runId, useLiteMode)
+    def checkCalibrationStateExists(self, runId: str):
+        return self.lookupService.checkCalibrationFileExists(runId)
 
     def getSamplePaths(self):
         return self.lookupService.readSamplePaths()

--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -29,7 +29,7 @@ class DataFactoryService:
             val = clazz()
         return val
 
-    def getReductionState(self, runId: str) -> ReductionState:
+    def getReductionState(self, runId: str, useLiteMode: bool) -> ReductionState:
         reductionState: ReductionState
 
         if runId in self.cache:
@@ -39,7 +39,7 @@ class DataFactoryService:
             # lookup and package data
             reductionState = ReductionState(
                 instrumentConfig=self.getInstrumentConfig(runId),
-                stateConfig=self.getStateConfig(runId),
+                stateConfig=self.getStateConfig(runId, useLiteMode),
             )
             self.cache[runId] = reductionState
 
@@ -54,8 +54,8 @@ class DataFactoryService:
     def getInstrumentConfig(self, runId: str) -> InstrumentConfig:  # noqa: ARG002
         return self.lookupService.readInstrumentConfig()
 
-    def getStateConfig(self, runId: str) -> StateConfig:  # noqa: ARG002
-        return self.lookupService.readStateConfig(runId)
+    def getStateConfig(self, runId: str, useLiteMode: bool) -> StateConfig:  # noqa: ARG002
+        return self.lookupService.readStateConfig(runId, useLiteMode)
 
     def constructStateId(self, runId):
         return self.lookupService._generateStateId(runId)
@@ -91,20 +91,20 @@ class DataFactoryService:
     def getWorkspaceSingleUse(self, runId: str, useLiteMode: bool):
         return self.groceryService.fetchNeutronDataSingleUse(runId, useLiteMode)
 
-    def getCalibrationRecord(self, runId, version: str = None):
-        return self.lookupService.readCalibrationRecord(runId, version)
+    def getCalibrationRecord(self, runId, version: str = None, useLiteMode: bool = False):
+        return self.lookupService.readCalibrationRecord(runId, version, useLiteMode)
 
     def getNormalizationRecord(self, runId):
         return self.lookupService.readNormalizationRecord(runId)
 
-    def getCalibrationIndex(self, runId: str):
-        return self.lookupService.readCalibrationIndex(runId)
+    def getCalibrationIndex(self, runId: str, useLiteMode: bool):
+        return self.lookupService.readCalibrationIndex(runId, useLiteMode)
 
-    def getGroupingMap(self, runId: str):
-        return self.lookupService.readGroupingMap(runId)
+    def getGroupingMap(self, runId: str, useLiteMode: bool):
+        return self.lookupService.readGroupingMap(runId, useLiteMode)
 
-    def checkCalibrationStateExists(self, runId: str):
-        return self.lookupService.checkCalibrationFileExists(runId)
+    def checkCalibrationStateExists(self, runId: str, useLiteMode: bool):
+        return self.lookupService.checkCalibrationFileExists(runId, useLiteMode)
 
     def getSamplePaths(self):
         return self.lookupService.readSamplePaths()

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -186,7 +186,7 @@ class GroceryService:
         if groupingScheme == "Lite":
             path = str(Config["instrument.lite.map.file"])
         else:
-            groupingMap = self.dataService.readGroupingMap(runNumber)
+            groupingMap = self.dataService.readGroupingMap(runNumber, useLiteMode)
             path = groupingMap.getMap(useLiteMode)[groupingScheme].definition
         return str(path)
 

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -187,7 +187,7 @@ class GroceryService:
         if groupingScheme == "Lite":
             path = str(Config["instrument.lite.map.file"])
         else:
-            groupingMap = self.dataService.readGroupingMap(runNumber, useLiteMode)
+            groupingMap = self.dataService.readGroupingMap(runNumber)
             path = groupingMap.getMap(useLiteMode)[groupingScheme].definition
         return str(path)
 

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -832,7 +832,7 @@ class LocalDataService:
         filename = Path(grocer._createDiffcalTableWorkspaceName("default", version) + ".h5")
         outWS = grocer.fetchDefaultDiffCalTable(runNumber, version, useLiteMode)
 
-        calibrationDataPath = self._constructCalibrationDataPath(runNumber, str(version))
+        calibrationDataPath = self._constructCalibrationDataPath(runNumber, str(version), useLiteMode)
 
         self.writeDiffCalWorkspaces(calibrationDataPath, filename, outWS)
 

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -825,7 +825,7 @@ class LocalDataService:
         version = 1
         grocer = GroceryService()
         filename = Path(grocer._createDiffcalTableWorkspaceName("default", version) + ".h5")
-        outWS = grocer.fetchDefaultDiffCalTable(runNumber, version, useLiteMode)
+        outWS = grocer.fetchDefaultDiffCalTable(runNumber, useLiteMode, version)
 
         calibrationDataPath = self._constructCalibrationDataPath(runNumber, str(version), useLiteMode)
 

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -130,7 +130,7 @@ class LocalDataService:
     def readStateConfig(self, runId: str, useLiteMode: bool) -> StateConfig:
         previousDiffCalRecord: CalibrationRecord = self.readCalibrationRecord(runId, useLiteMode=useLiteMode)
         if previousDiffCalRecord is None:
-            diffCalibration: Calibration = self.readCalibrationState(runId)
+            diffCalibration: Calibration = self.readCalibrationState(runId, useLiteMode)
         else:
             diffCalibration: Calibration = previousDiffCalRecord.calibrationFittingIngredients
 
@@ -528,7 +528,6 @@ class LocalDataService:
             recordPath: str = self.getCalibrationRecordPath(runId, "*", useLiteMode)
             recordFile = self._getLatestFile(recordPath)
         record: CalibrationRecord = None
-        print(recordPath)
         if recordFile:
             logger.info(f"reading CalibrationRecord from {recordFile}")
             record = parse_file_as(CalibrationRecord, recordFile)
@@ -841,7 +840,7 @@ class LocalDataService:
         self.writeDiffCalWorkspaces(calibrationDataPath, filename, outWS)
 
     @ExceptionHandler(StateValidationException)
-    def initializeState(self, runId: str, name: str = None):
+    def initializeState(self, runId: str, name: str = None, useLiteMode: bool = False):
         stateId, _ = self._generateStateId(runId)
 
         # Read the detector state from the pv data file
@@ -895,7 +894,7 @@ class LocalDataService:
             #   some order independence of initialization if the back-end is run separately (e.g. in unit tests).
             self._prepareStateRoot(stateId)
 
-        self.writeCalibrationState(runId, calibration)
+        self.writeCalibrationState(runId, calibration, useLiteMode=useLiteMode)
         self._writeDefaultDiffCalTable(runId, 1)
 
         return calibration

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -719,13 +719,13 @@ class LocalDataService:
         return statePath
 
     @ExceptionHandler(RecoverableException, "'NoneType' object has no attribute 'instrumentState'")
-    def readCalibrationState(self, runId: str, version: str = None, useLiteMode: bool = False):
+    def readCalibrationState(self, runId: str, useLiteMode: bool, version: str = None):
         # get stateId and check to see if such a folder exists, if not create it and initialize it
         stateId, _ = self._generateStateId(runId)
         calibrationStatePath = self._constructCalibrationParametersFilePath(runId, "*", useLiteMode)
 
         latestFile = ""
-        if version:
+        if version is not None:
             latestFile = self._getFileOfVersion(calibrationStatePath, version)
         else:
             # TODO: This should refer to the calibration index

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -233,7 +233,7 @@ class CalibrationService(Service):
 
     @FromString
     def initializeState(self, request: InitializeStateRequest):
-        return self.dataExportService.initializeState(request.runId, request.humanReadableName)
+        return self.dataExportService.initializeState(request.runId, request.humanReadableName, request.useLiteMode)
 
     @FromString
     def getState(self, runs: List[RunConfig]):

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -215,7 +215,7 @@ class CalibrationService(Service):
         calibrationRecord = self.dataExportService.exportCalibrationRecord(calibrationRecord)
         calibrationRecord = self.dataExportService.exportCalibrationWorkspaces(calibrationRecord)
         entry.version = calibrationRecord.version
-        self.saveCalibrationToIndex(entry, calibrationRecord.isLite)
+        self.saveCalibrationToIndex(entry, calibrationRecord.useLiteMode)
 
     @FromString
     def load(self, run: RunConfig):
@@ -233,7 +233,7 @@ class CalibrationService(Service):
 
     @FromString
     def initializeState(self, request: InitializeStateRequest):
-        return self.dataExportService.initializeState(request.runId, request.humanReadableName, request.useLiteMode)
+        return self.dataExportService.initializeState(request.runId, request.humanReadableName)
 
     @FromString
     def getState(self, runs: List[RunConfig]):
@@ -246,8 +246,7 @@ class CalibrationService(Service):
     @FromString
     def hasState(self, request: HasStateRequest):
         runId = request.runId
-        useLiteMode = request.useLiteMode
-        return self.dataFactoryService.checkCalibrationStateExists(runId, useLiteMode)
+        return self.dataFactoryService.checkCalibrationStateExists(runId)
 
     # TODO make the inputs here actually work
     def _collectMetrics(self, focussedData, focusGroup, pixelGroup):
@@ -369,7 +368,7 @@ class CalibrationService(Service):
 
         record = CalibrationRecord(
             runNumber=request.run.runNumber,
-            isLite=request.useLiteMode,
+            useLiteMode=request.useLiteMode,
             crystalInfo=self.sousChef.prepCrystallographicInfo(farmFresh),
             calibrationFittingIngredients=self.sousChef.prepCalibration(farmFresh),
             pixelGroups=[pixelGroup],

--- a/src/snapred/backend/service/ConfigLookupService.py
+++ b/src/snapred/backend/service/ConfigLookupService.py
@@ -27,8 +27,8 @@ class ConfigLookupService(Service):
     def name():
         return "config"
 
-    def getGroupingMap(self, runId: str, useLiteMode: bool = False):
-        return self.dataFactoryService.getGroupingMap(runId, useLiteMode)
+    def getGroupingMap(self, runId: str):
+        return self.dataFactoryService.getGroupingMap(runId)
 
     def getSamplePaths(self):
         return self.dataFactoryService.getSamplePaths()

--- a/src/snapred/backend/service/ConfigLookupService.py
+++ b/src/snapred/backend/service/ConfigLookupService.py
@@ -27,8 +27,8 @@ class ConfigLookupService(Service):
     def name():
         return "config"
 
-    def getGroupingMap(self, runId: str):
-        return self.dataFactoryService.getGroupingMap(runId)
+    def getGroupingMap(self, runId: str, useLiteMode: bool = False):
+        return self.dataFactoryService.getGroupingMap(runId, useLiteMode)
 
     def getSamplePaths(self):
         return self.dataFactoryService.getSamplePaths()
@@ -37,5 +37,5 @@ class ConfigLookupService(Service):
     def getConfigs(self, runs: List[RunConfig]):
         data = {}
         for run in runs:
-            data[run.runNumber] = self.dataFactoryService.getReductionState(run.runNumber)
+            data[run.runNumber] = self.dataFactoryService.getReductionState(run.runNumber, run.useLiteMode)
         return data

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -165,7 +165,7 @@ class NormalizationService(Service):
         calibration = self.sousChef.prepCalibration(farmFresh)
         record = NormalizationRecord(
             runNumber=request.runNumber,
-            isLite=request.useLiteMode,
+            useLiteMode=request.useLiteMode,
             backgroundRunNumber=request.backgroundRunNumber,
             smoothingParameter=request.smoothingParameter,
             calibration=calibration,
@@ -182,7 +182,7 @@ class NormalizationService(Service):
         normalizationRecord = self.dataExportService.exportNormalizationRecord(normalizationRecord)
         normalizationRecord = self.dataExportService.exportNormalizationWorkspaces(normalizationRecord)
         entry.version = normalizationRecord.version
-        self.saveNormalizationToIndex(entry, normalizationRecord.isLite)
+        self.saveNormalizationToIndex(entry, normalizationRecord.useLiteMode)
 
     def saveNormalizationToIndex(self, entry: NormalizationIndexEntry, useLiteMode: bool):
         if entry.appliesTo is None:

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -182,15 +182,15 @@ class NormalizationService(Service):
         normalizationRecord = self.dataExportService.exportNormalizationRecord(normalizationRecord)
         normalizationRecord = self.dataExportService.exportNormalizationWorkspaces(normalizationRecord)
         entry.version = normalizationRecord.version
-        self.saveNormalizationToIndex(entry)
+        self.saveNormalizationToIndex(entry, normalizationRecord.isLite)
 
-    def saveNormalizationToIndex(self, entry: NormalizationIndexEntry):
+    def saveNormalizationToIndex(self, entry: NormalizationIndexEntry, useLiteMode: bool):
         if entry.appliesTo is None:
             entry.appliesTo = ">" + entry.runNumber
         if entry.timestamp is None:
             entry.timestamp = int(round(time.time() * 1000))
         logger.info(f"Saving normalization index entry for Run Number {entry.runNumber}")
-        self.dataExportService.exportNormalizationIndexEntry(entry)
+        self.dataExportService.exportNormalizationIndexEntry(entry, useLiteMode)
 
     def vanadiumCorrection(self, request: VanadiumCorrectionRequest):
         cifPath = self.dataFactoryService.getCifFilePath(request.calibrantSamplePath.split("/")[-1].split(".")[0])

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -50,7 +50,7 @@ class SousChef(Service):
         return "souschef"
 
     def prepCalibration(self, ingredients: FarmFreshIngredients) -> Calibration:
-        calibration = self.dataFactoryService.getCalibrationState(ingredients.runNumber)
+        calibration = self.dataFactoryService.getCalibrationState(ingredients.runNumber, ingredients.useLiteMode)
         calibration.instrumentState.fwhmMultipliers = ingredients.fwhmMultipliers
         return calibration
 
@@ -67,7 +67,7 @@ class SousChef(Service):
         if self.dataFactoryService.fileExists(ingredients.focusGroup.definition):
             return ingredients.focusGroup
         else:
-            groupingMap = self.dataFactoryService.getGroupingMap(ingredients.runNumber, ingredients.useLiteMode)
+            groupingMap = self.dataFactoryService.getGroupingMap(ingredients.runNumber)
             return groupingMap.getMap(ingredients.useLiteMode)[ingredients.focusGroup.name]
 
     def prepPixelGroup(self, ingredients: FarmFreshIngredients) -> PixelGroup:

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -74,7 +74,7 @@ class SousChef(Service):
         if self.dataFactoryService.fileExists(ingredients.focusGroup.definition):
             return ingredients.focusGroup
         else:
-            groupingMap = self.dataFactoryService.getGroupingMap(ingredients.runNumber)
+            groupingMap = self.dataFactoryService.getGroupingMap(ingredients.runNumber, ingredients.useLiteMode)
             return groupingMap.getMap(ingredients.useLiteMode)[ingredients.focusGroup.name]
 
     def prepPixelGroup(self, ingredients: FarmFreshIngredients) -> PixelGroup:
@@ -157,7 +157,7 @@ class SousChef(Service):
 
     def prepReductionIngredients(self, ingredients: FarmFreshIngredients) -> ReductionIngredients:
         return ReductionIngredients(
-            reductionState=self.dataFactoryService.getReductionState(ingredients.runNumber),
+            reductionState=self.dataFactoryService.getReductionState(ingredients.runNumber, ingredients.useLiteMode),
             runConfig=self.prepRunConfig(ingredients.runNumber),
             pixelGroup=self.prepPixelGroup(ingredients),
         )

--- a/src/snapred/ui/handler/SNAPResponseHandler.py
+++ b/src/snapred/ui/handler/SNAPResponseHandler.py
@@ -112,7 +112,9 @@ class SNAPResponseHandler(QWidget):
 
         try:
             logger.info("Handling 'state' message.")
-            initializationMenu = InitializationMenu(runNumber=InitializeStateHandler.runId, parent=view)
+            initializationMenu = InitializationMenu(
+                runNumber=InitializeStateHandler.runId, parent=view, useLiteMode=InitializeStateHandler.useLiteMode
+            )
             initializationMenu.finished.connect(lambda: initializationMenu.deleteLater())
             initializationMenu.show()
         except Exception as e:  # noqa: BLE001

--- a/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
+++ b/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
@@ -56,9 +56,9 @@ class CalibrationAssessmentPresenter(QObject):
         if response.code == ResponseCode.ERROR:
             self.view.onError(response.message)
 
-    def loadCalibrationIndex(self, runNumber: str):
+    def loadCalibrationIndex(self, runNumber: str, useLiteMode: bool):
         payload = CalibrationIndexRequest(
-            run=RunConfig(runNumber=runNumber),
+            run=RunConfig(runNumber=runNumber, useLiteMode=useLiteMode),
         )
         loadCalibrationIndexRequest = SNAPRequest(path="calibration/index", payload=payload.json())
 

--- a/src/snapred/ui/presenter/InitializeStatePresenter.py
+++ b/src/snapred/ui/presenter/InitializeStatePresenter.py
@@ -29,16 +29,17 @@ class InitializeStatePresenter(QObject):
     def handleButtonClicked(self):
         runNumber = self.view.getRunNumber()
         stateName = self.view.getStateName()
+        useLiteMode = self.view.getMode()
 
         if not runNumber.isdigit():
             QMessageBox.warning(self.view, "Invalid Input", "Please enter a valid run number.")
             return
 
         self.view.beginFlowButton.setEnabled(False)
-        self._initializeState(runNumber, stateName)
+        self._initializeState(runNumber, stateName, useLiteMode)
 
-    def _initializeState(self, runNumber, stateName):
-        payload = InitializeStateRequest(runId=str(runNumber), humanReadableName=stateName)
+    def _initializeState(self, runNumber, stateName, useLiteMode):
+        payload = InitializeStateRequest(runId=str(runNumber), humanReadableName=stateName, useLiteMode=useLiteMode)
         request = SNAPRequest(path="/calibration/initializeState", payload=payload.json())
         response = self.interfaceController.executeRequest(request)
         self._handleResponse(response)

--- a/src/snapred/ui/view/DiffCalAssessmentView.py
+++ b/src/snapred/ui/view/DiffCalAssessmentView.py
@@ -25,7 +25,7 @@ class DiffCalAssessmentView(QWidget):
 
     """
 
-    signalRunNumberUpdate = Signal(str)
+    signalRunNumberUpdate = Signal(str, bool)
     signalError = Signal(str)
 
     def __init__(self, name, jsonSchemaMap, parent=None):
@@ -93,8 +93,8 @@ class DiffCalAssessmentView(QWidget):
         msgBox.setFixedSize(500, 200)
         msgBox.exec()
 
-    def updateRunNumber(self, runNumber):
-        self.signalRunNumberUpdate.emit(runNumber)
+    def updateRunNumber(self, runNumber, useLiteMode):
+        self.signalRunNumberUpdate.emit(runNumber, useLiteMode)
 
     def verify(self):
         # TODO vwhat fields need to be verified?

--- a/src/snapred/ui/view/DiffCalRequestView.py
+++ b/src/snapred/ui/view/DiffCalRequestView.py
@@ -64,3 +64,6 @@ class DiffCalRequestView(BackendRequestView):
 
     def getRunNumber(self):
         return self.runNumberField.text()
+
+    def getLiteMode(self):
+        return self.litemodeToggle.field.getState()

--- a/src/snapred/ui/view/InitializeStateCheckView.py
+++ b/src/snapred/ui/view/InitializeStateCheckView.py
@@ -14,12 +14,13 @@ from snapred.ui.presenter.InitializeStatePresenter import InitializeStatePresent
 
 
 class InitializationMenu(QDialog):
-    def __init__(self, runNumber=None, parent=None):
+    def __init__(self, runNumber=None, parent=None, useLiteMode=None):
         super(InitializationMenu, self).__init__(parent)
         self.setWindowTitle("Initialization Menu")
         self.setFixedSize(400, 300)
 
         self.runNumber = runNumber
+        self.useLiteMode = useLiteMode
         self.layout = QGridLayout(self)
         self.setLayout(self.layout)
 
@@ -63,6 +64,9 @@ class InitializationMenu(QDialog):
 
     def getStateName(self):
         return self.stateNameField.text() if self.stateNameField else ""
+
+    def getMode(self):
+        return self.useLiteMode
 
     def handleButtonClicked(self):
         runNumber = self.getRunNumber()

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -9,6 +9,7 @@ from snapred.backend.dao.request import (
     DiffractionCalibrationRequest,
     FitMultiplePeaksRequest,
     FocusSpectraRequest,
+    HasStateRequest,
 )
 from snapred.backend.dao.response.CalibrationAssessmentResponse import CalibrationAssessmentResponse
 from snapred.backend.log.logger import snapredLogger
@@ -115,7 +116,11 @@ class DiffCalWorkflow(WorkflowImplementer):
         # TODO: Use threads, account for fail cases
         try:
             # check if the state exists -- if so load its grouping map
-            hasState = self.request(path="calibration/hasState", payload=runNumber).data
+            payload = HasStateRequest(
+                runId=runNumber,
+                useLiteMode=useLiteMode,
+            )
+            hasState = self.request(path="calibration/hasState", payload=payload.json()).data
             if hasState:
                 self.groupingMap = self.request(path="config/groupingMap", payload=runNumber).data
             else:

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -346,7 +346,7 @@ class DiffCalWorkflow(WorkflowImplementer):
         self.outputs.extend(assessmentResponse.metricWorkspaces)
         for calibrationWorkspaces in self.calibrationRecord.workspaces.values():
             self.outputs.extend(calibrationWorkspaces)
-        self._assessmentView.updateRunNumber(self.runNumber)
+        self._assessmentView.updateRunNumber(self.runNumber, self.useLiteMode)
         return response
 
     def _assessCalibration(self, workflowPresenter):  # noqa: ARG002

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -5,6 +5,7 @@ from snapred.backend.api.InterfaceController import InterfaceController
 from snapred.backend.dao import SNAPRequest, SNAPResponse
 from snapred.backend.dao.normalization import NormalizationIndexEntry, NormalizationRecord
 from snapred.backend.dao.request import (
+    HasStateRequest,
     NormalizationCalibrationRequest,
     NormalizationExportRequest,
 )
@@ -98,7 +99,12 @@ class NormalizationWorkflow(WorkflowImplementer):
         # TODO: Use threads, account for fail cases
         try:
             # check if the state exists -- if so load its grouping map
-            hasState = self.request(path="calibration/hasState", payload=runNumber).data
+            payload = HasStateRequest(
+                runId=runNumber,
+                useLiteMode=useLiteMode,
+            )
+            hasState = self.request(path="calibration/hasState", payload=payload.json()).data
+            # hasState = self.request(path="calibration/hasState", payload=runNumber).data
             if hasState:
                 self.groupingMap = self.request(path="config/groupingMap", payload=runNumber).data
             else:

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -246,6 +246,7 @@ class NormalizationWorkflow(WorkflowImplementer):
 
         payload = SmoothDataExcludingPeaksRequest(
             inputWorkspace=focusWorkspace,
+            useLiteMode=self.useLiteMode,
             outputWorkspace=smoothWorkspace,
             calibrantSamplePath=self.samplePaths[self.sampleIndex],
             focusGroup=list(self.focusGroups.items())[index][1],

--- a/tests/resources/inputs/calibration/CalibrationRecord_v0001.json
+++ b/tests/resources/inputs/calibration/CalibrationRecord_v0001.json
@@ -1,6 +1,6 @@
 {
   "runNumber": 57514,
-  "isLite": true,
+  "useLiteMode": true,
   "crystalInfo": {
     "peaks": [
         {

--- a/tests/resources/inputs/calibration/CalibrationRecord_v0002.json
+++ b/tests/resources/inputs/calibration/CalibrationRecord_v0002.json
@@ -1,6 +1,6 @@
 {
   "runNumber": 57514,
-  "isLite": true,
+  "useLiteMode": true,
   "crystalInfo": {
     "peaks": [
         {

--- a/tests/resources/inputs/normalization/NormalizationRecord.json
+++ b/tests/resources/inputs/normalization/NormalizationRecord.json
@@ -1,6 +1,6 @@
 {
     "runNumber": 57514,
-    "isLite": true,
+    "useLiteMode": true,
     "backgroundRunNumber": 58813,
     "smoothingParameter": 0.5,
     "calibration":{

--- a/tests/unit/backend/api/test_InterfaceController.py
+++ b/tests/unit/backend/api/test_InterfaceController.py
@@ -56,7 +56,7 @@ with mock.patch.dict(
         interfaceController = mockedSuccessfulInterfaceController(raiseRecoverable=True)
         stateCheckRequest = mock.Mock()
         stateCheckRequest.path = "Test Service"
-        stateCheckRequest.payload = json.dumps({"runNumber": "12345"})
+        stateCheckRequest.payload = json.dumps({"runNumber": "12345", "useLiteMode": "True"})
 
         response = interfaceController.executeRequest(stateCheckRequest)
 

--- a/tests/unit/backend/data/test_DataExportService.py
+++ b/tests/unit/backend/data/test_DataExportService.py
@@ -21,7 +21,9 @@ with mock.patch.dict(
         dataExportService = DataExportService()
         dataExportService.dataService.writeCalibrationIndexEntry = mock.Mock()
         dataExportService.dataService.writeCalibrationIndexEntry.return_value = "expected"
-        dataExportService.exportCalibrationIndexEntry(CalibrationIndexEntry(runNumber="1", comments="", author=""))
+        dataExportService.exportCalibrationIndexEntry(
+            CalibrationIndexEntry(runNumber="1", comments="", author=""), useLiteMode=True
+        )
         assert dataExportService.dataService.writeCalibrationIndexEntry.called
 
     def test_exportCalibrationRecord():
@@ -49,7 +51,7 @@ with mock.patch.dict(
         dataExportService = DataExportService()
         dataExportService.dataService.initializeState = mock.Mock()
         dataExportService.dataService.initializeState.return_value = "expected"
-        dataExportService.initializeState(mock.Mock(), mock.Mock())
+        dataExportService.initializeState(mock.Mock(), mock.Mock(), mock.Mock())
         assert dataExportService.dataService.initializeState.called
 
     def test_exportNormalizationIndexEntry():
@@ -57,7 +59,7 @@ with mock.patch.dict(
         dataExportService.dataService.writeNormalizationIndexEntry = mock.Mock()
         dataExportService.dataService.writeNormalizationIndexEntry.return_value = "expected"
         dataExportService.exportNormalizationIndexEntry(
-            NormalizationIndexEntry(runNumber="1", backgroundRunNumber="2", comments="", author="")
+            NormalizationIndexEntry(runNumber="1", backgroundRunNumber="2", comments="", author=""), True
         )
         assert dataExportService.dataService.writeNormalizationIndexEntry.called
 

--- a/tests/unit/backend/data/test_DataExportService.py
+++ b/tests/unit/backend/data/test_DataExportService.py
@@ -51,7 +51,7 @@ with mock.patch.dict(
         dataExportService = DataExportService()
         dataExportService.dataService.initializeState = mock.Mock()
         dataExportService.dataService.initializeState.return_value = "expected"
-        dataExportService.initializeState(mock.Mock(), mock.Mock(), mock.Mock())
+        dataExportService.initializeState(mock.Mock(), mock.Mock())
         assert dataExportService.dataService.initializeState.called
 
     def test_exportNormalizationIndexEntry():

--- a/tests/unit/backend/data/test_DataExportService.py
+++ b/tests/unit/backend/data/test_DataExportService.py
@@ -51,7 +51,7 @@ with mock.patch.dict(
         dataExportService = DataExportService()
         dataExportService.dataService.initializeState = mock.Mock()
         dataExportService.dataService.initializeState.return_value = "expected"
-        dataExportService.initializeState(mock.Mock(), mock.Mock())
+        dataExportService.initializeState(mock.Mock(), mock.Mock(), mock.Mock())
         assert dataExportService.dataService.initializeState.called
 
     def test_exportNormalizationIndexEntry():

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -41,7 +41,7 @@ with mock.patch.dict(
         dataExportService.getInstrumentConfig.return_value = InstrumentConfig.construct({})
         dataExportService.getStateConfig = mock.Mock()
         dataExportService.getStateConfig.return_value = StateConfig.construct({})
-        actual = dataExportService.getReductionState(mock.Mock())
+        actual = dataExportService.getReductionState(mock.Mock(), mock.Mock())
 
         assert type(actual) == ReductionState
 
@@ -55,7 +55,7 @@ with mock.patch.dict(
     def test_getStateConfig():
         dataExportService = DataFactoryService()
         dataExportService.lookupService.readStateConfig = mock.Mock(return_value=StateConfig.construct())
-        actual = dataExportService.getStateConfig(mock.Mock())
+        actual = dataExportService.getStateConfig(mock.Mock(), mock.Mock())
 
         assert type(actual) == StateConfig
 
@@ -76,13 +76,13 @@ with mock.patch.dict(
     def test_getGroupingMap():
         dataExportService = DataFactoryService()
         dataExportService.lookupService.readGroupingMap = mock.Mock(return_value="expected")
-        actual = dataExportService.getGroupingMap(mock.Mock())
+        actual = dataExportService.getGroupingMap(mock.Mock(), mock.Mock())
         assert actual == "expected"
 
     def test_checkCalibrationStateExists():
         dataExportService = DataFactoryService()
         dataExportService.lookupService.checkCalibrationFileExists = mock.Mock(return_value="expected")
-        actual = dataExportService.checkCalibrationStateExists(mock.Mock())
+        actual = dataExportService.checkCalibrationStateExists(mock.Mock(), mock.Mock())
         assert actual == "expected"
 
     def test_getSamplePaths():
@@ -117,7 +117,7 @@ with mock.patch.dict(
         dataExportService = DataFactoryService()
         dataExportService.lookupService.readCalibrationIndex = mock.Mock(return_value="expected")
         run = MagicMock()
-        actual = dataExportService.getCalibrationIndex(run)
+        actual = dataExportService.getCalibrationIndex(run, mock.Mock())
 
         assert actual == "expected"
 

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -65,7 +65,7 @@ with mock.patch.dict(
     def test_getCalibrationState():
         dataExportService = DataFactoryService()
         dataExportService.lookupService.readCalibrationState = mock.Mock(return_value="expected")
-        actual = dataExportService.getCalibrationState(mock.Mock())
+        actual = dataExportService.getCalibrationState(mock.Mock(), mock.Mock())
 
         assert actual == "expected"
 

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -76,13 +76,13 @@ with mock.patch.dict(
     def test_getGroupingMap():
         dataExportService = DataFactoryService()
         dataExportService.lookupService.readGroupingMap = mock.Mock(return_value="expected")
-        actual = dataExportService.getGroupingMap(mock.Mock(), mock.Mock())
+        actual = dataExportService.getGroupingMap(mock.Mock())
         assert actual == "expected"
 
     def test_checkCalibrationStateExists():
         dataExportService = DataFactoryService()
         dataExportService.lookupService.checkCalibrationFileExists = mock.Mock(return_value="expected")
-        actual = dataExportService.checkCalibrationStateExists(mock.Mock(), mock.Mock())
+        actual = dataExportService.checkCalibrationStateExists(mock.Mock())
         assert actual == "expected"
 
     def test_getSamplePaths():

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -255,7 +255,7 @@ def test_prepareStateRoot_creates_state_root_directory():
         localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
 
         assert not stateRootPath.exists()
-        localDataService._prepareStateRoot(stateId, True)
+        localDataService._prepareStateRoot(stateId)
         assert stateRootPath.exists()
 
 
@@ -274,7 +274,7 @@ def test_prepareStateRoot_existing_state_root():
         localDataService._readDefaultGroupingMap = mock.Mock(return_value=defaultGroupingMap)
         localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
         assert stateRootPath.exists()
-        localDataService._prepareStateRoot(stateId, True)
+        localDataService._prepareStateRoot(stateId)
 
 
 def test_prepareStateRoot_writes_grouping_map():
@@ -292,7 +292,7 @@ def test_prepareStateRoot_writes_grouping_map():
         localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
 
         assert not groupingMapFilePath.exists()
-        localDataService._prepareStateRoot(stateId, True)
+        localDataService._prepareStateRoot(stateId)
         assert groupingMapFilePath.exists()
 
 
@@ -310,7 +310,7 @@ def test_prepareStateRoot_sets_grouping_map_stateid():
         localDataService._readDefaultGroupingMap = mock.Mock(return_value=defaultGroupingMap)
         localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
 
-        localDataService._prepareStateRoot(stateId, True)
+        localDataService._prepareStateRoot(stateId)
 
         with open(groupingMapFilePath, "r") as file:
             groupingMap = parse_raw_as(GroupingMap, file.read())
@@ -335,7 +335,7 @@ def test_prepareStateRoot_no_default_grouping_map():
             localDataService._constructCalibrationStateRoot = mock.Mock(return_value=str(stateRootPath))
             localDataService._defaultGroupingMapPath = mock.Mock(return_value=Path(defaultGroupingMapFilePath))
             localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
-            localDataService._prepareStateRoot(stateId, True)
+            localDataService._prepareStateRoot(stateId)
 
 
 def test_prepareStateRoot_does_not_overwrite_grouping_map():
@@ -364,7 +364,7 @@ def test_prepareStateRoot_does_not_overwrite_grouping_map():
         localDataService._readDefaultGroupingMap = mock.Mock(return_value=defaultGroupingMap)
         localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
 
-        localDataService._prepareStateRoot(stateId, True)
+        localDataService._prepareStateRoot(stateId)
 
         with open(groupingMapFilePath, "r") as file:
             groupingMap = parse_raw_as(GroupingMap, file.read())
@@ -394,7 +394,7 @@ def test_writeGroupingMap_relative_paths():
             with open(defaultGroupingMapFilePath, "r") as file:
                 groupingMap = parse_raw_as(GroupingMap, file.read())
             groupingMap.coerceStateId(stateId)
-            localDataService._writeGroupingMap(stateId, groupingMap, True)
+            localDataService._writeGroupingMap(stateId, groupingMap)
 
             # read it back
             groupingMap = GroupingMap.parse_file(groupingMapFilePath)
@@ -423,7 +423,7 @@ def test_calibrationFileExists(GetIPTS):  # noqa ARG002
         localDataService._generateStateId = mock.Mock(return_value=("ab8704b0bc2a2342", None))
         localDataService._constructCalibrationStateRoot = mock.Mock(return_value=tmpDir)
         runNumber = "654321"
-        assert localDataService.checkCalibrationFileExists(runNumber, True)
+        assert localDataService.checkCalibrationFileExists(runNumber)
 
 
 @mock.patch(ThisService + "GetIPTS")
@@ -432,12 +432,12 @@ def test_calibrationFileExists_stupid_number(GetIPTS):
 
     # try with a non-number
     runNumber = "fruitcake"
-    assert not localDataService.checkCalibrationFileExists(runNumber, True)
+    assert not localDataService.checkCalibrationFileExists(runNumber)
     assert not GetIPTS.called
 
     # try with a too-small number
     runNumber = "7"
-    assert not localDataService.checkCalibrationFileExists(runNumber, True)
+    assert not localDataService.checkCalibrationFileExists(runNumber)
     assert not GetIPTS.called
 
 
@@ -449,7 +449,7 @@ def test_calibrationFileExists_bad_ipts(GetIPTS):
         localDataService = LocalDataService()
         localDataService.iptsCache = {}  # clear the ipts cache
         runNumber = "654321"
-        assert not localDataService.checkCalibrationFileExists(runNumber, True)
+        assert not localDataService.checkCalibrationFileExists(runNumber)
 
 
 @mock.patch(ThisService + "GetIPTS")
@@ -461,7 +461,7 @@ def test_calibrationFileExists_not(GetIPTS):  # noqa ARG002
         assert not nonExistentPath.exists()
         localDataService._constructCalibrationStateRoot = mock.Mock(return_value=str(nonExistentPath))
         runNumber = "654321"
-        assert not localDataService.checkCalibrationFileExists(runNumber, True)
+        assert not localDataService.checkCalibrationFileExists(runNumber)
 
 
 @mock.patch(ThisService + "GetIPTS")
@@ -772,12 +772,13 @@ def test_readWriteCalibrationRecord_version_numbers():
 
         # write: version == 1
         localDataService.writeCalibrationRecord(testCalibrationRecord_v0001)
-        actualRecord = localDataService.readCalibrationRecord("57514")
+        actualRecord = localDataService.readCalibrationRecord("57514", useLiteMode=True)
+        print(actualRecord)
         assert actualRecord.version == 1
         assert actualRecord.calibrationFittingIngredients.version == 1
         # write: version == 2
         localDataService.writeCalibrationRecord(testCalibrationRecord_v0002)
-        actualRecord = localDataService.readCalibrationRecord("57514")
+        actualRecord = localDataService.readCalibrationRecord("57514", useLiteMode=True)
         assert actualRecord.version == 2
         assert actualRecord.calibrationFittingIngredients.version == 2
     assert actualRecord.runNumber == "57514"
@@ -801,14 +802,14 @@ def test_readWriteCalibrationRecord_specified_version():
 
         # write: version == 1
         localDataService.writeCalibrationRecord(testCalibrationRecord_v0001)
-        actualRecord = localDataService.readCalibrationRecord("57514")
+        actualRecord = localDataService.readCalibrationRecord("57514", useLiteMode=True)
         assert actualRecord.version == 1
         assert actualRecord.calibrationFittingIngredients.version == 1
         # write: version == 2
         localDataService.writeCalibrationRecord(testCalibrationRecord_v0002)
-        actualRecord = localDataService.readCalibrationRecord("57514", "1")
+        actualRecord = localDataService.readCalibrationRecord("57514", "1", True)
         assert actualRecord.version == 1
-        actualRecord = localDataService.readCalibrationRecord("57514", "2")
+        actualRecord = localDataService.readCalibrationRecord("57514", "2", True)
         assert actualRecord.version == 2
 
 
@@ -821,7 +822,7 @@ def test_readWriteCalibrationRecord_with_version():
         localDataService.writeCalibrationRecord(
             CalibrationRecord.parse_raw(Resource.read("inputs/calibration/CalibrationRecord_v0001.json"))
         )
-        actualRecord = localDataService.readCalibrationRecord("57514", "1")
+        actualRecord = localDataService.readCalibrationRecord("57514", "1", True)
     assert actualRecord.runNumber == "57514"
     assert actualRecord.version == 1
 
@@ -836,7 +837,7 @@ def test_readWriteCalibrationRecord():
         localDataService._generateStateId = mock.Mock(return_value=("ab8704b0bc2a2342", None))
         localDataService._constructCalibrationStateRoot = mock.Mock(return_value=f"{tempdir}/")
         localDataService.writeCalibrationRecord(testCalibrationRecord)
-        actualRecord = localDataService.readCalibrationRecord("57514")
+        actualRecord = localDataService.readCalibrationRecord("57514", useLiteMode=True)
     assert actualRecord.runNumber == "57514"
     assert actualRecord == testCalibrationRecord
 
@@ -1517,7 +1518,7 @@ def test_readGroupingMap_no(parse_file_as):
         localDataService._defaultGroupingMapPath = mock.Mock(return_value=Path(tmpDir))
 
         runNumber = "flan"
-        res = localDataService.readGroupingMap(runNumber, True)
+        res = localDataService.readGroupingMap(runNumber)
         assert res == parse_file_as.return_value
         assert not localDataService._generateStateId.called
 
@@ -1532,7 +1533,7 @@ def test_readGroupingMap_yes(parse_file_as):
         localDataService._readDefaultGroupingMap = mock.Mock(side_effect=RuntimeError("YOU IDIOT!"))
 
         runNumber = "flan"
-        res = localDataService.readGroupingMap(runNumber, True)
+        res = localDataService.readGroupingMap(runNumber)
         assert res == parse_file_as.return_value
         assert not localDataService._readDefaultGroupingMap.called
 
@@ -1581,7 +1582,7 @@ def test_readGroupingMap_initialized_state():
         service._constructCalibrationStateRoot.return_value = str(stateRoot)
         stateRoot.mkdir()
         shutil.copy(Path(Resource.getPath("inputs/pixel_grouping/groupingMap.json")), stateRoot)
-        groupingMap = service._readGroupingMap(stateId, True)
+        groupingMap = service._readGroupingMap(stateId)
         assert groupingMap.stateId == stateId
 
 

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -147,7 +147,7 @@ def test_readStateConfig():
 
     localDataService.instrumentConfig = getMockInstrumentConfig()
 
-    actual = localDataService.readStateConfig("57514")
+    actual = localDataService.readStateConfig("57514", True)
     assert actual is not None
     assert actual.stateId == "ab8704b0bc2a2342"
 
@@ -175,7 +175,7 @@ def test_readStateConfig_attaches_grouping_map():
 
     localDataService.instrumentConfig = getMockInstrumentConfig()
 
-    actual = localDataService.readStateConfig("57514")
+    actual = localDataService.readStateConfig("57514", True)
     assert actual.groupingMap == stateGroupingMap
 
 
@@ -208,7 +208,7 @@ def test_readStateConfig_invalid_grouping_map():
 
         localDataService.instrumentConfig = getMockInstrumentConfig()
 
-        localDataService.readStateConfig("57514")
+        localDataService.readStateConfig("57514", True)
 
 
 @mock.patch.object(LocalDataService, "_prepareStateRoot")
@@ -236,7 +236,7 @@ def test_readStateConfig_calls_prepareStateRoot(mockPrepareStateRoot):
 
     localDataService.instrumentConfig = getMockInstrumentConfig()
 
-    actual = localDataService.readStateConfig("57514")
+    actual = localDataService.readStateConfig("57514", True)
     assert actual is not None
     mockPrepareStateRoot.assert_called_once()
 
@@ -255,7 +255,7 @@ def test_prepareStateRoot_creates_state_root_directory():
         localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
 
         assert not stateRootPath.exists()
-        localDataService._prepareStateRoot(stateId)
+        localDataService._prepareStateRoot(stateId, True)
         assert stateRootPath.exists()
 
 
@@ -274,7 +274,7 @@ def test_prepareStateRoot_existing_state_root():
         localDataService._readDefaultGroupingMap = mock.Mock(return_value=defaultGroupingMap)
         localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
         assert stateRootPath.exists()
-        localDataService._prepareStateRoot(stateId)
+        localDataService._prepareStateRoot(stateId, True)
 
 
 def test_prepareStateRoot_writes_grouping_map():
@@ -292,7 +292,7 @@ def test_prepareStateRoot_writes_grouping_map():
         localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
 
         assert not groupingMapFilePath.exists()
-        localDataService._prepareStateRoot(stateId)
+        localDataService._prepareStateRoot(stateId, True)
         assert groupingMapFilePath.exists()
 
 
@@ -310,7 +310,7 @@ def test_prepareStateRoot_sets_grouping_map_stateid():
         localDataService._readDefaultGroupingMap = mock.Mock(return_value=defaultGroupingMap)
         localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
 
-        localDataService._prepareStateRoot(stateId)
+        localDataService._prepareStateRoot(stateId, True)
 
         with open(groupingMapFilePath, "r") as file:
             groupingMap = parse_raw_as(GroupingMap, file.read())
@@ -335,7 +335,7 @@ def test_prepareStateRoot_no_default_grouping_map():
             localDataService._constructCalibrationStateRoot = mock.Mock(return_value=str(stateRootPath))
             localDataService._defaultGroupingMapPath = mock.Mock(return_value=Path(defaultGroupingMapFilePath))
             localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
-            localDataService._prepareStateRoot(stateId)
+            localDataService._prepareStateRoot(stateId, True)
 
 
 def test_prepareStateRoot_does_not_overwrite_grouping_map():
@@ -364,7 +364,7 @@ def test_prepareStateRoot_does_not_overwrite_grouping_map():
         localDataService._readDefaultGroupingMap = mock.Mock(return_value=defaultGroupingMap)
         localDataService._groupingMapPath = mock.Mock(return_value=groupingMapFilePath)
 
-        localDataService._prepareStateRoot(stateId)
+        localDataService._prepareStateRoot(stateId, True)
 
         with open(groupingMapFilePath, "r") as file:
             groupingMap = parse_raw_as(GroupingMap, file.read())
@@ -394,7 +394,7 @@ def test_writeGroupingMap_relative_paths():
             with open(defaultGroupingMapFilePath, "r") as file:
                 groupingMap = parse_raw_as(GroupingMap, file.read())
             groupingMap.coerceStateId(stateId)
-            localDataService._writeGroupingMap(stateId, groupingMap)
+            localDataService._writeGroupingMap(stateId, groupingMap, True)
 
             # read it back
             groupingMap = GroupingMap.parse_file(groupingMapFilePath)
@@ -423,7 +423,7 @@ def test_calibrationFileExists(GetIPTS):  # noqa ARG002
         localDataService._generateStateId = mock.Mock(return_value=("ab8704b0bc2a2342", None))
         localDataService._constructCalibrationStateRoot = mock.Mock(return_value=tmpDir)
         runNumber = "654321"
-        assert localDataService.checkCalibrationFileExists(runNumber)
+        assert localDataService.checkCalibrationFileExists(runNumber, True)
 
 
 @mock.patch(ThisService + "GetIPTS")
@@ -432,12 +432,12 @@ def test_calibrationFileExists_stupid_number(GetIPTS):
 
     # try with a non-number
     runNumber = "fruitcake"
-    assert not localDataService.checkCalibrationFileExists(runNumber)
+    assert not localDataService.checkCalibrationFileExists(runNumber, True)
     assert not GetIPTS.called
 
     # try with a too-small number
     runNumber = "7"
-    assert not localDataService.checkCalibrationFileExists(runNumber)
+    assert not localDataService.checkCalibrationFileExists(runNumber, True)
     assert not GetIPTS.called
 
 
@@ -449,7 +449,7 @@ def test_calibrationFileExists_bad_ipts(GetIPTS):
         localDataService = LocalDataService()
         localDataService.iptsCache = {}  # clear the ipts cache
         runNumber = "654321"
-        assert not localDataService.checkCalibrationFileExists(runNumber)
+        assert not localDataService.checkCalibrationFileExists(runNumber, True)
 
 
 @mock.patch(ThisService + "GetIPTS")
@@ -461,7 +461,7 @@ def test_calibrationFileExists_not(GetIPTS):  # noqa ARG002
         assert not nonExistentPath.exists()
         localDataService._constructCalibrationStateRoot = mock.Mock(return_value=str(nonExistentPath))
         runNumber = "654321"
-        assert not localDataService.checkCalibrationFileExists(runNumber)
+        assert not localDataService.checkCalibrationFileExists(runNumber, True)
 
 
 @mock.patch(ThisService + "GetIPTS")
@@ -576,7 +576,7 @@ def test_write_model_pretty_StateConfig_excludes_grouping_map():
 
     localDataService.instrumentConfig = getMockInstrumentConfig()
 
-    actual = localDataService.readStateConfig("57514")
+    actual = localDataService.readStateConfig("57514", True)
     with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tempdir:
         stateConfigPath = Path(tempdir) / "stateConfig.json"
         write_model_pretty(actual, stateConfigPath)
@@ -643,7 +643,7 @@ def test_readCalibrationIndexMissing():
     localDataService._readReductionParameters = mock.Mock()
     localDataService._constructCalibrationStateRoot = mock.Mock()
     localDataService._constructCalibrationStateRoot.return_value = Resource.getPath("outputs")
-    assert len(localDataService.readCalibrationIndex("123")) == 0
+    assert len(localDataService.readCalibrationIndex("123", True)) == 0
 
 
 def test_readNormalizationIndexMissing():
@@ -654,7 +654,7 @@ def test_readNormalizationIndexMissing():
     localDataService._readReductionParameters = mock.Mock()
     localDataService._constructCalibrationStateRoot = mock.Mock()
     localDataService._constructCalibrationStateRoot.return_value = Resource.getPath("outputs")
-    assert len(localDataService.readNormalizationIndex("123")) == 0
+    assert len(localDataService.readNormalizationIndex("123", True)) == 0
 
 
 def test_writeCalibrationIndexEntry():
@@ -667,7 +667,7 @@ def test_writeCalibrationIndexEntry():
     localDataService._constructCalibrationStatePath.return_value = Resource.getPath("outputs")
     expectedFilePath = Resource.getPath("outputs") + "CalibrationIndex.json"
     localDataService.writeCalibrationIndexEntry(
-        CalibrationIndexEntry(runNumber="57514", comments="test comment", author="test author")
+        CalibrationIndexEntry(runNumber="57514", comments="test comment", author="test author"), True
     )
     assert os.path.exists(expectedFilePath)
 
@@ -693,7 +693,8 @@ def test_writeCalibrationIndexEntry():
     localDataService.writeNormalizationIndexEntry(
         NormalizationIndexEntry(
             runNumber="57514", backgroundRunNumber="58813", comments="test comment", author="test author"
-        )
+        ),
+        True,
     )
     assert os.path.exists(expectedFilePath)
 
@@ -718,9 +719,9 @@ def test_readCalibrationIndexExisting():
     localDataService._constructCalibrationStatePath.return_value = Resource.getPath("outputs")
     expectedFilePath = Resource.getPath("outputs") + "CalibrationIndex.json"
     localDataService.writeCalibrationIndexEntry(
-        CalibrationIndexEntry(runNumber="57514", comments="test comment", author="test author")
+        CalibrationIndexEntry(runNumber="57514", comments="test comment", author="test author"), True
     )
-    actualEntries = localDataService.readCalibrationIndex("57514")
+    actualEntries = localDataService.readCalibrationIndex("57514", True)
     os.remove(expectedFilePath)
 
     assert len(actualEntries) > 0
@@ -739,9 +740,10 @@ def test_readNormalizationIndexExisting():
     localDataService.writeNormalizationIndexEntry(
         NormalizationIndexEntry(
             runNumber="57514", backgroundRunNumber="58813", comments="test comment", author="test author"
-        )
+        ),
+        True,
     )
-    actualEntries = localDataService.readNormalizationIndex("57514")
+    actualEntries = localDataService.readNormalizationIndex("57514", True)
     os.remove(expectedFilePath)
 
     assert len(actualEntries) > 0
@@ -1084,7 +1086,7 @@ def test_getCalibrationRecordPath():
     localDataService._generateStateId.return_value = ("123", "456")
     localDataService._constructCalibrationStatePath = mock.Mock()
     localDataService._constructCalibrationStatePath.return_value = Resource.getPath("outputs/")
-    actualPath = localDataService.getCalibrationRecordPath("57514", 1)
+    actualPath = localDataService.getCalibrationRecordPath("57514", 1, True)
     assert actualPath == Resource.getPath("outputs") + "/v_0001/CalibrationRecord.json"
 
 
@@ -1094,7 +1096,7 @@ def test_getNormalizationRecordPath():
     localDataService._generateStateId.return_value = ("123", "456")
     localDataService._constructNormalizationCalibrationStatePath = mock.Mock()
     localDataService._constructNormalizationCalibrationStatePath.return_value = Resource.getPath("outputs/")
-    actualPath = localDataService.getNormalizationRecordPath("57514", 1)
+    actualPath = localDataService.getNormalizationRecordPath("57514", 1, True)
     assert actualPath == Resource.getPath("outputs") + "/v_0001/NormalizationRecord.json"
 
 
@@ -1172,7 +1174,7 @@ def test__getVersionFromCalibrationIndex():
     localDataService.readCalibrationIndex.return_value[0] = CalibrationIndexEntry(
         timestamp=123, version="1", appliesTo="123", runNumber="123", comments="", author=""
     )
-    actualVersion = localDataService._getVersionFromCalibrationIndex("123")
+    actualVersion = localDataService._getVersionFromCalibrationIndex("123", True)
     assert actualVersion == "1"
 
 
@@ -1189,7 +1191,7 @@ def test__getVersionFromNormalizationIndex():
         comments="",
         author="",
     )
-    actualVersion = localDataService._getVersionFromNormalizationIndex("123")
+    actualVersion = localDataService._getVersionFromNormalizationIndex("123", True)
     assert actualVersion == "1"
 
 
@@ -1200,7 +1202,7 @@ def test__getCurrentCalibrationRecord():
     localDataService.readCalibrationRecord = mock.Mock()
     mockRecord = mock.Mock()
     localDataService.readCalibrationRecord.return_value = mockRecord
-    actualRecord = localDataService._getCurrentCalibrationRecord("123")
+    actualRecord = localDataService._getCurrentCalibrationRecord("123", True)
     assert actualRecord == mockRecord
 
 
@@ -1211,7 +1213,7 @@ def test__getCurrentNormalizationRecord():
     localDataService.readNormalizationRecord = mock.Mock()
     mockRecord = mock.Mock()
     localDataService.readNormalizationRecord.return_value = mockRecord
-    actualRecord = localDataService._getCurrentNormalizationRecord("123")
+    actualRecord = localDataService._getCurrentNormalizationRecord("123", True)
     assert actualRecord == mockRecord
 
 
@@ -1221,7 +1223,7 @@ def test__constructCalibrationParametersFilePath():
     localDataService._generateStateId.return_value = ("ab8704b0bc2a2342", None)
     localDataService._constructCalibrationStatePath = mock.Mock()
     localDataService._constructCalibrationStatePath.return_value = Resource.getPath("outputs/")
-    actualPath = localDataService._constructCalibrationParametersFilePath("57514", 1)
+    actualPath = localDataService._constructCalibrationParametersFilePath("57514", 1, True)
     assert actualPath == Resource.getPath("outputs") + "/v_0001/CalibrationParameters.json"
 
 
@@ -1514,7 +1516,7 @@ def test_readGroupingMap_no(parse_file_as):
         localDataService._defaultGroupingMapPath = mock.Mock(return_value=Path(tmpDir))
 
         runNumber = "flan"
-        res = localDataService.readGroupingMap(runNumber)
+        res = localDataService.readGroupingMap(runNumber, True)
         assert res == parse_file_as.return_value
         assert not localDataService._generateStateId.called
 
@@ -1529,7 +1531,7 @@ def test_readGroupingMap_yes(parse_file_as):
         localDataService._readDefaultGroupingMap = mock.Mock(side_effect=RuntimeError("YOU IDIOT!"))
 
         runNumber = "flan"
-        res = localDataService.readGroupingMap(runNumber)
+        res = localDataService.readGroupingMap(runNumber, True)
         assert res == parse_file_as.return_value
         assert not localDataService._readDefaultGroupingMap.called
 
@@ -1578,7 +1580,7 @@ def test_readGroupingMap_initialized_state():
         service._constructCalibrationStateRoot.return_value = str(stateRoot)
         stateRoot.mkdir()
         shutil.copy(Path(Resource.getPath("inputs/pixel_grouping/groupingMap.json")), stateRoot)
-        groupingMap = service._readGroupingMap(stateId)
+        groupingMap = service._readGroupingMap(stateId, True)
         assert groupingMap.stateId == stateId
 
 

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -1213,7 +1213,7 @@ def test_readCalibrationState():
     localDataService._getLatestFile = mock.Mock()
     localDataService._getLatestFile.return_value = Resource.getPath("inputs/calibration/CalibrationParameters.json")
     testCalibrationState = Calibration.parse_raw(Resource.read("inputs/calibration/CalibrationParameters.json"))
-    actualState = localDataService.readCalibrationState("57514")
+    actualState = localDataService.readCalibrationState("57514", True)
 
     assert actualState == testCalibrationState
 

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -600,7 +600,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             useLiteMode=True,
         )
         self.instance.initializeState(request)
-        mockInitializeState.assert_called_once_with(request.runId, request.humanReadableName)
+        mockInitializeState.assert_called_once_with(request.runId, request.humanReadableName, request.useLiteMode)
 
     def test_getState(self):
         testCalibration = Calibration.parse_file(Resource.getPath("inputs/calibration/CalibrationParameters.json"))

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -47,6 +47,7 @@ with mock.patch.dict(
     from snapred.backend.dao.request.CalibrationAssessmentRequest import CalibrationAssessmentRequest
     from snapred.backend.dao.request.DiffractionCalibrationRequest import DiffractionCalibrationRequest
     from snapred.backend.dao.request.FarmFreshIngredients import FarmFreshIngredients
+    from snapred.backend.dao.request.HasStateRequest import HasStateRequest
     from snapred.backend.dao.state import PixelGroup
     from snapred.backend.dao.state.FocusGroup import FocusGroup
     from snapred.backend.recipe.DiffractionCalibrationRecipe import DiffractionCalibrationRecipe
@@ -70,7 +71,7 @@ with mock.patch.dict(
         calibrationService = CalibrationService()
         calibrationService.dataExportService.exportCalibrationIndexEntry = mock.Mock()
         calibrationService.dataExportService.exportCalibrationIndexEntry.return_value = "expected"
-        calibrationService.saveCalibrationToIndex(CalibrationIndexEntry(runNumber="1", comments="", author=""))
+        calibrationService.saveCalibrationToIndex(CalibrationIndexEntry(runNumber="1", comments="", author=""), True)
         assert calibrationService.dataExportService.exportCalibrationIndexEntry.called
         savedEntry = calibrationService.dataExportService.exportCalibrationIndexEntry.call_args.args[0]
         assert savedEntry.appliesTo == ">1"
@@ -596,9 +597,10 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         request = InitializeStateRequest(
             runId=testCalibration.seedRun,
             humanReadableName="friendly name",
+            useLiteMode=True,
         )
         self.instance.initializeState(request)
-        mockInitializeState.assert_called_once_with(request.runId, request.humanReadableName)
+        mockInitializeState.assert_called_once_with(request.runId, request.humanReadableName, request.useLiteMode)
 
     def test_getState(self):
         testCalibration = Calibration.parse_file(Resource.getPath("inputs/calibration/CalibrationParameters.json"))
@@ -618,8 +620,12 @@ class TestCalibrationServiceMethods(unittest.TestCase):
     def test_hasState(self):
         mockCheckCalibrationStateExists = mock.Mock(return_value=True)
         self.instance.dataFactoryService.checkCalibrationStateExists = mockCheckCalibrationStateExists
-        self.instance.hasState(self.runNumber)
-        mockCheckCalibrationStateExists.assert_called_once_with(self.runNumber)
+        request = HasStateRequest(
+            runId=self.runNumber,
+            useLiteMode=True,
+        )
+        self.instance.hasState(request)
+        mockCheckCalibrationStateExists.assert_called_once_with(self.runNumber, True)
 
 
 # this at teardown removes the loggers, eliminating logger error printouts

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -600,7 +600,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             useLiteMode=True,
         )
         self.instance.initializeState(request)
-        mockInitializeState.assert_called_once_with(request.runId, request.humanReadableName, request.useLiteMode)
+        mockInitializeState.assert_called_once_with(request.runId, request.humanReadableName)
 
     def test_getState(self):
         testCalibration = Calibration.parse_file(Resource.getPath("inputs/calibration/CalibrationParameters.json"))
@@ -625,7 +625,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             useLiteMode=True,
         )
         self.instance.hasState(request)
-        mockCheckCalibrationStateExists.assert_called_once_with(self.runNumber, True)
+        mockCheckCalibrationStateExists.assert_called_once_with(self.runNumber)
 
 
 # this at teardown removes the loggers, eliminating logger error printouts

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -61,7 +61,9 @@ with mock.patch.dict(
         normalizationService = NormalizationService()
         normalizationService.dataExportService.exportNormalizationIndexEntry = MagicMock()
         normalizationService.dataExportService.exportNormalizationIndexEntry.return_value = "expected"
-        normalizationService.saveNormalizationToIndex(NormalizationIndexEntry(runNumber="1", backgroundRunNumber="2"))
+        normalizationService.saveNormalizationToIndex(
+            NormalizationIndexEntry(runNumber="1", backgroundRunNumber="2"), True
+        )
         assert normalizationService.dataExportService.exportNormalizationIndexEntry.called
         savedEntry = normalizationService.dataExportService.exportNormalizationIndexEntry.call_args.args[0]
         assert savedEntry.appliesTo == ">1"

--- a/tests/unit/ui/presenter/test_InitializeStatePresenter.py
+++ b/tests/unit/ui/presenter/test_InitializeStatePresenter.py
@@ -16,6 +16,7 @@ class TestableQWidget(QWidget):
 
         self.getRunNumber = MagicMock(return_value="12345")
         self.getStateName = MagicMock(return_value="Test State")
+        self.getMode = MagicMock(return_value=True)
         self.beginFlowButton = MagicMock()
 
 
@@ -30,10 +31,11 @@ def test_handleButtonClicked_with_valid_input(setup_view_and_workflow):
     view, workflow = setup_view_and_workflow
     view.getRunNumber.return_value = "12345"
     view.getStateName.return_value = "Test State"
+    view.getMode.return_value = True
 
     with patch.object(workflow, "_initializeState") as mock_initializeState:
         workflow.handleButtonClicked()
-        mock_initializeState.assert_called_once_with("12345", "Test State")
+        mock_initializeState.assert_called_once_with("12345", "Test State", True)
 
 
 def test_handleButtonClicked_with_invalid_input(setup_view_and_workflow):
@@ -49,12 +51,13 @@ def test__initializeState(setup_view_and_workflow):
     view, workflow = setup_view_and_workflow
     view.getRunNumber.return_value = "12345"
     view.getStateName.return_value = "Test State"
+    view.getMode.return_value = "True"
     mock_response = SNAPResponse(code=ResponseCode.OK)
 
     with patch.object(workflow.interfaceController, "executeRequest", return_value=mock_response), patch(
         "snapred.ui.widget.SuccessDialog.SuccessDialog.exec_"
     ) as mock_dialog_exec_:
-        workflow._initializeState("12345", "Test State")
+        workflow._initializeState("12345", "Test State", True)
         mock_dialog_exec_.assert_called_once()
 
 


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->
This work is to add the mode(lite or native) to the paths where records are stored.
## Explanation of work

I started out with modifying the base function call that creates the path `_constructCalibrationStateRoot` in LocalDataService.py. If LiteMode is enabled, modify the path so that "lite" is added to the path, otherwise use "native". This function now takes in `useLiteMode` as a boolean parameter. Because of this, I had to update every related function call, and even more related calls to the already related calls to include the new boolean. 

## To test

### Dev testing

Make sure unit tests pass and do CIS testing below.

### CIS testing

Run both calibration and normalization tabs and complete the save step. Make sure the records are stored in the correct "lite" path.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4719](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4719)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
