### PR TITLE
Fix for initialize state issues.

### DIFF
--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -1031,7 +1031,7 @@ class LocalDataService:
             peakTailCoefficient=peakTailCoefficient,
         )
 
-        calibrationReturn = None
+        calibrationReturnValue = None
 
         for liteMode in [True, False]:
             # finally add seedRun, creation date, and a human readable name
@@ -1057,9 +1057,9 @@ class LocalDataService:
             self._writeDefaultDiffCalTable(runId, liteMode)
 
             if useLiteMode == liteMode:
-                calibrationReturn = calibration
+                calibrationReturnValue = calibration
 
-        return calibrationReturn
+        return calibrationReturnValue
 
     def _prepareStateRoot(self, stateId: str):
         """

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -1033,13 +1033,13 @@ class LocalDataService:
 
         calibrationReturn = None
 
-        for LiteMode in [True, False]:
+        for liteMode in [True, False]:
             # finally add seedRun, creation date, and a human readable name
             calibration = Calibration(
                 instrumentState=instrumentState,
                 name=name,
                 seedRun=runId,
-                useLiteMode=LiteMode,
+                useLiteMode=liteMode,
                 creationDate=datetime.datetime.now(),
                 version=self.VERSION_START,
             )
@@ -1054,9 +1054,9 @@ class LocalDataService:
             # write the calibration state
             self.writeCalibrationState(calibration, version)
             # write the default diffcal table
-            self._writeDefaultDiffCalTable(runId, LiteMode)
+            self._writeDefaultDiffCalTable(runId, liteMode)
 
-            if useLiteMode == LiteMode:
+            if useLiteMode == liteMode:
                 calibrationReturn = calibration
 
         return calibrationReturn

--- a/src/snapred/ui/handler/SNAPResponseHandler.py
+++ b/src/snapred/ui/handler/SNAPResponseHandler.py
@@ -33,11 +33,13 @@ class SNAPResponseHandler(QWidget):
             if userSelectedContinueAnyway:
                 self.continueAnyway.emit()
         else:
-            self.rethrow()
+            self.rethrow(result)
 
+    @staticmethod
     def _isErrorCode(code):
         return code >= ResponseCode.ERROR
 
+    @staticmethod
     def _isRecoverableError(code):
         return ResponseCode.RECOVERABLE <= code < ResponseCode.ERROR
 

--- a/src/snapred/ui/presenter/InitializeStatePresenter.py
+++ b/src/snapred/ui/presenter/InitializeStatePresenter.py
@@ -5,7 +5,6 @@ from snapred.backend.api.InterfaceController import InterfaceController
 from snapred.backend.dao.request.InitializeStateRequest import InitializeStateRequest
 from snapred.backend.dao.SNAPRequest import SNAPRequest
 from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
-from snapred.ui.threading.worker_pool import WorkerPool
 from snapred.ui.widget.SuccessDialog import SuccessDialog
 
 
@@ -18,7 +17,6 @@ class InitializeStatePresenter(QObject):
     based on the outcomes of these requests.
     """
 
-    worker_pool = WorkerPool()
     stateInitialized = Signal(SNAPResponse)
 
     def __init__(self, view):

--- a/src/snapred/ui/workflow/WorkflowImplementer.py
+++ b/src/snapred/ui/workflow/WorkflowImplementer.py
@@ -69,8 +69,10 @@ class WorkflowImplementer:
         return form.verify()
 
     def _handleComplications(self, result):
-        self.responseHandler.handle(result)
-        self.responseHandler.rethrow(result)
+        if result.code == 400:
+            self.responseHandler.rethrow(result)
+        else:
+            self.responseHandler.handle(result)
 
     @property
     def widget(self):

--- a/tests/util_tests/test_state_helpers.py
+++ b/tests/util_tests/test_state_helpers.py
@@ -106,7 +106,7 @@ def test_state_root_override_enter(
     mockDefaultGroupingMapPath.return_value = Path(Resource.getPath("inputs/pixel_grouping/defaultGroupingMap.json"))
 
     stateId = "ab8704b0bc2a2342"
-    decodedKey = "some_decoded_key"
+    decodedKey = None
     mockGenerateStateId.return_value = (stateId, decodedKey)
     runNumber = "123456"
     stateName = "my happy state"

--- a/tests/util_tests/test_state_helpers.py
+++ b/tests/util_tests/test_state_helpers.py
@@ -1,5 +1,6 @@
 # Unit tests for `tests/util/state_helpers.py`
 import shutil
+import pdb
 import unittest.mock as mock
 from pathlib import Path
 
@@ -26,7 +27,7 @@ def _cleanup_directories():
 
 def initPVFileMock() -> mock.Mock:
     mock_ = mock.Mock()
-    # 4X: seven required `readDetectorState` log entries:
+    # 8X: seven required `readDetectorState` log entries:
     #   * generated stateId hex-digest: 'ab8704b0bc2a2342',
     #   * generated `DetectorInfo` matches that from 'inputs/calibration/CalibrationParameters.json'
     mock_.get.side_effect = [
@@ -58,14 +59,42 @@ def initPVFileMock() -> mock.Mock:
         [1],
         [1.0],
         [2.0],
+        [1],
+        [2],
+        [1.1],
+        [1.2],
+        [1],
+        [1.0],
+        [2.0],
+        [1],
+        [2],
+        [1.1],
+        [1.2],
+        [1],
+        [1.0],
+        [2.0],
+        [1],
+        [2],
+        [1.1],
+        [1.2],
+        [1],
+        [1.0],
+        [2.0],
+        [1],
+        [2],
+        [1.1],
+        [1.2],
+        [1],
+        [1.0],
+        [2.0],        
     ]
     return mock_
 
-
+@mock.patch.object(LocalDataService, "_generateStateId")
 @mock.patch.object(LocalDataService, "_defaultGroupingMapPath")
 @mock.patch.object(LocalDataService, "readInstrumentConfig")
 @mock.patch.object(LocalDataService, "_readPVFile")
-def test_state_root_override_enter(mockReadPVFile, mockReadInstrumentConfig, mockDefaultGroupingMapPath):
+def test_state_root_override_enter(mockReadPVFile, mockReadInstrumentConfig, mockDefaultGroupingMapPath, mockGenerateStateId):
     # see `test_LocalDataService::test_initializeState`
     mockReadPVFile.return_value = initPVFileMock()
 
@@ -73,11 +102,13 @@ def test_state_root_override_enter(mockReadPVFile, mockReadInstrumentConfig, moc
     mockReadInstrumentConfig.return_value = testCalibrationData.instrumentState.instrumentConfig
 
     mockDefaultGroupingMapPath.return_value = Path(Resource.getPath("inputs/pixel_grouping/defaultGroupingMap.json"))
-
+    
     stateId = "ab8704b0bc2a2342"
+    mockGenerateStateId.return_value = stateId
     runNumber = "123456"
     stateName = "my happy state"
     useLiteMode = True
+    pdb.set_trace()
     with state_root_override(runNumber, stateName, useLiteMode) as stateRootPath:
         assert Path(stateRootPath) == Path(Config["instrument.calibration.powder.home"]) / stateId
         assert Path(stateRootPath).exists()

--- a/tests/util_tests/test_state_helpers.py
+++ b/tests/util_tests/test_state_helpers.py
@@ -1,6 +1,6 @@
 # Unit tests for `tests/util/state_helpers.py`
-import shutil
 import pdb
+import shutil
 import unittest.mock as mock
 from pathlib import Path
 
@@ -86,15 +86,18 @@ def initPVFileMock() -> mock.Mock:
         [1.2],
         [1],
         [1.0],
-        [2.0],        
+        [2.0],
     ]
     return mock_
+
 
 @mock.patch.object(LocalDataService, "_generateStateId")
 @mock.patch.object(LocalDataService, "_defaultGroupingMapPath")
 @mock.patch.object(LocalDataService, "readInstrumentConfig")
 @mock.patch.object(LocalDataService, "_readPVFile")
-def test_state_root_override_enter(mockReadPVFile, mockReadInstrumentConfig, mockDefaultGroupingMapPath, mockGenerateStateId):
+def test_state_root_override_enter(
+    mockReadPVFile, mockReadInstrumentConfig, mockDefaultGroupingMapPath, mockGenerateStateId
+):
     # see `test_LocalDataService::test_initializeState`
     mockReadPVFile.return_value = initPVFileMock()
 
@@ -102,7 +105,7 @@ def test_state_root_override_enter(mockReadPVFile, mockReadInstrumentConfig, moc
     mockReadInstrumentConfig.return_value = testCalibrationData.instrumentState.instrumentConfig
 
     mockDefaultGroupingMapPath.return_value = Path(Resource.getPath("inputs/pixel_grouping/defaultGroupingMap.json"))
-    
+
     stateId = "ab8704b0bc2a2342"
     mockGenerateStateId.return_value = stateId
     runNumber = "123456"

--- a/tests/util_tests/test_state_helpers.py
+++ b/tests/util_tests/test_state_helpers.py
@@ -1,5 +1,4 @@
 # Unit tests for `tests/util/state_helpers.py`
-import pdb
 import shutil
 import unittest.mock as mock
 from pathlib import Path
@@ -107,11 +106,11 @@ def test_state_root_override_enter(
     mockDefaultGroupingMapPath.return_value = Path(Resource.getPath("inputs/pixel_grouping/defaultGroupingMap.json"))
 
     stateId = "ab8704b0bc2a2342"
-    mockGenerateStateId.return_value = stateId
+    decodedKey = "some_decoded_key"
+    mockGenerateStateId.return_value = (stateId, decodedKey)
     runNumber = "123456"
     stateName = "my happy state"
     useLiteMode = True
-    pdb.set_trace()
     with state_root_override(runNumber, stateName, useLiteMode) as stateRootPath:
         assert Path(stateRootPath) == Path(Config["instrument.calibration.powder.home"]) / stateId
         assert Path(stateRootPath).exists()


### PR DESCRIPTION
## Description of work
This PR is for fixing the initialize state workflow.   
<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work
This PR adds a feature that allows for the simultaneous initialization of both native and lite modes. Along with this, a rather quick fix was found for the issue of two instances of the initialize state workflow being substantiated when a Recoverable error is thrown. The majority of the time in this PR went to stack tracing and finding the location of the issue.

Some helpful debugging commands I picked up along the way [all pdb.set_trace() commands]:
`list .` - to see what breakpoint is being accessed
`w` - to see a stack trace of the executed methods leading up to any given breakpoint
<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test
Insure all pytests pass. Launch SNAPRed with an empty state folder in order to proceed through the initialize state workflow and insure that only one instance is present. After the initialize state workflow is complete, inspect the logging stack trace or the state directory produced to insure that both native and lite modes are initialized. 
<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM # 5405](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=5405)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
