### PR TITLE
added workbench arg to start snapred in workbench and preload necessa…

### DIFF
--- a/src/snapred/__main__.py
+++ b/src/snapred/__main__.py
@@ -86,7 +86,7 @@ def _createArgparser():
         action="store_true",
         help="Stop the error reporter from opening if you suffer an exception or crash.",
     )
-    parser.add_argument("script")
+    parser.add_argument("script", default=None)
     return parser
 
 

--- a/src/snapred/__main__.py
+++ b/src/snapred/__main__.py
@@ -86,7 +86,7 @@ def _createArgparser():
         action="store_true",
         help="Stop the error reporter from opening if you suffer an exception or crash.",
     )
-    parser.add_argument("script", default=None)
+    parser.add_argument("script", nargs="?", default=None)
     return parser
 
 

--- a/src/snapred/__main__.py
+++ b/src/snapred/__main__.py
@@ -5,7 +5,10 @@ from typing import List
 from mantid.kernel import amend_config
 
 from snapred import __version__ as snapred_version
+from snapred.backend.log.logger import snapredLogger
 from snapred.meta.Config import Config, Resource, datasearch_directories
+
+logger = snapredLogger.getLogger(__name__)
 
 
 def _print_text_splash():
@@ -111,6 +114,12 @@ def main(args=None):
     }
     with amend_config(**new_config):
         if options.workbench:
+            warningMessage = (
+                "WARNING: --workbench is a temporary means of starting workbench with the ability to launch SNAPRed"
+            )
+            warningSeperator = "/" * len(warningMessage)
+            warningSeperator = f"{warningSeperator}\n{warningSeperator}"
+            logger.warning(f"\n{warningSeperator}\n\n{warningMessage}\n\n{warningSeperator}\n")
             _preloadImports()
             import os
 


### PR DESCRIPTION
…ry imports

## Description of work

fixes snapred workbench startup issues by preimporting webui widget.

## Explanation of work

its necessary to start workbench through snapred because workbench will by default create a qapp, which messes with the import order of one of our dependencies.


## To test

launch snapred with 
```
snapred --workbench
```

see that workbench starts,
open snapred ui from workbench
see that the ui now comes up
