### PR TITLE
Move remaining references of pyqt5 to use qtpy

### DIFF
--- a/docs/source/developer/architecture/frontend/normalization/initialize_state_presenter.rst
+++ b/docs/source/developer/architecture/frontend/normalization/initialize_state_presenter.rst
@@ -29,7 +29,7 @@ Attributes:
 - worker_pool (WorkerPool): Utilized to manage and execute background tasks, this attribute significantly enhances UI responsiveness by offloading
   intensive operations to a separate thread pool. It allows the main UI thread to remain responsive and fluid during backend operations.
 
-- stateInitialized (pyqtSignal): A PyQt signal emitted upon the successful completion of a state initialization process. This signal is connected to
+- stateInitialized ``Signal``): A Qt signal emitted upon the successful completion of a state initialization process. This signal is connected to
   UI components that need to react or update based on the initialization outcome, facilitating real-time feedback and interactions within the
   application.
 

--- a/docs/source/developer/architecture/frontend/normalization/normalization_save_view.rst
+++ b/docs/source/developer/architecture/frontend/normalization/normalization_save_view.rst
@@ -1,7 +1,7 @@
 NormalizationSaveView Class Documentation
 =========================================
 
-NormalizationSaveView is a PyQt5 widget interface developed for the efficient handling of normalization data saving in SNAPRed after user assessment.
+NormalizationSaveView is a qt widget interface developed for the efficient handling of normalization data saving in SNAPRed after user assessment.
 Decked with the @Resettable decorator, it furnishes users with a systematic and intuitive platform for inputting and reviewing critical details such
 as run numbers and versioning information. Through the dynamic generation of forms and the organized presentation of UI elements, it ensures data
 coherence and simplifies user interaction. The principal aim is to refine the process of confirming and saving normalization data, thereby elevating

--- a/docs/source/developer/architecture/frontend/normalization/normalization_tweak_peak_view.rst
+++ b/docs/source/developer/architecture/frontend/normalization/normalization_tweak_peak_view.rst
@@ -34,7 +34,7 @@ UI Components:
 Interactivity and Signal Handling:
 ----------------------------------
 
-- PyQt Signals: Employs PyQt signals to manage UI actions, linking user interactions with corresponding methods for a seamless and responsive user
+- Qt ``Signals``: Employs Qt signals to manage UI actions, linking user interactions with corresponding methods for a seamless and responsive user
   experience. This mechanism facilitates the real-time update of UI components in response to user inputs or changes in external data.
 
 

--- a/docs/source/developer/architecture/frontend/normalization/normalization_tweak_peak_view.rst
+++ b/docs/source/developer/architecture/frontend/normalization/normalization_tweak_peak_view.rst
@@ -1,7 +1,7 @@
 NormalizationTweakPeakView Class Documentation
 ==============================================
 
-NormalizationTweakPeakView is a PyQt5-based GUI component crafted for the precise adjustment of peak normalization parameters within SNAPRed. By
+NormalizationTweakPeakView is a qt-based GUI component crafted for the precise adjustment of peak normalization parameters within SNAPRed. By
 inheriting from BackendRequestView and featuring an array of interactive components such as input fields, dropdowns, sliders, and a real-time
 matplotlib plot area, it offers a comprehensive environment for dynamic interaction and visualization. This GUI is designed to allow users to
 instantly observe the effects of their parameter adjustments on normalization settings, thereby enhancing the analytical capabilities and user

--- a/docs/source/developer/architecture/frontend/normalization/normalization_workflow.rst
+++ b/docs/source/developer/architecture/frontend/normalization/normalization_workflow.rst
@@ -43,7 +43,7 @@ Dynamic Configuration and Adaptation:
 Signal-Slot Mechanism for Asynchronous Updates:
 -----------------------------------------------
 
-- Utilizes PyQt's signal-slot mechanism to manage asynchronous UI updates, enhancing the application's responsiveness. This mechanism ensures that
+- Utilizes Qt's signal-slot mechanism to manage asynchronous UI updates, enhancing the application's responsiveness. This mechanism ensures that
   users receive timely feedback on their interactions and the progress of normalization tasks.
 
 

--- a/docs/source/developer/architecture/frontend/normalization/normalization_workflow.rst
+++ b/docs/source/developer/architecture/frontend/normalization/normalization_workflow.rst
@@ -2,7 +2,7 @@ NormalizationWorkflow Class Documentation
 =========================================
 
 NormalizationWorkflow orchestrates a comprehensive and interactive workflow for scientific data normalization tasks within applications. Leveraging
-PyQt5 widgets and custom views, it guides users through every step of the normalization process. Starting from initialization with default settings,
+qt widgets and custom views, it guides users through every step of the normalization process. Starting from initialization with default settings,
 the workflow progresses through calibration, parameter adjustments, and concludes with saving the normalization data. It ensures a responsive,
 user-friendly experience while maintaining flexibility in the workflow and data integrity through thorough validation and error handling.
 

--- a/docs/source/developer/architecture/frontend/normalization/smoothing_slider.rst
+++ b/docs/source/developer/architecture/frontend/normalization/smoothing_slider.rst
@@ -1,7 +1,7 @@
 SmoothingSlider Class Documentation
 ===================================
 
-SmoothingSlider is a custom PyQt5 QWidget crafted to provide an enhanced interface for adjusting a smoothing parameter, skillfully integrating a
+SmoothingSlider is a custom qt QWidget crafted to provide an enhanced interface for adjusting a smoothing parameter, skillfully integrating a
 graphical slider with a numerical input field. This combination caters to diverse user preferences, allowing for both rapid visual adjustments via
 the slider and precise value entry through the numerical input. It's particularly suited for applications requiring detailed parameter settings,
 offering users a versatile tool for fine-tuning smoothing levels.

--- a/docs/source/developer/architecture/frontend/success_dialog.rst
+++ b/docs/source/developer/architecture/frontend/success_dialog.rst
@@ -1,7 +1,7 @@
 SuccessDialog Class Documentation
 =================================
 
-SuccessDialog is a PyQt5 dialog constructed to deliver succinct and clear feedback to users following successful operations, such as the completion
+SuccessDialog is a qt dialog constructed to deliver succinct and clear feedback to users following successful operations, such as the completion
 of a setup process or state initialization. It adheres to GUI design principles emphasizing straightforward communication, offering a minimalistic
 yet effective interface for conveying success messages. This approach serves to enhance the user experience within applications by affirmatively
 acknowledging positive action outcomes in a clear and uncomplicated manner.

--- a/src/snapred/ui/view/NormalizationSaveView.py
+++ b/src/snapred/ui/view/NormalizationSaveView.py
@@ -10,7 +10,7 @@ from snapred.ui.widget.LabeledField import LabeledField
 @Resettable
 class NormalizationSaveView(QWidget):
     """
-    This class creates a PyQt5 widget interface for efficiently saving normalization data in SNAPRed
+    This class creates a qt widget interface for efficiently saving normalization data in SNAPRed
     after user assessment. It provides a structured and intuitive environment for users to input and
     review important details such as run numbers and versioning. By leveraging dynamic form generation
     and organized UI elements, it ensures data consistency and facilitates user interaction. The main

--- a/src/snapred/ui/view/NormalizationTweakPeakView.py
+++ b/src/snapred/ui/view/NormalizationTweakPeakView.py
@@ -25,7 +25,7 @@ from snapred.ui.widget.SmoothingSlider import SmoothingSlider
 class NormalizationTweakPeakView(BackendRequestView):
     """
 
-    This PyQt5 GUI component is designed for adjusting peak normalization parameters in SNAPRed,
+    This qt GUI component is designed for adjusting peak normalization parameters in SNAPRed,
     offering a user-friendly interface that combines input fields, dropdowns, sliders, and a
     real-time matplotlib plot area. It is built for dynamic interaction and visualization, allowing
     users to see the impact of their adjustments on the normalization settings instantly. Key

--- a/src/snapred/ui/widget/LabeledCheckBox.py
+++ b/src/snapred/ui/widget/LabeledCheckBox.py
@@ -1,5 +1,5 @@
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtWidgets import QCheckBox, QHBoxLayout, QLabel, QWidget
+from qtpy.QtCore import Signal as pyqtSignal
+from qtpy.QtWidgets import QCheckBox, QHBoxLayout, QLabel, QWidget
 
 
 class LabeledCheckBox(QWidget):

--- a/src/snapred/ui/widget/SmoothingSlider.py
+++ b/src/snapred/ui/widget/SmoothingSlider.py
@@ -7,7 +7,7 @@ from qtpy.QtWidgets import QHBoxLayout, QLineEdit, QMessageBox, QSlider, QWidget
 class SmoothingSlider(QWidget):
     """
 
-    This PyQt5 custom QWidget is designed to facilitate the adjustment of a smoothing parameter, combining a graphical
+    This qt custom QWidget is designed to facilitate the adjustment of a smoothing parameter, combining a graphical
     slider for intuitive control with a numerical input for precision. It caters to user preferences for either a quick
     visual adjustment or specific numerical entry, enhancing the usability of applications requiring fine-tuned
     parameter settings. The widget features logarithmic mapping for the slider to cover a broad range of values and

--- a/src/snapred/ui/widget/SuccessDialog.py
+++ b/src/snapred/ui/widget/SuccessDialog.py
@@ -5,7 +5,7 @@ from qtpy.QtWidgets import QDialog, QLabel, QPushButton, QVBoxLayout
 class SuccessDialog(QDialog):
     """
 
-    This PyQt5 dialog is crafted to provide users with immediate, clear feedback on successful operations,
+    This qt dialog is crafted to provide users with immediate, clear feedback on successful operations,
     like confirming the successful setup of a state, aligning with GUI design principles for straightforward
     communication. It features a simple, minimalistic design with a fixed size and essential window options
     to focus user attention on the success message. The layout includes a vertically arranged message label

--- a/src/snapred/ui/widget/UserDocsButton.py
+++ b/src/snapred/ui/widget/UserDocsButton.py
@@ -1,6 +1,6 @@
-from PyQt5.QtCore import QUrl
-from PyQt5.QtWebEngineWidgets import QWebEngineView
-from PyQt5.QtWidgets import QHBoxLayout, QPushButton, QWidget
+from qtpy.QtCore import QUrl
+from qtpy.QtWebEngineWidgets import QWebEngineView
+from qtpy.QtWidgets import QHBoxLayout, QPushButton, QWidget
 
 from snapred.meta.Config import Config
 

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -22,7 +22,7 @@ class NormalizationWorkflow(WorkflowImplementer):
     """
 
     This system orchestrates a full workflow for scientific data normalization, guiding users through each step with
-    interactive PyQt5 widgets and custom views. Starting with default settings for initialization, it progresses
+    interactive qt widgets and custom views. Starting with default settings for initialization, it progresses
     through calibration, parameter adjustments, and ends with saving normalization data, offering views like
     NormalizationRequestView, NormalizationTweakPeakView, and NormalizationSaveView for an interactive user workflow.
     The workflow dynamically adjusts to different datasets and requirements, ensuring adaptability. Key phases include


### PR DESCRIPTION
## Description of work

Most of the repository has already been moved to qtpy, this changes the last two files and moves the references in the docs to something version agnostic.

## To test

This is a minor refactor. If the GUI comes up then it was done correctly.


*There isn't an EWM item*
