### PR TITLE
Do not purge peaks within normalization workflow

### DIFF
--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -166,7 +166,7 @@ class SousChef(Service):
         return NormalizationIngredients(
             pixelGroup=self.prepPixelGroup(ingredients),
             calibrantSample=self.prepCalibrantSample(ingredients.calibrantSamplePath),
-            detectorPeaks=self.prepDetectorPeaks(ingredients),
+            detectorPeaks=self.prepDetectorPeaks(ingredients, purgePeaks=False),
         )
 
     def prepDiffractionCalibrationIngredients(


### PR DESCRIPTION
## Description of work

Normalization was errantly purging peaks before running.  Only diffcal should purge peaks.

From story:
> This is a defect as peaks should not be purged during normalization. This step is only required for diffraction calibration as PDCalibration algorithm requires non-overlapping peaks. The alternate algo of "Strip peaks/smooth" does not have this requirement.

The fix is to change a single parameter when building normalization ingredients in `SousChef`

## To test

1. Open Normalization tab
2. Enter Run number: 58810, Background: 58813 liteMode=True, calibrant sample = "V-Nb_cylinder_001.json", ixel group = "column"
3. Continue
4. Observe no error

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4866](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4866)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
