### PR TITLE
Fix reduction cis test script

### DIFF
--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -880,10 +880,10 @@ class GroceryService:
                             item.runNumber, item.useLiteMode
                         )
                         record = self.dataService.readCalibrationRecord(item.runNumber, item.useLiteMode, item.version)
+                        item.runNumber = record.runNumber
                     tableWorkspaceName = self._createDiffcalTableWorkspaceName(
-                        record.runNumber, item.useLiteMode, item.version
+                        item.runNumber, item.useLiteMode, item.version
                     )
-                    item.runNumber = record.runNumber
                     if item.isOutput:
                         res = {"result": True, "workspace": tableWorkspaceName}
                     else:

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -879,9 +879,11 @@ class GroceryService:
                         item.version = self.dataService._getVersionFromCalibrationIndex(
                             item.runNumber, item.useLiteMode
                         )
+                        record = self.dataService.readCalibrationRecord(item.runNumber, item.useLiteMode, item.version)
                     tableWorkspaceName = self._createDiffcalTableWorkspaceName(
-                        item.runNumber, item.useLiteMode, item.version
+                        record.runNumber, item.useLiteMode, item.version
                     )
+                    item.runNumber = record.runNumber
                     if item.isOutput:
                         res = {"result": True, "workspace": tableWorkspaceName}
                     else:

--- a/tests/cis_tests/reduction_recipe_script.py
+++ b/tests/cis_tests/reduction_recipe_script.py
@@ -27,12 +27,13 @@ calibrantSamplePath = "SNS/SNAP/shared/Calibration/CalibrationSamples/vanadium_c
 peakThreshold = 0.01
 isLite = True
 Config._config["cis_mode"] = True
-version="*"
+version=None
 
 localdataservice = LocalDataService()
 
 normalizationRecord = localdataservice._getCurrentNormalizationRecord(runNumber, isLite)
-print(localdataservice._constructNormalizationDataPath(runNumber, isLite, version))
+print(localdataservice._constructNormalizationDataPath(runNumber, isLite, version if version else "*"))
+if not normalizationRecord: raise ValueError("Normalization missing for given run and version, please correct your data")
 version = normalizationRecord.version
 
 normalizationPath = Path(localdataservice._constructNormalizationDataPath(runNumber, isLite, version))


### PR DESCRIPTION
unrevert groceryservice such that diffcal_table is looked up via targetRunnumber -> calibrationRecord -> table in calib version named with calibRecord.runnumber


## To test

Setup your calibration directory such that it has a valid calibration and a valid normalization in lite mode.
Run the cis test script for reduction to completion.