### PR TITLE
fix bug in FocusSpectra that prevented workflows :space_invader: 

### DIFF
--- a/src/snapred/backend/dao/calibration/CalibrationIndexEntry.py
+++ b/src/snapred/backend/dao/calibration/CalibrationIndexEntry.py
@@ -18,7 +18,7 @@ class CalibrationIndexEntry(BaseModel):
 
     runNumber: str
     useLiteMode: bool
-    version: Optional[str]
+    version: Optional[int]
     appliesTo: Optional[str]
     comments: str
     author: str

--- a/src/snapred/backend/dao/normalization/NormalizationIndexEntry.py
+++ b/src/snapred/backend/dao/normalization/NormalizationIndexEntry.py
@@ -19,7 +19,7 @@ class NormalizationIndexEntry(BaseModel):
     runNumber: str
     useLiteMode: bool
     backgroundRunNumber: str
-    version: Optional[str]
+    version: Optional[int]
     appliesTo: Optional[str]
     comments: Optional[str]
     author: Optional[str]

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -322,7 +322,7 @@ class LocalDataService:
             # filter for latest applicable
             relevantEntries = list(filter(lambda x: self._isApplicableEntry(x, runId), calibrationIndex))
             if len(relevantEntries) < 1:
-                raise ValueError(f"No applicable calibration index entries found for runId {runId}")
+                return None
             latestCalibration = relevantEntries[-1]
             version = latestCalibration.version
         return version
@@ -343,7 +343,7 @@ class LocalDataService:
             # filter for latest applicable
             relevantEntries = list(filter(lambda x: self._isApplicableEntry(x, runId), normalizationIndex))
             if len(relevantEntries) < 1:
-                raise ValueError(f"No applicable calibration index entries found for runId {runId}")
+                return None
             latestNormalization = relevantEntries[-1]
             version = latestNormalization.version
         return version

--- a/src/snapred/backend/recipe/algorithm/FocusSpectraAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FocusSpectraAlgorithm.py
@@ -54,7 +54,7 @@ class FocusSpectraAlgorithm(PythonAlgorithm):
         self.inputWSName = self.getPropertyValue("InputWorkspace")
         self.groupingWSName = self.getPropertyValue("GroupingWorkspace")
         self.outputWSName = self.getPropertyValue("OutputWorkspace")
-        self.rebinOutput = self.getPropertyValue("RebinOutput")
+        self.rebinOutput = self.getProperty("RebinOutput").value
 
     def validateInputs(self) -> Dict[str, str]:
         errors = {}

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -142,7 +142,6 @@ class SousChef(Service):
         )
         dMin = ingredients.crystalDBounds.minimum
         dMax = ingredients.crystalDBounds.maximum
-        res = None
         if key not in self._peaksCache:
             ingredients = self.prepPeakIngredients(ingredients)
             res = DetectorPeakPredictorRecipe().executeRecipe(

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -369,6 +369,12 @@ class DiffCalWorkflow(WorkflowImplementer):
 
     def _saveCalibration(self, workflowPresenter):
         view = workflowPresenter.widget.tabView
+        # validate the version number
+        try:
+            version = int(view.fieldVersion.get(None))
+            assert version >= 0
+        except (AssertionError, ValueError, TypeError):
+            raise TypeError("Version must be a nonnegative integer")
         # pull fields from view for calibration save
         calibrationIndexEntry = CalibrationIndexEntry(
             runNumber=view.fieldRunNumber.get(),

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -203,6 +203,13 @@ class NormalizationWorkflow(WorkflowImplementer):
         normalizationRecord.workspaceNames.append(self.responses[-2].data["focusedVanadium"])
         normalizationRecord.workspaceNames.append(self.responses[-2].data["correctedVanadium"])
 
+        # validate the version number
+        try:
+            version = int(view.fieldVersion.get(None))
+            assert version >= 0
+        except (AssertionError, ValueError, TypeError):
+            raise TypeError("Version must be a nonnegative integer.")
+
         normalizationIndexEntry = NormalizationIndexEntry(
             runNumber=view.fieldRunNumber.get(),
             useLiteMode=self.useLiteMode,

--- a/tests/unit/backend/dao/test_CalibrationIndexEntry.py
+++ b/tests/unit/backend/dao/test_CalibrationIndexEntry.py
@@ -4,7 +4,7 @@ from snapred.backend.dao.calibration.CalibrationIndexEntry import CalibrationInd
 testData = {
     "runNumber": "1234",
     "useLiteMode": False,
-    "version": "1.0",
+    "version": 1,
     "appliesTo": "1234",
     "comments": "test",
     "author": "test",

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -1198,10 +1198,16 @@ def test__getVersionFromCalibrationIndex():
     localDataService.readCalibrationIndex = mock.Mock()
     localDataService.readCalibrationIndex.return_value = [mock.Mock()]
     localDataService.readCalibrationIndex.return_value[0] = CalibrationIndexEntry(
-        timestamp=123, useLiteMode=True, version="1", appliesTo="123", runNumber="123", comments="", author=""
+        timestamp=123,
+        useLiteMode=True,
+        version=1,
+        appliesTo="123",
+        runNumber="123",
+        comments="",
+        author="",
     )
     actualVersion = localDataService._getVersionFromCalibrationIndex("123", True)
-    assert actualVersion == "1"
+    assert actualVersion == 1
 
 
 def test__getVersionFromNormalizationIndex():
@@ -1210,7 +1216,7 @@ def test__getVersionFromNormalizationIndex():
     localDataService.readNormalizationIndex.return_value = [mock.Mock()]
     localDataService.readNormalizationIndex.return_value[0] = NormalizationIndexEntry(
         timestamp=123,
-        version="1",
+        version=1,
         appliesTo="123",
         runNumber="123",
         useLiteMode=True,
@@ -1219,7 +1225,7 @@ def test__getVersionFromNormalizationIndex():
         author="",
     )
     actualVersion = localDataService._getVersionFromNormalizationIndex("123", True)
-    assert actualVersion == "1"
+    assert actualVersion == 1
 
 
 def test__getCurrentCalibrationRecord():

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -1210,6 +1210,23 @@ def test__getVersionFromCalibrationIndex():
     assert actualVersion == 1
 
 
+def test__getVersionFromCalibrationIndex_nuffink():
+    localDataService = LocalDataService()
+    localDataService.readCalibrationIndex = mock.Mock()
+    localDataService.readCalibrationIndex.return_value = [mock.Mock()]
+    localDataService.readCalibrationIndex.return_value[0] = CalibrationIndexEntry(
+        timestamp=123,
+        useLiteMode=True,
+        version=1,
+        appliesTo=">123",
+        runNumber="123",
+        comments="",
+        author="",
+    )
+    actualVersion = localDataService._getVersionFromCalibrationIndex("123", True)
+    assert actualVersion is None
+
+
 def test__getVersionFromNormalizationIndex():
     localDataService = LocalDataService()
     localDataService.readNormalizationIndex = mock.Mock()
@@ -1226,6 +1243,24 @@ def test__getVersionFromNormalizationIndex():
     )
     actualVersion = localDataService._getVersionFromNormalizationIndex("123", True)
     assert actualVersion == 1
+
+
+def test__getVersionFromNormalizationIndex_nuffink():
+    localDataService = LocalDataService()
+    localDataService.readNormalizationIndex = mock.Mock()
+    localDataService.readNormalizationIndex.return_value = [mock.Mock()]
+    localDataService.readNormalizationIndex.return_value[0] = NormalizationIndexEntry(
+        timestamp=123,
+        version=1,
+        appliesTo=">123",
+        runNumber="123",
+        useLiteMode=True,
+        backgroundRunNumber="456",
+        comments="",
+        author="",
+    )
+    actualVersion = localDataService._getVersionFromNormalizationIndex("123", True)
+    assert actualVersion is None
 
 
 def test__getCurrentCalibrationRecord():

--- a/tests/unit/ui/view/test_CalibrationAssessmentView.py
+++ b/tests/unit/ui/view/test_CalibrationAssessmentView.py
@@ -11,7 +11,7 @@ def test_calibration_record_dropdown(qtbot):
     # test filling in the dropdown
     runNumber = "1234"
     useLiteMode = False
-    version = "1"
+    version = 1
     calibrationIndexEntries = [
         CalibrationIndexEntry(runNumber=runNumber, useLiteMode=useLiteMode, version=version, comments="", author="")
     ]


### PR DESCRIPTION
## Description of work

This should fix the bug that has been preventing us from running diffcal or normalization workflows.

## Explanation of work

The difference is 
``` python
self.getPropertyValue()
```
vs
``` python
self.getProperty().value
```
Most properties are string properties, and the two are equivalent for strings.

For a boolean property, the second is [the actual boolean](https://docs.mantidproject.org/nightly/api/python/mantid/kernel/BoolPropertyWithValue.html#mantid.kernel.BoolPropertyWithValue.value) `True` or `False`, while the first is a [string representation of the boolean](https://docs.mantidproject.org/nightly/api/python/mantid/api/Algorithm.html#mantid.api.Algorithm.getPropertyValue).

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing

In dev calibration, delete the state folder.

Run calibration, including initializing the state.  
At tweak peak, try entering nonsense valeus for FHWM, like 0, -1, or "matthew".  Confirm it gives an error and can be corrected.

You should be able to get all the way to the save step.

At save step, try entering nonsense as the version number, and confirm it requires an integer.

Run back through workflow, confirm it does not give an error about no applicable records.

Do the same in normalization/

### CIS testing

Run calibration.  Use a legit run, make sure it saves.  At tweak peak peek, try changing absolutely everything: grouping, dmin, threshold, etc.

Do the same in normalization.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#5237](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=5237)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
