### PR TITLE
fix pv file path

### DIFF
--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -178,10 +178,10 @@ class LocalDataService:
 
     def _constructPVFilePath(self, runId: str) -> Path:
         runConfig = self._readRunConfig(runId)
-        return (
-            Path(runConfig.IPTS) / self.instrumentConfig.nexusDirectory / "/SNAP_"
-            + str(runConfig.runNumber)
-            + self.instrumentConfig.nexusFileExtension
+        return Path(
+            runConfig.IPTS,
+            self.instrumentConfig.nexusDirectory,
+            f"SNAP_{str(runConfig.runNumber)}{self.instrumentConfig.nexusFileExtension}",
         )
 
     def _readPVFile(self, runId: str):

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -619,14 +619,15 @@ def test__readRunConfig():
 
 
 def test_constructPVFilePath():
-    # ensure the file path is pointing at the correct place
-    with tempfile.TemporaryDirectory(dir=Resource.getPath("outputs")) as tmpdir:
-        mockRunConfig = mock.Mock(IPTS=tmpdir)
-        localDataService = LocalDataService()
-        localDataService._readRunConfig = mock.Mock(return_value=mockRunConfig)
-        path = localDataService._constructPVFilePath("123")
-        print(list(path.parents))
-        assert tmpdir == str(path.parents[1])
+    # ensure the file path points to inside the IPTS folder
+    localDataService = LocalDataService()
+    # mock the IPTS to point to somewhere then construct the path
+    mockIPTS = Resource.getPath("inputs/testInstrument/IPTS-456")
+    mockRunConfig = mock.Mock(IPTS=mockIPTS)
+    localDataService._readRunConfig = mock.Mock(return_value=mockRunConfig)
+    path = localDataService._constructPVFilePath("123")
+    # the path should be /path/to/outpurs/<tmpdir>/nexus/SNAP_123.nxs.h5
+    assert mockIPTS == str(path.parents[1])
 
 
 @mock.patch("h5py.File", return_value="not None")

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -618,6 +618,17 @@ def test__readRunConfig():
     assert actual.runNumber == "57514"
 
 
+def test_constructPVFilePath():
+    # ensure the file path is pointing at the correct place
+    with tempfile.TemporaryDirectory(dir=Resource.getPath("outputs")) as tmpdir:
+        mockRunConfig = mock.Mock(IPTS=tmpdir)
+        localDataService = LocalDataService()
+        localDataService._readRunConfig = mock.Mock(return_value=mockRunConfig)
+        path = localDataService._constructPVFilePath("123")
+        print(list(path.parents))
+        assert tmpdir == str(path.parents[1])
+
+
 @mock.patch("h5py.File", return_value="not None")
 def test_readPVFile(h5pyMock):  # noqa: ARG001
     localDataService = LocalDataService()

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -626,7 +626,7 @@ def test_constructPVFilePath():
     mockRunConfig = mock.Mock(IPTS=mockIPTS)
     localDataService._readRunConfig = mock.Mock(return_value=mockRunConfig)
     path = localDataService._constructPVFilePath("123")
-    # the path should be /path/to/outpurs/<tmpdir>/nexus/SNAP_123.nxs.h5
+    # the path should be /path/to/testInstrument/IPTS-456/nexus/SNAP_123.nxs.h5
     assert mockIPTS == str(path.parents[1])
 
 


### PR DESCRIPTION
## Description of work

When assembling a path using Python's `pathlib` module, it will interpret any `/` inside at the start of a path component as meaning "root directory" and drop everything before that `/`.

When constructing a `Path` object, string components do not need to, and should not, have initial `/` characters.

## Explanation of work

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing

On `next`, open the GUI, enter any valid run number.  You will get a pop up that it doesn't exist.

Switch to this branch.  Do the same.  Should be no popup, you should be able to get to save stage.

### CIS testing


## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
