### PR TITLE
Fix labeling of diffcal table

### DIFF
--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -67,11 +67,6 @@ class GroceryListItem(BaseModel):
     # name the property the workspace will be used for
     propertyName: Optional[str]
 
-    # flag to indicate if this is an _output_ workspace:
-    # an output workspace will not be loaded,
-    # it may or may not already exist in the ADS
-    isOutput: bool = False
-
     def builder():
         # NOTE this import is here to avoid circular dependencies -- don't bother trying to move it
         from snapred.meta.builder.GroceryListBuilder import GroceryListBuilder

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -945,7 +945,7 @@ class GroceryService:
         :param groceryDict: a dictionary of GroceryListItems, keyed by a property name
         :type groceryDict: Dict[str, GrocerListItem]
         :param kwargs: keyword arguments will be added to the created dictionary as argName: argValue.
-        Use this to add additional workspaces to the dictionary for easier use in recipes.
+            Use this to add additional workspaces to the dictionary for easier use in recipes.
         :type kwargs: Dict[string, WorkspaceName]
         :return: the workspace names of the fetched groceries, matched to their original keys
         :rtype: List[WorkspaceName]

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -909,7 +909,7 @@ class GroceryService:
                     res["workspace"] = tableWorkspaceName
                 case "diffcal_mask":
                     # NOTE: fetchCalibrationWorkspaces will set the workspace name
-                    # to that of the table workspace, not the mask.  This must be 
+                    # to that of the table workspace, not the mask.  This must be
                     # manually overwritten with correct workspace name.
                     maskWorkspaceName = self._createDiffcalMaskWorkspaceName(
                         item.runNumber, item.useLiteMode, item.version

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -944,6 +944,9 @@ class GroceryService:
 
         :param groceryDict: a dictionary of GroceryListItems, keyed by a property name
         :type groceryDict: Dict[str, GrocerListItem]
+        :param kwargs: keyword arguments will be added to the created dictionary as argName: argValue.
+        Use this to add additional workspaces to the dictionary for easier use in recipes.
+        :type kwargs: Dict[string, WorkspaceName]
         :return: the workspace names of the fetched groceries, matched to their original keys
         :rtype: List[WorkspaceName]
         """

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -880,25 +880,17 @@ class GroceryService:
                     )
                 # for diffraction-calibration workspaces
                 case "diffcal_output":
-                    diffcalOutputWorkspaceName = self._createDiffcalOutputWorkspaceName(item)
-                    if item.isOutput:
-                        res = {"result": True, "workspace": diffcalOutputWorkspaceName}
-                    else:
-                        res = self.fetchWorkspace(
-                            self._createDiffcalOutputWorkspaceFilename(item),
-                            diffcalOutputWorkspaceName,
-                            loader="ReheatLeftovers",
-                        )
+                    res = self.fetchWorkspace(
+                        self._createDiffcalOutputWorkspaceFilename(item),
+                        self._createDiffcalOutputWorkspaceName(item),
+                        loader="ReheatLeftovers",
+                    )
                 case "diffcal_diagnostic":
-                    diffcalDiagnosticWorkspaceName = self._createDiffcalOutputWorkspaceName(item)
-                    if item.isOutput:
-                        res = {"result": True, "workspace": diffcalDiagnosticWorkspaceName}
-                    else:
-                        res = self.fetchWorkspace(
-                            self._createDiffcalDiagnosticWorkspaceFilename(item),
-                            diffcalDiagnosticWorkspaceName,
-                            loader="LoadNexusProcessed",
-                        )
+                    self.fetchWorkspace(
+                        self._createDiffcalDiagnosticWorkspaceFilename(item),
+                        self._createDiffcalOutputWorkspaceName(item),
+                        loader="LoadNexusProcessed",
+                    )
                 case "diffcal_table":
                     if not isinstance(item.version, int):
                         item.version = self.dataService._getVersionFromCalibrationIndex(
@@ -907,23 +899,23 @@ class GroceryService:
                         record = self.dataService.readCalibrationRecord(item.runNumber, item.useLiteMode, item.version)
                         if record is not None:
                             item.runNumber = record.runNumber
+                    # NOTE: fetchCalibrationWorkspaces will set the workspace name
+                    # to that of the table workspace.  Because of possible confusion with
+                    # the behavior of mask workspace, the workspace name is manually set here.
                     tableWorkspaceName = self._createDiffcalTableWorkspaceName(
                         item.runNumber, item.useLiteMode, item.version
                     )
-                    if item.isOutput:
-                        res = {"result": True, "workspace": tableWorkspaceName}
-                    else:
-                        res = self.fetchCalibrationWorkspaces(item)
-                        res["workspace"] = tableWorkspaceName
+                    res = self.fetchCalibrationWorkspaces(item)
+                    res["workspace"] = tableWorkspaceName
                 case "diffcal_mask":
+                    # NOTE: fetchCalibrationWorkspaces will set the workspace name
+                    # to that of the table workspace, not the mask.  This must be 
+                    # manually overwritten with correct workspace name.
                     maskWorkspaceName = self._createDiffcalMaskWorkspaceName(
                         item.runNumber, item.useLiteMode, item.version
                     )
-                    if item.isOutput:
-                        res = {"result": True, "workspace": maskWorkspaceName}
-                    else:
-                        res = self.fetchCalibrationWorkspaces(item)
-                        res["workspace"] = maskWorkspaceName
+                    res = self.fetchCalibrationWorkspaces(item)
+                    res["workspace"] = maskWorkspaceName
                 case "normalization":
                     if not isinstance(item.version, int):
                         item.version = self.dataService._getVersionFromNormalizationIndex(
@@ -934,13 +926,7 @@ class GroceryService:
                         )
                         if record is not None:
                             item.runNumber = record.runNumber
-                    normalizationWorkspaceName = self._createNormalizationWorkspaceName(
-                        item.runNumber, item.useLiteMode, item.version
-                    )
-                    if item.isOutput:
-                        res = {"result": True, "workspace": normalizationWorkspaceName}
-                    else:
-                        res = self.fetchNormalizationWorkspaces(item)
+                    res = self.fetchNormalizationWorkspaces(item)
                 case _:
                     raise RuntimeError(f"unrecognized 'workspaceType': '{item.workspaceType}'")
             # check that the fetch operation succeeded and if so append the workspace

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -128,20 +128,22 @@ class CalibrationService(Service):
         self.groceryClerk.name("groupingWorkspace").fromRun(request.runNumber).grouping(
             request.focusGroup.name
         ).useLiteMode(request.useLiteMode).add()
-        self.groceryClerk.specialOrder().name("diagnosticWorkspace").diffcal_output(request.runNumber).unit(
-            wng.Units.DIAG
-        ).group(request.focusGroup.name).useLiteMode(request.useLiteMode).add()
-        self.groceryClerk.specialOrder().name("outputWorkspace").diffcal_output(request.runNumber).unit(
-            wng.Units.DSP
-        ).group(request.focusGroup.name).useLiteMode(request.useLiteMode).add()
-        self.groceryClerk.specialOrder().name("calibrationTable").diffcal_table(request.runNumber).useLiteMode(
-            request.useLiteMode
-        ).add()
-        self.groceryClerk.specialOrder().name("maskWorkspace").diffcal_mask(request.runNumber).useLiteMode(
-            request.useLiteMode
-        ).add()
+        diffcalOutputName = (
+            wng.diffCalOutput().unit(wng.Units.DSP).runNumber(request.runNumber).group(request.focusGroup.name).build()
+        )
+        diagnosticWorkspaceName = (
+            wng.diffCalOutput().unit(wng.Units.DIAG).runNumber(request.runNumber).group(request.focusGroup.name).build()
+        )
+        calibrationTableName = wng.diffCalTable().runNumber(request.runNumber).build()
+        calibrationMaskName = wng.diffCalMask().runNumber(request.runNumber).build()
 
-        return self.groceryService.fetchGroceryDict(self.groceryClerk.buildDict())
+        return self.groceryService.fetchGroceryDict(
+            self.groceryClerk.buildDict(),
+            outputWorkspace=diffcalOutputName,
+            diagnosticWorkspace=diagnosticWorkspaceName,
+            calibrationTable=calibrationTableName,
+            maskWorkspace=calibrationMaskName,
+        )
 
     @FromString
     def diffractionCalibration(self, request: DiffractionCalibrationRequest):

--- a/src/snapred/meta/builder/GroceryListBuilder.py
+++ b/src/snapred/meta/builder/GroceryListBuilder.py
@@ -30,10 +30,6 @@ class GroceryListBuilder:
         self._tokens["runNumber"] = runId
         return self
 
-    def specialOrder(self):
-        self._tokens["isOutput"] = True
-        return self
-
     def diffcal(self, runId: str):
         self._tokens["workspaceType"] = "diffcal"
         self._tokens["runNumber"] = runId

--- a/tests/unit/backend/dao/test_GroceryListBuilder.py
+++ b/tests/unit/backend/dao/test_GroceryListBuilder.py
@@ -41,30 +41,6 @@ class TestGroceryListBuilder(unittest.TestCase):
         assert item.useLiteMode is False
         assert item.workspaceType == "diffcal"
 
-    def test_diffcal_output_tof(self):
-        item = GroceryListBuilder().specialOrder().diffcal_output(self.runNumber).unit(wng.Units.TOF).lite().build()
-        assert item.runNumber == self.runNumber
-        assert item.isOutput is True
-        assert item.workspaceType == "diffcal_output"
-
-    def test_diffcal_output_dsp(self):
-        item = GroceryListBuilder().specialOrder().diffcal_output(self.runNumber).unit(wng.Units.DSP).lite().build()
-        assert item.runNumber == self.runNumber
-        assert item.isOutput is True
-        assert item.workspaceType == "diffcal_output"
-
-    def test_diffcal_table(self):
-        item = GroceryListBuilder().specialOrder().diffcal_table(self.runNumber).lite().build()
-        assert item.runNumber == self.runNumber
-        assert item.isOutput is True
-        assert item.workspaceType == "diffcal_table"
-
-    def test_diffcal_mask(self):
-        item = GroceryListBuilder().specialOrder().diffcal_mask(self.runNumber).lite().build()
-        assert item.runNumber == self.runNumber
-        assert item.isOutput is True
-        assert item.workspaceType == "diffcal_mask"
-
     def test_nexus_native_lite(self):
         item = GroceryListBuilder().neutron(self.runNumber).native().build()
         assert item.runNumber == self.runNumber

--- a/tests/unit/backend/dao/test_GroceryListBuilder.py
+++ b/tests/unit/backend/dao/test_GroceryListBuilder.py
@@ -10,7 +10,6 @@ from mantid.simpleapi import (
 from pydantic import ValidationError
 from snapred.meta.builder.GroceryListBuilder import GroceryListBuilder
 from snapred.meta.Config import Resource
-from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 
 
 class TestGroceryListBuilder(unittest.TestCase):

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -1027,35 +1027,6 @@ class TestGroceryService(unittest.TestCase):
         ):
             self.instance.fetchGroceryList(groceryList)
 
-    def test_fetch_grocery_list_specialOrder_diffcal_output(self):
-        # Test of workspace type "diffcal_output" as `Output` (i.e. "specialOrder") argument in the `GroceryList`
-        self.instance._getDetectorState = mock.Mock(return_value=self.detectorState1)
-        groceryList = (
-            GroceryListItem.builder()
-            .specialOrder()
-            .native()
-            .diffcal_output(self.runNumber)
-            .group(wng.Groups.UNFOC)
-            .unit(wng.Units.TOF)
-            .buildList()
-        )
-        items = self.instance.fetchGroceryList(groceryList)
-        assert items[0] == wng.diffCalOutput().unit(wng.Units.TOF).runNumber(self.runNumber).build()
-
-    def test_fetch_grocery_list_specialOrder_diffcal_table(self):
-        # Test of workspace type "diffcal_table" as `Output` (i.e. "specialOrder") argument in the `GroceryList`
-        self.instance._getDetectorState = mock.Mock(return_value=self.detectorState1)
-        groceryList = GroceryListItem.builder().specialOrder().native().diffcal_table(self.runNumber).buildList()
-        items = self.instance.fetchGroceryList(groceryList)
-        assert items[0] == wng.diffCalTable().runNumber(self.runNumber).build() + f"_{wnvf.formatVersion(self.version)}"
-
-    def test_fetch_grocery_list_specialOrder_diffcal_mask(self):
-        # Test of workspace type "diffcal_mask" as `Output` (i.e. "specialOrder") argument in the `GroceryList`
-        self.instance._getDetectorState = mock.Mock(return_value=self.detectorState1)
-        groceryList = GroceryListItem.builder().specialOrder().native().diffcal_mask(self.runNumber).buildList()
-        items = self.instance.fetchGroceryList(groceryList)
-        assert items[0] == wng.diffCalMask().runNumber(self.runNumber).build()
-
     def test_fetch_grocery_list_diffcal_output(self):
         # Test of workspace type "diffcal_output" as `Input` argument in the `GroceryList`
         with state_root_redirect(self.instance.dataService) as tmpRoot:

--- a/tests/util/InstaEats.py
+++ b/tests/util/InstaEats.py
@@ -224,39 +224,21 @@ class InstaEats(GroceryService):
                     )
                 # for diffraction-calibration workspaces
                 case "diffcal_output":
-                    diffcalOutputWorkspaceName = self._createDiffcalOutputWorkspaceName(item)
-                    if item.isOutput:
-                        res = {"result": True, "workspace": diffcalOutputWorkspaceName}
-                    else:
-                        res = self.fetchWorkspace(
-                            self._createDiffcalOutputWorkspaceFilename(item),
-                            diffcalOutputWorkspaceName,
-                            loader="ReheatLeftovers",
-                        )
-                case "diffcal_table":
-                    tableWorkspaceName = self._createDiffcalTableWorkspaceName(
-                        item.runNumber, item.useLiteMode, item.version
+                    res = self.fetchWorkspace(
+                        self._createDiffcalOutputWorkspaceFilename(item),
+                        self._createDiffcalOutputWorkspaceName(item),
+                        loader="ReheatLeftovers",
                     )
-                    if item.isOutput:
-                        res = {"result": True, "workspace": tableWorkspaceName}
-                    else:
-                        res = self.fetchCalibrationWorkspaces(item)
-                        res["workspace"] = tableWorkspaceName
+                case "diffcal_table":
+                    res = self.fetchCalibrationWorkspaces(item)
                 case "diffcal_mask":
                     maskWorkspaceName = self._createDiffcalMaskWorkspaceName(
                         item.runNumber, item.useLiteMode, item.version
                     )
-                    if item.isOutput:
-                        res = {"result": True, "workspace": maskWorkspaceName}
-                    else:
-                        res = self.fetchCalibrationWorkspaces(item)
-                        res["workspace"] = maskWorkspaceName
+                    res = self.fetchCalibrationWorkspaces(item)
+                    res["workspace"] = maskWorkspaceName
                 case "normalization":
-                    normalizationWorkspaceName = self._createNormalizationWorkspaceName(item.runNumber, item.version)
-                    if item.isOutput:
-                        res = {"result": True, "workspace": normalizationWorkspaceName}
-                    else:
-                        res = self.fetchNormalizationWorkspaces(item)
+                    res = self.fetchNormalizationWorkspaces(item)
                 case _:
                     raise RuntimeError(f"unrecognized 'workspaceType': '{item.workspaceType}'")
             # check that the fetch operation succeeded and if so append the workspace


### PR DESCRIPTION
## Description of work

The `GroceryService` was being used like a wrapper of the `WNG` in order to create workspace names for diffcal output.

That isn't a problem, except the expectation was `GroceryService` would only be used to _load_ data.  In this case, it anticipated loading previous calibration tables.

The collision left an incorrect version number on the produced diffcal table.  The version applied to the previously-created record and was added to the name inside `GroceryService`.  However, it was being added to the prospective, newly-created diffcal table instead in the process of generating a name.

The easiest fix was to not use the `GroceryService` as a wrapper of the `WNG`, and to instead use the `WNG` to create the output names.  This also simplified the `fetchGroceryList` method.

## Explanation of work

Removed all reference to `specialOrder` or `isOutput` in the `GroceryListItem` and its builder.

Removed the conditionals checking on `isOutput` from the `fetchGroceryList` method inside `GroceryService`.

Inside calibration service, construct the output names using the `wng` and pass them to `fetchGroceryDict` as additional keyword arguments, which adds them to the dictionary in an exactly equivalent way.

## To test

### Dev testing

#### First, reproduce the error on `next`

Clear your state folder and run diffcal.  Check the created diffcal table, and it has no version on its name -- this is because there is no record, so the line to add the version is not being executed.  At assessment, there are no versions.  Continue and save.

Run diffcal again.  Check the created diffcal table.  It has `_v0001` tagged to its name.  This is because `GroceryService` loaded a previous record (`v_0001`) and added its version number to the workspace name.  At assessment, try to load `v0001`.  You can't, because it thinks `v0001` is already loaded due to the presence of the errantly-named diffcal table.

#### Second, switch to this branch and see error is gone

Clear your state folder and run diffcal.  Check the created diffcal table, and it has no version on its name.  At assessment, there are no versions.  Continue to save.

Run diffcal again.  The created diffcal table should **NOT** have any version on its name.

At asessment, try to load `v0001`.  It will load with no issue and you will see the associated workspaces with `_v0001` appear in the workspace list.

Save again.

Run normalization, and make sure you can save.

### CIS testing

As above. Inspect the diffcal tables to make sure the values appear reasonable (right number of pixels, values around 5000-8000, etc.).

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#5542](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=5542)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
