### PR TITLE
Add lite mode to calibration and normalization entries

### DIFF
--- a/src/snapred/backend/dao/calibration/Calibration.py
+++ b/src/snapred/backend/dao/calibration/Calibration.py
@@ -17,6 +17,7 @@ class Calibration(BaseModel):
 
     instrumentState: InstrumentState
     seedRun: int
+    useLiteMode: bool
     creationDate: datetime
     name: str
     version: int = 0

--- a/src/snapred/backend/dao/calibration/CalibrationIndexEntry.py
+++ b/src/snapred/backend/dao/calibration/CalibrationIndexEntry.py
@@ -17,6 +17,7 @@ class CalibrationIndexEntry(BaseModel):
     """
 
     runNumber: str
+    useLiteMode: bool
     version: Optional[str]
     appliesTo: Optional[str]
     comments: str

--- a/src/snapred/backend/dao/normalization/Normalization.py
+++ b/src/snapred/backend/dao/normalization/Normalization.py
@@ -17,6 +17,7 @@ class Normalization(BaseModel):
 
     instrumentState: InstrumentState
     seedRun: int
+    useLiteMode: bool
     creationDate: datetime
     name: str
     version: int = 0

--- a/src/snapred/backend/dao/normalization/NormalizationIndexEntry.py
+++ b/src/snapred/backend/dao/normalization/NormalizationIndexEntry.py
@@ -15,6 +15,7 @@ class NormalizationIndexEntry(BaseModel):
     """
 
     runNumber: str
+    useLiteMode: bool
     backgroundRunNumber: str
     version: Optional[str]
     appliesTo: Optional[str]

--- a/src/snapred/backend/dao/request/CalibrationLoadAssessmentRequest.py
+++ b/src/snapred/backend/dao/request/CalibrationLoadAssessmentRequest.py
@@ -14,4 +14,5 @@ class CalibrationLoadAssessmentRequest(BaseModel):
 
     runId: str
     version: str
+    useLiteMode: bool
     checkExistent: bool  # if true, do not generate assessment if it already exists

--- a/src/snapred/backend/data/DataExportService.py
+++ b/src/snapred/backend/data/DataExportService.py
@@ -23,8 +23,8 @@ class DataExportService:
             val = clazz()
         return val
 
-    def exportCalibrationIndexEntry(self, entry: CalibrationIndexEntry, useLiteMode: bool):
-        self.dataService.writeCalibrationIndexEntry(entry, useLiteMode)
+    def exportCalibrationIndexEntry(self, entry: CalibrationIndexEntry):
+        self.dataService.writeCalibrationIndexEntry(entry)
 
     def exportCalibrationRecord(self, record: CalibrationRecord):
         return self.dataService.writeCalibrationRecord(record)
@@ -35,11 +35,11 @@ class DataExportService:
     def exportCalibrantSampleFile(self, entry: CalibrantSamples):
         self.dataService.writeCalibrantSample(entry)
 
-    def exportCalibrationState(self, runId: str, calibration: Calibration):
-        return self.dataService.writeCalibrationState(runId, calibration)
+    def exportCalibrationState(self, calibration: Calibration):
+        return self.dataService.writeCalibrationState(calibration)
 
-    def exportNormalizationIndexEntry(self, entry: NormalizationIndexEntry, useLiteMode: bool):
-        self.dataService.writeNormalizationIndexEntry(entry, useLiteMode)
+    def exportNormalizationIndexEntry(self, entry: NormalizationIndexEntry):
+        self.dataService.writeNormalizationIndexEntry(entry)
 
     def exportNormalizationRecord(self, record: NormalizationRecord):
         return self.dataService.writeNormalizationRecord(record)

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -368,21 +368,21 @@ class LocalDataService:
         )
         return normalizationVersionPath
 
-    def writeCalibrationIndexEntry(self, entry: CalibrationIndexEntry, useLiteMode: bool):
+    def writeCalibrationIndexEntry(self, entry: CalibrationIndexEntry):
         stateId, _ = self._generateStateId(entry.runNumber)
-        calibrationPath: str = self._constructCalibrationStatePath(stateId, useLiteMode)
+        calibrationPath: str = self._constructCalibrationStatePath(stateId, entry.useLiteMode)
         indexPath: str = calibrationPath + "CalibrationIndex.json"
         # append to index and write to file
-        calibrationIndex = self.readCalibrationIndex(entry.runNumber, useLiteMode)
+        calibrationIndex = self.readCalibrationIndex(entry.runNumber, entry.useLiteMode)
         calibrationIndex.append(entry)
         write_model_list_pretty(calibrationIndex, indexPath)
 
-    def writeNormalizationIndexEntry(self, entry: NormalizationIndexEntry, useLiteMode: bool):
+    def writeNormalizationIndexEntry(self, entry: NormalizationIndexEntry):
         stateId, _ = self._generateStateId(entry.runNumber)
-        normalizationPath: str = self._constructNormalizationCalibrationStatePath(stateId, useLiteMode)
+        normalizationPath: str = self._constructNormalizationCalibrationStatePath(stateId, entry.useLiteMode)
         indexPath: str = normalizationPath + "NormalizationIndex.json"
         # append to index and write to file
-        normalizationIndex = self.readNormalizationIndex(entry.runNumber, useLiteMode)
+        normalizationIndex = self.readNormalizationIndex(entry.runNumber, entry.useLiteMode)
         normalizationIndex.append(entry)
         write_model_list_pretty(normalizationIndex, indexPath)
 
@@ -603,7 +603,7 @@ class LocalDataService:
         # write record to file
         write_model_pretty(savedRecord, recordPath)
 
-        self.writeCalibrationState(runNumber, record.calibrationFittingIngredients, str(version), record.useLiteMode)
+        self.writeCalibrationState(record.calibrationFittingIngredients, str(version))
 
         logger.info(f"Wrote CalibrationRecord: version: {version}")
         return record
@@ -757,49 +757,55 @@ class LocalDataService:
 
         return normalizationState
 
-    def writeCalibrationState(
-        self, runId: str, calibration: Calibration, version: str = None, useLiteMode: bool = False
-    ):
+    def writeCalibrationState(self, calibration: Calibration, version: str = None):
         """
         Writes a `Calibration` to either a new version folder, or overwrites a specific version.
         -- side effect: updates version number of incoming `Calibration`.
         """
-        stateId, _ = self._generateStateId(runId)
-        previousVersion: int = self._getLatestCalibrationVersionNumber(stateId, useLiteMode)
-        if not version:
-            version = previousVersion + 1
+        stateId, _ = self._generateStateId(calibration.seedRun)
+        previousVersion: int = self._getLatestCalibrationVersionNumber(stateId, calibration.useLiteMode)
+        if version is None:
+            version = max(calibration.version, previousVersion + 1)
 
         # Check for the existence of a calibration parameters file
-        calibrationParametersFilePath = self._constructCalibrationParametersFilePath(runId, str(version), useLiteMode)
+        calibrationParametersFilePath = self._constructCalibrationParametersFilePath(
+            calibration.seedRun, str(version), calibration.useLiteMode
+        )
         if os.path.exists(calibrationParametersFilePath):
             logger.warning(f"overwriting calibration parameters at {calibrationParametersFilePath}")
 
         calibration.version = int(version)
-        calibrationDataPath = self._constructCalibrationDataPath(runId, str(version), useLiteMode)
+        calibrationDataPath = self._constructCalibrationDataPath(
+            calibration.seedRun, str(version), calibration.useLiteMode
+        )
         if not os.path.exists(calibrationDataPath):
             os.makedirs(calibrationDataPath)
         # write the calibration state.
         write_model_pretty(calibration, calibrationParametersFilePath)
 
-    def writeNormalizationState(
-        self, runId: str, normalization: Normalization, version: str = None, useLiteMode: bool = False
-    ):  # noqa: F821
+    def writeNormalizationState(self, normalization: Normalization, version: str = None):  # noqa: F821
         """
         Writes a `Normalization` to either a new version folder, or overwrites a specific version.
         -- side effect: updates version number of incoming `Normalization`.
         """
-        stateId, _ = self._generateStateId(runId)
-        previousVersion: int = self._getLatestNormalizationCalibrationVersionNumber(stateId, useLiteMode)
-        if not version:
-            version = previousVersion + 1
+        stateId, _ = self._generateStateId(normalization.seedRun)
+        previousVersion: int = self._getLatestNormalizationCalibrationVersionNumber(stateId, normalization.useLiteMode)
+        if version is None:
+            version = max(normalization.version, previousVersion + 1)
         # check for the existence of a normalization parameters file
         normalizationParametersFilePath = self._constructNormalizationParametersFilePath(
-            runId, str(version), useLiteMode
+            normalization.seedRun,
+            str(version),
+            normalization.useLiteMode,
         )
         if os.path.exists(normalizationParametersFilePath):
             logger.warning(f"overwriting normalization parameters at {normalizationParametersFilePath}")
-        normalization.version = version
-        normalizationDataPath = self._constructNormalizationCalibrationDataPath(runId, str(version), useLiteMode)
+        normalization.version = int(version)
+        normalizationDataPath = self._constructNormalizationCalibrationDataPath(
+            normalization.seedRun,
+            str(version),
+            normalization.useLiteMode,
+        )
         if not os.path.exists(normalizationDataPath):
             os.makedirs(normalizationDataPath)
         write_model_pretty(normalization, normalizationParametersFilePath)
@@ -832,11 +838,12 @@ class LocalDataService:
         self.writeDiffCalWorkspaces(calibrationDataPath, filename, outWS)
         calibrationIndexEntry = CalibrationIndexEntry(
             runNumber=runNumber,
+            useLiteMode=useLiteMode,
             version=version,
             comments="Inferred from the instrument geometry",
             author="Generated automatically by SNAPRed",
         )
-        self.writeCalibrationIndexEntry(calibrationIndexEntry, useLiteMode)
+        self.writeCalibrationIndexEntry(calibrationIndexEntry)
 
     @ExceptionHandler(StateValidationException)
     def initializeState(self, runId: str, name: str = None, useLiteMode: bool = False):
@@ -882,6 +889,7 @@ class LocalDataService:
             instrumentState=instrumentState,
             name=name,
             seedRun=runId,
+            useLiteMode=useLiteMode,
             creationDate=datetime.datetime.now(),
             version=0,
         )
@@ -893,7 +901,7 @@ class LocalDataService:
             #   some order independence of initialization if the back-end is run separately (e.g. in unit tests).
             self._prepareStateRoot(stateId)
 
-        self.writeCalibrationState(runId, calibration, useLiteMode=useLiteMode)
+        self.writeCalibrationState(calibration)
         self._writeDefaultDiffCalTable(runId, useLiteMode)
 
         return calibration

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -210,7 +210,7 @@ class CalibrationService(Service):
         calibrationRecord = self.dataExportService.exportCalibrationRecord(calibrationRecord)
         calibrationRecord = self.dataExportService.exportCalibrationWorkspaces(calibrationRecord)
         entry.version = calibrationRecord.version
-        self.saveCalibrationToIndex(entry, calibrationRecord.useLiteMode)
+        self.saveCalibrationToIndex(entry)
 
     @FromString
     def load(self, run: RunConfig):
@@ -218,13 +218,13 @@ class CalibrationService(Service):
         return self.dataFactoryService.getCalibrationRecord(runId)
 
     @FromString
-    def saveCalibrationToIndex(self, entry: CalibrationIndexEntry, useLiteMode: bool):
+    def saveCalibrationToIndex(self, entry: CalibrationIndexEntry):
         if entry.appliesTo is None:
             entry.appliesTo = ">" + entry.runNumber
         if entry.timestamp is None:
             entry.timestamp = int(round(time.time() * self.MILLISECONDS_PER_SECOND))
         logger.info("Saving calibration index entry for Run Number {}".format(entry.runNumber))
-        self.dataExportService.exportCalibrationIndexEntry(entry, useLiteMode)
+        self.dataExportService.exportCalibrationIndexEntry(entry)
 
     @FromString
     def initializeState(self, request: InitializeStateRequest):

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -263,9 +263,10 @@ class CalibrationService(Service):
     @FromString
     def loadQualityAssessment(self, request: CalibrationLoadAssessmentRequest):
         runId = request.runId
+        useLiteMode = request.useLiteMode
         version = request.version
 
-        calibrationRecord = self.dataFactoryService.getCalibrationRecord(runId, version)
+        calibrationRecord = self.dataFactoryService.getCalibrationRecord(runId, version, useLiteMode)
         if calibrationRecord is None:
             errorTxt = f"No calibration record found for run {runId}, version {version}."
             logger.error(errorTxt)

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -179,15 +179,15 @@ class NormalizationService(Service):
         normalizationRecord = self.dataExportService.exportNormalizationRecord(normalizationRecord)
         normalizationRecord = self.dataExportService.exportNormalizationWorkspaces(normalizationRecord)
         entry.version = normalizationRecord.version
-        self.saveNormalizationToIndex(entry, normalizationRecord.useLiteMode)
+        self.saveNormalizationToIndex(entry)
 
-    def saveNormalizationToIndex(self, entry: NormalizationIndexEntry, useLiteMode: bool):
+    def saveNormalizationToIndex(self, entry: NormalizationIndexEntry):
         if entry.appliesTo is None:
             entry.appliesTo = ">" + entry.runNumber
         if entry.timestamp is None:
             entry.timestamp = int(round(time.time() * 1000))
         logger.info(f"Saving normalization index entry for Run Number {entry.runNumber}")
-        self.dataExportService.exportNormalizationIndexEntry(entry, useLiteMode)
+        self.dataExportService.exportNormalizationIndexEntry(entry)
 
     def vanadiumCorrection(self, request: VanadiumCorrectionRequest):
         cifPath = self.dataFactoryService.getCifFilePath(request.calibrantSamplePath.split("/")[-1].split(".")[0])

--- a/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
+++ b/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
@@ -40,8 +40,13 @@ class CalibrationAssessmentPresenter(QObject):
             self.view.onError("No calibration record selected.")
             return
 
-        runId, version = self.view.getSelectedCalibrationRecordData()
-        payload = CalibrationLoadAssessmentRequest(runId=runId, version=version, checkExistent=True)
+        runId, useLiteMode, version = self.view.getSelectedCalibrationRecordData()
+        payload = CalibrationLoadAssessmentRequest(
+            runId=runId,
+            useLiteMode=useLiteMode,
+            version=version,
+            checkExistent=True,
+        )
         loadAssessmentRequest = SNAPRequest(path="/calibration/loadQualityAssessment", payload=payload.json())
 
         self.view.loadButton.setEnabled(False)

--- a/src/snapred/ui/view/DiffCalAssessmentView.py
+++ b/src/snapred/ui/view/DiffCalAssessmentView.py
@@ -70,7 +70,7 @@ class DiffCalAssessmentView(QWidget):
             # populate the combo-box from the input calibration index entries
             for entry in calibrationIndex:
                 name = f"Version: {entry.version}; Run: {entry.runNumber}"
-                self.calibrationRecordDropdown.addItem(name, (entry.runNumber, entry.version))
+                self.calibrationRecordDropdown.addItem(name, (entry.runNumber, entry.useLiteMode, entry.version))
         self.calibrationRecordDropdown.setCurrentIndex(0)
 
     def getCalibrationRecordCount(self):

--- a/src/snapred/ui/view/DiffCalSaveView.py
+++ b/src/snapred/ui/view/DiffCalSaveView.py
@@ -20,7 +20,6 @@ class DiffCalSaveView(QWidget):
     """
 
     signalRunNumberUpdate = Signal(str)
-    signalUseLiteMode = Signal(bool)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -33,9 +32,6 @@ class DiffCalSaveView(QWidget):
         self.fieldRunNumber = LabeledField("Run Number :", QLineEdit(parent=self), self)
         self.fieldRunNumber.setEnabled(False)
         self.signalRunNumberUpdate.connect(self._updateRunNumber)
-
-        self.useLiteMode: bool = True
-        self.signalUseLiteMode.connect(self._useLiteMode)
 
         self.fieldVersion = LabeledField("Version :", QLineEdit(parent=self), self)
         # add tooltip to leave blank for new version
@@ -71,12 +67,6 @@ class DiffCalSaveView(QWidget):
 
     def updateRunNumber(self, runNumber):
         self.signalRunNumberUpdate.emit(runNumber)
-
-    def _useLiteMode(self, useLiteMode):
-        self.useLiteMode = useLiteMode
-
-    def updateLiteMode(self, useLiteMode):
-        self.signalUseLiteMode.emit(useLiteMode)
 
     def enableIterationDropdown(self):
         self.iterationWidget.setVisible(True)

--- a/src/snapred/ui/view/DiffCalSaveView.py
+++ b/src/snapred/ui/view/DiffCalSaveView.py
@@ -20,6 +20,7 @@ class DiffCalSaveView(QWidget):
     """
 
     signalRunNumberUpdate = Signal(str)
+    signalUseLiteMode = Signal(bool)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -32,6 +33,9 @@ class DiffCalSaveView(QWidget):
         self.fieldRunNumber = LabeledField("Run Number :", QLineEdit(parent=self), self)
         self.fieldRunNumber.setEnabled(False)
         self.signalRunNumberUpdate.connect(self._updateRunNumber)
+
+        self.useLiteMode: bool = True
+        self.signalUseLiteMode.connect(self._useLiteMode)
 
         self.fieldVersion = LabeledField("Version :", QLineEdit(parent=self), self)
         # add tooltip to leave blank for new version
@@ -67,6 +71,12 @@ class DiffCalSaveView(QWidget):
 
     def updateRunNumber(self, runNumber):
         self.signalRunNumberUpdate.emit(runNumber)
+
+    def _useLiteMode(self, useLiteMode):
+        self.useLiteMode = useLiteMode
+
+    def updateLiteMode(self, useLiteMode):
+        self.signalUseLiteMode.emit(useLiteMode)
 
     def enableIterationDropdown(self):
         self.iterationWidget.setVisible(True)

--- a/src/snapred/ui/view/NormalizationSaveView.py
+++ b/src/snapred/ui/view/NormalizationSaveView.py
@@ -20,6 +20,7 @@ class NormalizationSaveView(QWidget):
 
     signalRunNumberUpdate = Signal(str)
     signalBackgroundRunNumberUpdate = Signal(str)
+    signalUseLiteMode = Signal(bool)
 
     def __init__(self, name, jsonSchemaMap, parent=None):
         super().__init__(parent)
@@ -35,6 +36,9 @@ class NormalizationSaveView(QWidget):
         )
         self.fieldRunNumber.setEnabled(False)
         self.signalRunNumberUpdate.connect(self._updateRunNumber)
+
+        self.useLiteMode: bool = True
+        self.signalUseLiteMode.connect(self._useLiteMode)
 
         self.fieldBackgroundRunNumber = LabeledField(
             "Background Run Number :", self._jsonFormList.getField("normalizationIndexEntry.backgroundRunNumber"), self
@@ -83,6 +87,12 @@ class NormalizationSaveView(QWidget):
 
     def updateBackgroundRunNumber(self, backgroundRunNumber):
         self.signalBackgroundRunNumberUpdate.emit(backgroundRunNumber)
+
+    def _useLiteMode(self, useLiteMode):
+        self.useLiteMode = useLiteMode
+
+    def updateLiteMode(self, useLiteMode):
+        self.signalUseLiteMode.emit(useLiteMode)
 
     def verify(self):
         if self.fieldAuthor.text() == "":

--- a/src/snapred/ui/view/NormalizationSaveView.py
+++ b/src/snapred/ui/view/NormalizationSaveView.py
@@ -20,7 +20,6 @@ class NormalizationSaveView(QWidget):
 
     signalRunNumberUpdate = Signal(str)
     signalBackgroundRunNumberUpdate = Signal(str)
-    signalUseLiteMode = Signal(bool)
 
     def __init__(self, name, jsonSchemaMap, parent=None):
         super().__init__(parent)
@@ -36,9 +35,6 @@ class NormalizationSaveView(QWidget):
         )
         self.fieldRunNumber.setEnabled(False)
         self.signalRunNumberUpdate.connect(self._updateRunNumber)
-
-        self.useLiteMode: bool = True
-        self.signalUseLiteMode.connect(self._useLiteMode)
 
         self.fieldBackgroundRunNumber = LabeledField(
             "Background Run Number :", self._jsonFormList.getField("normalizationIndexEntry.backgroundRunNumber"), self
@@ -87,12 +83,6 @@ class NormalizationSaveView(QWidget):
 
     def updateBackgroundRunNumber(self, backgroundRunNumber):
         self.signalBackgroundRunNumberUpdate.emit(backgroundRunNumber)
-
-    def _useLiteMode(self, useLiteMode):
-        self.useLiteMode = useLiteMode
-
-    def updateLiteMode(self, useLiteMode):
-        self.signalUseLiteMode.emit(useLiteMode)
 
     def verify(self):
         if self.fieldAuthor.text() == "":

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -160,6 +160,7 @@ class DiffCalWorkflow(WorkflowImplementer):
 
         self._tweakPeakView.updateRunNumber(self.runNumber)
         self._saveView.updateRunNumber(self.runNumber)
+        self._saveView.updateLiteMode(self.useLiteMode)
 
         # fields with defaults
         self.convergenceThreshold = view.fieldConvergenceThreshold.get(self.DEFAULT_CONV)
@@ -301,6 +302,7 @@ class DiffCalWorkflow(WorkflowImplementer):
 
         self.runNumber = view.runNumberField.text()
         self._saveView.updateRunNumber(self.runNumber)
+        self._saveView.updateLiteMode(self.useLiteMode)
         self.focusGroupPath = view.groupingFileDropdown.currentText()
 
         payload = DiffractionCalibrationRequest(
@@ -372,6 +374,7 @@ class DiffCalWorkflow(WorkflowImplementer):
         # pull fields from view for calibration save
         calibrationIndexEntry = CalibrationIndexEntry(
             runNumber=view.fieldRunNumber.get(),
+            useLiteMode=view.useLiteMode,
             comments=view.fieldComments.get(),
             author=view.fieldAuthor.get(),
             appliesTo=view.fieldAppliesTo.get(),

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -160,7 +160,6 @@ class DiffCalWorkflow(WorkflowImplementer):
 
         self._tweakPeakView.updateRunNumber(self.runNumber)
         self._saveView.updateRunNumber(self.runNumber)
-        self._saveView.updateLiteMode(self.useLiteMode)
 
         # fields with defaults
         self.convergenceThreshold = view.fieldConvergenceThreshold.get(self.DEFAULT_CONV)
@@ -302,7 +301,6 @@ class DiffCalWorkflow(WorkflowImplementer):
 
         self.runNumber = view.runNumberField.text()
         self._saveView.updateRunNumber(self.runNumber)
-        self._saveView.updateLiteMode(self.useLiteMode)
         self.focusGroupPath = view.groupingFileDropdown.currentText()
 
         payload = DiffractionCalibrationRequest(
@@ -374,7 +372,7 @@ class DiffCalWorkflow(WorkflowImplementer):
         # pull fields from view for calibration save
         calibrationIndexEntry = CalibrationIndexEntry(
             runNumber=view.fieldRunNumber.get(),
-            useLiteMode=view.useLiteMode,
+            useLiteMode=self.useLiteMode,
             comments=view.fieldComments.get(),
             author=view.fieldAuthor.get(),
             appliesTo=view.fieldAppliesTo.get(),

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -168,7 +168,6 @@ class NormalizationWorkflow(WorkflowImplementer):
 
         self._saveView.updateRunNumber(self.runNumber)
         self._saveView.updateBackgroundRunNumber(self.backgroundRunNumber)
-        self._saveView.updateLiteMode(self.useLiteMode)
 
         response = self.request(path="normalization", payload=payload.json())
         focusWorkspace = self.responses[-1].data["focusedVanadium"]
@@ -206,7 +205,7 @@ class NormalizationWorkflow(WorkflowImplementer):
 
         normalizationIndexEntry = NormalizationIndexEntry(
             runNumber=view.fieldRunNumber.get(),
-            useLiteMode=view.useLiteMode,
+            useLiteMode=self.useLiteMode,
             backgroundRunNumber=view.fieldBackgroundRunNumber.get(),
             comments=view.fieldComments.get(),
             author=view.fieldAuthor.get(),

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -168,6 +168,7 @@ class NormalizationWorkflow(WorkflowImplementer):
 
         self._saveView.updateRunNumber(self.runNumber)
         self._saveView.updateBackgroundRunNumber(self.backgroundRunNumber)
+        self._saveView.updateLiteMode(self.useLiteMode)
 
         response = self.request(path="normalization", payload=payload.json())
         focusWorkspace = self.responses[-1].data["focusedVanadium"]
@@ -205,6 +206,7 @@ class NormalizationWorkflow(WorkflowImplementer):
 
         normalizationIndexEntry = NormalizationIndexEntry(
             runNumber=view.fieldRunNumber.get(),
+            useLiteMode=view.useLiteMode,
             backgroundRunNumber=view.fieldBackgroundRunNumber.get(),
             comments=view.fieldComments.get(),
             author=view.fieldAuthor.get(),

--- a/tests/resources/inputs/calibration/CalibrationParameters.json
+++ b/tests/resources/inputs/calibration/CalibrationParameters.json
@@ -62,6 +62,7 @@
     "peakTailCoefficient": 2.0
   },
   "seedRun": 123,
+  "useLiteMode": true,
   "creationDate": "2023-05-25T11:50:23.438776",
   "name": "test",
   "version": 0

--- a/tests/resources/inputs/calibration/CalibrationRecord_v0001.json
+++ b/tests/resources/inputs/calibration/CalibrationRecord_v0001.json
@@ -384,260 +384,261 @@
             "multiplicity": 24
         }
     ]
-},
-    "calibrationFittingIngredients": {
-      "instrumentState": {
-        "id": "ab8704b0bc2a2342",
-        "peakTailCoefficient": 1.1,
-        "instrumentConfig": {
-          "version": "1.4",
-          "facility": "SNS",
-          "name": "SNAP",
-          "nexusFileExtension": ".nxs.h5",
-          "nexusFilePrefix": "SNAP_",
-          "calibrationFileExtension": "json",
-          "calibrationFilePrefix": "SNAPcalibLog",
-          "calibrationDirectory": "/SNS/SNAP/shared/Calibration/",
-          "pixelGroupingDirectory": "PixelGroupingDefinitions/",
-          "sharedDirectory": "shared/",
-          "nexusDirectory": "nexus/",
-          "reducedDataDirectory": "shared/manualReduced/",
-          "reductionRecordDirectory": "shared/manualReduced/reductionRecord/",
-          "bandwidth": 3,
-          "maxBandwidth": 3.2,
-          "L1": 15,
-          "L2": 0.5,
-          "delTOverT": 0.002,
-          "delLOverL": 0.00006452,
-          "delThNoGuide": 0.0006667,
-          "delThWithGuide": 0.0032
+  },
+  "calibrationFittingIngredients": {
+    "instrumentState": {
+      "id": "ab8704b0bc2a2342",
+      "peakTailCoefficient": 1.1,
+      "instrumentConfig": {
+        "version": "1.4",
+        "facility": "SNS",
+        "name": "SNAP",
+        "nexusFileExtension": ".nxs.h5",
+        "nexusFilePrefix": "SNAP_",
+        "calibrationFileExtension": "json",
+        "calibrationFilePrefix": "SNAPcalibLog",
+        "calibrationDirectory": "/SNS/SNAP/shared/Calibration/",
+        "pixelGroupingDirectory": "PixelGroupingDefinitions/",
+        "sharedDirectory": "shared/",
+        "nexusDirectory": "nexus/",
+        "reducedDataDirectory": "shared/manualReduced/",
+        "reductionRecordDirectory": "shared/manualReduced/reductionRecord/",
+        "bandwidth": 3,
+        "maxBandwidth": 3.2,
+        "L1": 15,
+        "L2": 0.5,
+        "delTOverT": 0.002,
+        "delLOverL": 0.00006452,
+        "delThNoGuide": 0.0006667,
+        "delThWithGuide": 0.0032
+      },
+      "detectorState": {
+        "arc": [
+          -65.3,
+          104.95
+        ],
+        "wav": 2.1,
+        "freq": 60,
+        "guideStat": 1,
+        "lin": [
+          0.045,
+          0.043
+        ]
+      },
+      "gsasParameters": {
+        "alpha": 0.1,
+        "beta": [
+          0.02,
+          0.05
+        ]
+      },
+      "particleBounds": {
+        "wavelength": {
+          "minimum": 0.7,
+          "maximum": 3.5
         },
-        "detectorState": {
-          "arc": [
-            -65.3,
-            104.95
-          ],
-          "wav": 2.1,
-          "freq": 60,
-          "guideStat": 1,
-          "lin": [
-            0.045,
-            0.043
-          ]
-        },
-        "gsasParameters": {
-          "alpha": 0.1,
-          "beta": [
-            0.02,
-            0.05
-          ]
-        },
-        "particleBounds": {
-          "wavelength": {
-            "minimum": 0.7,
-            "maximum": 3.5
-          },
-          "tof": {
-            "minimum": 2742.6,
-            "maximum": 13713
-          }
-        },
-        "defaultGroupingSliceValue": 5,
-        "fwhmMultipliers": {
-          "minimum": 1.3,
-          "maximum": 1.3
+        "tof": {
+          "minimum": 2742.6,
+          "maximum": 13713
         }
       },
-      "seedRun": 57514,
-      "creationDate": "2023-06-05T15:49:59.583421",
-      "name": "test",
-      "version": 0
-    },
-    "pixelGroups":[
-      {
-        "focusGroup": {
-          "name": "Column",
-          "definition": ""
-        },
-        "timeOfFlight": {
-          "minimum": 2742.6,
-          "maximum": 13713,
-          "binWidth": 1,
-          "binningMode": 1
-        },
-        "pixelGroupingParameters": [
-          {
-            "groupID": 0,
-            "isMasked": false,
-            "twoTheta": 2.1108948177427838,
-            "dResolution": {
-              "minimum": 0.40224298673776404,
-              "maximum": 2.0112149336888203
-            },
-            "dRelativeResolution": 0.002771822370612031
-          },
-          {
-            "groupID": 1,
-            "isMasked": false,
-            "twoTheta": 1.82310673131693,
-            "dResolution": {
-              "minimum": 0.44278229953817677,
-              "maximum": 2.213911497690884
-            },
-            "dRelativeResolution": 0.003234525153614593
-          },
-          {
-            "groupID": 2,
-            "isMasked": false,
-            "twoTheta": 1.5352228379083572,
-            "dResolution": {
-              "minimum": 0.5040188478793922,
-              "maximum": 2.5200942393969608
-            },
-            "dRelativeResolution": 0.004014748859873182
-          },
-          {
-            "groupID": 3,
-            "isMasked": false,
-            "twoTheta": 1.440276389170165,
-            "dResolution": {
-              "minimum": 0.530714277849788,
-              "maximum": 2.6535713892489396
-            },
-            "dRelativeResolution": 0.004309856397320412
-          },
-          {
-            "groupID": 4,
-            "isMasked": false,
-            "twoTheta": 1.1543988461042238,
-            "dResolution": {
-              "minimum": 0.6414024711539658,
-              "maximum": 3.207012355769829
-            },
-            "dRelativeResolution": 0.005408489642872038
-          },
-          {
-            "groupID": 5,
-            "isMasked": false,
-            "twoTheta": 0.8690010092470938,
-            "dResolution": {
-              "minimum": 0.831438096217031,
-              "maximum": 4.157190481085156
-            },
-            "dRelativeResolution": 0.007548513084996265
-          }
-        ]
-      },
-      {
-        "focusGroup": {
-          "name": "Bank",
-          "definition": ""
-        },
-        "timeOfFlight": {
-          "minimum": 2742.6,
-          "maximum": 13713,
-          "binWidth": 1,
-          "binningMode": 1
-        },
-        "pixelGroupingParameters": [
-          {
-            "groupID": 0,
-            "isMasked": false,
-            "twoTheta": 1.8230747956560218,
-            "dResolution": {
-              "minimum": 0.4427877783643468,
-              "maximum": 2.2139388918217344
-            },
-            "dRelativeResolution": 0.003379514789208845
-          },
-          {
-            "groupID": 1,
-            "isMasked": false,
-            "twoTheta": 1.1545587481738246,
-            "dResolution": {
-              "minimum": 0.641323731469231,
-              "maximum": 3.2066186573461555
-            },
-            "dRelativeResolution": 0.005910630879382727
-          }
-        ]
-      },
-      {
-        "focusGroup": {
-          "name": "All",
-          "definition": ""
-        },
-        "timeOfFlight": {
-          "minimum": 2742.6,
-          "maximum": 13713,
-          "binWidth": 1,
-          "binningMode": 1
-        },
-        "pixelGroupingParameters": [
-          {
-            "groupID": 0,
-            "isMasked": false,
-            "twoTheta": 1.4888167719149363,
-            "dResolution": {
-              "minimum": 0.5165770976155033,
-              "maximum": 2.5828854880775167
-            },
-            "dRelativeResolution": 0.004814388725622084
-          }
-        ]
+      "defaultGroupingSliceValue": 5,
+      "fwhmMultipliers": {
+        "minimum": 1.3,
+        "maximum": 1.3
       }
-    ],
-    "focusGroupCalibrationMetrics":{
-      "focusGroupName": "Column",
-      "calibrationMetric": [
+    },
+    "seedRun": 57514,
+    "useLiteMode": true,
+    "creationDate": "2023-06-05T15:49:59.583421",
+    "name": "test",
+    "version": 0
+  },
+  "pixelGroups":[
+    {
+      "focusGroup": {
+        "name": "Column",
+        "definition": ""
+      },
+      "timeOfFlight": {
+        "minimum": 2742.6,
+        "maximum": 13713,
+        "binWidth": 1,
+        "binningMode": 1
+      },
+      "pixelGroupingParameters": [
         {
-          "sigmaAverage": 0.002517952998136214,
-          "sigmaStandardDeviation": 0.00000878421857231147,
-          "strainAverage": 0.1515216185900471,
-          "strainStandardDeviation": 0.013151225165758604,
-          "twoThetaAverage": 2.110894794556694
+          "groupID": 0,
+          "isMasked": false,
+          "twoTheta": 2.1108948177427838,
+          "dResolution": {
+            "minimum": 0.40224298673776404,
+            "maximum": 2.0112149336888203
+          },
+          "dRelativeResolution": 0.002771822370612031
         },
         {
-          "sigmaAverage": 0.003176206362503416,
-          "sigmaStandardDeviation": 0.000014979115537326051,
-          "strainAverage": 0.11967297872183888,
-          "strainStandardDeviation": 0.010670589671407833,
-          "twoThetaAverage": 1.8231067294302894
+          "groupID": 1,
+          "isMasked": false,
+          "twoTheta": 1.82310673131693,
+          "dResolution": {
+            "minimum": 0.44278229953817677,
+            "maximum": 2.213911497690884
+          },
+          "dRelativeResolution": 0.003234525153614593
         },
         {
-          "sigmaAverage": 0.0020173258481625943,
-          "sigmaStandardDeviation": 0.0011833789198171258,
-          "strainAverage": 2.9472523966464146,
-          "strainStandardDeviation": 1.7234726438089345,
-          "twoThetaAverage": 1.5352228117682118
+          "groupID": 2,
+          "isMasked": false,
+          "twoTheta": 1.5352228379083572,
+          "dResolution": {
+            "minimum": 0.5040188478793922,
+            "maximum": 2.5200942393969608
+          },
+          "dRelativeResolution": 0.004014748859873182
         },
         {
-          "sigmaAverage": 0.0019681238298694874,
-          "sigmaStandardDeviation": 0.0012719855843628899,
-          "strainAverage": 2.97560355438957,
-          "strainStandardDeviation": 1.7073076840182733,
-          "twoThetaAverage": 1.440276416886144
+          "groupID": 3,
+          "isMasked": false,
+          "twoTheta": 1.440276389170165,
+          "dResolution": {
+            "minimum": 0.530714277849788,
+            "maximum": 2.6535713892489396
+          },
+          "dRelativeResolution": 0.004309856397320412
         },
         {
-          "sigmaAverage": 0.002792254157654066,
-          "sigmaStandardDeviation": 0.0018788822023715769,
-          "strainAverage": 2.6968257593469005,
-          "strainStandardDeviation": 1.5521868842356747,
-          "twoThetaAverage": 1.1543988480234637
+          "groupID": 4,
+          "isMasked": false,
+          "twoTheta": 1.1543988461042238,
+          "dResolution": {
+            "minimum": 0.6414024711539658,
+            "maximum": 3.207012355769829
+          },
+          "dRelativeResolution": 0.005408489642872038
         },
         {
-          "sigmaAverage": 0.0035439650966407016,
-          "sigmaStandardDeviation": 0.0026213074118901255,
-          "strainAverage": 2.9942330576453013,
-          "strainStandardDeviation": 1.7458314136551056,
-          "twoThetaAverage": 0.8690010316506124
+          "groupID": 5,
+          "isMasked": false,
+          "twoTheta": 0.8690010092470938,
+          "dResolution": {
+            "minimum": 0.831438096217031,
+            "maximum": 4.157190481085156
+          },
+          "dRelativeResolution": 0.007548513084996265
         }
       ]
     },
-    "workspaces": {
-      "diffCalOutput": ["_tof_column_057514_v0001", "_dsp_column_057514_v0001"],
-      "diffCalTable": ["_diffract_consts_057514_v0001"],
-      "diffCalMask": ["_diffract_consts_mask_057514_v0001"]
+    {
+      "focusGroup": {
+        "name": "Bank",
+        "definition": ""
+      },
+      "timeOfFlight": {
+        "minimum": 2742.6,
+        "maximum": 13713,
+        "binWidth": 1,
+        "binningMode": 1
+      },
+      "pixelGroupingParameters": [
+        {
+          "groupID": 0,
+          "isMasked": false,
+          "twoTheta": 1.8230747956560218,
+          "dResolution": {
+            "minimum": 0.4427877783643468,
+            "maximum": 2.2139388918217344
+          },
+          "dRelativeResolution": 0.003379514789208845
+        },
+        {
+          "groupID": 1,
+          "isMasked": false,
+          "twoTheta": 1.1545587481738246,
+          "dResolution": {
+            "minimum": 0.641323731469231,
+            "maximum": 3.2066186573461555
+          },
+          "dRelativeResolution": 0.005910630879382727
+        }
+      ]
     },
-    "version": 1
-  }
+    {
+      "focusGroup": {
+        "name": "All",
+        "definition": ""
+      },
+      "timeOfFlight": {
+        "minimum": 2742.6,
+        "maximum": 13713,
+        "binWidth": 1,
+        "binningMode": 1
+      },
+      "pixelGroupingParameters": [
+        {
+          "groupID": 0,
+          "isMasked": false,
+          "twoTheta": 1.4888167719149363,
+          "dResolution": {
+            "minimum": 0.5165770976155033,
+            "maximum": 2.5828854880775167
+          },
+          "dRelativeResolution": 0.004814388725622084
+        }
+      ]
+    }
+  ],
+  "focusGroupCalibrationMetrics":{
+    "focusGroupName": "Column",
+    "calibrationMetric": [
+      {
+        "sigmaAverage": 0.002517952998136214,
+        "sigmaStandardDeviation": 0.00000878421857231147,
+        "strainAverage": 0.1515216185900471,
+        "strainStandardDeviation": 0.013151225165758604,
+        "twoThetaAverage": 2.110894794556694
+      },
+      {
+        "sigmaAverage": 0.003176206362503416,
+        "sigmaStandardDeviation": 0.000014979115537326051,
+        "strainAverage": 0.11967297872183888,
+        "strainStandardDeviation": 0.010670589671407833,
+        "twoThetaAverage": 1.8231067294302894
+      },
+      {
+        "sigmaAverage": 0.0020173258481625943,
+        "sigmaStandardDeviation": 0.0011833789198171258,
+        "strainAverage": 2.9472523966464146,
+        "strainStandardDeviation": 1.7234726438089345,
+        "twoThetaAverage": 1.5352228117682118
+      },
+      {
+        "sigmaAverage": 0.0019681238298694874,
+        "sigmaStandardDeviation": 0.0012719855843628899,
+        "strainAverage": 2.97560355438957,
+        "strainStandardDeviation": 1.7073076840182733,
+        "twoThetaAverage": 1.440276416886144
+      },
+      {
+        "sigmaAverage": 0.002792254157654066,
+        "sigmaStandardDeviation": 0.0018788822023715769,
+        "strainAverage": 2.6968257593469005,
+        "strainStandardDeviation": 1.5521868842356747,
+        "twoThetaAverage": 1.1543988480234637
+      },
+      {
+        "sigmaAverage": 0.0035439650966407016,
+        "sigmaStandardDeviation": 0.0026213074118901255,
+        "strainAverage": 2.9942330576453013,
+        "strainStandardDeviation": 1.7458314136551056,
+        "twoThetaAverage": 0.8690010316506124
+      }
+    ]
+  },
+  "workspaces": {
+    "diffCalOutput": ["_tof_column_057514_v0001", "_dsp_column_057514_v0001"],
+    "diffCalTable": ["_diffract_consts_057514_v0001"],
+    "diffCalMask": ["_diffract_consts_mask_057514_v0001"]
+  },
+  "version": 1
+}

--- a/tests/resources/inputs/calibration/CalibrationRecord_v0002.json
+++ b/tests/resources/inputs/calibration/CalibrationRecord_v0002.json
@@ -384,260 +384,261 @@
             "multiplicity": 24
         }
     ]
-},
-    "calibrationFittingIngredients": {
-      "instrumentState": {
-        "id": "ab8704b0bc2a2342",
-        "peakTailCoefficient": 1.1,
-        "instrumentConfig": {
-          "version": "1.4",
-          "facility": "SNS",
-          "name": "SNAP",
-          "nexusFileExtension": ".nxs.h5",
-          "nexusFilePrefix": "SNAP_",
-          "calibrationFileExtension": "json",
-          "calibrationFilePrefix": "SNAPcalibLog",
-          "calibrationDirectory": "/SNS/SNAP/shared/Calibration/",
-          "pixelGroupingDirectory": "PixelGroupingDefinitions/",
-          "sharedDirectory": "shared/",
-          "nexusDirectory": "nexus/",
-          "reducedDataDirectory": "shared/manualReduced/",
-          "reductionRecordDirectory": "shared/manualReduced/reductionRecord/",
-          "bandwidth": 3,
-          "maxBandwidth": 3.2,
-          "L1": 15,
-          "L2": 0.5,
-          "delTOverT": 0.002,
-          "delLOverL": 0.00006452,
-          "delThNoGuide": 0.0006667,
-          "delThWithGuide": 0.0032
+  },
+  "calibrationFittingIngredients": {
+    "instrumentState": {
+      "id": "ab8704b0bc2a2342",
+      "peakTailCoefficient": 1.1,
+      "instrumentConfig": {
+        "version": "1.4",
+        "facility": "SNS",
+        "name": "SNAP",
+        "nexusFileExtension": ".nxs.h5",
+        "nexusFilePrefix": "SNAP_",
+        "calibrationFileExtension": "json",
+        "calibrationFilePrefix": "SNAPcalibLog",
+        "calibrationDirectory": "/SNS/SNAP/shared/Calibration/",
+        "pixelGroupingDirectory": "PixelGroupingDefinitions/",
+        "sharedDirectory": "shared/",
+        "nexusDirectory": "nexus/",
+        "reducedDataDirectory": "shared/manualReduced/",
+        "reductionRecordDirectory": "shared/manualReduced/reductionRecord/",
+        "bandwidth": 3,
+        "maxBandwidth": 3.2,
+        "L1": 15,
+        "L2": 0.5,
+        "delTOverT": 0.002,
+        "delLOverL": 0.00006452,
+        "delThNoGuide": 0.0006667,
+        "delThWithGuide": 0.0032
+      },
+      "detectorState": {
+        "arc": [
+          -65.3,
+          104.95
+        ],
+        "wav": 2.1,
+        "freq": 60,
+        "guideStat": 1,
+        "lin": [
+          0.045,
+          0.043
+        ]
+      },
+      "gsasParameters": {
+        "alpha": 0.1,
+        "beta": [
+          0.02,
+          0.05
+        ]
+      },
+      "particleBounds": {
+        "wavelength": {
+          "minimum": 0.7,
+          "maximum": 3.5
         },
-        "detectorState": {
-          "arc": [
-            -65.3,
-            104.95
-          ],
-          "wav": 2.1,
-          "freq": 60,
-          "guideStat": 1,
-          "lin": [
-            0.045,
-            0.043
-          ]
-        },
-        "gsasParameters": {
-          "alpha": 0.1,
-          "beta": [
-            0.02,
-            0.05
-          ]
-        },
-        "particleBounds": {
-          "wavelength": {
-            "minimum": 0.7,
-            "maximum": 3.5
-          },
-          "tof": {
-            "minimum": 2742.6,
-            "maximum": 13713
-          }
-        },
-        "defaultGroupingSliceValue": 5,
-        "fwhmMultipliers": {
-          "minimum": 1.3,
-          "maximum": 1.3
+        "tof": {
+          "minimum": 2742.6,
+          "maximum": 13713
         }
       },
-      "seedRun": 57514,
-      "creationDate": "2023-06-05T15:49:59.583421",
-      "name": "test",
-      "version": 0
-    },
-    "pixelGroups":[
-      {
-        "focusGroup": {
-          "name": "Column",
-          "definition": ""
-        },
-        "timeOfFlight": {
-          "minimum": 2742.6,
-          "maximum": 13713,
-          "binWidth": 1,
-          "binningMode": 1
-        },
-        "pixelGroupingParameters": [
-          {
-            "groupID": 0,
-            "isMasked": false,
-            "twoTheta": 2.1108948177427838,
-            "dResolution": {
-              "minimum": 0.40224298673776404,
-              "maximum": 2.0112149336888203
-            },
-            "dRelativeResolution": 0.002771822370612031
-          },
-          {
-            "groupID": 1,
-            "isMasked": false,
-            "twoTheta": 1.82310673131693,
-            "dResolution": {
-              "minimum": 0.44278229953817677,
-              "maximum": 2.213911497690884
-            },
-            "dRelativeResolution": 0.003234525153614593
-          },
-          {
-            "groupID": 2,
-            "isMasked": false,
-            "twoTheta": 1.5352228379083572,
-            "dResolution": {
-              "minimum": 0.5040188478793922,
-              "maximum": 2.5200942393969608
-            },
-            "dRelativeResolution": 0.004014748859873182
-          },
-          {
-            "groupID": 3,
-            "isMasked": false,
-            "twoTheta": 1.440276389170165,
-            "dResolution": {
-              "minimum": 0.530714277849788,
-              "maximum": 2.6535713892489396
-            },
-            "dRelativeResolution": 0.004309856397320412
-          },
-          {
-            "groupID": 4,
-            "isMasked": false,
-            "twoTheta": 1.1543988461042238,
-            "dResolution": {
-              "minimum": 0.6414024711539658,
-              "maximum": 3.207012355769829
-            },
-            "dRelativeResolution": 0.005408489642872038
-          },
-          {
-            "groupID": 5,
-            "isMasked": false,
-            "twoTheta": 0.8690010092470938,
-            "dResolution": {
-              "minimum": 0.831438096217031,
-              "maximum": 4.157190481085156
-            },
-            "dRelativeResolution": 0.007548513084996265
-          }
-        ]
-      },
-      {
-        "focusGroup": {
-          "name": "Bank",
-          "definition": ""
-        },
-        "timeOfFlight": {
-          "minimum": 2742.6,
-          "maximum": 13713,
-          "binWidth": 1,
-          "binningMode": 1
-        },
-        "pixelGroupingParameters": [
-          {
-            "groupID": 0,
-            "isMasked": false,
-            "twoTheta": 1.8230747956560218,
-            "dResolution": {
-              "minimum": 0.4427877783643468,
-              "maximum": 2.2139388918217344
-            },
-            "dRelativeResolution": 0.003379514789208845
-          },
-          {
-            "groupID": 1,
-            "isMasked": false,
-            "twoTheta": 1.1545587481738246,
-            "dResolution": {
-              "minimum": 0.641323731469231,
-              "maximum": 3.2066186573461555
-            },
-            "dRelativeResolution": 0.005910630879382727
-          }
-        ]
-      },
-      {
-        "focusGroup": {
-          "name": "All",
-          "definition": ""
-        },
-        "timeOfFlight": {
-          "minimum": 2742.6,
-          "maximum": 13713,
-          "binWidth": 1,
-          "binningMode": 1
-        },
-        "pixelGroupingParameters": [
-          {
-            "groupID": 0,
-            "isMasked": false,
-            "twoTheta": 1.4888167719149363,
-            "dResolution": {
-              "minimum": 0.5165770976155033,
-              "maximum": 2.5828854880775167
-            },
-            "dRelativeResolution": 0.004814388725622084
-          }
-        ]
+      "defaultGroupingSliceValue": 5,
+      "fwhmMultipliers": {
+        "minimum": 1.3,
+        "maximum": 1.3
       }
-    ],
-    "focusGroupCalibrationMetrics":{
-      "focusGroupName": "Column",
-      "calibrationMetric": [
+    },
+    "seedRun": 57514,
+    "useLiteMode": true,
+    "creationDate": "2023-06-05T15:49:59.583421",
+    "name": "test",
+    "version": 0
+  },
+  "pixelGroups":[
+    {
+      "focusGroup": {
+        "name": "Column",
+        "definition": ""
+      },
+      "timeOfFlight": {
+        "minimum": 2742.6,
+        "maximum": 13713,
+        "binWidth": 1,
+        "binningMode": 1
+      },
+      "pixelGroupingParameters": [
         {
-          "sigmaAverage": 0.002517952998136214,
-          "sigmaStandardDeviation": 0.00000878421857231147,
-          "strainAverage": 0.1515216185900471,
-          "strainStandardDeviation": 0.013151225165758604,
-          "twoThetaAverage": 2.110894794556694
+          "groupID": 0,
+          "isMasked": false,
+          "twoTheta": 2.1108948177427838,
+          "dResolution": {
+            "minimum": 0.40224298673776404,
+            "maximum": 2.0112149336888203
+          },
+          "dRelativeResolution": 0.002771822370612031
         },
         {
-          "sigmaAverage": 0.003176206362503416,
-          "sigmaStandardDeviation": 0.000014979115537326051,
-          "strainAverage": 0.11967297872183888,
-          "strainStandardDeviation": 0.010670589671407833,
-          "twoThetaAverage": 1.8231067294302894
+          "groupID": 1,
+          "isMasked": false,
+          "twoTheta": 1.82310673131693,
+          "dResolution": {
+            "minimum": 0.44278229953817677,
+            "maximum": 2.213911497690884
+          },
+          "dRelativeResolution": 0.003234525153614593
         },
         {
-          "sigmaAverage": 0.0020173258481625943,
-          "sigmaStandardDeviation": 0.0011833789198171258,
-          "strainAverage": 2.9472523966464146,
-          "strainStandardDeviation": 1.7234726438089345,
-          "twoThetaAverage": 1.5352228117682118
+          "groupID": 2,
+          "isMasked": false,
+          "twoTheta": 1.5352228379083572,
+          "dResolution": {
+            "minimum": 0.5040188478793922,
+            "maximum": 2.5200942393969608
+          },
+          "dRelativeResolution": 0.004014748859873182
         },
         {
-          "sigmaAverage": 0.0019681238298694874,
-          "sigmaStandardDeviation": 0.0012719855843628899,
-          "strainAverage": 2.97560355438957,
-          "strainStandardDeviation": 1.7073076840182733,
-          "twoThetaAverage": 1.440276416886144
+          "groupID": 3,
+          "isMasked": false,
+          "twoTheta": 1.440276389170165,
+          "dResolution": {
+            "minimum": 0.530714277849788,
+            "maximum": 2.6535713892489396
+          },
+          "dRelativeResolution": 0.004309856397320412
         },
         {
-          "sigmaAverage": 0.002792254157654066,
-          "sigmaStandardDeviation": 0.0018788822023715769,
-          "strainAverage": 2.6968257593469005,
-          "strainStandardDeviation": 1.5521868842356747,
-          "twoThetaAverage": 1.1543988480234637
+          "groupID": 4,
+          "isMasked": false,
+          "twoTheta": 1.1543988461042238,
+          "dResolution": {
+            "minimum": 0.6414024711539658,
+            "maximum": 3.207012355769829
+          },
+          "dRelativeResolution": 0.005408489642872038
         },
         {
-          "sigmaAverage": 0.0035439650966407016,
-          "sigmaStandardDeviation": 0.0026213074118901255,
-          "strainAverage": 2.9942330576453013,
-          "strainStandardDeviation": 1.7458314136551056,
-          "twoThetaAverage": 0.8690010316506124
+          "groupID": 5,
+          "isMasked": false,
+          "twoTheta": 0.8690010092470938,
+          "dResolution": {
+            "minimum": 0.831438096217031,
+            "maximum": 4.157190481085156
+          },
+          "dRelativeResolution": 0.007548513084996265
         }
       ]
     },
-    "workspaces": {
-      "diffCalOutput": ["_tof_column_057514_v0002"],
-      "diffCalTable": ["_diffract_consts_057514_v0002"],
-      "diffCalMask": ["_diffract_consts_mask_057514_v0002"]
+    {
+      "focusGroup": {
+        "name": "Bank",
+        "definition": ""
+      },
+      "timeOfFlight": {
+        "minimum": 2742.6,
+        "maximum": 13713,
+        "binWidth": 1,
+        "binningMode": 1
+      },
+      "pixelGroupingParameters": [
+        {
+          "groupID": 0,
+          "isMasked": false,
+          "twoTheta": 1.8230747956560218,
+          "dResolution": {
+            "minimum": 0.4427877783643468,
+            "maximum": 2.2139388918217344
+          },
+          "dRelativeResolution": 0.003379514789208845
+        },
+        {
+          "groupID": 1,
+          "isMasked": false,
+          "twoTheta": 1.1545587481738246,
+          "dResolution": {
+            "minimum": 0.641323731469231,
+            "maximum": 3.2066186573461555
+          },
+          "dRelativeResolution": 0.005910630879382727
+        }
+      ]
     },
-    "version": 2
-  }
+    {
+      "focusGroup": {
+        "name": "All",
+        "definition": ""
+      },
+      "timeOfFlight": {
+        "minimum": 2742.6,
+        "maximum": 13713,
+        "binWidth": 1,
+        "binningMode": 1
+      },
+      "pixelGroupingParameters": [
+        {
+          "groupID": 0,
+          "isMasked": false,
+          "twoTheta": 1.4888167719149363,
+          "dResolution": {
+            "minimum": 0.5165770976155033,
+            "maximum": 2.5828854880775167
+          },
+          "dRelativeResolution": 0.004814388725622084
+        }
+      ]
+    }
+  ],
+  "focusGroupCalibrationMetrics":{
+    "focusGroupName": "Column",
+    "calibrationMetric": [
+      {
+        "sigmaAverage": 0.002517952998136214,
+        "sigmaStandardDeviation": 0.00000878421857231147,
+        "strainAverage": 0.1515216185900471,
+        "strainStandardDeviation": 0.013151225165758604,
+        "twoThetaAverage": 2.110894794556694
+      },
+      {
+        "sigmaAverage": 0.003176206362503416,
+        "sigmaStandardDeviation": 0.000014979115537326051,
+        "strainAverage": 0.11967297872183888,
+        "strainStandardDeviation": 0.010670589671407833,
+        "twoThetaAverage": 1.8231067294302894
+      },
+      {
+        "sigmaAverage": 0.0020173258481625943,
+        "sigmaStandardDeviation": 0.0011833789198171258,
+        "strainAverage": 2.9472523966464146,
+        "strainStandardDeviation": 1.7234726438089345,
+        "twoThetaAverage": 1.5352228117682118
+      },
+      {
+        "sigmaAverage": 0.0019681238298694874,
+        "sigmaStandardDeviation": 0.0012719855843628899,
+        "strainAverage": 2.97560355438957,
+        "strainStandardDeviation": 1.7073076840182733,
+        "twoThetaAverage": 1.440276416886144
+      },
+      {
+        "sigmaAverage": 0.002792254157654066,
+        "sigmaStandardDeviation": 0.0018788822023715769,
+        "strainAverage": 2.6968257593469005,
+        "strainStandardDeviation": 1.5521868842356747,
+        "twoThetaAverage": 1.1543988480234637
+      },
+      {
+        "sigmaAverage": 0.0035439650966407016,
+        "sigmaStandardDeviation": 0.0026213074118901255,
+        "strainAverage": 2.9942330576453013,
+        "strainStandardDeviation": 1.7458314136551056,
+        "twoThetaAverage": 0.8690010316506124
+      }
+    ]
+  },
+  "workspaces": {
+    "diffCalOutput": ["_tof_column_057514_v0002"],
+    "diffCalTable": ["_diffract_consts_057514_v0002"],
+    "diffCalMask": ["_diffract_consts_mask_057514_v0002"]
+  },
+  "version": 2
+}

--- a/tests/resources/inputs/calibration/ReductionIngredients.json
+++ b/tests/resources/inputs/calibration/ReductionIngredients.json
@@ -96,6 +96,7 @@
           "peakTailCoefficient": 2
         },
         "seedRun": 57514,
+        "useLiteMode": true,
         "creationDate": "2023-09-13T16:40:25.754664",
         "name": "this is a test state initialisation",
         "version": 49

--- a/tests/resources/inputs/normalization/NormalizationParameters.json
+++ b/tests/resources/inputs/normalization/NormalizationParameters.json
@@ -62,6 +62,7 @@
       "peakTailCoefficient": 2.0
     },
     "seedRun": 123,
+    "useLiteMode": true,
     "creationDate": "2023-05-25T11:50:23.438776",
     "name": "test",
     "version": 0

--- a/tests/resources/inputs/normalization/NormalizationRecord.json
+++ b/tests/resources/inputs/normalization/NormalizationRecord.json
@@ -67,6 +67,7 @@
             }
           },
           "seedRun": 57514,
+          "useLiteMode": true,
           "creationDate": "2023-06-05T15:49:59.583421",
           "name": "test",
           "version": 0

--- a/tests/resources/inputs/normalization/ReductionIngredients.json
+++ b/tests/resources/inputs/normalization/ReductionIngredients.json
@@ -96,6 +96,7 @@
           "peakTailCoefficient": 2
         },
         "seedRun": 57514,
+        "useLiteMode": true,
         "creationDate": "2023-09-13T16:40:25.754664",
         "name": "this is a test state initialisation",
         "version": 49

--- a/tests/resources/inputs/pixel_grouping/CalibrationParameters.json
+++ b/tests/resources/inputs/pixel_grouping/CalibrationParameters.json
@@ -41,6 +41,7 @@
     "peakTailCoefficient" : 2.0
   },
   "seedRun": 57514,
+  "useLiteMode": true,
   "creationDate": "2023-06-05T15:49:59.583421",
   "name": "test"
 }

--- a/tests/unit/backend/dao/test_CalibrationIndexEntry.py
+++ b/tests/unit/backend/dao/test_CalibrationIndexEntry.py
@@ -3,6 +3,7 @@ from snapred.backend.dao.calibration.CalibrationIndexEntry import CalibrationInd
 
 testData = {
     "runNumber": "1234",
+    "useLiteMode": False,
     "version": "1.0",
     "appliesTo": "1234",
     "comments": "test",

--- a/tests/unit/backend/data/test_DataExportService.py
+++ b/tests/unit/backend/data/test_DataExportService.py
@@ -22,7 +22,7 @@ with mock.patch.dict(
         dataExportService.dataService.writeCalibrationIndexEntry = mock.Mock()
         dataExportService.dataService.writeCalibrationIndexEntry.return_value = "expected"
         dataExportService.exportCalibrationIndexEntry(
-            CalibrationIndexEntry(runNumber="1", comments="", author=""), useLiteMode=True
+            CalibrationIndexEntry(runNumber="1", useLiteMode=True, comments="", author="")
         )
         assert dataExportService.dataService.writeCalibrationIndexEntry.called
 
@@ -44,7 +44,7 @@ with mock.patch.dict(
         dataExportService = DataExportService()
         dataExportService.dataService.writeCalibrationState = mock.Mock()
         dataExportService.dataService.writeCalibrationState.return_value = "expected"
-        dataExportService.exportCalibrationState(mock.Mock(), mock.Mock())
+        dataExportService.exportCalibrationState(mock.Mock())
         assert dataExportService.dataService.writeCalibrationState.called
 
     def test_initializeState():
@@ -59,7 +59,7 @@ with mock.patch.dict(
         dataExportService.dataService.writeNormalizationIndexEntry = mock.Mock()
         dataExportService.dataService.writeNormalizationIndexEntry.return_value = "expected"
         dataExportService.exportNormalizationIndexEntry(
-            NormalizationIndexEntry(runNumber="1", backgroundRunNumber="2", comments="", author=""), True
+            NormalizationIndexEntry(runNumber="1", useLiteMode=True, backgroundRunNumber="2", comments="", author="")
         )
         assert dataExportService.dataService.writeNormalizationIndexEntry.called
 

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -665,7 +665,7 @@ def test_writeCalibrationIndexEntry():
     localDataService._constructCalibrationStatePath.return_value = Resource.getPath("outputs")
     expectedFilePath = Resource.getPath("outputs") + "CalibrationIndex.json"
     localDataService.writeCalibrationIndexEntry(
-        CalibrationIndexEntry(runNumber="57514", comments="test comment", author="test author"), True
+        CalibrationIndexEntry(runNumber="57514", useLiteMode=True, comments="test comment", author="test author"),
     )
     assert os.path.exists(expectedFilePath)
 
@@ -690,9 +690,12 @@ def test_writeCalibrationIndexEntry():
     expectedFilePath = Resource.getPath("outputs") + "NormalizationIndex.json"
     localDataService.writeNormalizationIndexEntry(
         NormalizationIndexEntry(
-            runNumber="57514", backgroundRunNumber="58813", comments="test comment", author="test author"
+            runNumber="57514",
+            useLiteMode=True,
+            backgroundRunNumber="58813",
+            comments="test comment",
+            author="test author",
         ),
-        True,
     )
     assert os.path.exists(expectedFilePath)
 
@@ -717,7 +720,7 @@ def test_readCalibrationIndexExisting():
     localDataService._constructCalibrationStatePath.return_value = Resource.getPath("outputs")
     expectedFilePath = Resource.getPath("outputs") + "CalibrationIndex.json"
     localDataService.writeCalibrationIndexEntry(
-        CalibrationIndexEntry(runNumber="57514", comments="test comment", author="test author"), True
+        CalibrationIndexEntry(runNumber="57514", useLiteMode=True, comments="test comment", author="test author"),
     )
     actualEntries = localDataService.readCalibrationIndex("57514", True)
     os.remove(expectedFilePath)
@@ -737,9 +740,12 @@ def test_readNormalizationIndexExisting():
     expectedFilePath = Resource.getPath("outputs") + "NormalizationIndex.json"
     localDataService.writeNormalizationIndexEntry(
         NormalizationIndexEntry(
-            runNumber="57514", backgroundRunNumber="58813", comments="test comment", author="test author"
-        ),
-        True,
+            runNumber="57514",
+            useLiteMode=True,
+            backgroundRunNumber="58813",
+            comments="test comment",
+            author="test author",
+        )
     )
     actualEntries = localDataService.readNormalizationIndex("57514", True)
     os.remove(expectedFilePath)
@@ -1147,7 +1153,7 @@ def test__getVersionFromCalibrationIndex():
     localDataService.readCalibrationIndex = mock.Mock()
     localDataService.readCalibrationIndex.return_value = [mock.Mock()]
     localDataService.readCalibrationIndex.return_value[0] = CalibrationIndexEntry(
-        timestamp=123, version="1", appliesTo="123", runNumber="123", comments="", author=""
+        timestamp=123, useLiteMode=True, version="1", appliesTo="123", runNumber="123", comments="", author=""
     )
     actualVersion = localDataService._getVersionFromCalibrationIndex("123", True)
     assert actualVersion == "1"
@@ -1162,6 +1168,7 @@ def test__getVersionFromNormalizationIndex():
         version="1",
         appliesTo="123",
         runNumber="123",
+        useLiteMode=True,
         backgroundRunNumber="456",
         comments="",
         author="",
@@ -1255,7 +1262,7 @@ def test_writeCalibrationState():
         localDataService._constructCalibrationStatePath = mock.Mock(return_value=f"{tempdir}/")
         localDataService._getCurrentCalibrationRecord = mock.Mock(return_value=Calibration.construct({"name": "test"}))
         calibration = Calibration.parse_raw(Resource.read("/inputs/calibration/CalibrationParameters.json"))
-        localDataService.writeCalibrationState("123", calibration)
+        localDataService.writeCalibrationState(calibration)
         assert os.path.exists(tempdir + "/v_0001/CalibrationParameters.json")
 
 
@@ -1279,7 +1286,7 @@ def test_writeCalibrationState_overwrite_warning(caplog):
             localDataService._constructCalibrationParametersFilePath.return_value = calibrationParametersFilePath
 
             calibration = Calibration.parse_raw(Resource.read("/inputs/calibration/CalibrationParameters.json"))
-            localDataService.writeCalibrationState("123", calibration)
+            localDataService.writeCalibrationState(calibration)
             assert os.path.exists(calibrationParametersFilePath)
         assert f"overwriting calibration parameters at {calibrationParametersFilePath}" in caplog.text
 
@@ -1321,10 +1328,12 @@ def test_writeNormalizationState():
         localDataService._constructNormalizationCalibrationStatePath = mock.Mock()
         localDataService._constructNormalizationCalibrationStatePath.return_value = f"{tempdir}/"
         localDataService._getCurrentNormalizationRecord = mock.Mock()
-        localDataService._getCurrentNormalizationRecord.return_value = Normalization.construct({"name": "test"})
-        with Resource.open("/inputs/normalization/NormalizationParameters.json", "r") as f:
-            normalization = Normalization.parse_raw(f.read())
-        localDataService.writeNormalizationState("123", normalization)
+        localDataService._getCurrentNormalizationRecord.return_value = Normalization.construct(
+            {"seedRun": "123", "useLiteMode": True, "name": "test"}
+        )
+        normalization = Normalization.parse_file(Resource.getPath("/inputs/normalization/NormalizationParameters.json"))
+        normalization.version = 1
+        localDataService.writeNormalizationState(normalization, 1)
         assert os.path.exists(tempdir + "/v_0001/NormalizationParameters.json")
 
 
@@ -1380,6 +1389,9 @@ def test_readDetectorState_bad_logs():
 def test_initializeState():
     # Test 'initializeState'; test basic functionality.
 
+    runNumber = "123"
+    useLiteMode = True
+
     localDataService = LocalDataService()
     localDataService._readPVFile = mock.Mock()
 
@@ -1407,21 +1419,25 @@ def test_initializeState():
     localDataService._writeDefaultDiffCalTable = mock.Mock()
 
     testCalibrationData = Calibration.parse_file(Resource.getPath("inputs/calibration/CalibrationParameters.json"))
+    testCalibrationData.useLiteMode = useLiteMode
 
     localDataService.readInstrumentConfig = mock.Mock()
     localDataService.readInstrumentConfig.return_value = testCalibrationData.instrumentState.instrumentConfig
     localDataService.writeCalibrationState = mock.Mock()
     localDataService._prepareStateRoot = mock.Mock()
-    actual = localDataService.initializeState("123", "test")
+    actual = localDataService.initializeState(runNumber, "test", useLiteMode)
     actual.creationDate = testCalibrationData.creationDate
 
     assert actual == testCalibrationData
-    assert localDataService._writeDefaultDiffCalTable.called_once_with("123")
+    assert localDataService._writeDefaultDiffCalTable.called_once_with(runNumber, useLiteMode)
 
 
 @mock.patch.object(LocalDataService, "_prepareStateRoot")
 def test_initializeState_calls_prepareStateRoot(mockPrepareStateRoot):
     # Test that 'initializeState' initializes the <state root> directory.
+
+    runNumber = "123"
+    useLiteMode = True
 
     localDataService = LocalDataService()
     localDataService._readPVFile = mock.Mock()
@@ -1461,7 +1477,7 @@ def test_initializeState_calls_prepareStateRoot(mockPrepareStateRoot):
         localDataService._constructCalibrationStateRoot = mock.Mock(return_value=str(stateRootPath))
 
         assert not stateRootPath.exists()
-        localDataService.initializeState("123", "test")
+        localDataService.initializeState(runNumber, "test", useLiteMode)
         mockPrepareStateRoot.assert_called_once()
 
 

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -67,7 +67,9 @@ with mock.patch.dict(
         calibrationService = CalibrationService()
         calibrationService.dataExportService.exportCalibrationIndexEntry = mock.Mock()
         calibrationService.dataExportService.exportCalibrationIndexEntry.return_value = "expected"
-        calibrationService.saveCalibrationToIndex(CalibrationIndexEntry(runNumber="1", comments="", author=""), True)
+        calibrationService.saveCalibrationToIndex(
+            CalibrationIndexEntry(runNumber="1", useLiteMode=True, comments="", author="")
+        )
         assert calibrationService.dataExportService.exportCalibrationIndexEntry.called
         savedEntry = calibrationService.dataExportService.exportCalibrationIndexEntry.call_args.args[0]
         assert savedEntry.appliesTo == ">1"
@@ -95,7 +97,7 @@ with mock.patch.dict(
     def test_getCalibrationIndex():
         calibrationService = CalibrationService()
         calibrationService.dataFactoryService.getCalibrationIndex = mock.Mock(
-            return_value=CalibrationIndexEntry(runNumber="1", comments="", author="")
+            return_value=CalibrationIndexEntry(runNumber="1", useLiteMode=True, comments="", author="")
         )
         calibrationService.getCalibrationIndex(MagicMock(run=MagicMock(runNumber="123")))
         assert calibrationService.dataFactoryService.getCalibrationIndex.called

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -60,7 +60,7 @@ with mock.patch.dict(
         normalizationService.dataExportService.exportNormalizationIndexEntry = MagicMock()
         normalizationService.dataExportService.exportNormalizationIndexEntry.return_value = "expected"
         normalizationService.saveNormalizationToIndex(
-            NormalizationIndexEntry(runNumber="1", backgroundRunNumber="2"), True
+            NormalizationIndexEntry(runNumber="1", useLiteMode=True, backgroundRunNumber="2")
         )
         assert normalizationService.dataExportService.exportNormalizationIndexEntry.called
         savedEntry = normalizationService.dataExportService.exportNormalizationIndexEntry.call_args.args[0]

--- a/tests/unit/ui/presenter/test_CalibrationAssessmentPresenter.py
+++ b/tests/unit/ui/presenter/test_CalibrationAssessmentPresenter.py
@@ -13,10 +13,13 @@ def calibrationAssessmentPresenter():
 
 
 def test_load_record(calibrationAssessmentPresenter):
+    runNumber = "12345"
+    useLiteMode = False
+    version = "1"
     view = calibrationAssessmentPresenter.view
     view.getCalibrationRecordCount = MagicMock(return_value=1)
     view.getSelectedCalibrationRecordIndex = MagicMock(return_value=0)
-    view.getSelectedCalibrationRecordData = MagicMock(return_value=("12345", "1"))
+    view.getSelectedCalibrationRecordData = MagicMock(return_value=(runNumber, useLiteMode, version))
 
     with patch.object(calibrationAssessmentPresenter, "worker_pool") as worker_pool, patch.object(
         calibrationAssessmentPresenter, "interfaceController"
@@ -28,8 +31,9 @@ def test_load_record(calibrationAssessmentPresenter):
         view.getSelectedCalibrationRecordData.assert_called_once()
 
         payload = CalibrationLoadAssessmentRequest(
-            runId="12345",
-            version="1",
+            runId=runNumber,
+            useLiteMode=useLiteMode,
+            version=version,
             checkExistent=True,
         )
         request = SNAPRequest(path="/calibration/loadQualityAssessment", payload=payload.json())

--- a/tests/unit/ui/view/test_CalibrationAssessmentView.py
+++ b/tests/unit/ui/view/test_CalibrationAssessmentView.py
@@ -11,7 +11,9 @@ def test_calibration_record_dropdown(qtbot):
     # test filling in the dropdown
     runNumber = "1234"
     version = "1"
-    calibrationIndexEntries = [CalibrationIndexEntry(runNumber=runNumber, version=version, comments="", author="")]
+    calibrationIndexEntries = [
+        CalibrationIndexEntry(runNumber=runNumber, useLiteMode=True, version=version, comments="", author="")
+    ]
     view.updateCalibrationRecordList(calibrationIndexEntries)
     assert view.getCalibrationRecordCount() == 1
     assert view.getSelectedCalibrationRecordIndex() == -1

--- a/tests/unit/ui/view/test_CalibrationAssessmentView.py
+++ b/tests/unit/ui/view/test_CalibrationAssessmentView.py
@@ -10,9 +10,10 @@ def test_calibration_record_dropdown(qtbot):
 
     # test filling in the dropdown
     runNumber = "1234"
+    useLiteMode = False
     version = "1"
     calibrationIndexEntries = [
-        CalibrationIndexEntry(runNumber=runNumber, useLiteMode=True, version=version, comments="", author="")
+        CalibrationIndexEntry(runNumber=runNumber, useLiteMode=useLiteMode, version=version, comments="", author="")
     ]
     view.updateCalibrationRecordList(calibrationIndexEntries)
     assert view.getCalibrationRecordCount() == 1
@@ -22,7 +23,7 @@ def test_calibration_record_dropdown(qtbot):
     qtbot.addWidget(view.calibrationRecordDropdown)
     qtbot.keyClicks(view.calibrationRecordDropdown, "Version: 1; Run: 1234")
     assert view.getSelectedCalibrationRecordIndex() == 0
-    assert view.getSelectedCalibrationRecordData() == (runNumber, version)
+    assert view.getSelectedCalibrationRecordData() == (runNumber, useLiteMode, version)
 
 
 def test_error_on_load_calibration_record(qtbot):


### PR DESCRIPTION
## Description of work

The entries in the calibration and normalization indices do not record if they used lite mode or not.

This updates them so that they do.

Also, this simplifies and standardizes the API for writing calibration and normalization artifacts, as they can all be written using only the DAO, with no additional data.

## Explanation of work

Added `useLiteMode` as a required member on four DAOs.

The rest was making that work.

## To test

### Dev testing

Delete the dev calibration folder.  Start diffcal workflow.  

Initialize state, and make sure the `v_0001` directory is created and has two files.

At assessment make sure `v_0001` shows up on drop down.

Save.  Make sure the `v_0002` directory is created and has four files.

Star normalization workflow.  Save.  Make sure `v_0001` directory is created and has four files.

Inspect the index .json files, the `CalibrationParameters.json` files, and the `NormalizationParameters.json` files.  Make sure they all indicate the lite mode status of the runs.

Do the same, initializing diffcal and normalization in native mode.  Do not actually run the entire calculation.

### CIS testing

Do the above.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
