### PR TITLE
Restore ruff removal of unused imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ markers = [
 line-length = 120
 # https://beta.ruff.rs/docs/rules/
 select = ["A", "ARG", "BLE", "E", "F", "I", "PT"]
-ignore = ["F403", "F405", "F401", # wild imports and  unknown names
+ignore = ["F403", "F405", # wild imports and  unknown names
 ]
 
 [[tool.mypy.overrides]]

--- a/src/snapred/backend/api/InterfaceController.py
+++ b/src/snapred/backend/api/InterfaceController.py
@@ -1,4 +1,3 @@
-import inspect
 import json
 
 from snapred.backend.dao import SNAPRequest, SNAPResponse

--- a/src/snapred/backend/dao/Limit.py
+++ b/src/snapred/backend/dao/Limit.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from typing import Generic, Literal, Tuple, TypeVar
+from typing import Generic, Tuple, TypeVar
 
 from pydantic import root_validator
 from pydantic.generics import GenericModel

--- a/src/snapred/backend/dao/ObjectSHA.py
+++ b/src/snapred/backend/dao/ObjectSHA.py
@@ -2,7 +2,7 @@ import hashlib
 import json
 from typing import Any, Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field
 
 
 class ObjectSHA(BaseModel):

--- a/src/snapred/backend/dao/StateConfig.py
+++ b/src/snapred/backend/dao/StateConfig.py
@@ -1,11 +1,10 @@
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, Field, root_validator, validate_model, validator
 
 from snapred.backend.dao.calibration import Calibration
 from snapred.backend.dao.ObjectSHA import ObjectSHA
 from snapred.backend.dao.state.DiffractionCalibrant import DiffractionCalibrant
-from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.backend.dao.state.GroupingMap import GroupingMap
 from snapred.backend.dao.state.NormalizationCalibrant import NormalizationCalibrant
 

--- a/src/snapred/backend/dao/StateId.py
+++ b/src/snapred/backend/dao/StateId.py
@@ -1,5 +1,3 @@
-import hashlib
-import json
 from dataclasses import dataclass
 
 

--- a/src/snapred/backend/dao/calibration/FocusGroupMetric.py
+++ b/src/snapred/backend/dao/calibration/FocusGroupMetric.py
@@ -3,7 +3,6 @@ from typing import List
 from pydantic import BaseModel
 
 from snapred.backend.dao.calibration.CalibrationMetric import CalibrationMetric
-from snapred.backend.dao.state.FocusGroup import FocusGroup
 
 
 class FocusGroupMetric(BaseModel):

--- a/src/snapred/backend/dao/ingredients/DiffractionCalibrationIngredients.py
+++ b/src/snapred/backend/dao/ingredients/DiffractionCalibrationIngredients.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import List
 
 from pydantic import BaseModel
 

--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -3,7 +3,6 @@ from typing import ClassVar, Literal, Optional
 from pydantic import BaseModel, root_validator
 
 from snapred.backend.log.logger import snapredLogger
-from snapred.meta.Config import Config
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 
 logger = snapredLogger.getLogger(__name__)

--- a/src/snapred/backend/dao/ingredients/NormalizationIngredients.py
+++ b/src/snapred/backend/dao/ingredients/NormalizationIngredients.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List
 
 from pydantic import BaseModel
 

--- a/src/snapred/backend/dao/ingredients/PeakIngredients.py
+++ b/src/snapred/backend/dao/ingredients/PeakIngredients.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pydantic import BaseModel
 
 from snapred.backend.dao.CrystallographicInfo import CrystallographicInfo

--- a/src/snapred/backend/dao/ingredients/PreprocessReductionIngredients.py
+++ b/src/snapred/backend/dao/ingredients/PreprocessReductionIngredients.py
@@ -2,7 +2,6 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
-from snapred.backend.dao.state.PixelGroup import PixelGroup
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
 

--- a/src/snapred/backend/dao/ingredients/ReductionIngredients.py
+++ b/src/snapred/backend/dao/ingredients/ReductionIngredients.py
@@ -1,6 +1,4 @@
-from typing import List
-
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from snapred.backend.dao.ReductionState import ReductionState
 from snapred.backend.dao.RunConfig import RunConfig

--- a/src/snapred/backend/dao/request/CalibrationIndexRequest.py
+++ b/src/snapred/backend/dao/request/CalibrationIndexRequest.py
@@ -1,9 +1,6 @@
-from typing import Optional
-
 from pydantic import BaseModel
 
 from snapred.backend.dao.RunConfig import RunConfig
-from snapred.meta.Config import Config
 
 
 class CalibrationIndexRequest(BaseModel):

--- a/src/snapred/backend/dao/request/CalibrationLoadAssessmentRequest.py
+++ b/src/snapred/backend/dao/request/CalibrationLoadAssessmentRequest.py
@@ -1,9 +1,4 @@
-from typing import Optional
-
 from pydantic import BaseModel
-
-from snapred.backend.dao.RunConfig import RunConfig
-from snapred.meta.Config import Config
 
 
 class CalibrationLoadAssessmentRequest(BaseModel):

--- a/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
+++ b/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
@@ -1,11 +1,9 @@
 # TODO this can probably be relaced in the code with FarmFreshIngredients
 
-from typing import Optional
 
 from pydantic import BaseModel
 
 from snapred.backend.dao.Limit import Pair
-from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.meta.Config import Config
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum

--- a/src/snapred/backend/dao/request/FarmFreshIngredients.py
+++ b/src/snapred/backend/dao/request/FarmFreshIngredients.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel
 
 from snapred.backend.dao.Limit import Limit, Pair
 from snapred.backend.dao.state import FocusGroup

--- a/src/snapred/backend/dao/request/FocusSpectraRequest.py
+++ b/src/snapred/backend/dao/request/FocusSpectraRequest.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-from matplotlib import use
 from pydantic import BaseModel
 
 from snapred.backend.dao.state.FocusGroup import FocusGroup

--- a/src/snapred/backend/dao/state/FocusGroup.py
+++ b/src/snapred/backend/dao/state/FocusGroup.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pydantic import BaseModel
 
 

--- a/src/snapred/backend/dao/state/GroupingMap.py
+++ b/src/snapred/backend/dao/state/GroupingMap.py
@@ -1,5 +1,3 @@
-import logging
-import os
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List
 

--- a/src/snapred/backend/dao/state/InstrumentState.py
+++ b/src/snapred/backend/dao/state/InstrumentState.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any
 
 from pydantic import BaseModel, validator
 

--- a/src/snapred/backend/dao/state/PixelGroup.py
+++ b/src/snapred/backend/dao/state/PixelGroup.py
@@ -1,8 +1,7 @@
 from enum import IntEnum
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Union
 
-import numpy as np
-from pydantic import BaseModel, parse_obj_as
+from pydantic import BaseModel
 
 from snapred.backend.dao.Limit import BinnedValue, Limit
 from snapred.backend.dao.state.FocusGroup import FocusGroup

--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -1,12 +1,9 @@
 import os
-from pdb import run
 from typing import Dict
 
-from snapred.backend.dao import calibration
 from snapred.backend.dao.InstrumentConfig import InstrumentConfig
 from snapred.backend.dao.ReductionState import ReductionState
 from snapred.backend.dao.RunConfig import RunConfig
-from snapred.backend.dao.state.PixelGroup import PixelGroup
 from snapred.backend.dao.StateConfig import StateConfig
 from snapred.backend.data.GroceryService import GroceryService
 from snapred.backend.data.LocalDataService import LocalDataService

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Tuple
 from mantid.simpleapi import mtd
 
 from snapred.backend.dao.ingredients import GroceryListItem
-from snapred.backend.dao.state import DetectorState, GroupingMap
+from snapred.backend.dao.state import DetectorState
 from snapred.backend.data.LocalDataService import LocalDataService
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.backend.recipe.FetchGroceriesRecipe import FetchGroceriesRecipe
@@ -16,7 +16,6 @@ from snapred.meta.Config import Config
 from snapred.meta.decorators.Singleton import Singleton
 from snapred.meta.mantid.WorkspaceNameGenerator import NameBuilder, WorkspaceName
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
-from snapred.meta.redantic import list_to_raw_pretty
 
 
 @Singleton

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -8,8 +8,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 import h5py
-from mantid.api import ITableWorkspace
-from mantid.dataobjects import MaskWorkspace
 from mantid.kernel import PhysicalConstants
 from mantid.simpleapi import GetIPTS, mtd
 from pydantic import parse_file_as
@@ -28,22 +26,19 @@ from snapred.backend.dao.Limit import Limit, Pair
 from snapred.backend.dao.normalization import Normalization, NormalizationIndexEntry, NormalizationRecord
 from snapred.backend.dao.state import (
     DetectorState,
-    DiffractionCalibrant,
-    FocusGroup,
     GroupingMap,
     InstrumentState,
-    NormalizationCalibrant,
 )
 from snapred.backend.dao.state.CalibrantSample import CalibrantSamples
 from snapred.backend.error.RecoverableException import RecoverableException
 from snapred.backend.error.StateValidationException import StateValidationException
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
-from snapred.meta.Config import Config, Resource
+from snapred.meta.Config import Config
 from snapred.meta.decorators.ExceptionHandler import ExceptionHandler
 from snapred.meta.decorators.Singleton import Singleton
 from snapred.meta.mantid.WorkspaceNameGenerator import ValueFormatter as wnvf
-from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName, WorkspaceType
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceType as wngt
 from snapred.meta.redantic import (

--- a/src/snapred/backend/recipe/CrystallographicInfoRecipe.py
+++ b/src/snapred/backend/recipe/CrystallographicInfoRecipe.py
@@ -3,7 +3,6 @@ from typing import Any, Dict
 from snapred.backend.dao.CrystallographicInfo import CrystallographicInfo
 from snapred.backend.dao.state.CalibrantSample.Crystallography import Crystallography
 from snapred.backend.log.logger import snapredLogger
-from snapred.backend.recipe.algorithm.CrystallographicInfoAlgorithm import CrystallographicInfoAlgorithm
 from snapred.backend.recipe.algorithm.Utensils import Utensils
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Singleton import Singleton

--- a/src/snapred/backend/recipe/DiffractionCalibrationRecipe.py
+++ b/src/snapred/backend/recipe/DiffractionCalibrationRecipe.py
@@ -5,10 +5,8 @@ from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients as
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.GroupDiffractionCalibration import GroupDiffractionCalibration
 from snapred.backend.recipe.algorithm.PixelDiffractionCalibration import PixelDiffractionCalibration
-from snapred.backend.recipe.algorithm.WashDishes import WashDishes
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Singleton import Singleton
-from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 
 logger = snapredLogger.getLogger(__name__)
 

--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -1,15 +1,8 @@
-import os
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict
 
-from mantid.simpleapi import CloneWorkspace, mtd
-
-from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.FetchGroceriesAlgorithm import FetchGroceriesAlgorithm as FetchAlgo
-from snapred.meta.Config import Config
 from snapred.meta.decorators.Singleton import Singleton
-from snapred.meta.mantid.WorkspaceNameGenerator import NameBuilder
-from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 
 logger = snapredLogger.getLogger(__name__)
 

--- a/src/snapred/backend/recipe/GenerateFocussedVanadiumRecipe.py
+++ b/src/snapred/backend/recipe/GenerateFocussedVanadiumRecipe.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, Dict
 
 from snapred.backend.dao.ingredients import GenerateFocussedVanadiumIngredients as Ingredients

--- a/src/snapred/backend/recipe/GenericRecipe.py
+++ b/src/snapred/backend/recipe/GenericRecipe.py
@@ -15,7 +15,7 @@ from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.backend.recipe.algorithm.PurgeOverlappingPeaksAlgorithm import PurgeOverlappingPeaksAlgorithm
 from snapred.backend.recipe.algorithm.RawVanadiumCorrectionAlgorithm import RawVanadiumCorrectionAlgorithm
 from snapred.backend.recipe.algorithm.SmoothDataExcludingPeaksAlgo import SmoothDataExcludingPeaksAlgo
-from snapred.meta.decorators.FromString import isBaseModel, isListOfBaseModel
+from snapred.meta.decorators.FromString import isBaseModel
 
 logger = snapredLogger.getLogger(__name__)
 

--- a/src/snapred/backend/recipe/PixelGroupingParametersCalculationRecipe.py
+++ b/src/snapred/backend/recipe/PixelGroupingParametersCalculationRecipe.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, Dict, List
 
 from pydantic import parse_raw_as

--- a/src/snapred/backend/recipe/PreprocessReductionRecipe.py
+++ b/src/snapred/backend/recipe/PreprocessReductionRecipe.py
@@ -2,10 +2,7 @@ from typing import Any, Dict, List, Tuple
 
 from snapred.backend.dao.ingredients import PreprocessReductionIngredients as Ingredients
 from snapred.backend.log.logger import snapredLogger
-from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
-from snapred.backend.recipe.algorithm.Utensils import Utensils
 from snapred.backend.recipe.Recipe import Recipe
-from snapred.meta.Config import Config
 from snapred.meta.decorators.Singleton import Singleton
 
 logger = snapredLogger.getLogger(__name__)

--- a/src/snapred/backend/recipe/ReadWorkspaceMetadata.py
+++ b/src/snapred/backend/recipe/ReadWorkspaceMetadata.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, Dict, Tuple
 
 from snapred.backend.dao.WorkspaceMetadata import UNSET, WorkspaceMetadata

--- a/src/snapred/backend/recipe/Recipe.py
+++ b/src/snapred/backend/recipe/Recipe.py
@@ -1,10 +1,9 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Generic, List, Tuple, TypeVar, get_args
+from typing import Dict, Generic, List, Tuple, TypeVar, get_args
 
 from pydantic import BaseModel, ValidationError
 
 from snapred.backend.log.logger import snapredLogger
-from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.backend.recipe.algorithm.Utensils import Utensils
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 

--- a/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
+++ b/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, List, Tuple
 
 from snapred.backend.log.logger import snapredLogger
-from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.backend.recipe.algorithm.Utensils import Utensils
 from snapred.meta.decorators.Singleton import Singleton
 

--- a/src/snapred/backend/recipe/WriteWorkspaceMetadata.py
+++ b/src/snapred/backend/recipe/WriteWorkspaceMetadata.py
@@ -1,5 +1,4 @@
-import json
-from typing import Any, Dict, List, Tuple
+from typing import Dict, Tuple
 
 from snapred.backend.dao.WorkspaceMetadata import UNSET, WorkspaceMetadata
 from snapred.backend.log.logger import snapredLogger

--- a/src/snapred/backend/recipe/algorithm/CalculateDiffCalTable.py
+++ b/src/snapred/backend/recipe/algorithm/CalculateDiffCalTable.py
@@ -1,7 +1,3 @@
-import json
-from typing import Dict, List, Tuple
-
-import numpy as np
 from mantid.api import (
     AlgorithmFactory,
     ITableWorkspaceProperty,

--- a/src/snapred/backend/recipe/algorithm/CalibrationMetricExtractionAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/CalibrationMetricExtractionAlgorithm.py
@@ -1,10 +1,8 @@
 import json
-from typing import List
 
 import numpy as np
 from mantid.api import AlgorithmFactory, PythonAlgorithm
 from mantid.kernel import Direction
-from pydantic import parse_raw_as
 
 from snapred.backend.dao.calibration.CalibrationMetric import CalibrationMetric
 from snapred.backend.dao.state import PixelGroup

--- a/src/snapred/backend/recipe/algorithm/CustomGroupWorkspace.py
+++ b/src/snapred/backend/recipe/algorithm/CustomGroupWorkspace.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict
 
 from mantid.api import AlgorithmFactory, PropertyMode, PythonAlgorithm, WorkspaceGroupProperty
 from mantid.kernel import Direction, StringArrayProperty

--- a/src/snapred/backend/recipe/algorithm/DetectorPeakPredictor.py
+++ b/src/snapred/backend/recipe/algorithm/DetectorPeakPredictor.py
@@ -1,5 +1,3 @@
-import json
-
 import numpy as np
 from mantid.api import AlgorithmFactory, PythonAlgorithm
 from mantid.kernel import Direction, PhysicalConstants

--- a/src/snapred/backend/recipe/algorithm/DiffractionSpectrumWeightCalculator.py
+++ b/src/snapred/backend/recipe/algorithm/DiffractionSpectrumWeightCalculator.py
@@ -1,4 +1,3 @@
-import json
 from typing import Dict, List
 
 import numpy as np

--- a/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
@@ -1,7 +1,6 @@
 import json
-from typing import Dict, List, Tuple
+from typing import Dict
 
-import numpy as np
 from mantid.api import (
     AlgorithmFactory,
     FileAction,

--- a/src/snapred/backend/recipe/algorithm/FitMultiplePeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FitMultiplePeaksAlgorithm.py
@@ -1,4 +1,3 @@
-import json
 from enum import Enum
 from typing import Dict, List
 

--- a/src/snapred/backend/recipe/algorithm/FocusSpectraAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FocusSpectraAlgorithm.py
@@ -1,5 +1,3 @@
-import json
-from ast import In
 from typing import Dict
 
 from mantid.api import (

--- a/src/snapred/backend/recipe/algorithm/GenerateTableWorkspaceFromListOfDict.py
+++ b/src/snapred/backend/recipe/algorithm/GenerateTableWorkspaceFromListOfDict.py
@@ -4,7 +4,6 @@ from mantid.api import AlgorithmFactory, ITableWorkspaceProperty, PropertyMode, 
 from mantid.kernel import Direction
 
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
-from snapred.meta.Config import Config
 
 
 class GenerateTableWorkspaceFromListOfDict(PythonAlgorithm):

--- a/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
@@ -1,5 +1,4 @@
-import json
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
 from mantid.api import (
     AlgorithmFactory,
@@ -12,7 +11,6 @@ from mantid.dataobjects import MaskWorkspaceProperty
 from mantid.kernel import Direction, StringMandatoryValidator
 
 from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients as Ingredients
-from snapred.backend.dao.state.PixelGroup import PixelGroup
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
@@ -72,7 +70,6 @@ class GroupDiffractionCalibration(PythonAlgorithm):
 
     def chopIngredients(self, ingredients: Ingredients) -> None:
         """Receive the ingredients from the recipe, and exctract the needed pieces for this algorithm."""
-        from datetime import date
 
         """Receive the ingredients from the recipe, and exctract the needed pieces for this algorithm."""
         self.runNumber: str = ingredients.runConfig.runNumber

--- a/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
@@ -1,4 +1,3 @@
-import json
 from typing import Dict
 
 from mantid.api import (
@@ -9,7 +8,6 @@ from mantid.api import (
 )
 from mantid.kernel import Direction
 
-from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
 

--- a/src/snapred/backend/recipe/algorithm/LoadCalibrationWorkspaces.py
+++ b/src/snapred/backend/recipe/algorithm/LoadCalibrationWorkspaces.py
@@ -1,5 +1,4 @@
 import pathlib
-from datetime import datetime
 from typing import Dict
 
 from mantid.api import (
@@ -17,7 +16,6 @@ from mantid.kernel import Direction
 
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
-from snapred.meta.Config import Config
 
 logger = snapredLogger.getLogger(__name__)
 

--- a/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
+++ b/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
@@ -1,10 +1,6 @@
-import json
-from typing import Dict, List, Tuple
-
-import numpy as np
 from mantid.api import AlgorithmFactory, PythonAlgorithm
-from mantid.kernel import Direction, StringArrayProperty
-from mantid.simpleapi import CloneWorkspace, mtd
+from mantid.kernel import Direction
+from mantid.simpleapi import CloneWorkspace
 
 from snapred.meta.Config import Config
 

--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -4,7 +4,6 @@ from collections import namedtuple
 from mantid.api import AlgorithmManager, Progress, mtd
 from mantid.kernel import Direction
 
-import snapred.backend.recipe.algorithm
 from snapred.backend.error.AlgorithmException import AlgorithmException
 from snapred.backend.log.logger import snapredLogger
 

--- a/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculationAlgorithm.py
@@ -1,7 +1,4 @@
-import json
 import math
-import pathlib
-from statistics import mean
 
 import numpy as np
 from mantid.api import (

--- a/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
@@ -1,4 +1,3 @@
-import json
 from typing import Dict, List
 
 import numpy as np
@@ -6,7 +5,6 @@ from mantid.api import AlgorithmFactory, PythonAlgorithm
 from mantid.kernel import Direction
 from pydantic import parse_raw_as
 
-from snapred.backend.dao import CrystallographicInfo
 from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.ingredients import PeakIngredients
 from snapred.backend.log.logger import snapredLogger

--- a/src/snapred/backend/recipe/algorithm/RawVanadiumCorrectionAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/RawVanadiumCorrectionAlgorithm.py
@@ -1,6 +1,3 @@
-from typing import Dict, Tuple
-
-import numpy as np
 from mantid.api import (
     AlgorithmFactory,
     MatrixWorkspaceProperty,
@@ -10,7 +7,6 @@ from mantid.api import (
 from mantid.kernel import Direction, StringMandatoryValidator
 
 from snapred.backend.dao.ingredients import NormalizationIngredients as Ingredients
-from snapred.backend.dao.state.CalibrantSample.CalibrantSamples import CalibrantSamples
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 
 

--- a/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py
@@ -12,7 +12,6 @@ from mantid.api import (
 )
 from mantid.kernel import Direction
 
-from snapred.backend.error.AlgorithmException import AlgorithmException
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 
 

--- a/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
@@ -10,12 +10,10 @@ implement csaps
 create new workspace with csaps data
 """
 
-import json
 from datetime import datetime
 from typing import Dict
 
-import numpy as np
-from mantid.api import AlgorithmFactory, IEventWorkspace, MatrixWorkspaceProperty, PropertyMode, PythonAlgorithm
+from mantid.api import AlgorithmFactory, MatrixWorkspaceProperty, PropertyMode, PythonAlgorithm
 from mantid.kernel import Direction
 from scipy.interpolate import make_smoothing_spline
 

--- a/src/snapred/backend/recipe/algorithm/WashDishes.py
+++ b/src/snapred/backend/recipe/algorithm/WashDishes.py
@@ -1,7 +1,3 @@
-import json
-from typing import Dict, List, Tuple
-
-import numpy as np
 from mantid.api import AlgorithmFactory, PythonAlgorithm
 from mantid.kernel import Direction, StringArrayProperty
 from mantid.simpleapi import DeleteWorkspace, DeleteWorkspaces, mtd

--- a/src/snapred/backend/recipe/algorithm/data/ReheatLeftovers.py
+++ b/src/snapred/backend/recipe/algorithm/data/ReheatLeftovers.py
@@ -1,26 +1,16 @@
 import glob
-import json
-import os
 import tarfile
 import tempfile
-import time
-from typing import Dict, List, Tuple
 
-import numpy as np
 from mantid.api import (
     AlgorithmFactory,
     FileAction,
     FileProperty,
-    MatrixWorkspace,
-    MatrixWorkspaceProperty,
-    PropertyMode,
     PythonAlgorithm,
 )
-from mantid.kernel import Direction, StringArrayProperty
-from mantid.simpleapi import CloneWorkspace, mtd
+from mantid.kernel import Direction
 
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
-from snapred.meta.Config import Config
 
 
 class ReheatLeftovers(PythonAlgorithm):

--- a/src/snapred/backend/recipe/algorithm/data/WrapLeftovers.py
+++ b/src/snapred/backend/recipe/algorithm/data/WrapLeftovers.py
@@ -1,10 +1,7 @@
-import json
 import os
 import tarfile
 import time
-from typing import Dict, List, Tuple
 
-import numpy as np
 from mantid.api import (
     AlgorithmFactory,
     FileAction,
@@ -13,11 +10,9 @@ from mantid.api import (
     PropertyMode,
     PythonAlgorithm,
 )
-from mantid.kernel import Direction, StringArrayProperty
-from mantid.simpleapi import CloneWorkspace, mtd
+from mantid.kernel import Direction
 
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
-from snapred.meta.Config import Config
 
 
 class WrapLeftovers(PythonAlgorithm):

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -1,8 +1,7 @@
-import json
 import time
 from typing import Dict, List
 
-from pydantic import parse_file_as, parse_raw_as
+from pydantic import parse_raw_as
 
 from snapred.backend.dao import Limit, RunConfig
 from snapred.backend.dao.calibration import (
@@ -38,18 +37,14 @@ from snapred.backend.recipe.GenericRecipe import (
     CalibrationMetricExtractionRecipe,
     FitMultiplePeaksRecipe,
     FocusSpectraRecipe,
-    GenerateTableWorkspaceFromListOfDictRecipe,
 )
-from snapred.backend.recipe.GroupWorkspaceIterator import GroupWorkspaceIterator
 from snapred.backend.service.Service import Service
 from snapred.backend.service.SousChef import SousChef
 from snapred.meta.Config import Config
 from snapred.meta.decorators.FromString import FromString
 from snapred.meta.decorators.Singleton import Singleton
-from snapred.meta.mantid.WorkspaceNameGenerator import ValueFormatter as wnvf
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceType as wngt
-from snapred.meta.redantic import list_to_raw
 
 logger = snapredLogger.getLogger(__name__)
 

--- a/src/snapred/backend/service/LiteDataService.py
+++ b/src/snapred/backend/service/LiteDataService.py
@@ -1,7 +1,5 @@
-import os
-from typing import Any, Dict, List
+from typing import Any, Dict
 
-from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.recipe.GenericRecipe import LiteDataRecipe as Recipe
 from snapred.backend.service.Service import Service
 from snapred.meta.decorators.FromString import FromString

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -1,13 +1,10 @@
-import re
 import time
-from typing import Any, Dict
 
 from snapred.backend.dao import Limit
 from snapred.backend.dao.ingredients import (
     GroceryListItem,
 )
 from snapred.backend.dao.normalization import (
-    Normalization,
     NormalizationIndexEntry,
     NormalizationRecord,
 )

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -1,8 +1,3 @@
-import json
-import os.path
-import time
-from datetime import date
-from functools import lru_cache
 from typing import Dict, List, Tuple
 
 from pydantic import parse_raw_as
@@ -30,9 +25,7 @@ from snapred.backend.recipe.PixelGroupingParametersCalculationRecipe import Pixe
 from snapred.backend.service.CrystallographicInfoService import CrystallographicInfoService
 from snapred.backend.service.Service import Service
 from snapred.meta.Config import Config
-from snapred.meta.decorators.FromString import FromString
 from snapred.meta.decorators.Singleton import Singleton
-from snapred.meta.redantic import list_to_raw
 
 
 @Singleton

--- a/src/snapred/backend/service/WorkspaceMetadataService.py
+++ b/src/snapred/backend/service/WorkspaceMetadataService.py
@@ -1,11 +1,9 @@
-import os
-from typing import Any, Dict, List
+from typing import List
 
 from snapred.backend.dao.WorkspaceMetadata import WorkspaceMetadata
 from snapred.backend.recipe.ReadWorkspaceMetadata import ReadWorkspaceMetadata
 from snapred.backend.recipe.WriteWorkspaceMetadata import WriteWorkspaceMetadata
 from snapred.backend.service.Service import Service
-from snapred.meta.decorators.FromString import FromString
 from snapred.meta.decorators.Singleton import Singleton
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 

--- a/src/snapred/meta/builder/GroceryListBuilder.py
+++ b/src/snapred/meta/builder/GroceryListBuilder.py
@@ -1,7 +1,6 @@
 from typing import Dict, List
 
 from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
-from snapred.meta.Config import Config
 
 
 class GroceryListBuilder:

--- a/src/snapred/meta/decorators/Builder.py
+++ b/src/snapred/meta/decorators/Builder.py
@@ -1,6 +1,3 @@
-from functools import wraps
-
-
 class _PydanticBuilder:
     def __init__(self, orig_cls):
         self.cls = orig_cls

--- a/src/snapred/meta/decorators/ExceptionToErrLog.py
+++ b/src/snapred/meta/decorators/ExceptionToErrLog.py
@@ -1,7 +1,6 @@
 import functools
-from typing import Any, Callable, Optional, Type
+from typing import Any, Callable
 
-from snapred.backend.error.RecoverableException import RecoverableException
 from snapred.backend.log.logger import snapredLogger
 
 logger = snapredLogger.getLogger(__name__)

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -1,6 +1,6 @@
 import re
 from enum import Enum
-from typing import Dict, List
+from typing import List
 
 from snapred.meta.Config import Config
 

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -6,7 +6,6 @@ from qtpy.QtWidgets import (
     QApplication,
     QMainWindow,
     QPushButton,
-    QSizePolicy,
     QSplitter,
     QStatusBar,
     QVBoxLayout,

--- a/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
+++ b/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
@@ -1,5 +1,4 @@
-from qtpy.QtCore import QObject, Qt, Signal
-from qtpy.QtWidgets import QLabel, QMessageBox, QVBoxLayout, QWidget
+from qtpy.QtCore import QObject
 
 from snapred.backend.api.InterfaceController import InterfaceController
 from snapred.backend.dao import RunConfig, SNAPRequest

--- a/src/snapred/ui/presenter/LogTablePresenter.py
+++ b/src/snapred/ui/presenter/LogTablePresenter.py
@@ -1,10 +1,6 @@
-from time import sleep
-
-from qtpy.QtWidgets import QLabel, QMessageBox, QVBoxLayout, QWidget
+from qtpy.QtWidgets import QLabel, QVBoxLayout, QWidget
 
 from snapred.backend.api.InterfaceController import InterfaceController
-from snapred.backend.dao.RunConfig import RunConfig
-from snapred.backend.dao.SNAPRequest import SNAPRequest
 from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.ui.threading.worker_pool import WorkerPool
 

--- a/src/snapred/ui/presenter/TestPanelPresenter.py
+++ b/src/snapred/ui/presenter/TestPanelPresenter.py
@@ -1,7 +1,6 @@
 import json
 
-from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QComboBox, QGridLayout, QWidget
+from qtpy.QtWidgets import QGridLayout, QWidget
 
 from snapred.backend.api.InterfaceController import InterfaceController
 from snapred.backend.dao.SNAPRequest import SNAPRequest

--- a/src/snapred/ui/presenter/WorkflowPresenter.py
+++ b/src/snapred/ui/presenter/WorkflowPresenter.py
@@ -1,11 +1,8 @@
-from os import path
-
-from qtpy.QtWidgets import QMainWindow, QMessageBox
+from qtpy.QtWidgets import QMainWindow
 
 from snapred.backend.api.InterfaceController import InterfaceController
 from snapred.backend.dao import SNAPRequest
 from snapred.backend.dao.request import ClearWorkspaceRequest
-from snapred.backend.dao.SNAPResponse import ResponseCode
 from snapred.backend.log.logger import snapredLogger
 from snapred.ui.handler.SNAPResponseHandler import SNAPResponseHandler
 from snapred.ui.model.WorkflowNodeModel import WorkflowNodeModel

--- a/src/snapred/ui/threading/worker_pool.py
+++ b/src/snapred/ui/threading/worker_pool.py
@@ -1,4 +1,3 @@
-import code
 from typing import Dict, List
 
 from qtpy.QtCore import QObject, QThread, Signal

--- a/src/snapred/ui/view/BackendRequestView.py
+++ b/src/snapred/ui/view/BackendRequestView.py
@@ -1,9 +1,6 @@
-import json
-
-from qtpy.QtWidgets import QGridLayout, QHBoxLayout, QLabel, QMessageBox, QPushButton, QWidget
+from qtpy.QtWidgets import QGridLayout, QWidget
 
 from snapred.backend.api.InterfaceController import InterfaceController
-from snapred.backend.dao.SNAPRequest import SNAPRequest
 from snapred.ui.threading.worker_pool import WorkerPool
 from snapred.ui.widget.LabeledCheckBox import LabeledCheckBox
 from snapred.ui.widget.LabeledField import LabeledField

--- a/src/snapred/ui/view/DiffCalAssessmentView.py
+++ b/src/snapred/ui/view/DiffCalAssessmentView.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List
 
 # from qtpy import signals and widgets
 from qtpy.QtCore import Signal

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -1,9 +1,6 @@
-import math
-import unittest.mock as mock
 from typing import List
 
 import matplotlib.pyplot as plt
-import numpy as np
 from mantid.plots.datafunctions import get_spectrum
 from mantid.simpleapi import mtd
 from pydantic import parse_obj_as
@@ -14,7 +11,7 @@ from qtpy.QtWidgets import (
     QMessageBox,
     QPushButton,
 )
-from workbench.plotting.figuremanager import FigureManagerWorkbench, MantidFigureCanvas
+from workbench.plotting.figuremanager import MantidFigureCanvas
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
 
 from snapred.backend.dao import GroupPeakList

--- a/src/snapred/ui/view/FitMultiplePeaksView.py
+++ b/src/snapred/ui/view/FitMultiplePeaksView.py
@@ -1,5 +1,3 @@
-import os
-
 from qtpy.QtWidgets import QLabel, QVBoxLayout, QWidget
 
 from snapred.backend.dao.ingredients import PeakIngredients as Ingredients

--- a/src/snapred/ui/view/InitializeStateCheckView.py
+++ b/src/snapred/ui/view/InitializeStateCheckView.py
@@ -5,9 +5,6 @@ from qtpy.QtWidgets import (
     QLineEdit,
     QMessageBox,
     QPushButton,
-    QSizePolicy,
-    QSpacerItem,
-    QWidget,
 )
 
 from snapred.ui.presenter.InitializeStatePresenter import InitializeStatePresenter

--- a/src/snapred/ui/view/IterateView.py
+++ b/src/snapred/ui/view/IterateView.py
@@ -1,13 +1,6 @@
-import json
+from qtpy.QtWidgets import QGridLayout, QLabel, QWidget
 
-from qtpy.QtWidgets import QGridLayout, QHBoxLayout, QLabel, QMessageBox, QPushButton, QWidget
-
-from snapred.backend.api.InterfaceController import InterfaceController
-from snapred.backend.dao.SNAPRequest import SNAPRequest
 from snapred.meta.decorators.Resettable import Resettable
-from snapred.ui.threading.worker_pool import WorkerPool
-from snapred.ui.widget.LabeledField import LabeledField
-from snapred.ui.widget.SampleDropDown import SampleDropDown
 
 
 @Resettable

--- a/src/snapred/ui/view/JsonFormListView.py
+++ b/src/snapred/ui/view/JsonFormListView.py
@@ -1,7 +1,4 @@
-from qtpy.QtWidgets import QGridLayout, QMainWindow, QPushButton, QTabWidget, QWidget
-
-from snapred.ui.model.WorkflowNodeModel import WorkflowNodeModel
-from snapred.ui.view.WorkflowNodeView import WorkflowNodeView
+from qtpy.QtWidgets import QGridLayout, QWidget
 
 
 class JsonFormListView(QWidget):

--- a/src/snapred/ui/view/NormalizationTweakPeakView.py
+++ b/src/snapred/ui/view/NormalizationTweakPeakView.py
@@ -1,4 +1,3 @@
-import math
 from typing import List
 
 import matplotlib.pyplot as plt
@@ -12,7 +11,7 @@ from qtpy.QtWidgets import (
     QMessageBox,
     QPushButton,
 )
-from workbench.plotting.figuremanager import FigureManagerWorkbench, MantidFigureCanvas
+from workbench.plotting.figuremanager import MantidFigureCanvas
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
 
 from snapred.backend.dao import GroupPeakList
@@ -20,7 +19,6 @@ from snapred.meta.Config import Config
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.view.BackendRequestView import BackendRequestView
 from snapred.ui.widget.SmoothingSlider import SmoothingSlider
-from snapred.ui.widget.Toggle import Toggle
 
 
 @Resettable

--- a/src/snapred/ui/view/WorkflowNodeView.py
+++ b/src/snapred/ui/view/WorkflowNodeView.py
@@ -1,4 +1,4 @@
-from qtpy.QtWidgets import QGridLayout, QMainWindow, QPushButton, QWidget
+from qtpy.QtWidgets import QGridLayout, QPushButton, QWidget
 
 
 class WorkflowNodeView(QWidget):

--- a/src/snapred/ui/view/WorkflowView.py
+++ b/src/snapred/ui/view/WorkflowView.py
@@ -1,4 +1,4 @@
-from qtpy.QtWidgets import QGridLayout, QMainWindow, QPushButton, QTabWidget, QWidget
+from qtpy.QtWidgets import QGridLayout, QTabWidget, QWidget
 
 from snapred.ui.model.WorkflowNodeModel import WorkflowNodeModel
 from snapred.ui.view.WorkflowNodeView import WorkflowNodeView

--- a/src/snapred/ui/widget/JsonFormList.py
+++ b/src/snapred/ui/widget/JsonFormList.py
@@ -1,5 +1,3 @@
-from qtpy.QtWidgets import QGridLayout, QMainWindow, QPushButton, QTabWidget, QWidget
-
 from snapred.ui.view.JsonFormListView import JsonFormListView
 from snapred.ui.widget.JsonForm import JsonForm
 

--- a/src/snapred/ui/widget/Workflow.py
+++ b/src/snapred/ui/widget/Workflow.py
@@ -1,6 +1,5 @@
 from snapred.ui.model.WorkflowNodeModel import WorkflowNodeModel
 from snapred.ui.presenter.WorkflowPresenter import WorkflowPresenter
-from snapred.ui.view.WorkflowView import WorkflowView
 
 
 class Workflow:

--- a/src/snapred/ui/widget/WorkflowNode.py
+++ b/src/snapred/ui/widget/WorkflowNode.py
@@ -1,4 +1,3 @@
-from snapred.ui.model.WorkflowNodeModel import WorkflowNodeModel
 from snapred.ui.presenter.WorkflowNodePresenter import WorkflowPresenter
 from snapred.ui.view.WorkflowNodeView import WorkflowNodeView
 

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -1,5 +1,4 @@
 import json
-from sys import version
 
 from snapred.backend.dao import RunConfig
 from snapred.backend.dao.calibration import CalibrationIndexEntry
@@ -10,7 +9,6 @@ from snapred.backend.dao.request import (
     FitMultiplePeaksRequest,
     FocusSpectraRequest,
 )
-from snapred.backend.dao.response.CalibrationAssessmentResponse import CalibrationAssessmentResponse
 from snapred.backend.log.logger import snapredLogger
 from snapred.meta.Config import Config
 from snapred.meta.decorators.ExceptionToErrLog import ExceptionToErrLog

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -1,9 +1,6 @@
 import json
-from sys import version
 
-from snapred.backend.api.InterfaceController import InterfaceController
-from snapred.backend.dao import SNAPRequest, SNAPResponse
-from snapred.backend.dao.normalization import NormalizationIndexEntry, NormalizationRecord
+from snapred.backend.dao.normalization import NormalizationIndexEntry
 from snapred.backend.dao.request import (
     NormalizationCalibrationRequest,
     NormalizationExportRequest,

--- a/src/snapred/ui/workflow/WorkflowImplementer.py
+++ b/src/snapred/ui/workflow/WorkflowImplementer.py
@@ -4,11 +4,8 @@ from snapred.backend.dao.request import (
     ClearWorkspaceRequest,
     RenameWorkspaceRequest,
 )
-from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
-from snapred.backend.error.RecoverableException import RecoverableException
 from snapred.backend.log.logger import snapredLogger
 from snapred.ui.handler.SNAPResponseHandler import SNAPResponseHandler
-from snapred.ui.view.IterateView import IterateView
 from snapred.ui.widget.ActionPrompt import ActionPrompt
 from snapred.ui.widget.Workflow import Workflow
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import os
 import unittest.mock as mock
 
-import pytest
 from snapred.meta.decorators import Resettable
 
 # import sys

--- a/tests/unit/backend/api/test_InterfaceController.py
+++ b/tests/unit/backend/api/test_InterfaceController.py
@@ -1,7 +1,6 @@
 import json
 import unittest.mock as mock
 
-import pytest
 from snapred.backend.dao.SNAPResponse import ResponseCode
 from snapred.backend.error.RecoverableException import RecoverableException
 

--- a/tests/unit/backend/dao/test_GroceryListBuilder.py
+++ b/tests/unit/backend/dao/test_GroceryListBuilder.py
@@ -1,7 +1,6 @@
 # ruff: noqa: E722, PT011, PT012
 
 import unittest
-from unittest import mock
 
 import pytest
 from mantid.simpleapi import (
@@ -9,7 +8,6 @@ from mantid.simpleapi import (
     LoadEmptyInstrument,
 )
 from pydantic import ValidationError
-from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
 from snapred.meta.builder.GroceryListBuilder import GroceryListBuilder
 from snapred.meta.Config import Resource
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng

--- a/tests/unit/backend/dao/test_GroceryListItem.py
+++ b/tests/unit/backend/dao/test_GroceryListItem.py
@@ -1,14 +1,12 @@
 # ruff: noqa: E722, PT011, PT012
 
 import unittest
-from unittest import mock
 
 import pytest
 from mantid.simpleapi import (
     DeleteWorkspace,
     LoadEmptyInstrument,
 )
-from pydantic import ValidationError
 from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
 from snapred.meta.builder.GroceryListBuilder import GroceryListBuilder
 from snapred.meta.Config import Resource

--- a/tests/unit/backend/dao/test_GroupingMap.py
+++ b/tests/unit/backend/dao/test_GroupingMap.py
@@ -5,8 +5,6 @@ from pathlib import Path
 # Important: this is a *pure* pytest module: no `unittest` imports should be used.
 import pytest
 from snapred.backend.dao.state import GroupingMap as GroupingMapModule
-from snapred.backend.dao.state.FocusGroup import FocusGroup
-from snapred.backend.log.logger import snapredLogger
 from snapred.meta.Config import Resource
 from util.groupingMapUtil import GroupingMapTestFactory
 

--- a/tests/unit/backend/dao/test_PixelGroup.py
+++ b/tests/unit/backend/dao/test_PixelGroup.py
@@ -1,14 +1,8 @@
 # ruff: noqa: E722, PT011, PT012
 
 import unittest
-from unittest import mock
 
 import pytest
-from mantid.simpleapi import (
-    DeleteWorkspace,
-    LoadEmptyInstrument,
-)
-from pydantic.error_wrappers import ValidationError
 from snapred.backend.dao.Limit import BinnedValue, Limit
 from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.backend.dao.state.PixelGroup import PixelGroup

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -3,13 +3,9 @@ import tempfile
 import unittest.mock as mock
 from unittest.mock import MagicMock
 
-import pytest
-from snapred.backend.dao.ingredients import ReductionIngredients
 from snapred.backend.dao.InstrumentConfig import InstrumentConfig
-from snapred.backend.dao.Limit import BinnedValue, Limit
 from snapred.backend.dao.ReductionState import ReductionState
 from snapred.backend.dao.RunConfig import RunConfig
-from snapred.backend.dao.state.PixelGroup import PixelGroup
 from snapred.backend.dao.StateConfig import StateConfig
 
 # Mock out of scope modules before importing DataFactoryService

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -6,32 +6,22 @@ import tarfile
 import tempfile
 import unittest
 from pathlib import Path
-from typing import Dict, Tuple
 from unittest import mock
 from unittest.mock import ANY
 
 import pytest
-import snapred.backend.recipe.algorithm.GenerateTableWorkspaceFromListOfDict
 from mantid.kernel import V3D, Quat
 from mantid.simpleapi import (
     CloneWorkspace,
-    CreateEmptyTableWorkspace,
-    CreateGroupingWorkspace,
-    CreateLogPropertyTable,
     CreateWorkspace,
     DeleteWorkspace,
-    ExtractMask,
     GenerateTableWorkspaceFromListOfDict,
     LoadEmptyInstrument,
-    LoadInstrument,
-    LoadParameterFile,
     SaveDiffCal,
     SaveNexusProcessed,
-    SaveParameterFile,
     mtd,
 )
 from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
-from pydantic import ValidationError
 from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
 from snapred.backend.dao.state import DetectorState
 from snapred.backend.dao.WorkspaceMetadata import UNSET, WorkspaceMetadata, diffcal_metadata_state_list

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -16,15 +16,13 @@ from mantid.api import ITableWorkspace, MatrixWorkspace
 from mantid.dataobjects import MaskWorkspace
 from mantid.simpleapi import (
     CloneWorkspace,
-    ConvertUnits,
     CreateGroupingWorkspace,
     CreateSampleWorkspace,
     LoadEmptyInstrument,
     LoadInstrument,
     mtd,
 )
-from pydantic import BaseModel, parse_raw_as
-from pydantic.error_wrappers import ValidationError
+from pydantic import parse_raw_as
 from snapred.backend.dao import StateConfig
 from snapred.backend.dao.calibration.Calibration import Calibration
 from snapred.backend.dao.calibration.CalibrationIndexEntry import CalibrationIndexEntry

--- a/tests/unit/backend/recipe/algorithm/test_CalculateDiffCalTable.py
+++ b/tests/unit/backend/recipe/algorithm/test_CalculateDiffCalTable.py
@@ -1,6 +1,5 @@
 import unittest
 
-import snapred.backend.recipe.algorithm
 from mantid.simpleapi import (
     CalculateDiffCalTable,
     DeleteWorkspace,

--- a/tests/unit/backend/recipe/algorithm/test_CalibrationMetricExtractionAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_CalibrationMetricExtractionAlgorithm.py
@@ -1,10 +1,9 @@
 import unittest
 from typing import List
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
-from mantid.kernel import Direction
 from pydantic import parse_raw_as
 from snapred.backend.dao.calibration.CalibrationMetric import CalibrationMetric
 from snapred.backend.dao.state import PixelGroup, PixelGroupingParameters

--- a/tests/unit/backend/recipe/algorithm/test_DetectorPeakPredictor.py
+++ b/tests/unit/backend/recipe/algorithm/test_DetectorPeakPredictor.py
@@ -1,4 +1,3 @@
-import json
 import socket
 import unittest.mock as mock
 from typing import List

--- a/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
+++ b/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
@@ -1,4 +1,3 @@
-import json
 import socket
 import unittest.mock as mock
 

--- a/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import pytest
 from mantid.simpleapi import (
-    CreateSampleWorkspace,
     CreateWorkspace,
     DeleteWorkspace,
     LoadInstrument,

--- a/tests/unit/backend/recipe/algorithm/test_FocusSpectraAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FocusSpectraAlgorithm.py
@@ -4,7 +4,6 @@ from mantid.simpleapi import (
     DeleteWorkspace,
     mtd,
 )
-from snapred.backend.dao.ingredients import ReductionIngredients
 from snapred.backend.dao.state.PixelGroup import PixelGroup
 
 # the algorithm to test

--- a/tests/unit/backend/recipe/algorithm/test_GroupDiffractionCalibration.py
+++ b/tests/unit/backend/recipe/algorithm/test_GroupDiffractionCalibration.py
@@ -1,19 +1,11 @@
 import unittest
 from collections.abc import Sequence
-from typing import Any, Dict, List, Tuple
-from unittest import mock
 
 import pytest
-from mantid.api import ITableWorkspace, MatrixWorkspace
-from mantid.dataobjects import GroupingWorkspace, MaskWorkspace
-from snapred.backend.dao.DetectorPeak import DetectorPeak
-from snapred.backend.dao.GroupPeakList import GroupPeakList
-from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients
+from mantid.api import MatrixWorkspace
+from mantid.dataobjects import GroupingWorkspace
 
 # needed to make mocked ingredients
-from snapred.backend.dao.RunConfig import RunConfig
-from snapred.backend.dao.state.FocusGroup import FocusGroup
-from snapred.backend.dao.state.PixelGroup import PixelGroup
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.CalculateDiffCalTable import CalculateDiffCalTable
 
@@ -21,7 +13,6 @@ from snapred.backend.recipe.algorithm.CalculateDiffCalTable import CalculateDiff
 from snapred.backend.recipe.algorithm.GroupDiffractionCalibration import (
     GroupDiffractionCalibration as ThisAlgo,  # noqa: E402
 )
-from snapred.meta.Config import Resource
 from util.diffraction_calibration_synthetic_data import SyntheticData
 from util.helpers import deleteWorkspaceNoThrow, maskGroups, mutableWorkspaceClones, setGroupSpectraToZero
 

--- a/tests/unit/backend/recipe/algorithm/test_LiteDataCreationAlgo.py
+++ b/tests/unit/backend/recipe/algorithm/test_LiteDataCreationAlgo.py
@@ -3,8 +3,6 @@ import unittest.mock as mock
 
 import pytest
 from mantid.simpleapi import DeleteWorkspace, mtd
-from snapred.backend.dao.RunConfig import RunConfig
-from snapred.backend.data.DataFactoryService import DataFactoryService
 from snapred.backend.recipe.algorithm.LiteDataCreationAlgo import LiteDataCreationAlgo
 from snapred.meta.Config import Resource
 
@@ -123,7 +121,6 @@ def test_fail_with_no_output():
         DeleteWorkspace,
         LoadDetectorsGroupingFile,
         LoadInstrument,
-        mtd,
     )
 
     fullInstrumentWS = "_test_lite_algo_native"

--- a/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
+++ b/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
@@ -1,23 +1,18 @@
-import os.path
 import socket
 import unittest
 import unittest.mock as mock
-from typing import Dict, Tuple
+from typing import Dict
 
 import pytest
 from mantid.simpleapi import (
     DeleteWorkspace,
     LoadDetectorsGroupingFile,
-    LoadDiffCal,
     LoadEmptyInstrument,
-    LoadNexusProcessed,
     mtd,
 )
 from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
 from snapred.backend.recipe.algorithm.LoadGroupingDefinition import LoadGroupingDefinition as LoadingAlgo
-from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Resource
-from util.helpers import workspacesEqual
 
 IS_ON_ANALYSIS_MACHINE = socket.gethostname().startswith("analysis")
 

--- a/tests/unit/backend/recipe/algorithm/test_MaskDetectorFlags.py
+++ b/tests/unit/backend/recipe/algorithm/test_MaskDetectorFlags.py
@@ -1,6 +1,3 @@
-from collections.abc import Sequence
-from typing import Any, Dict, List, Tuple
-
 import pytest
 from mantid.simpleapi import (
     CloneWorkspace,
@@ -8,9 +5,6 @@ from mantid.simpleapi import (
     LoadEmptyInstrument,
     mtd,
 )
-from snapred.backend.dao.DetectorPeak import DetectorPeak
-from snapred.backend.dao.GroupPeakList import GroupPeakList
-from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients
 from snapred.backend.log.logger import snapredLogger
 
 # the algorithm to test

--- a/tests/unit/backend/recipe/algorithm/test_PixelDiffractionCalibration.py
+++ b/tests/unit/backend/recipe/algorithm/test_PixelDiffractionCalibration.py
@@ -2,28 +2,18 @@ import json
 import unittest
 from collections.abc import Sequence
 from itertools import permutations
-from typing import Any, Dict, List, Tuple
 
-import numpy as np
 import pytest
 from mantid.api import MatrixWorkspace
-from mantid.dataobjects import MaskWorkspace
 from mantid.simpleapi import mtd
-from snapred.backend.dao.DetectorPeak import DetectorPeak
-from snapred.backend.dao.GroupPeakList import GroupPeakList
-from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients
 
 # needed to make mocked ingredients
-from snapred.backend.dao.RunConfig import RunConfig
-from snapred.backend.dao.state.PixelGroup import PixelGroup
-
 # the algorithm to test
 from snapred.backend.recipe.algorithm.PixelDiffractionCalibration import (
     PixelDiffractionCalibration as ThisAlgo,  # noqa: E402
 )
-from snapred.meta.Config import Resource
 from util.diffraction_calibration_synthetic_data import SyntheticData
-from util.helpers import deleteWorkspaceNoThrow, maskSpectra, setSpectraToZero
+from util.helpers import maskSpectra, setSpectraToZero
 
 
 class TestPixelDiffractionCalibration(unittest.TestCase):

--- a/tests/unit/backend/recipe/algorithm/test_PixelGroupingParametersCalculationAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_PixelGroupingParametersCalculationAlgorithm.py
@@ -5,24 +5,19 @@
 import json
 import socket
 import unittest
-import unittest.mock as mock
-from datetime import date
 from pathlib import Path
 from typing import Dict, List, Union
 
 import pytest
 from mantid.simpleapi import (
-    CheckForSampleLogs,
-    CreateWorkspace,
     DeleteWorkspace,
-    DeleteWorkspaces,
     LoadDetectorsGroupingFile,
     LoadDiffCal,
     LoadEmptyInstrument,
     RenameWorkspace,
     mtd,
 )
-from pydantic import parse_file_as, parse_obj_as, parse_raw_as
+from pydantic import parse_file_as, parse_raw_as
 from snapred.backend.dao.calibration.Calibration import Calibration
 from snapred.backend.dao.ingredients.PixelGroupingIngredients import PixelGroupingIngredients
 from snapred.backend.dao.state.InstrumentState import InstrumentState

--- a/tests/unit/backend/recipe/algorithm/test_PurgeOverlappingPeaksAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_PurgeOverlappingPeaksAlgorithm.py
@@ -17,7 +17,6 @@ with mock.patch.dict(
     )
     from snapred.meta.Config import Resource
     from snapred.meta.redantic import list_to_raw
-    from util.SculleryBoy import SculleryBoy
 
     def test_validate():
         """Test ability to initialize purge overlapping peaks algo"""

--- a/tests/unit/backend/recipe/algorithm/test_RawVanadiumCorrection.py
+++ b/tests/unit/backend/recipe/algorithm/test_RawVanadiumCorrection.py
@@ -14,17 +14,8 @@ from mantid.simpleapi import (
     Rebin,
     mtd,
 )
-from snapred.backend.dao.ingredients import NormalizationIngredients as Ingredients
 
 # needed to make mocked ingredients
-from snapred.backend.dao.ingredients.ReductionIngredients import ReductionIngredients
-from snapred.backend.dao.RunConfig import RunConfig
-from snapred.backend.dao.state.CalibrantSample.Atom import Atom
-from snapred.backend.dao.state.CalibrantSample.CalibrantSamples import CalibrantSamples
-from snapred.backend.dao.state.CalibrantSample.Crystallography import Crystallography
-from snapred.backend.dao.state.CalibrantSample.Geometry import Geometry
-from snapred.backend.dao.state.CalibrantSample.Material import Material
-
 # the algorithm to test
 from snapred.backend.recipe.algorithm.RawVanadiumCorrectionAlgorithm import (
     RawVanadiumCorrectionAlgorithm as Algo,  # noqa: E402

--- a/tests/unit/backend/recipe/algorithm/test_SmoothDataExcludingPeaksAlgo.py
+++ b/tests/unit/backend/recipe/algorithm/test_SmoothDataExcludingPeaksAlgo.py
@@ -1,9 +1,5 @@
-import json
 import unittest
-import unittest.mock as mock
-from typing import List
 
-import pytest
 from mantid.simpleapi import (
     CreateSingleValuedWorkspace,
     CreateWorkspace,

--- a/tests/unit/backend/recipe/test_DiffractionCalibrationRecipe.py
+++ b/tests/unit/backend/recipe/test_DiffractionCalibrationRecipe.py
@@ -1,19 +1,10 @@
-import json
 import unittest
-from typing import List
 from unittest import mock
 
 import pytest
-from mantid.api import PythonAlgorithm
-from mantid.kernel import Direction
 from mantid.simpleapi import mtd
-from snapred.backend.dao.DetectorPeak import DetectorPeak
-from snapred.backend.dao.GroupPeakList import GroupPeakList
-from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients as TheseIngredients
-from snapred.backend.dao.RunConfig import RunConfig
-from snapred.backend.dao.state.PixelGroup import PixelGroup
 from snapred.backend.recipe.DiffractionCalibrationRecipe import DiffractionCalibrationRecipe as Recipe
-from snapred.meta.Config import Config, Resource
+from snapred.meta.Config import Config
 from util.diffraction_calibration_synthetic_data import SyntheticData
 from util.helpers import deleteWorkspaceNoThrow
 
@@ -122,7 +113,6 @@ class TestDiffractionCalibrationRecipe(unittest.TestCase):
 
     def test_execute_with_algos(self):
         # create sample data
-        from datetime import date
 
         rawWS = "_test_diffcal_rx_data"
         groupingWS = "_test_diffcal_grouping"

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -2,7 +2,6 @@
 
 import os
 import unittest
-from unittest import mock
 
 import pytest
 from mantid.simpleapi import (
@@ -16,11 +15,10 @@ from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
 from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
 
 # needed to make mocked ingredients
-from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.recipe.FetchGroceriesRecipe import (
     FetchGroceriesRecipe as Recipe,  # noqa: E402
 )
-from snapred.meta.Config import Config, Resource
+from snapred.meta.Config import Resource
 
 
 class TestFetchGroceriesRecipe(unittest.TestCase):

--- a/tests/unit/backend/recipe/test_GenerateFocussedVanadiumRecipe.py
+++ b/tests/unit/backend/recipe/test_GenerateFocussedVanadiumRecipe.py
@@ -3,13 +3,10 @@ from unittest import mock
 
 import pytest
 from mantid.simpleapi import (
-    CreateWorkspace,
     LoadNexusProcessed,
     mtd,
 )
-from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.ingredients import GenerateFocussedVanadiumIngredients as Ingredients
-from snapred.backend.recipe.algorithm.SmoothDataExcludingPeaksAlgo import SmoothDataExcludingPeaksAlgo
 from snapred.backend.recipe.GenerateFocussedVanadiumRecipe import GenerateFocussedVanadiumRecipe as Recipe
 from snapred.meta.Config import Resource
 from util.helpers import deleteWorkspaceNoThrow

--- a/tests/unit/backend/recipe/test_GroupWorkspaceIterator.py
+++ b/tests/unit/backend/recipe/test_GroupWorkspaceIterator.py
@@ -1,7 +1,6 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.backend.recipe.GroupWorkspaceIterator import GroupWorkspaceIterator
 
 

--- a/tests/unit/backend/recipe/test_PixelGroupingParametersCalculationRecipe.py
+++ b/tests/unit/backend/recipe/test_PixelGroupingParametersCalculationRecipe.py
@@ -1,9 +1,7 @@
-import json
 import unittest.mock as mock
 from typing import List
 
 import pytest
-from snapred.backend.dao.ingredients.PixelGroupingIngredients import PixelGroupingIngredients
 from snapred.backend.dao.Limit import Limit
 from snapred.backend.dao.state.PixelGroupingParameters import PixelGroupingParameters
 from snapred.backend.recipe.PixelGroupingParametersCalculationRecipe import PixelGroupingParametersCalculationRecipe

--- a/tests/unit/backend/recipe/test_PreprocessReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_PreprocessReductionRecipe.py
@@ -1,6 +1,5 @@
 import unittest
 
-import pytest
 from mantid.simpleapi import CreateEmptyTableWorkspace, CreateSingleValuedWorkspace, mtd
 from snapred.backend.recipe.algorithm.Utensils import Utensils
 from snapred.backend.recipe.PreprocessReductionRecipe import Ingredients, PreprocessReductionRecipe

--- a/tests/unit/backend/recipe/test_ReductionGroupProcessingRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionGroupProcessingRecipe.py
@@ -1,6 +1,5 @@
 import unittest
 
-import pytest
 from snapred.backend.recipe.ReductionGroupProcessingRecipe import ReductionGroupProcessingRecipe, Utensils
 
 

--- a/tests/unit/backend/recipe/test_WriteWorkspaceMetadata.py
+++ b/tests/unit/backend/recipe/test_WriteWorkspaceMetadata.py
@@ -1,4 +1,3 @@
-import json
 import unittest
 from typing import Dict, Literal
 from unittest import mock

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -1,12 +1,11 @@
 # ruff: noqa: E402, ARG002
-import os
 import tempfile
 import unittest
 import unittest.mock as mock
 from copy import deepcopy
 from pathlib import Path
 from typing import Dict, List
-from unittest.mock import ANY, MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from mantid.simpleapi import (
@@ -20,7 +19,6 @@ from snapred.backend.dao.request.InitializeStateRequest import InitializeStateRe
 from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.dao.StateConfig import StateConfig
 from snapred.meta.Config import Config
-from snapred.meta.mantid.WorkspaceNameGenerator import ValueFormatter as wnvf
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName, WorkspaceType
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceType as wngt
@@ -38,14 +36,12 @@ with mock.patch.dict(
         "snapred.backend.log.logger": mock.Mock(),
     },
 ):
-    from snapred.backend.dao import Limit
     from snapred.backend.dao.calibration.CalibrationIndexEntry import CalibrationIndexEntry
     from snapred.backend.dao.calibration.CalibrationMetric import CalibrationMetric
     from snapred.backend.dao.calibration.CalibrationRecord import CalibrationRecord
     from snapred.backend.dao.calibration.FocusGroupMetric import FocusGroupMetric
     from snapred.backend.dao.ingredients.ReductionIngredients import ReductionIngredients
     from snapred.backend.dao.request.CalibrationAssessmentRequest import CalibrationAssessmentRequest
-    from snapred.backend.dao.request.DiffractionCalibrationRequest import DiffractionCalibrationRequest
     from snapred.backend.dao.request.FarmFreshIngredients import FarmFreshIngredients
     from snapred.backend.dao.state import PixelGroup
     from snapred.backend.dao.state.FocusGroup import FocusGroup

--- a/tests/unit/backend/service/test_CrystallographicInfoService.py
+++ b/tests/unit/backend/service/test_CrystallographicInfoService.py
@@ -1,9 +1,8 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 from snapred.backend.service.CrystallographicInfoService import CrystallographicInfoService
-from snapred.meta.Config import Config
 
 thisService = "snapred.backend.service.CrystallographicInfoService."
 

--- a/tests/unit/backend/service/test_LiteDataService.py
+++ b/tests/unit/backend/service/test_LiteDataService.py
@@ -2,7 +2,6 @@ import unittest
 from unittest.mock import Mock, patch
 
 import pytest
-from snapred.backend.dao.RunConfig import RunConfig
 
 
 class TestLiteDataService(unittest.TestCase):

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -1,12 +1,10 @@
 # ruff: noqa: E402, ARG002
 import unittest
 import unittest.mock as mock
-from typing import Any, Dict
-from unittest.mock import ANY, MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from mantid.simpleapi import (
-    CreateWorkspace,
     mtd,
 )
 

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -3,11 +3,8 @@ import tempfile
 import unittest
 from unittest import mock
 
-import pytest
 from mantid.simpleapi import DeleteWorkspace, mtd
-from snapred.backend.dao.calibration.Calibration import Calibration
 from snapred.backend.dao.request.FarmFreshIngredients import FarmFreshIngredients
-from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.service.SousChef import SousChef
 from snapred.meta.Config import Config
 

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -99,7 +99,6 @@ class TestSousChef(unittest.TestCase):
         res = self.instance.prepCalibrantSample(self.ingredients)
         assert res == self.instance.dataFactoryService.lookupService.readCalibrantSample.return_value
 
-    @mock.patch(thisService + "os.path.isfile", mock.Mock(return_value=True))
     @mock.patch(thisService + "PixelGroup")
     @mock.patch(thisService + "PixelGroupingParametersCalculationRecipe")
     @mock.patch(thisService + "PixelGroupingIngredients")

--- a/tests/unit/backend/service/test_WorkspaceMetadataService.py
+++ b/tests/unit/backend/service/test_WorkspaceMetadataService.py
@@ -1,11 +1,9 @@
 import unittest
-from typing import Dict, Literal
-from unittest import mock
 
 import pytest
 from mantid.simpleapi import AddSampleLogMultiple, CreateSingleValuedWorkspace, mtd
 from pydantic import ValidationError
-from snapred.backend.dao.WorkspaceMetadata import UNSET, WorkspaceMetadata
+from snapred.backend.dao.WorkspaceMetadata import WorkspaceMetadata
 from snapred.backend.service.WorkspaceMetadataService import WorkspaceMetadataService
 from snapred.meta.Config import Config
 from util.helpers import deleteWorkspaceNoThrow

--- a/tests/unit/meta/test_Decorators.py
+++ b/tests/unit/meta/test_Decorators.py
@@ -1,5 +1,4 @@
 import json
-from re import match
 from typing import List
 from unittest.mock import MagicMock, patch
 

--- a/tests/unit/ui/presenter/test_CalibrationAssessmentPresenter.py
+++ b/tests/unit/ui/presenter/test_CalibrationAssessmentPresenter.py
@@ -1,9 +1,8 @@
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from snapred.backend.dao.request.CalibrationLoadAssessmentRequest import CalibrationLoadAssessmentRequest
 from snapred.backend.dao.SNAPRequest import SNAPRequest
-from snapred.backend.dao.SNAPResponse import SNAPResponse
 from snapred.ui.presenter.CalibrationAssessmentPresenter import CalibrationAssessmentPresenter
 
 

--- a/tests/unit/ui/presenter/test_InitializeStatePresenter.py
+++ b/tests/unit/ui/presenter/test_InitializeStatePresenter.py
@@ -1,8 +1,8 @@
 import sys
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
-from qtpy.QtWidgets import QApplication, QMessageBox, QWidget
+from qtpy.QtWidgets import QApplication, QWidget
 from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.ui.presenter.InitializeStatePresenter import InitializeStatePresenter
 

--- a/tests/unit/ui/view/test_CalibrationAssessmentView.py
+++ b/tests/unit/ui/view/test_CalibrationAssessmentView.py
@@ -1,7 +1,5 @@
-from unittest.mock import MagicMock, Mock, call, patch
+from unittest.mock import MagicMock
 
-from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QComboBox, QMessageBox
 from snapred.backend.dao.calibration import CalibrationIndexEntry
 from snapred.ui.view.DiffCalAssessmentView import DiffCalAssessmentView
 

--- a/tests/unit/ui/widget/test_Workflow.py
+++ b/tests/unit/ui/widget/test_Workflow.py
@@ -2,10 +2,8 @@ from unittest.mock import MagicMock
 
 import pytest
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QApplication, QGridLayout, QPushButton, QWidget
+from qtpy.QtWidgets import QGridLayout, QPushButton, QWidget
 from snapred.ui.model.WorkflowNodeModel import WorkflowNodeModel
-from snapred.ui.presenter.WorkflowPresenter import WorkflowPresenter
-from snapred.ui.view.WorkflowView import WorkflowView
 from snapred.ui.workflow.WorkflowBuilder import WorkflowBuilder
 
 

--- a/tests/util/diffraction_calibration_synthetic_data.py
+++ b/tests/util/diffraction_calibration_synthetic_data.py
@@ -8,14 +8,11 @@
 
 import secrets
 from collections import namedtuple
-from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Dict, List, Tuple
 
 import mantid
 import numpy as np
-from mantid.api import ITableWorkspace, MatrixWorkspace
-from mantid.dataobjects import GroupingWorkspace, MaskWorkspace
 from mantid.simpleapi import (
     ConvertUnits,
     CreateSampleWorkspace,

--- a/tests/util/helpers.py
+++ b/tests/util/helpers.py
@@ -5,10 +5,9 @@
 
 import unittest
 from collections.abc import Sequence
-from typing import Any, Dict, List, Tuple
+from typing import Any, Tuple
 
 import numpy as np
-import pytest
 from mantid.api import ITableWorkspace, MatrixWorkspace
 from mantid.dataobjects import GroupingWorkspace, MaskWorkspace
 from mantid.simpleapi import (
@@ -18,12 +17,10 @@ from mantid.simpleapi import (
     DeleteWorkspace,
     ExtractMask,
     LoadInstrument,
-    ScaleX,
     WorkspaceFactory,
     mtd,
 )
 from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
-from snapred.meta.Config import Resource
 
 
 def createCompatibleDiffCalTable(tableWSName: str, templateWSName: str) -> ITableWorkspace:


### PR DESCRIPTION
## Description of work

Ruff will automatically remove unused imports.

We had turned this off due to the annoyance with "unused" algorithm imports.

It is no longer necessary to import algorithms individually to use them with MantidSnapper, so we can turn this check back on.

## Explanation of work

Removed `F401` from the ruff ignore list.

## To test

### Dev testing

Step 1: be Michael
Step 2: agree this is a good idea

### CIS testing

Not needed.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
