### PR TITLE
Explore SNAPRed Backend & create inventory of algos

### DIFF
--- a/docs/source/developer/architecture/backend/algorithms/calculate_diffcal_table.rst
+++ b/docs/source/developer/architecture/backend/algorithms/calculate_diffcal_table.rst
@@ -1,0 +1,30 @@
+### Algorithm: `CalculateDiffCalTable`
+
+#### Description:
+This algorithm calculates a diffraction calibration table based on the input workspace. It uses the instrument definition within the workspace to create a DIFC table and then converts this table into a calibration table.
+
+#### Expected Inputs:
+1. **InputWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Workspace containing the instrument definition.
+
+2. **OffsetMode**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Mode for the offset calculation. Valid options are `Signed`, `Relative`, and `Absolute`.
+
+3. **BinWidth**:
+   - **Type**: `Double`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Width of the bin.
+
+#### Expected Outputs:
+1. **CalibrationTable**:
+   - **Type**: `ITableWorkspace`
+   - **Direction**: `Output`
+   - **Property Mode**: `Optional`
+   - **Description**: The resulting calibration table.

--- a/docs/source/developer/architecture/backend/algorithms/calculate_diffcal_table.rst
+++ b/docs/source/developer/architecture/backend/algorithms/calculate_diffcal_table.rst
@@ -1,9 +1,14 @@
-### Algorithm: `CalculateDiffCalTable`
+Algorithm: `CalculateDiffCalTable`
+==================================
 
-#### Description:
-This algorithm calculates a diffraction calibration table based on the input workspace. It uses the instrument definition within the workspace to create a DIFC table and then converts this table into a calibration table.
+Description:
+------------
+This algorithm calculates a diffraction calibration table based on the input workspace. It uses the
+instrument definition within the workspace to create a DIFC table and then converts this table into
+a calibration table.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **InputWorkspace**:
    - **Type**: `MatrixWorkspace`
    - **Direction**: `Input`
@@ -14,7 +19,8 @@ This algorithm calculates a diffraction calibration table based on the input wor
    - **Type**: `String`
    - **Direction**: `Input`
    - **Property Mode**: `Mandatory`
-   - **Description**: Mode for the offset calculation. Valid options are `Signed`, `Relative`, and `Absolute`.
+   - **Description**: Mode for the offset calculation. Valid options are `Signed`, `Relative`, and
+   `Absolute`.
 
 3. **BinWidth**:
    - **Type**: `Double`
@@ -22,7 +28,8 @@ This algorithm calculates a diffraction calibration table based on the input wor
    - **Property Mode**: `Mandatory`
    - **Description**: Width of the bin.
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 1. **CalibrationTable**:
    - **Type**: `ITableWorkspace`
    - **Direction**: `Output`

--- a/docs/source/developer/architecture/backend/algorithms/calculate_diffcal_table.rst
+++ b/docs/source/developer/architecture/backend/algorithms/calculate_diffcal_table.rst
@@ -4,8 +4,8 @@ Algorithm: `CalculateDiffCalTable`
 Description:
 ------------
 This algorithm calculates a diffraction calibration table based on the input workspace. It uses the
-instrument definition within the workspace to create a DIFC table and then converts this table into
-a calibration table.
+instrument definition within the workspace and calls the CalculateDIFC algorithm, which moronically
+creates matrix workspace, and converts the matrix workspace into a calibration table.
 
 Expected Inputs:
 ----------------

--- a/docs/source/developer/architecture/backend/algorithms/calculate_diffcal_table.rst
+++ b/docs/source/developer/architecture/backend/algorithms/calculate_diffcal_table.rst
@@ -3,9 +3,9 @@ Algorithm: `CalculateDiffCalTable`
 
 Description:
 ------------
-This algorithm calculates a diffraction calibration table based on the input workspace. It uses the
-instrument definition within the workspace and calls the CalculateDIFC algorithm, which moronically
-creates matrix workspace, and converts the matrix workspace into a calibration table.
+It uses the instrument definition within the workspace and calls the CalculateDIFC algorithm,
+which moronically creates matrix workspace, and converts the matrix workspace into a
+calibration table.
 
 Expected Inputs:
 ----------------

--- a/docs/source/developer/architecture/backend/algorithms/calibration_metric_extraction_algorithm.rst
+++ b/docs/source/developer/architecture/backend/algorithms/calibration_metric_extraction_algorithm.rst
@@ -1,0 +1,28 @@
+### Algorithm: `CalibrationMetricExtractionAlgorithm`
+
+#### Description:
+This algorithm extracts calibration metrics from the output of the peak
+fitting algorithm `FitMultiplePeaks`. It calculates the sigma and strain
+averages and standard deviations, and then packages them with the
+two-theta average. This is done per group, with strain and sigma
+collected over spectra within the group.
+
+#### Expected Inputs:
+1. **InputWorkspace**:
+   - **Type**: `WorkspaceGroup`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Group of workspaces containing the peak fitting results.
+
+2. **PixelGroup**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: JSON string defining the pixel group.
+
+#### Expected Outputs:
+1. **OutputMetrics**:
+   - **Type**: `String`
+   - **Direction**: `Output`
+   - **Property Mode**: `Optional`
+   - **Description**: JSON string containing the extracted calibration metrics.

--- a/docs/source/developer/architecture/backend/algorithms/calibration_metric_extraction_algorithm.rst
+++ b/docs/source/developer/architecture/backend/algorithms/calibration_metric_extraction_algorithm.rst
@@ -1,13 +1,16 @@
-### Algorithm: `CalibrationMetricExtractionAlgorithm`
+Algorithm: `CalibrationMetricExtractionAlgorithm`
+=================================================
 
-#### Description:
+Description:
+------------
 This algorithm extracts calibration metrics from the output of the peak
 fitting algorithm `FitMultiplePeaks`. It calculates the sigma and strain
 averages and standard deviations, and then packages them with the
 two-theta average. This is done per group, with strain and sigma
 collected over spectra within the group.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **InputWorkspace**:
    - **Type**: `WorkspaceGroup`
    - **Direction**: `Input`
@@ -20,7 +23,8 @@ collected over spectra within the group.
    - **Property Mode**: `Mandatory`
    - **Description**: JSON string defining the pixel group.
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 1. **OutputMetrics**:
    - **Type**: `String`
    - **Direction**: `Output`

--- a/docs/source/developer/architecture/backend/algorithms/conjoin_table_workspaces.rst
+++ b/docs/source/developer/architecture/backend/algorithms/conjoin_table_workspaces.rst
@@ -1,0 +1,28 @@
+### Algorithm: `ConjoinTableWorkspaces`
+
+#### Description:
+This algorithm combines two table workspaces by adding the rows of the second workspace
+to the first. It ensures that the columns of both workspaces match in number, names, and
+types.
+
+#### Expected Inputs:
+1. **InputWorkspace1**:
+   - **Type**: `ITableWorkspace`
+   - **Direction**: `InOut`
+   - **Property Mode**: `Mandatory`
+   - **Description**: The first workspace, which will have the rows added to it.
+
+2. **InputWorkspace2**:
+   - **Type**: `ITableWorkspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: The second workspace to be conjoined to the first.
+
+3. **AutoDelete**:
+   - **Type**: `Bool`
+   - **Direction**: `Input`
+   - **Property Mode**: `Optional`
+   - **Description**: Flag indicating whether to automatically delete the second workspace after conjoining.
+
+#### Expected Outputs:
+- **InputWorkspace1**: The modified workspace with rows from `InputWorkspace2` added.

--- a/docs/source/developer/architecture/backend/algorithms/conjoin_table_workspaces.rst
+++ b/docs/source/developer/architecture/backend/algorithms/conjoin_table_workspaces.rst
@@ -1,11 +1,14 @@
-### Algorithm: `ConjoinTableWorkspaces`
+Algorithm: `ConjoinTableWorkspaces`
+===================================
 
-#### Description:
+Description:
+------------
 This algorithm combines two table workspaces by adding the rows of the second workspace
 to the first. It ensures that the columns of both workspaces match in number, names, and
 types.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **InputWorkspace1**:
    - **Type**: `ITableWorkspace`
    - **Direction**: `InOut`
@@ -24,5 +27,6 @@ types.
    - **Property Mode**: `Optional`
    - **Description**: Flag indicating whether to automatically delete the second workspace after conjoining.
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 - **InputWorkspace1**: The modified workspace with rows from `InputWorkspace2` added.

--- a/docs/source/developer/architecture/backend/algorithms/crystallographic_info_algorithm.rst
+++ b/docs/source/developer/architecture/backend/algorithms/crystallographic_info_algorithm.rst
@@ -1,0 +1,39 @@
+### Algorithm: `CrystallographicInfoAlgorithm`
+
+#### Description:
+This algorithm ingests crystallographic information from a CIF file or a provided
+crystallography JSON string. It generates unique reflections within a specified
+d-spacing range, calculates the d-values and structure factors (F^2), and
+packages this information into a `CrystallographicInfo` object.
+
+#### Expected Inputs:
+1. **CifPath**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Path to the CIF file containing crystallographic information.
+
+2. **Crystallography**:
+   - **Type**: `String`
+   - **Direction**: `InOut`
+   - **Property Mode**: `Mandatory`
+   - **Description**: JSON string defining the crystallography data.
+
+3. **dMin**:
+   - **Type**: `Float`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Minimum d-spacing for reflection generation. Default value is set from configuration.
+
+4. **dMax**:
+   - **Type**: `Float`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Maximum d-spacing for reflection generation. Default value is set from configuration.
+
+#### Expected Outputs:
+1. **CrystalInfo**:
+   - **Type**: `String`
+   - **Direction**: `Output`
+   - **Property Mode**: `Optional`
+   - **Description**: JSON string containing the extracted crystallographic information.

--- a/docs/source/developer/architecture/backend/algorithms/crystallographic_info_algorithm.rst
+++ b/docs/source/developer/architecture/backend/algorithms/crystallographic_info_algorithm.rst
@@ -1,12 +1,15 @@
-### Algorithm: `CrystallographicInfoAlgorithm`
+Algorithm: `CrystallographicInfoAlgorithm`
+==========================================
 
-#### Description:
+Description:
+------------
 This algorithm ingests crystallographic information from a CIF file or a provided
 crystallography JSON string. It generates unique reflections within a specified
 d-spacing range, calculates the d-values and structure factors (F^2), and
 packages this information into a `CrystallographicInfo` object.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **CifPath**:
    - **Type**: `String`
    - **Direction**: `Input`
@@ -31,7 +34,8 @@ packages this information into a `CrystallographicInfo` object.
    - **Property Mode**: `Mandatory`
    - **Description**: Maximum d-spacing for reflection generation. Default value is set from configuration.
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 1. **CrystalInfo**:
    - **Type**: `String`
    - **Direction**: `Output`

--- a/docs/source/developer/architecture/backend/algorithms/crystallographic_info_algorithm.rst
+++ b/docs/source/developer/architecture/backend/algorithms/crystallographic_info_algorithm.rst
@@ -3,10 +3,11 @@ Algorithm: `CrystallographicInfoAlgorithm`
 
 Description:
 ------------
-This algorithm ingests crystallographic information from a CIF file or a provided
-crystallography JSON string. It generates unique reflections within a specified
-d-spacing range, calculates the d-values and structure factors (F^2), and
-packages this information into a `CrystallographicInfo` object.
+This algorithm ingests `Crystallography` information from a CIF file or a provided
+crystallography JSON string. It generates unique reflections by parsing in a mantid
+`CrystalStructure` object. Then given a specified d-spacing range, it calculates
+the d-values and structure factors (F^2), and packages this information into a
+`CrystallographicInfo` object.
 
 Expected Inputs:
 ----------------
@@ -20,7 +21,7 @@ Expected Inputs:
    - **Type**: `String`
    - **Direction**: `InOut`
    - **Property Mode**: `Mandatory`
-   - **Description**: JSON string defining the crystallography data.
+   - **Description**: SNAPRed DAO pydantic object containing crystallographic information.
 
 3. **dMin**:
    - **Type**: `Float`

--- a/docs/source/developer/architecture/backend/algorithms/custom_group_workspace.rst
+++ b/docs/source/developer/architecture/backend/algorithms/custom_group_workspace.rst
@@ -4,10 +4,7 @@ Algorithm: `CustomGroupWorkspace`
 Description:
 ------------
 This algorithm orchestrates loading grouping workspaces and then grouping them
-into a `GroupedWorkspace`. Although the loading behavior is no longer needed,
-the algorithm is retained to call Mantid's `GroupWorkspaces` for maintaining
-conformity with previous processes.
-
+into a `WorkspaceGroup`.
 Expected Inputs:
 ----------------
 1. **GroupingWorkspaces**:

--- a/docs/source/developer/architecture/backend/algorithms/custom_group_workspace.rst
+++ b/docs/source/developer/architecture/backend/algorithms/custom_group_workspace.rst
@@ -5,6 +5,7 @@ Description:
 ------------
 This algorithm orchestrates loading grouping workspaces and then grouping them
 into a `WorkspaceGroup`.
+
 Expected Inputs:
 ----------------
 1. **GroupingWorkspaces**:

--- a/docs/source/developer/architecture/backend/algorithms/custom_group_workspace.rst
+++ b/docs/source/developer/architecture/backend/algorithms/custom_group_workspace.rst
@@ -1,0 +1,27 @@
+### Algorithm: `CustomGroupWorkspace`
+
+#### Description:
+This algorithm orchestrates loading grouping workspaces and then grouping them
+into a `GroupedWorkspace`. Although the loading behavior is no longer needed,
+the algorithm is retained to call Mantid's `GroupWorkspaces` for maintaining
+conformity with previous processes.
+
+#### Expected Inputs:
+1. **GroupingWorkspaces**:
+   - **Type**: `StringArrayProperty`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: List of workspace names to be grouped.
+
+2. **FocusGroups**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Optional`
+   - **Description**: Focus group information (additional metadata, usage not explicitly defined in the provided code).
+
+#### Expected Outputs:
+1. **OutputWorkspace**:
+   - **Type**: `WorkspaceGroup`
+   - **Direction**: `Output`
+   - **Property Mode**: `Optional`
+   - **Description**: The group of grouping workspaces.

--- a/docs/source/developer/architecture/backend/algorithms/custom_group_workspace.rst
+++ b/docs/source/developer/architecture/backend/algorithms/custom_group_workspace.rst
@@ -1,12 +1,15 @@
-### Algorithm: `CustomGroupWorkspace`
+Algorithm: `CustomGroupWorkspace`
+=================================
 
-#### Description:
+Description:
+------------
 This algorithm orchestrates loading grouping workspaces and then grouping them
 into a `GroupedWorkspace`. Although the loading behavior is no longer needed,
 the algorithm is retained to call Mantid's `GroupWorkspaces` for maintaining
 conformity with previous processes.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **GroupingWorkspaces**:
    - **Type**: `StringArrayProperty`
    - **Direction**: `Input`
@@ -19,7 +22,8 @@ conformity with previous processes.
    - **Property Mode**: `Optional`
    - **Description**: Focus group information (additional metadata, usage not explicitly defined in the provided code).
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 1. **OutputWorkspace**:
    - **Type**: `WorkspaceGroup`
    - **Direction**: `Output`

--- a/docs/source/developer/architecture/backend/algorithms/detector_peak_predictor.rst
+++ b/docs/source/developer/architecture/backend/algorithms/detector_peak_predictor.rst
@@ -1,11 +1,14 @@
-### Algorithm: `DetectorPeakPredictor`
+Algorithm: `DetectorPeakPredictor`
+==================================
 
-#### Description:
+Description:
+------------
 This algorithm predicts detector peaks based on the provided detector peak ingredients.
 It calculates the beta terms, full width at half maximum (FWHM), and generates a list
 of `DetectorPeak` objects for each group, optionally purging duplicates.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **Ingredients**:
    - **Type**: `String`
    - **Direction**: `Input`
@@ -18,7 +21,8 @@ of `DetectorPeak` objects for each group, optionally purging duplicates.
    - **Property Mode**: `Optional`
    - **Description**: Flag to indicate whether to purge duplicate peaks.
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 1. **DetectorPeaks**:
    - **Type**: `String`
    - **Direction**: `Output`

--- a/docs/source/developer/architecture/backend/algorithms/detector_peak_predictor.rst
+++ b/docs/source/developer/architecture/backend/algorithms/detector_peak_predictor.rst
@@ -3,9 +3,10 @@ Algorithm: `DetectorPeakPredictor`
 
 Description:
 ------------
-This algorithm predicts detector peaks based on the provided detector peak ingredients.
-It calculates the beta terms, full width at half maximum (FWHM), and generates a list
-of `DetectorPeak` objects for each group, optionally purging duplicates.
+This algorithm predicts locations based on crystallographic information, and predicts
+peak widths based on resolution estimates of the instrument. It calculates the beta
+terms, full width at half maximum (FWHM), and generates a list of `DetectorPeak`
+objects for each group, optionally purging duplicates.
 
 Expected Inputs:
 ----------------

--- a/docs/source/developer/architecture/backend/algorithms/detector_peak_predictor.rst
+++ b/docs/source/developer/architecture/backend/algorithms/detector_peak_predictor.rst
@@ -1,0 +1,26 @@
+### Algorithm: `DetectorPeakPredictor`
+
+#### Description:
+This algorithm predicts detector peaks based on the provided detector peak ingredients.
+It calculates the beta terms, full width at half maximum (FWHM), and generates a list
+of `DetectorPeak` objects for each group, optionally purging duplicates.
+
+#### Expected Inputs:
+1. **Ingredients**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: The detector peak ingredients.
+
+2. **PurgeDuplicates**:
+   - **Type**: `Bool`
+   - **Direction**: `Input`
+   - **Property Mode**: `Optional`
+   - **Description**: Flag to indicate whether to purge duplicate peaks.
+
+#### Expected Outputs:
+1. **DetectorPeaks**:
+   - **Type**: `String`
+   - **Direction**: `Output`
+   - **Property Mode**: `Optional`
+   - **Description**: The returned list of `GroupPeakList` objects.

--- a/docs/source/developer/architecture/backend/algorithms/diffraction_spectrum_weight_calculator.rst
+++ b/docs/source/developer/architecture/backend/algorithms/diffraction_spectrum_weight_calculator.rst
@@ -1,12 +1,15 @@
-### Algorithm: `DiffractionSpectrumWeightCalculator`
+Algorithm: `DiffractionSpectrumWeightCalculator`
+================================================
 
-#### Description:
+Description:
+------------
 This algorithm calculates weights for diffraction spectra based on predicted peaks.
 It clones the input workspace to create a weight workspace, applies zero weights to
 regions around the predicted peaks, and handles event data by converting it to
 histogram data if necessary.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **InputWorkspace**:
    - **Type**: `MatrixWorkspace`
    - **Direction**: `Input`
@@ -19,7 +22,8 @@ histogram data if necessary.
    - **Property Mode**: `Mandatory`
    - **Description**: JSON string of predicted peaks.
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 1. **WeightWorkspace**:
    - **Type**: `MatrixWorkspace`
    - **Direction**: `Output`

--- a/docs/source/developer/architecture/backend/algorithms/diffraction_spectrum_weight_calculator.rst
+++ b/docs/source/developer/architecture/backend/algorithms/diffraction_spectrum_weight_calculator.rst
@@ -1,0 +1,27 @@
+### Algorithm: `DiffractionSpectrumWeightCalculator`
+
+#### Description:
+This algorithm calculates weights for diffraction spectra based on predicted peaks.
+It clones the input workspace to create a weight workspace, applies zero weights to
+regions around the predicted peaks, and handles event data by converting it to
+histogram data if necessary.
+
+#### Expected Inputs:
+1. **InputWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Workspace peaks to be weighted.
+
+2. **DetectorPeaks**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: JSON string of predicted peaks.
+
+#### Expected Outputs:
+1. **WeightWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Output`
+   - **Property Mode**: `Mandatory`
+   - **Description**: The output workspace with calculated weights.

--- a/docs/source/developer/architecture/backend/algorithms/diffraction_spectrum_weight_calculator.rst
+++ b/docs/source/developer/architecture/backend/algorithms/diffraction_spectrum_weight_calculator.rst
@@ -3,10 +3,11 @@ Algorithm: `DiffractionSpectrumWeightCalculator`
 
 Description:
 ------------
-This algorithm calculates weights for diffraction spectra based on predicted peaks.
-It clones the input workspace to create a weight workspace, applies zero weights to
-regions around the predicted peaks, and handles event data by converting it to
-histogram data if necessary.
+This algorithm calculates smoothing weights for the smoothed cubic spline method
+to allow it to exclude peaks from its fit of the background. It clones the input
+workspace to create a weight workspace, applies zero weights to regions around
+the predicted peaks, and handles event data by converting it to histogram data
+if necessary.
 
 Expected Inputs:
 ----------------

--- a/docs/source/developer/architecture/backend/algorithms/fetch_groceries_algorithm.rst
+++ b/docs/source/developer/architecture/backend/algorithms/fetch_groceries_algorithm.rst
@@ -1,10 +1,13 @@
-### Algorithm: `FetchGroceriesAlgorithm`
+Algorithm: `FetchGroceriesAlgorithm`
+====================================
 
-#### Description:
+Description:
+------------
 This algorithm is used for general-purpose loading of Nexus data or grouping workspaces.
 It supports various loader types and handles different file formats.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **Filename**:
    - **Type**: `FileProperty`
    - **Direction**: `Input`
@@ -41,7 +44,8 @@ It supports various loader types and handles different file formats.
    - **Property Mode**: `Optional`
    - **Description**: Workspace to optionally take the instrument from.
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 1. **OutputWorkspace**:
    - **Type**: `Workspace`
    - **Direction**: `Output`

--- a/docs/source/developer/architecture/backend/algorithms/fetch_groceries_algorithm.rst
+++ b/docs/source/developer/architecture/backend/algorithms/fetch_groceries_algorithm.rst
@@ -1,0 +1,49 @@
+### Algorithm: `FetchGroceriesAlgorithm`
+
+#### Description:
+This algorithm is used for general-purpose loading of Nexus data or grouping workspaces.
+It supports various loader types and handles different file formats.
+
+#### Expected Inputs:
+1. **Filename**:
+   - **Type**: `FileProperty`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Path to the file to be loaded. Supported extensions are `xml`, `h5`, `nxs`, `hd5`.
+
+2. **LoaderType**:
+   - **Type**: `String`
+   - **Direction**: `InOut`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Type of loader to use. Valid options include `LoadGroupingDefinition`, `LoadCalibrationWorkspaces`, `LoadNexus`, `LoadEventNexus`, `LoadNexusProcessed`, `ReheatLeftovers`.
+
+3. **LoaderArgs**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Optional`
+   - **Description**: Loader keyword arguments in JSON format.
+
+4. **InstrumentName**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Optional`
+   - **Description**: Name of an associated instrument.
+
+5. **InstrumentFilename**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Optional`
+   - **Description**: Path of an associated instrument definition file.
+
+6. **InstrumentDonor**:
+   - **Type**: `WorkspaceProperty`
+   - **Direction**: `Input`
+   - **Property Mode**: `Optional`
+   - **Description**: Workspace to optionally take the instrument from.
+
+#### Expected Outputs:
+1. **OutputWorkspace**:
+   - **Type**: `Workspace`
+   - **Direction**: `Output`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Workspace containing the loaded data.

--- a/docs/source/developer/architecture/backend/algorithms/fit_mutliple_peaks_algorithm.rst
+++ b/docs/source/developer/architecture/backend/algorithms/fit_mutliple_peaks_algorithm.rst
@@ -1,0 +1,32 @@
+### Algorithm: `FitMultiplePeaksAlgorithm`
+
+#### Description:
+This algorithm fits multiple peaks in a given workspace using a specified peak function.
+It processes the input workspace, fits the peaks, and outputs the results in various
+workspaces, grouped together.
+
+#### Expected Inputs:
+1. **InputWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Workspace containing the peaks to be fit.
+
+2. **DetectorPeaks**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Input list of peaks to be fit.
+
+3. **PeakFunction**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Type of peak function to use. Valid options are those in `allowed_peak_type_list`.
+
+#### Expected Outputs:
+1. **OutputWorkspaceGroup**:
+   - **Type**: `WorkspaceGroup`
+   - **Direction**: `Output`
+   - **Property Mode**: `Mandatory`
+   - **Description**: The group of workspaces containing the fit results.

--- a/docs/source/developer/architecture/backend/algorithms/fit_mutliple_peaks_algorithm.rst
+++ b/docs/source/developer/architecture/backend/algorithms/fit_mutliple_peaks_algorithm.rst
@@ -1,11 +1,14 @@
-### Algorithm: `FitMultiplePeaksAlgorithm`
+Algorithm: `FitMultiplePeaksAlgorithm`
+======================================
 
-#### Description:
+Description:
+------------
 This algorithm fits multiple peaks in a given workspace using a specified peak function.
 It processes the input workspace, fits the peaks, and outputs the results in various
 workspaces, grouped together.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **InputWorkspace**:
    - **Type**: `MatrixWorkspace`
    - **Direction**: `Input`
@@ -24,7 +27,8 @@ workspaces, grouped together.
    - **Property Mode**: `Mandatory`
    - **Description**: Type of peak function to use. Valid options are those in `allowed_peak_type_list`.
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 1. **OutputWorkspaceGroup**:
    - **Type**: `WorkspaceGroup`
    - **Direction**: `Output`

--- a/docs/source/developer/architecture/backend/algorithms/focus_spectra_algorithm.rst
+++ b/docs/source/developer/architecture/backend/algorithms/focus_spectra_algorithm.rst
@@ -1,0 +1,38 @@
+### Algorithm: `FocusSpectraAlgorithm`
+
+#### Description:
+This algorithm focuses diffraction data using a specified grouping workspace.
+It converts the input workspace to d-spacing, applies diffraction focusing,
+and optionally rebins the output.
+
+#### Expected Inputs:
+1. **InputWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Workspace containing values at each pixel.
+
+2. **GroupingWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Workspace defining the grouping for diffraction focusing.
+
+3. **Ingredients**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: JSON string containing the ingredients for focusing.
+
+4. **RebinOutput**:
+   - **Type**: `Bool`
+   - **Direction**: `Input`
+   - **Property Mode**: `Optional`
+   - **Description**: Flag indicating whether to rebin the output workspace.
+
+#### Expected Outputs:
+1. **OutputWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Output`
+   - **Property Mode**: `Mandatory`
+   - **Description**: The diffraction-focused data.

--- a/docs/source/developer/architecture/backend/algorithms/focus_spectra_algorithm.rst
+++ b/docs/source/developer/architecture/backend/algorithms/focus_spectra_algorithm.rst
@@ -1,11 +1,14 @@
-### Algorithm: `FocusSpectraAlgorithm`
+Algorithm: `FocusSpectraAlgorithm`
+==================================
 
-#### Description:
+Description:
+------------
 This algorithm focuses diffraction data using a specified grouping workspace.
 It converts the input workspace to d-spacing, applies diffraction focusing,
 and optionally rebins the output.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **InputWorkspace**:
    - **Type**: `MatrixWorkspace`
    - **Direction**: `Input`
@@ -30,7 +33,8 @@ and optionally rebins the output.
    - **Property Mode**: `Optional`
    - **Description**: Flag indicating whether to rebin the output workspace.
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 1. **OutputWorkspace**:
    - **Type**: `MatrixWorkspace`
    - **Direction**: `Output`

--- a/docs/source/developer/architecture/backend/algorithms/generate_table_workspace_from_list_of_dict.rst
+++ b/docs/source/developer/architecture/backend/algorithms/generate_table_workspace_from_list_of_dict.rst
@@ -1,0 +1,20 @@
+### Algorithm: `GenerateTableWorkspaceFromListOfDict`
+
+#### Description:
+This algorithm generates a table workspace from a list of dictionaries.
+Each dictionary represents a row in the table, and the keys in the
+dictionaries are used as column names.
+
+#### Expected Inputs:
+1. **ListOfDict**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: JSON string representing a list of dictionaries.
+
+#### Expected Outputs:
+1. **OutputWorkspace**:
+   - **Type**: `ITableWorkspace`
+   - **Direction**: `Output`
+   - **Property Mode**: `Mandatory`
+   - **Description**: The table workspace created from the input list of dictionaries.

--- a/docs/source/developer/architecture/backend/algorithms/generate_table_workspace_from_list_of_dict.rst
+++ b/docs/source/developer/architecture/backend/algorithms/generate_table_workspace_from_list_of_dict.rst
@@ -1,18 +1,22 @@
-### Algorithm: `GenerateTableWorkspaceFromListOfDict`
+Algorithm: `GenerateTableWorkspaceFromListOfDict`
+=================================================
 
-#### Description:
+Description:
+------------
 This algorithm generates a table workspace from a list of dictionaries.
 Each dictionary represents a row in the table, and the keys in the
 dictionaries are used as column names.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **ListOfDict**:
    - **Type**: `String`
    - **Direction**: `Input`
    - **Property Mode**: `Mandatory`
    - **Description**: JSON string representing a list of dictionaries.
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 1. **OutputWorkspace**:
    - **Type**: `ITableWorkspace`
    - **Direction**: `Output`

--- a/docs/source/developer/architecture/backend/algorithms/group_diffraction_calibration.rst
+++ b/docs/source/developer/architecture/backend/algorithms/group_diffraction_calibration.rst
@@ -1,0 +1,56 @@
+### Algorithm: `GroupDiffractionCalibration`
+
+#### Description:
+This algorithm calculates the group-aligned DIFC associated with a given workspace,
+as part of diffraction calibration. It processes input neutron data, applies
+diffraction calibration, and outputs various calibration and diagnostic workspaces.
+
+#### Expected Inputs:
+1. **InputWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Workspace containing TOF neutron data.
+
+2. **GroupingWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Workspace containing the grouping information.
+
+3. **PreviousCalibrationTable**:
+   - **Type**: `ITableWorkspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Optional`
+   - **Description**: Table workspace with previous pixel-calibrated DIFC values; if none given, will be calculated.
+
+4. **Ingredients**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: JSON string containing the ingredients for the algorithm.
+
+#### Expected Outputs:
+1. **OutputWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Output`
+   - **Property Mode**: `Optional`
+   - **Description**: A diffraction-focused workspace in dSpacing, after calibration constants have been adjusted.
+
+2. **DiagnosticWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Output`
+   - **Property Mode**: `Optional`
+   - **Description**: A workspace group containing the fitted peaks, fit parameters, and the TOF-focused data for comparison to fits.
+
+3. **MaskWorkspace**:
+   - **Type**: `MaskWorkspace`
+   - **Direction**: `Output`
+   - **Property Mode**: `Optional`
+   - **Description**: If mask workspace exists: incoming mask values will be used (1.0 => dead-pixel, 0.0 => live-pixel).
+
+4. **FinalCalibrationTable**:
+   - **Type**: `ITableWorkspace`
+   - **Direction**: `Output`
+   - **Property Mode**: `Optional`
+   - **Description**: Table workspace with group-corrected DIFC values.

--- a/docs/source/developer/architecture/backend/algorithms/group_diffraction_calibration.rst
+++ b/docs/source/developer/architecture/backend/algorithms/group_diffraction_calibration.rst
@@ -1,11 +1,14 @@
-### Algorithm: `GroupDiffractionCalibration`
+Algorithm: `GroupDiffractionCalibration`
+========================================
 
-#### Description:
+Description:
+------------
 This algorithm calculates the group-aligned DIFC associated with a given workspace,
 as part of diffraction calibration. It processes input neutron data, applies
 diffraction calibration, and outputs various calibration and diagnostic workspaces.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **InputWorkspace**:
    - **Type**: `MatrixWorkspace`
    - **Direction**: `Input`
@@ -30,7 +33,8 @@ diffraction calibration, and outputs various calibration and diagnostic workspac
    - **Property Mode**: `Mandatory`
    - **Description**: JSON string containing the ingredients for the algorithm.
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 1. **OutputWorkspace**:
    - **Type**: `MatrixWorkspace`
    - **Direction**: `Output`

--- a/docs/source/developer/architecture/backend/algorithms/group_diffraction_calibration.rst
+++ b/docs/source/developer/architecture/backend/algorithms/group_diffraction_calibration.rst
@@ -25,7 +25,8 @@ Expected Inputs:
    - **Type**: `ITableWorkspace`
    - **Direction**: `Input`
    - **Property Mode**: `Optional`
-   - **Description**: Table workspace with previous pixel-calibrated DIFC values; if none given, will be calculated.
+   - **Description**: Table workspace with previous pixel-calibrated DIFC values; if none given,
+   will be calculated using the instrument geometry.
 
 4. **Ingredients**:
    - **Type**: `String`

--- a/docs/source/developer/architecture/backend/algorithms/lite_data_creation_algo.rst
+++ b/docs/source/developer/architecture/backend/algorithms/lite_data_creation_algo.rst
@@ -1,0 +1,38 @@
+### Algorithm: `LiteDataCreationAlgo`
+
+#### Description:
+This algorithm converts a full-resolution dataset to a lite resolution dataset
+using a specified grouping workspace. It optionally compresses the output and
+can delete the non-lite workspace.
+
+#### Expected Inputs:
+1. **InputWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Workspace containing the full resolution dataset to be converted to lite.
+
+2. **LiteDataMapWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Grouping workspace which maps full pixel resolution to lite data.
+
+3. **LiteInstrumentDefinitionFile**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Path to the lite instrument definition file.
+
+4. **AutoDeleteNonLiteWS**:
+   - **Type**: `Bool`
+   - **Direction**: `Input`
+   - **Property Mode**: `Optional`
+   - **Description**: Flag indicating whether to automatically delete the non-lite workspace after conversion.
+
+#### Expected Outputs:
+1. **OutputWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Output`
+   - **Property Mode**: `Mandatory`
+   - **Description**: The workspace reduced to lite resolution and compressed.

--- a/docs/source/developer/architecture/backend/algorithms/lite_data_creation_algo.rst
+++ b/docs/source/developer/architecture/backend/algorithms/lite_data_creation_algo.rst
@@ -1,11 +1,14 @@
-### Algorithm: `LiteDataCreationAlgo`
+Algorithm: `LiteDataCreationAlgo`
+=================================
 
-#### Description:
+Description:
+------------
 This algorithm converts a full-resolution dataset to a lite resolution dataset
 using a specified grouping workspace. It optionally compresses the output and
 can delete the non-lite workspace.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **InputWorkspace**:
    - **Type**: `MatrixWorkspace`
    - **Direction**: `Input`
@@ -30,7 +33,8 @@ can delete the non-lite workspace.
    - **Property Mode**: `Optional`
    - **Description**: Flag indicating whether to automatically delete the non-lite workspace after conversion.
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 1. **OutputWorkspace**:
    - **Type**: `MatrixWorkspace`
    - **Direction**: `Output`

--- a/docs/source/developer/architecture/backend/algorithms/load_calibration_workspaces.rst
+++ b/docs/source/developer/architecture/backend/algorithms/load_calibration_workspaces.rst
@@ -1,0 +1,32 @@
+### Algorithm: `LoadCalibrationWorkspaces`
+
+#### Description:
+This algorithm creates a table workspace and a mask workspace from a calibration-data
+HDF5 file. It uses an instrument donor workspace to load the calibration constants and
+mask data.
+
+#### Expected Inputs:
+1. **Filename**:
+   - **Type**: `FileProperty`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Path to the HDF5 format file to be loaded.
+
+2. **InstrumentDonor**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Workspace to use as an instrument donor.
+
+#### Expected Outputs:
+1. **CalibrationTable**:
+   - **Type**: `ITableWorkspace`
+   - **Direction**: `Output`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Name of the output table workspace.
+
+2. **MaskWorkspace**:
+   - **Type**: `MaskWorkspace`
+   - **Direction**: `Output`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Name of the output mask workspace.

--- a/docs/source/developer/architecture/backend/algorithms/load_calibration_workspaces.rst
+++ b/docs/source/developer/architecture/backend/algorithms/load_calibration_workspaces.rst
@@ -1,11 +1,14 @@
-### Algorithm: `LoadCalibrationWorkspaces`
+Algorithm: `LoadCalibrationWorkspaces`
+======================================
 
-#### Description:
+Description:
+------------
 This algorithm creates a table workspace and a mask workspace from a calibration-data
 HDF5 file. It uses an instrument donor workspace to load the calibration constants and
 mask data.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **Filename**:
    - **Type**: `FileProperty`
    - **Direction**: `Input`
@@ -18,7 +21,8 @@ mask data.
    - **Property Mode**: `Mandatory`
    - **Description**: Workspace to use as an instrument donor.
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 1. **CalibrationTable**:
    - **Type**: `ITableWorkspace`
    - **Direction**: `Output`

--- a/docs/source/developer/architecture/backend/algorithms/load_grouping_definition.rst
+++ b/docs/source/developer/architecture/backend/algorithms/load_grouping_definition.rst
@@ -1,0 +1,38 @@
+### Algorithm: `LoadGroupingDefinition`
+
+#### Description:
+This algorithm creates a grouping workspace from a grouping definition file.
+It supports NEXUS, XML, and HDF formats and uses an associated instrument
+specified by various means.
+
+#### Expected Inputs:
+1. **GroupingFilename**:
+   - **Type**: `FileProperty`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Path to the grouping file to be loaded.
+
+2. **InstrumentName**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Optional`
+   - **Description**: Name of an associated instrument.
+
+3. **InstrumentFilename**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Optional`
+   - **Description**: Path of an associated instrument definition file.
+
+4. **InstrumentDonor**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Optional`
+   - **Description**: Workspace to optionally take the instrument from, when GroupingFilename is in XML format.
+
+#### Expected Outputs:
+1. **OutputWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Output`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Name of an output grouping workspace.

--- a/docs/source/developer/architecture/backend/algorithms/load_grouping_definition.rst
+++ b/docs/source/developer/architecture/backend/algorithms/load_grouping_definition.rst
@@ -1,11 +1,14 @@
-### Algorithm: `LoadGroupingDefinition`
+Algorithm: `LoadGroupingDefinition`
+===================================
 
-#### Description:
+Description:
+------------
 This algorithm creates a grouping workspace from a grouping definition file.
 It supports NEXUS, XML, and HDF formats and uses an associated instrument
 specified by various means.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **GroupingFilename**:
    - **Type**: `FileProperty`
    - **Direction**: `Input`
@@ -30,7 +33,8 @@ specified by various means.
    - **Property Mode**: `Optional`
    - **Description**: Workspace to optionally take the instrument from, when GroupingFilename is in XML format.
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 1. **OutputWorkspace**:
    - **Type**: `MatrixWorkspace`
    - **Direction**: `Output`

--- a/docs/source/developer/architecture/backend/algorithms/make_dirty_dish.rst
+++ b/docs/source/developer/architecture/backend/algorithms/make_dirty_dish.rst
@@ -1,0 +1,19 @@
+### Algorithm: `MakeDirtyDish`
+
+#### Description:
+This algorithm records a workspace in a state for the CIS to view later by
+cloning the input workspace to an output workspace if CIS mode is enabled.
+
+#### Expected Inputs:
+1. **InputWorkspace**:
+   - **Type**: `Workspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: The workspace to be cloned.
+
+#### Expected Outputs:
+1. **OutputWorkspace**:
+   - **Type**: `Workspace`
+   - **Direction**: `Output`
+   - **Property Mode**: `Mandatory`
+   - **Description**: The cloned workspace.

--- a/docs/source/developer/architecture/backend/algorithms/make_dirty_dish.rst
+++ b/docs/source/developer/architecture/backend/algorithms/make_dirty_dish.rst
@@ -1,17 +1,21 @@
-### Algorithm: `MakeDirtyDish`
+Algorithm: `MakeDirtyDish`
+==========================
 
-#### Description:
+Description:
+------------
 This algorithm records a workspace in a state for the CIS to view later by
 cloning the input workspace to an output workspace if CIS mode is enabled.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **InputWorkspace**:
    - **Type**: `Workspace`
    - **Direction**: `Input`
    - **Property Mode**: `Mandatory`
    - **Description**: The workspace to be cloned.
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 1. **OutputWorkspace**:
    - **Type**: `Workspace`
    - **Direction**: `Output`

--- a/docs/source/developer/architecture/backend/algorithms/mask_detector_flags.rst
+++ b/docs/source/developer/architecture/backend/algorithms/mask_detector_flags.rst
@@ -1,0 +1,19 @@
+### Algorithm: `MaskDetectorFlags`
+
+#### Description:
+This algorithm initializes detector flags from a mask workspace. Unlike Mantid's `MaskDetectors`,
+it does not clear any masked spectra or move masked detectors to group zero for grouping
+workspaces.
+
+#### Expected Inputs:
+1. **MaskWorkspace**:
+   - **Type**: `MaskWorkspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Workspace containing the mask.
+
+2. **OutputWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `InOut`
+   - **Property Mode**: `Mandatory`
+   - **Description**: The workspace for which to set the detector flags.

--- a/docs/source/developer/architecture/backend/algorithms/mask_detector_flags.rst
+++ b/docs/source/developer/architecture/backend/algorithms/mask_detector_flags.rst
@@ -1,11 +1,14 @@
-### Algorithm: `MaskDetectorFlags`
+Algorithm: `MaskDetectorFlags`
+==============================
 
-#### Description:
+Description:
+------------
 This algorithm initializes detector flags from a mask workspace. Unlike Mantid's `MaskDetectors`,
 it does not clear any masked spectra or move masked detectors to group zero for grouping
 workspaces.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **MaskWorkspace**:
    - **Type**: `MaskWorkspace`
    - **Direction**: `Input`

--- a/docs/source/developer/architecture/backend/algorithms/normalize_by_current_but_the_correct_way.rst
+++ b/docs/source/developer/architecture/backend/algorithms/normalize_by_current_but_the_correct_way.rst
@@ -1,11 +1,14 @@
-### Algorithm: `NormalizeByCurrentButTheCorrectWay`
+Algorithm: `NormalizeByCurrentButTheCorrectWay`
+===============================================
 
-#### Description:
+Description:
+------------
 This algorithm normalizes a workspace by current, ensuring it does not crash if
 the workspace has already been normalized. If the workspace has already been
 normalized, it simply clones the workspace.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **InputWorkspace**:
    - **Type**: `MatrixWorkspace`
    - **Direction**: `Input`
@@ -18,7 +21,8 @@ normalized, it simply clones the workspace.
    - **Property Mode**: `Optional`
    - **Description**: Flag indicating whether to recalculate the proton charge.
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 1. **OutputWorkspace**:
    - **Type**: `MatrixWorkspace`
    - **Direction**: `Output`

--- a/docs/source/developer/architecture/backend/algorithms/normalize_by_current_but_the_correct_way.rst
+++ b/docs/source/developer/architecture/backend/algorithms/normalize_by_current_but_the_correct_way.rst
@@ -1,0 +1,26 @@
+### Algorithm: `NormalizeByCurrentButTheCorrectWay`
+
+#### Description:
+This algorithm normalizes a workspace by current, ensuring it does not crash if
+the workspace has already been normalized. If the workspace has already been
+normalized, it simply clones the workspace.
+
+#### Expected Inputs:
+1. **InputWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Name of the input workspace.
+
+2. **RecalculatePCharge**:
+   - **Type**: `Bool`
+   - **Direction**: `Input`
+   - **Property Mode**: `Optional`
+   - **Description**: Flag indicating whether to recalculate the proton charge.
+
+#### Expected Outputs:
+1. **OutputWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Output`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Name of the output workspace.

--- a/docs/source/developer/architecture/backend/algorithms/pixel_diffraction_calibration.rst
+++ b/docs/source/developer/architecture/backend/algorithms/pixel_diffraction_calibration.rst
@@ -1,10 +1,13 @@
-### Algorithm: `PixelDiffractionCalibration`
+Algorithm: `PixelDiffractionCalibration`
+========================================
 
-#### Description:
+Description:
+------------
 This algorithm calculates the offset-corrected DIFC associated with a given workspace as part of diffraction calibration.
 It may be re-called iteratively with `execute` to ensure convergence.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **InputWorkspace**:
    - **Type**: `MatrixWorkspace`
    - **Direction**: `Input`
@@ -23,7 +26,8 @@ It may be re-called iteratively with `execute` to ensure convergence.
    - **Property Mode**: `Mandatory`
    - **Description**: JSON string of the DiffractionCalibrationIngredients.
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 1. **CalibrationTable**:
    - **Type**: `ITableWorkspace`
    - **Direction**: `Output`

--- a/docs/source/developer/architecture/backend/algorithms/pixel_diffraction_calibration.rst
+++ b/docs/source/developer/architecture/backend/algorithms/pixel_diffraction_calibration.rst
@@ -1,0 +1,43 @@
+### Algorithm: `PixelDiffractionCalibration`
+
+#### Description:
+This algorithm calculates the offset-corrected DIFC associated with a given workspace as part of diffraction calibration.
+It may be re-called iteratively with `execute` to ensure convergence.
+
+#### Expected Inputs:
+1. **InputWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Workspace containing the TOF neutron data.
+
+2. **GroupingWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Workspace containing the grouping information.
+
+3. **Ingredients**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: JSON string of the DiffractionCalibrationIngredients.
+
+#### Expected Outputs:
+1. **CalibrationTable**:
+   - **Type**: `ITableWorkspace`
+   - **Direction**: `Output`
+   - **Property Mode**: `Optional`
+   - **Description**: Workspace containing the corrected calibration constants.
+
+2. **MaskWorkspace**:
+   - **Type**: `MaskWorkspace`
+   - **Direction**: `Output`
+   - **Property Mode**: `Optional`
+   - **Description**: Mask workspace (1.0 => dead-pixel, 0.0 => live-pixel).
+
+3. **data**:
+    - **Type**: `String`
+    - **Direction**: `Output`
+    - **Property Mode**: `Optional`
+    - **Description**: JSON string containing statistics of the offsets for testing convergence.

--- a/docs/source/developer/architecture/backend/algorithms/pixel_grouping_parameters_calculation_algorithm.rst
+++ b/docs/source/developer/architecture/backend/algorithms/pixel_grouping_parameters_calculation_algorithm.rst
@@ -1,0 +1,34 @@
+### Algorithm: `PixelGroupingParametersCalculationAlgorithm`
+
+#### Description:
+This algorithm calculates state-derived parameters for pixel groupings.
+It uses information from the provided grouping workspace and optional
+mask workspace to compute various grouping parameters such as mean L2,
+twoTheta, azimuth, and dSpacing resolution.
+
+#### Expected Inputs:
+1. **Ingredients**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: JSON string of the PixelGroupingIngredients.
+
+2. **GroupingWorkspace**:
+   - **Type**: `MatrixWorkspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: The grouping workspace defining this grouping scheme,
+   with instrument-location parameters initialized according to the run number.
+
+3. **MaskWorkspace**:
+   - **Type**: `MaskWorkspace`
+   - **Direction**: `Input`
+   - **Property Mode**: `Optional`
+   - **Description**: The mask workspace for a specified calibration run number and version.
+
+#### Expected Outputs:
+1. **OutputParameters**:
+   - **Type**: `String`
+   - **Direction**: `Output`
+   - **Property Mode**: `Mandatory`
+   - **Description**: JSON string containing the calculated grouping parameters.

--- a/docs/source/developer/architecture/backend/algorithms/pixel_grouping_parameters_calculation_algorithm.rst
+++ b/docs/source/developer/architecture/backend/algorithms/pixel_grouping_parameters_calculation_algorithm.rst
@@ -1,12 +1,15 @@
-### Algorithm: `PixelGroupingParametersCalculationAlgorithm`
+Algorithm: `PixelGroupingParametersCalculationAlgorithm`
+========================================================
 
-#### Description:
+Description:
+------------
 This algorithm calculates state-derived parameters for pixel groupings.
 It uses information from the provided grouping workspace and optional
 mask workspace to compute various grouping parameters such as mean L2,
 twoTheta, azimuth, and dSpacing resolution.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **Ingredients**:
    - **Type**: `String`
    - **Direction**: `Input`
@@ -26,7 +29,8 @@ twoTheta, azimuth, and dSpacing resolution.
    - **Property Mode**: `Optional`
    - **Description**: The mask workspace for a specified calibration run number and version.
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 1. **OutputParameters**:
    - **Type**: `String`
    - **Direction**: `Output`

--- a/docs/source/developer/architecture/backend/algorithms/purge_overlapping_peaks_algorithm.rst
+++ b/docs/source/developer/architecture/backend/algorithms/purge_overlapping_peaks_algorithm.rst
@@ -1,11 +1,14 @@
-### Algorithm: `PurgeOverlappingPeaksAlgorithm`
+Algorithm: `PurgeOverlappingPeaksAlgorithm`
+===========================================
 
-#### Description:
+Description:
+------------
 This algorithm purges overlapping peaks from a list of peaks based on intensity and d-spacing range. It
 ensures that only non-overlapping peaks within a specified d-spacing range and above a specified
 intensity threshold are retained.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **Ingredients**:
    - **Type**: `String`
    - **Direction**: `Input`
@@ -30,7 +33,8 @@ intensity threshold are retained.
    - **Property Mode**: `Mandatory`
    - **Description**: Maximum d-spacing for peak selection.
 
-#### Expected Outputs:
+Expected Outputs:
+-----------------
 1. **OutputPeakMap**:
    - **Type**: `String`
    - **Direction**: `Output`

--- a/docs/source/developer/architecture/backend/algorithms/purge_overlapping_peaks_algorithm.rst
+++ b/docs/source/developer/architecture/backend/algorithms/purge_overlapping_peaks_algorithm.rst
@@ -1,0 +1,38 @@
+### Algorithm: `PurgeOverlappingPeaksAlgorithm`
+
+#### Description:
+This algorithm purges overlapping peaks from a list of peaks based on intensity and d-spacing range. It
+ensures that only non-overlapping peaks within a specified d-spacing range and above a specified
+intensity threshold are retained.
+
+#### Expected Inputs:
+1. **Ingredients**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: The CrystalInfo and Intensity Threshold ingredients.
+
+2. **DetectorPeaks**:
+   - **Type**: `String`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Input list of peaks.
+
+3. **dMin**:
+   - **Type**: `Float`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Minimum d-spacing for peak selection.
+
+4. **dMax**:
+   - **Type**: `Float`
+   - **Direction**: `Input`
+   - **Property Mode**: `Mandatory`
+   - **Description**: Maximum d-spacing for peak selection.
+
+#### Expected Outputs:
+1. **OutputPeakMap**:
+   - **Type**: `String`
+   - **Direction**: `Output`
+   - **Property Mode**: `Mandatory`
+   - **Description**: The resulting, non-overlapping list of peaks.

--- a/docs/source/developer/architecture/backend/algorithms/raw_vanadium_correction_algorithm.rst
+++ b/docs/source/developer/architecture/backend/algorithms/raw_vanadium_correction_algorithm.rst
@@ -1,0 +1,32 @@
+### Algorithm: `RawVanadiumCorrectionAlgorithm`
+
+#### Description:
+This algorithm processes raw vanadium data, correcting it by subtracting background data,
+scaling, and applying absorption corrections based on the sample geometry. The result is
+a corrected dataset suitable for further analysis.
+
+#### Expected Inputs:
+1. **InputWorkspace**:
+    - **Type**: `MatrixWorkspace`
+    - **Direction**: `Input`
+    - **Property Mode**: `Mandatory`
+    - **Description**: Workspace containing the raw vanadium data.
+
+2. **BackgroundWorkspace**:
+    - **Type**: `MatrixWorkspace`
+    - **Direction**: `Input`
+    - **Property Mode**: `Mandatory``
+    - **Description**: Workspace containing the raw vanadium background data.
+
+3. **OutputWorkspace**:
+    - **Type**: `MatrixWorkspace`
+    - **Direction**: `Input`
+    - **Property Mode**: `Mandatory`
+    - **Description**: Workspace containing corrected data; if none given, the
+    InputWorkspace will be overwritten.
+
+4. **Ingredients**:
+    - **Type**: `String`
+    - **Direction**: `Input`
+    - **Property Mode**: `Mandatory`
+    - **Description**: JSON string containing the NormalizationIngredients.

--- a/docs/source/developer/architecture/backend/algorithms/raw_vanadium_correction_algorithm.rst
+++ b/docs/source/developer/architecture/backend/algorithms/raw_vanadium_correction_algorithm.rst
@@ -3,9 +3,8 @@ Algorithm: `RawVanadiumCorrectionAlgorithm`
 
 Description:
 ------------
-This algorithm processes raw vanadium data, correcting it by subtracting background data,
-scaling, and applying absorption corrections based on the sample geometry. The result is
-a corrected dataset suitable for further analysis.
+This algorithm creates the raw vanadium data which is unfocused and
+is later used in the reduction process.
 
 Expected Inputs:
 ----------------

--- a/docs/source/developer/architecture/backend/algorithms/raw_vanadium_correction_algorithm.rst
+++ b/docs/source/developer/architecture/backend/algorithms/raw_vanadium_correction_algorithm.rst
@@ -1,11 +1,14 @@
-### Algorithm: `RawVanadiumCorrectionAlgorithm`
+Algorithm: `RawVanadiumCorrectionAlgorithm`
+===========================================
 
-#### Description:
+Description:
+------------
 This algorithm processes raw vanadium data, correcting it by subtracting background data,
 scaling, and applying absorption corrections based on the sample geometry. The result is
 a corrected dataset suitable for further analysis.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **InputWorkspace**:
     - **Type**: `MatrixWorkspace`
     - **Direction**: `Input`
@@ -22,8 +25,7 @@ a corrected dataset suitable for further analysis.
     - **Type**: `MatrixWorkspace`
     - **Direction**: `Input`
     - **Property Mode**: `Mandatory`
-    - **Description**: Workspace containing corrected data; if none given, the
-    InputWorkspace will be overwritten.
+    - **Description**: Workspace containing corrected data; if none given, the InputWorkspace will be overwritten.
 
 4. **Ingredients**:
     - **Type**: `String`

--- a/docs/source/developer/architecture/backend/algorithms/save_grouping_definition.rst
+++ b/docs/source/developer/architecture/backend/algorithms/save_grouping_definition.rst
@@ -1,0 +1,44 @@
+### Algorithm: `SaveGroupingDefinition`
+
+#### Description:
+This algorithm takes in a grouping definition (file or object) and saves it in a diffraction
+calibration file format. Either a grouping filename or a grouping workspace must be specified,
+but not both.
+
+#### Expected Inputs:
+1. **GroupingFilename**:
+    - **Type**: `FileProperty`
+    - **Direction**: `Input`
+    - **Property Mode**: `Optional`
+    - **Description**: Path of an input grouping file (in NEXUS or XML format).
+
+2. **GroupingWorkspace**:
+    - **Type**: `MatrixWorkspace`
+    - **Direction**: `Input`
+    - **Property Mode**: `Optional`
+    - **Description**: Name of an input grouping workspace.
+
+3. **OutputFilename**:
+    - **Type**: `FileProperty`
+    - **Direction**: `Input`
+    - **Property Mode**: `Mandatory`
+    - **Description**: Path of an output file. Supported file name extensions: "h5", "hd5", "hdf".
+
+4. **InstrumentName**:
+    - **Type**: `String`
+    - **Direction**: `Input`
+    - **Property Mode**: `Optional`
+    - **Description**: Name of an associated instrument.
+
+5. **InstrumentFilename**:
+    - **Type**: `String`
+    - **Direction**: `Input`
+    - **Property Mode**: `Optional`
+    - **Description**: Path of an associated instrument definition file.
+
+6. **InstrumentDonor**:
+    - **Type**: `MatrixWorkspace`
+    - **Direction**: `Input`
+    - **Property Mode**: `Optional`
+    - **Description**: Workspace to optionally take the instrument from, when GroupingFilename is
+    in XML format.

--- a/docs/source/developer/architecture/backend/algorithms/save_grouping_definition.rst
+++ b/docs/source/developer/architecture/backend/algorithms/save_grouping_definition.rst
@@ -1,11 +1,14 @@
-### Algorithm: `SaveGroupingDefinition`
+Algorithm: `SaveGroupingDefinition`
+===================================
 
-#### Description:
+Description:
+------------
 This algorithm takes in a grouping definition (file or object) and saves it in a diffraction
 calibration file format. Either a grouping filename or a grouping workspace must be specified,
 but not both.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **GroupingFilename**:
     - **Type**: `FileProperty`
     - **Direction**: `Input`
@@ -40,5 +43,4 @@ but not both.
     - **Type**: `MatrixWorkspace`
     - **Direction**: `Input`
     - **Property Mode**: `Optional`
-    - **Description**: Workspace to optionally take the instrument from, when GroupingFilename is
-    in XML format.
+    - **Description**: Workspace to optionally take the instrument from, when GroupingFilename is in XML format.

--- a/docs/source/developer/architecture/backend/algorithms/smooth_data_excluding_peaks_algo.rst
+++ b/docs/source/developer/architecture/backend/algorithms/smooth_data_excluding_peaks_algo.rst
@@ -1,0 +1,30 @@
+### Algorithm: `SmoothDataExcludingPeaksAlgo`
+
+#### Description:
+This algorithm removes peaks from a given workspace and smooths the data using a spline function. It processes the
+input workspace to exclude specified peaks and then applies a smoothing spline to the remaining data.
+
+#### Expected Inputs:
+1. **InputWorkspace**:
+    - **Type**: `MatrixWorkspace`
+    - **Direction**: `Input`
+    - **Property Mode**: `Mandatory`
+    - **Description**: Workspace containing the peaks to be removed.
+
+2. **OutputWorkspace**:
+    - **Type**: `MatrixWorkspace`
+    - **Direction**: `Output`
+    - **Property Mode**: `Mandatory`
+    - **Description**: Histogram Workspace with removed peaks.
+
+3. **DetectorPeaks**:
+    - **Type**: `String`
+    - **Direction**: `Input`
+    - **Property Mode**: `Mandatory`
+    - **Description**: JSON string containing the detector peaks.
+
+4. **SmoothingParameter**:
+    - **Type**: `Float`
+    - **Direction**: `Input`
+    - **Property Mode**: `Mandatory`
+    - **Description**: Smoothing parameter for the spline function.

--- a/docs/source/developer/architecture/backend/algorithms/smooth_data_excluding_peaks_algo.rst
+++ b/docs/source/developer/architecture/backend/algorithms/smooth_data_excluding_peaks_algo.rst
@@ -1,10 +1,13 @@
-### Algorithm: `SmoothDataExcludingPeaksAlgo`
+Algorithm: `SmoothDataExcludingPeaksAlgo`
+=========================================
 
-#### Description:
+Description:
+------------
 This algorithm removes peaks from a given workspace and smooths the data using a spline function. It processes the
 input workspace to exclude specified peaks and then applies a smoothing spline to the remaining data.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **InputWorkspace**:
     - **Type**: `MatrixWorkspace`
     - **Direction**: `Input`

--- a/docs/source/developer/architecture/backend/algorithms/utensils.rst
+++ b/docs/source/developer/architecture/backend/algorithms/utensils.rst
@@ -1,5 +1,7 @@
-### Algorithm: `Utensils`
+Algorithm: `Utensils`
+=====================
 
-#### Description:
+Description:
+------------
 This is an empty algorithm used as a workaround for progress requiring an algorithm. It does not perform any operations
 and is intended for internal use within the SNAPRed framework.

--- a/docs/source/developer/architecture/backend/algorithms/utensils.rst
+++ b/docs/source/developer/architecture/backend/algorithms/utensils.rst
@@ -1,0 +1,5 @@
+### Algorithm: `Utensils`
+
+#### Description:
+This is an empty algorithm used as a workaround for progress requiring an algorithm. It does not perform any operations
+and is intended for internal use within the SNAPRed framework.

--- a/docs/source/developer/architecture/backend/algorithms/wash_dishes.rst
+++ b/docs/source/developer/architecture/backend/algorithms/wash_dishes.rst
@@ -1,9 +1,12 @@
-### Algorithm: `WashDishes`
+Algorithm: `WashDishes`
+=======================
 
-#### Description:
+Description:
+------------
 This algorithm deletes specified workspaces from the Mantid workspace list unless the CIS mode is enabled. It ensures that only existing workspaces are attempted to be deleted.
 
-#### Expected Inputs:
+Expected Inputs:
+----------------
 1. **Workspace**:
     - **Type**: `String`
     - **Direction**: `Input`

--- a/docs/source/developer/architecture/backend/algorithms/wash_dishes.rst
+++ b/docs/source/developer/architecture/backend/algorithms/wash_dishes.rst
@@ -1,0 +1,17 @@
+### Algorithm: `WashDishes`
+
+#### Description:
+This algorithm deletes specified workspaces from the Mantid workspace list unless the CIS mode is enabled. It ensures that only existing workspaces are attempted to be deleted.
+
+#### Expected Inputs:
+1. **Workspace**:
+    - **Type**: `String`
+    - **Direction**: `Input`
+    - **Property Mode**: Optional
+    - **Description**: The name of the workspace to be deleted.
+
+2. **WorkspaceList**:
+    - **Type**: `StringArrayProperty`
+    - **Direction**: `Input`
+    - **Property Mode**: Optional
+    - **Description**: List of workspaces to be deleted.

--- a/docs/source/developer/architecture/backend/index.rst
+++ b/docs/source/developer/architecture/backend/index.rst
@@ -89,3 +89,29 @@ For a simplified breakdown of where you may want to implement parts of your code
    api/calibration/diffraction_calibration_request
    api/calibration/focus_group_metric
    api/calibration/generate_calibration_metrics_workspace_recipe
+   algorithms/calculate_diffcal_table
+   algorithms/calibration_metric_extraction_algorithm
+   algorithms/conjoin_table_workspaces
+   algorithms/crystallographic_info_algorithm
+   algorithms/custom_group_workspace
+   algorithms/detector_peak_predictor
+   algorithms/diffraction_spectrum_weight_calculator
+   algorithms/fetch_groceries_algorithm
+   algorithms/fit_mutliple_peaks_algorithm
+   algorithms/focus_spectra_algorithm
+   algorithms/generate_table_workspace_from_list_of_dict
+   algorithms/group_diffraction_calibration
+   algorithms/lite_data_creation_algo
+   algorithms/load_calibration_workspaces
+   algorithms/load_grouping_definition
+   algorithms/make_dirty_dish
+   algorithms/mask_detector_flags
+   algorithms/normalize_by_current_but_the_correct_way
+   algorithms/pixel_diffraction_calibration
+   algorithms/pixel_grouping_parameters_calculation_algorithm
+   algorithms/purge_overlapping_peaks_algorithm
+   algorithms/raw_vanadium_correction_algorithm
+   algorithms/save_grouping_definition
+   algorithms/smooth_data_excluding_peaks_algo
+   algorithms/utensils
+   algorithms/wash_dishes


### PR DESCRIPTION
## Description of work
This was an exploration story to achieve two main goals:
1. Inspect backend algos to see where Mantid `WorkspaceUnitValidators` are applicable and appropriate.
2. Create developer documentation for backend algos specifying in particular the inputs and outputs.
<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work
Through inspection, a list was complied to show where I believe that `WorkspaceUnitValidator` should be used. One thing to note is that it turned out to be a fewer number of areas than expected and with some of the algos, I could not reliably deduce what the units are to be of the input data so it would be helpful for a more domain experienced dev or even Malcolm to come back to this and review it.

Here is the compiled list:
[Validators_for_SNAPRed_algos.ods](https://github.com/user-attachments/files/15789069/Validators_for_SNAPRed_algos.ods)
<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test
No testing needed, just in-depth review please. I guess insure that docs build successfully.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM # 5567](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=5567)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
