### PR TITLE
Setup algorithm to normalize by current the correct way

### DIFF
--- a/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
+++ b/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
@@ -62,8 +62,8 @@ class ReductionGroupProcessingRecipe(Recipe[Ingredients]):
             RebinOutput=False,
         )
 
-        self.mantidSnapper.NormaliseByCurrent(
-            "Normalizing Current ...",
+        self.mantidSnapper.NormalizeByCurrentButTheCorrectWay(
+            "Normalizing Current ... but the correct way!",
             InputWorkspace=self.rawInput,
             OutputWorkspace=self.rawInput,
         )

--- a/src/snapred/backend/recipe/algorithm/NormalizeByCurrentButTheCorrectWay.py
+++ b/src/snapred/backend/recipe/algorithm/NormalizeByCurrentButTheCorrectWay.py
@@ -1,0 +1,46 @@
+from mantid.api import AlgorithmFactory, MatrixWorkspaceProperty, PropertyMode, PythonAlgorithm
+from mantid.kernel import Direction
+from mantid.simpleapi import CloneWorkspace, NormaliseByCurrent, mtd
+
+
+class NormalizeByCurrentButTheCorrectWay(PythonAlgorithm):
+    """
+    You want to normalise but current.
+    But you don't want it to just crash if you already did.
+    This makes sure it won't.
+    """
+
+    def category(self):
+        return "SNAPRed Reduction"
+
+    def PyInit(self):
+        # declare properties
+        self.declareProperty(
+            MatrixWorkspaceProperty("InputWorkspace", "", Direction.Input, PropertyMode.Mandatory),
+            doc="Name of the input workspace",
+        )
+        self.declareProperty(
+            MatrixWorkspaceProperty("OutputWorkspace", "", Direction.Output, PropertyMode.Mandatory),
+            doc="Name of the output workspace",
+        )
+        self.declareProperty("RecalculatePCharge", False, direction=Direction.Input)  # noqa: F821
+        self.setRethrows(True)
+
+    def PyExec(self):
+        self.log().notice("Normalizing by current, but properly")
+        workspace = self.getPropertyValue("InputWorkspace")
+        if mtd[workspace].mutableRun().hasProperty("NormalizationFactor"):
+            CloneWorkspace(
+                InputWorkspace=workspace,
+                OutputWorkspace=self.getPropertyValue("OutputWorkspace"),
+            )
+        else:
+            NormaliseByCurrent(
+                InputWorkspace=workspace,
+                OutputWorkspace=self.getPropertyValue("OutputWorkspace"),
+                RecalculatePCharge=self.getProperty("RecalculatePCharge").value,
+            )
+
+
+# Register algorithm with Mantid
+AlgorithmFactory.subscribe(NormalizeByCurrentButTheCorrectWay)

--- a/tests/unit/backend/recipe/algorithm/test_NormalizeByCurrentButTheCorrectWay.py
+++ b/tests/unit/backend/recipe/algorithm/test_NormalizeByCurrentButTheCorrectWay.py
@@ -1,7 +1,9 @@
 import unittest
 
+import pytest
+
 # mantid imports
-from mantid.simpleapi import CreateWorkspace, NormalizeByCurrentButTheCorrectWay, mtd
+from mantid.simpleapi import CreateWorkspace, NormaliseByCurrent, NormalizeByCurrentButTheCorrectWay, mtd
 
 
 class TestNormalizeByCurrent(unittest.TestCase):
@@ -28,6 +30,11 @@ class TestNormalizeByCurrent(unittest.TestCase):
         ws = CreateWorkspace(OutputWorkspace=wsname, DataX=[1], DataY=[value])
         ws.mutableRun().addProperty("gd_prtn_chrg", protoncharge, True)
         ws.mutableRun().addProperty("NormalizationFactor", protoncharge, True)
+        with pytest.raises(RuntimeError):
+            NormaliseByCurrent(
+                InputWorkspace=wsname,
+                OutputWorkspace=wsname,
+            )
         NormalizeByCurrentButTheCorrectWay(
             InputWorkspace=wsname,
             OutputWorkspace=wsname,

--- a/tests/unit/backend/recipe/algorithm/test_NormalizeByCurrentButTheCorrectWay.py
+++ b/tests/unit/backend/recipe/algorithm/test_NormalizeByCurrentButTheCorrectWay.py
@@ -7,7 +7,6 @@ from mantid.simpleapi import CreateWorkspace, NormaliseByCurrent, NormalizeByCur
 
 
 class TestNormalizeByCurrent(unittest.TestCase):
-    # @mock.patch("snaped.backend.recipe.algorithm.NormalizeByCurrentButTheCorrectWay.NormaliseByCurrent")
     def test_normalize_unnormalized(self):
         value = 16
         protoncharge = 2

--- a/tests/unit/backend/recipe/algorithm/test_NormalizeByCurrentButTheCorrectWay.py
+++ b/tests/unit/backend/recipe/algorithm/test_NormalizeByCurrentButTheCorrectWay.py
@@ -1,0 +1,37 @@
+import unittest
+
+# mantid imports
+from mantid.simpleapi import CreateWorkspace, NormalizeByCurrentButTheCorrectWay, mtd
+
+
+class TestNormalizeByCurrent(unittest.TestCase):
+    # @mock.patch("snaped.backend.recipe.algorithm.NormalizeByCurrentButTheCorrectWay.NormaliseByCurrent")
+    def test_normalize_unnormalized(self):
+        value = 16
+        protoncharge = 2
+        wsname = mtd.unique_name()
+        ws = CreateWorkspace(OutputWorkspace=wsname, DataX=[1], DataY=[value])
+        ws.mutableRun().addProperty("gd_prtn_chrg", float(protoncharge), True)
+        assert not ws.run().hasProperty("NormalizationFactor")
+        NormalizeByCurrentButTheCorrectWay(
+            InputWorkspace=wsname,
+            OutputWorkspace=wsname,
+        )
+        assert ws.run().hasProperty("NormalizationFactor")
+        assert ws.run().getProperty("NormalizationFactor").value == protoncharge
+        assert ws.dataY(0) == [value / protoncharge]
+
+    def test_normalize_already_normalized(self):
+        value = 16
+        protoncharge = 2
+        wsname = mtd.unique_name()
+        ws = CreateWorkspace(OutputWorkspace=wsname, DataX=[1], DataY=[value])
+        ws.mutableRun().addProperty("gd_prtn_chrg", protoncharge, True)
+        ws.mutableRun().addProperty("NormalizationFactor", protoncharge, True)
+        NormalizeByCurrentButTheCorrectWay(
+            InputWorkspace=wsname,
+            OutputWorkspace=wsname,
+        )
+        assert ws.run().hasProperty("NormalizationFactor")
+        print(ws.run().getProperty("NormalizationFactor").value)
+        assert ws.dataY(0) == [value]

--- a/tests/unit/backend/recipe/test_ReductionGroupProcessingRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionGroupProcessingRecipe.py
@@ -50,9 +50,9 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
         normCurr = queuedAlgos[1]
 
         assert diffFoc[0] == "FocusSpectraAlgorithm"
-        assert normCurr[0] == "NormaliseByCurrent"
+        assert normCurr[0] == "NormalizeByCurrentButTheCorrectWay"
         assert diffFoc[1] == "Focusing Spectra..."
-        assert normCurr[1] == "Normalizing Current ..."
+        assert normCurr[1] == "Normalizing Current ... but the correct way!"
         assert diffFoc[2]["InputWorkspace"] == groceries["inputWorkspace"]
         assert diffFoc[2]["GroupingWorkspace"] == groceries["groupingWorkspace"]
         assert diffFoc[2]["OutputWorkspace"] == groceries["inputWorkspace"]
@@ -81,7 +81,7 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
 
         assert mockSnapper.executeQueue.called
         assert mockSnapper.FocusSpectraAlgorithm.called
-        assert mockSnapper.NormaliseByCurrent.called
+        assert mockSnapper.NormalizeByCurrentButTheCorrectWay.called
 
     def test_cater(self):
         untensils = Utensils()
@@ -105,4 +105,4 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
 
         assert mockSnapper.executeQueue.called
         assert mockSnapper.FocusSpectraAlgorithm.called
-        assert mockSnapper.NormaliseByCurrent.called
+        assert mockSnapper.NormalizeByCurrentButTheCorrectWay.called


### PR DESCRIPTION
## Description of work

When trying to test PR #339, we encountered repeated issues that then `NormaliseByCurrent` is called on a workspace that has already been normalized by current, then the mantid algorithm just fails.  It just stops, fails, and crashes the app.

Instead, if it's already been normalized, then it just doesn't get normalized again.

We're already normalized!  We can't normalize any further!


## Explanation of work

Made a very simple algorithm that checks if the `NormalizationFactor` log exists on a workspace.

If it does, that means the workspace has already been normalized by current, and instead it just clones the input into the output.

If it doesn't, then it has not been normalized by current, so it calls the mantid algorithm.

## To test

The unit tests should cover the relevant scenarios.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
