### PR TITLE
Introduce parameter to exclude short wavelengths

### DIFF
--- a/src/snapred/backend/dao/InstrumentConfig.py
+++ b/src/snapred/backend/dao/InstrumentConfig.py
@@ -27,3 +27,4 @@ class InstrumentConfig(BaseModel):
     delThWithGuide: float
     width: float
     frequency: float
+    lowWavelengthCrop: float = 0.05

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -1036,7 +1036,7 @@ class LocalDataService:
         )
         # then calculate the derived values
         lambdaLimit = Limit(
-            minimum=detectorState.wav - (instrumentConfig.bandwidth / 2),
+            minimum=detectorState.wav - (instrumentConfig.bandwidth / 2) + instrumentConfig.lowWavelengthCrop,
             maximum=detectorState.wav + (instrumentConfig.bandwidth / 2),
         )
         L = instrumentConfig.L1 + instrumentConfig.L2

--- a/tests/resources/inputs/calibration/CalibrationParameters.json
+++ b/tests/resources/inputs/calibration/CalibrationParameters.json
@@ -48,11 +48,11 @@
     },
     "particleBounds": {
       "wavelength": {
-        "minimum": -0.3999999999999999,
+        "minimum": -0.3499999999999999,
         "maximum": 2.6
       },
       "tof": {
-        "minimum": -1567.226174506943,
+        "minimum": -1371.3229026935753,
         "maximum": 10186.970134295134
       }
     },


### PR DESCRIPTION
## Description of work
In inspection of normalized diffraction focused sample data, Malcolm found that at low d-spacing values, the observed signal was essentially zero (100% background). This story is meant to act as a fix for this issue. The main work for this story and the majority of the hours went into inspecting the difference between original diffraction focused workspace and the post fix diffraction focused workspace within the Normalization Workflow.  
<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work
A parameter called `lowWavelengthCrop` was added based on Malcolm's suggestion and set to a default value of 0.05. This parameter was then exposed within the `intializeState` method within `LocalDataService`.

In testing this myself, I ran the Normalization workflow for many different run numbers and parameters, found in most cases that the post fix values for dSpacing were in fact noticeably different:

Pre-fix:
![image](https://github.com/neutrons/SNAPRed/assets/106342815/7872e8d7-d919-4e5a-83b1-2152235647cc)

Post-Fix:
![image](https://github.com/neutrons/SNAPRed/assets/106342815/6f6979f6-02e3-46de-bf30-9ef1a0f01e4d)

Malcolm will have to come back and insure this is the difference we truly want from a scientific perspective.
<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing
Run this 
<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->
To test, please follow these steps:
1. Make sure you are on the `next` branch.
2. Delete all initialized states within Powder directory for your local directory.
3. Run normalization workflow with the following inputs:
    - Run Number: 58882
    - Background: 58813
    - Sample: Silicon_NIST_640D_001.json
    - Grouping: Default
4. When on the `Tweak Parameters` page, go to the main SNAPRed application and from within the workspaces viewer, double click on the workspace title `tof_all_default_lite_s+f-vanadium_058882`.
5. Inspect the lower dSpacing range by using the zoom tool.

Then switch to branch `introduce-parameter-to-exclude-short-wavelength` and follow all the same steps as listed above in order. If you take screenshots of both instances, you should get the same result as within the explanation of the work above. 

**Note:** It is import that you delete states and initialize from scratch both times as this new parameter get substantiated through the initialization workflow.
### CIS testing
Please follow the steps above to run the Normalization Workflow and confirm that values at low d-Spacing are proper.

[EWM # 3520](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3520)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
