### PR TITLE
Added map for request groupings to base service class

### DIFF
--- a/src/snapred/backend/service/Service.py
+++ b/src/snapred/backend/service/Service.py
@@ -1,9 +1,8 @@
-from abc import ABC, ABCMeta, abstractmethod
-from typing import Any, Dict, Callable, List
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Dict, List
 
 from snapred.backend.dao.SNAPRequest import SNAPRequest
 from snapred.meta.Config import Config
-from snapred.backend.dao.SNAPRequest import SNAPRequest
 
 # Type define which is a callable function with a List of SNAPRequests as input,
 # and a Dict of str keys and List of SNAPRequests values as expected output.
@@ -15,7 +14,7 @@ class Service(ABC):
 
     def __init__(self):
         self._paths: Dict[str, Any] = {}
-        self._lambdas : Dict[str, List[GroupingLambda]] = {}
+        self._lambdas: Dict[str, List[GroupingLambda]] = {}
 
     @abstractmethod
     def name(self):
@@ -49,7 +48,7 @@ class Service(ABC):
                 self._lambdas[path] = []
             self._lambdas[path].append(groupingLambda)
         else:
-            raise ValueError(f"Given path does not exist")
+            raise ValueError("Given path does not exist")
 
-    def getGroupings(self, path: str):        
+    def getGroupings(self, path: str):
         return self._lambdas[path]

--- a/tests/unit/backend/service/test_ReductionService.py
+++ b/tests/unit/backend/service/test_ReductionService.py
@@ -123,7 +123,10 @@ class TestReductionService(unittest.TestCase):
         payload = self.request.json()
         request = SNAPRequest(path="test", payload=payload)
         scheduler = RequestScheduler()
-        result = scheduler.handle([request], [self.instance._groupByStateId, self.instance._groupByVanadiumVersion])
+        self.instance.registerGrouping("", self.instance._groupByStateId)
+        self.instance.registerGrouping("", self.instance._groupByVanadiumVersion)
+        groupings = self.instance.getGroupings("")
+        result = scheduler.handle([request], groupings)
 
         # outpus/2kfxjiqm is the state id defined in WhateversInTheFridge util
         # Verify the request is sorted by state id then normalization version


### PR DESCRIPTION
## Description of work

This adds a map for request groupings in the base service class.


## Explanation of work

The map of groupings is a dict of paths to grouping lambdas. There is a function to insert a lambda into the map for a given path, and multiple groupings can be inserted for a given path. Then there is a function to get the grouping lambdas for a given path, that only takes a path as an argument and returns a list of grouping lambdas.

## To test

### Dev testing

Make sure unit tests pass.

### CIS testing

None.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#5008](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=5008)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
