### PR TITLE
Enable `parse_file_as`, `parse_obj_as`, `parse_raw_as` methods in `redantic`

### DIFF
--- a/tests/unit/meta/test_redantic.py
+++ b/tests/unit/meta/test_redantic.py
@@ -9,6 +9,9 @@ from snapred.meta.redantic import (
     list_from_raw,
     list_to_raw,
     list_to_raw_pretty,
+    parse_file_as,
+    parse_obj_as,
+    parse_raw_as,
     write_model,
     write_model_list,
     write_model_list_pretty,
@@ -38,6 +41,27 @@ class TestRedantic(TestCase):
         for file in files:
             os.remove(file)
         cls.files = []
+
+    def test_parse_raw_as(self):
+        assert parse_raw_as(ModelTest, self.model.model_dump_json()) == self.model
+
+    def test_parse_raw_as_list(self):
+        assert parse_raw_as(List[ModelTest], list_to_raw(self.modelList)) == self.modelList
+
+    def test_parse_obj_as(self):
+        assert parse_obj_as(ModelTest, self.model.model_dump()) == self.model
+
+    def test_parse_obj_as_obj(self):
+        assert parse_obj_as(ModelTest, self.model) == self.model
+
+    def test_parse_obj_as_list(self):
+        assert parse_obj_as(List[ModelTest], [model.model_dump() for model in self.modelList])
+
+    def test_parse_obj_as_list_obj(self):
+        assert parse_obj_as(List[ModelTest], self.modelList) == self.modelList
+
+    def test_parse_file_as(self):
+        assert parse_file_as(List[ModelTest], Resource.getPath("outputs/meta/redantic/list.json")) == self.modelList
 
     def test_list_to_raw(self):
         assert list_to_raw(self.modelList) == Resource.read("outputs/meta/redantic/list.json").strip()


### PR DESCRIPTION
## Description of work

Pydantic V2 fatuously removed extremely useful methods that we had come to rely on, and are [completely unwilling](https://github.com/pydantic/pydantic/issues/9634) to re-include the very useful file parsing methods after their users became reliant on them (thanks pydantic guys!)

This adds similar methods inside redantic which should make it easier to read files.

## Explanation of work

I used the pydantic V2 `TypeAdapter` to write methods similar to the `parse_file_as` and related methods.

## To test

### Dev testing

Check the unit tests.  If you want, try running some parses in a script or interpreter.

### CIS testing

Not needed, this is purely internal.

## Link to EWM item

This is not from an EWM, though it originated out of the V2 bump and I found these useful during work on the Indexor PR.

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
