### PR TITLE
Fix things again :fire: :dog2: :fire: 

### DIFF
--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -880,7 +880,8 @@ class GroceryService:
                             item.runNumber, item.useLiteMode
                         )
                         record = self.dataService.readCalibrationRecord(item.runNumber, item.useLiteMode, item.version)
-                        item.runNumber = record.runNumber
+                        if record is not None:
+                            item.runNumber = record.runNumber
                     tableWorkspaceName = self._createDiffcalTableWorkspaceName(
                         item.runNumber, item.useLiteMode, item.version
                     )

--- a/src/snapred/ui/view/NormalizationSaveView.py
+++ b/src/snapred/ui/view/NormalizationSaveView.py
@@ -1,8 +1,7 @@
 from qtpy.QtCore import Signal
-from qtpy.QtWidgets import QGridLayout, QLabel, QWidget
+from qtpy.QtWidgets import QGridLayout, QLabel, QLineEdit, QWidget
 
 from snapred.meta.decorators.Resettable import Resettable
-from snapred.ui.widget.JsonFormList import JsonFormList
 from snapred.ui.widget.LabeledField import LabeledField
 
 
@@ -21,47 +20,36 @@ class NormalizationSaveView(QWidget):
     signalRunNumberUpdate = Signal(str)
     signalBackgroundRunNumberUpdate = Signal(str)
 
-    def __init__(self, name, jsonSchemaMap, parent=None):
+    def __init__(self, parent=None):
         super().__init__(parent)
-        self._jsonFormList = JsonFormList(name, jsonSchemaMap, parent=parent)
 
         self.layout = QGridLayout()
         self.setLayout(self.layout)
 
         self.interactionText = QLabel("Assessment Complete! Would you like to save the normalization now?")
 
-        self.fieldRunNumber = LabeledField(
-            "Run Number :", self._jsonFormList.getField("normalizationIndexEntry.runNumber"), self
-        )
+        self.fieldRunNumber = LabeledField("Run Number :", QLineEdit(parent=self), self)
         self.fieldRunNumber.setEnabled(False)
         self.signalRunNumberUpdate.connect(self._updateRunNumber)
 
-        self.fieldBackgroundRunNumber = LabeledField(
-            "Background Run Number :", self._jsonFormList.getField("normalizationIndexEntry.backgroundRunNumber"), self
-        )
+        self.fieldBackgroundRunNumber = LabeledField("Background Run Number :", QLineEdit(parent=self), self)
         self.fieldBackgroundRunNumber.setEnabled(False)
         self.signalBackgroundRunNumberUpdate.connect(self._updateBackgroundRunNumber)
 
-        self.fieldVersion = LabeledField(
-            "Version :", self._jsonFormList.getField("normalizationIndexEntry.version"), self
-        )
+        self.fieldVersion = LabeledField("Version :", QLineEdit(parent=self), self)
         # add tooltip to leave blank for new version
         self.fieldVersion.setToolTip("Leave blank for new version!")
 
-        self.fieldAppliesTo = LabeledField(
-            "Applies To :", self._jsonFormList.getField("normalizationIndexEntry.appliesTo"), self
-        )
+        self.fieldAppliesTo = LabeledField("Applies To :", QLineEdit(parent=self), self)
         self.fieldAppliesTo.setToolTip(
             "Determines which runs this normalization applies to. 'runNumber', '>runNumber', or \
                 '<runNumber', default is '>runNumber'."
         )
 
-        self.fieldComments = LabeledField(
-            "Comments :", self._jsonFormList.getField("normalizationIndexEntry.comments"), self
-        )
+        self.fieldComments = LabeledField("Comments :", QLineEdit(parent=self), self)
         self.fieldComments.setToolTip("Comments about the normalization, documentation of important information.")
 
-        self.fieldAuthor = LabeledField("Author :", self._jsonFormList.getField("normalizationIndexEntry.author"), self)
+        self.fieldAuthor = LabeledField("Author :", QLineEdit(parent=self), self)
         self.fieldAuthor.setToolTip("Author of the normalization.")
 
         self.layout.addWidget(self.interactionText)

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -370,11 +370,13 @@ class DiffCalWorkflow(WorkflowImplementer):
     def _saveCalibration(self, workflowPresenter):
         view = workflowPresenter.widget.tabView
         # validate the version number
-        try:
-            version = int(view.fieldVersion.get(None))
-            assert version >= 0
-        except (AssertionError, ValueError, TypeError):
-            raise TypeError("Version must be a nonnegative integer")
+        version = view.fieldVersion.get(None)
+        if version is not None:
+            try:
+                version = int(version)
+                assert version >= 0
+            except (AssertionError, ValueError, TypeError):
+                raise TypeError("Version must be a nonnegative integer")
         # pull fields from view for calibration save
         calibrationIndexEntry = CalibrationIndexEntry(
             runNumber=view.fieldRunNumber.get(),
@@ -382,7 +384,7 @@ class DiffCalWorkflow(WorkflowImplementer):
             comments=view.fieldComments.get(),
             author=view.fieldAuthor.get(),
             appliesTo=view.fieldAppliesTo.get(),
-            version=view.fieldVersion.get(None),
+            version=version,
         )
 
         # if this is not the first iteration, account for choice.

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -61,11 +61,7 @@ class NormalizationWorkflow(WorkflowImplementer):
             groups=list(self.focusGroups.keys()),
             parent=parent,
         )
-        self._saveView = NormalizationSaveView(
-            "Saving Normalization",
-            self.saveSchema,
-            parent,
-        )
+        self._saveView = NormalizationSaveView(parent)
 
         # connect signal to populate the grouping dropdown after run is selected
         self._requestView.litemodeToggle.field.connectUpdate(self._switchLiteNativeGroups)
@@ -204,11 +200,13 @@ class NormalizationWorkflow(WorkflowImplementer):
         normalizationRecord.workspaceNames.append(self.responses[-2].data["correctedVanadium"])
 
         # validate the version number
-        try:
-            version = int(view.fieldVersion.get(None))
-            assert version >= 0
-        except (AssertionError, ValueError, TypeError):
-            raise TypeError("Version must be a nonnegative integer.")
+        version = view.fieldVersion.get(None)
+        if version is not None:
+            try:
+                version = int(version)
+                assert version >= 0
+            except (AssertionError, ValueError, TypeError):
+                raise TypeError("Version must be a nonnegative integer.")
 
         normalizationIndexEntry = NormalizationIndexEntry(
             runNumber=view.fieldRunNumber.get(),
@@ -217,7 +215,7 @@ class NormalizationWorkflow(WorkflowImplementer):
             comments=view.fieldComments.get(),
             author=view.fieldAuthor.get(),
             appliesTo=view.fieldAppliesTo.get(),
-            version=view.fieldVersion.get(None),
+            version=version,
         )
 
         payload = NormalizationExportRequest(


### PR DESCRIPTION
## Description of work

1. Version was being correctly validated to be a nonnegative integer, but it was preventing `None` which sets the current version.
2. Setting `item.runNumber = record.runNumber` in `GroceryService` blocks the workflow if no records exist.  This guards that with a check that the record was found.
3. There was an issue in the `NormalizationSaveView` that prevented the user from visibly editing a field.  This view was still using the JSON form view basis, and was changed to a simple view, mirroring `DiffCalSaveView`.

## Explanation of work

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing

Delete your dev calibration state folder.  Run calibration.  It should ask you to initialize state.  Make sure you can get all the way to save.  At save, try entering "matt" in the version field.  It should fail.  Delete "matt" and leave the field blank.  It should save.

Run calibration again.  At assessment try loading version 0001.  You should be able to.  Get to saving, save as version 3.

Run calibration again.  At assessment, ensure you can load version 0001 and 0003.

In normalization, get to save screen.  Try writing "matt" in the version.  You should see it, and it should fail to validate.

Delete it and leave it blank.  IT should save,

### CIS testing

<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

``` python
# replace with your test script below
```

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
