### PR TITLE
Added MetadataLookupService to verify list of multiple runs

### DIFF
--- a/src/snapred/backend/service/MetadataLookupService.py
+++ b/src/snapred/backend/service/MetadataLookupService.py
@@ -29,16 +29,13 @@ class MetadataLookupService(Service):
     @FromString
     def verifyMultipleRuns(self, runs: str):
         maxRuns = Config["instrument.maxNumberOfRuns"]
-        try:
-            allRuns = IntArrayProperty(name="RunList", values=runs).value
-        except Exception as e:
-            raise e
+        allRuns = IntArrayProperty(name="RunList", values=runs).value
         validRuns = []
         for run in allRuns:
             if RunNumberValidator.validateRunNumber(str(run)):
                 validRuns.append(run)
         if len(validRuns) > maxRuns:
-            logger.warning(f"Maximum vale of {maxRuns} run numbers exceeded")
+            logger.warning(f"Maximum value of {maxRuns} run numbers exceeded")
             validRuns = []
 
         return validRuns

--- a/src/snapred/backend/service/MetadataLookupService.py
+++ b/src/snapred/backend/service/MetadataLookupService.py
@@ -1,0 +1,44 @@
+from mantid.kernel import IntArrayProperty
+
+from snapred.backend.data.DataFactoryService import DataFactoryService
+from snapred.backend.log.logger import snapredLogger
+from snapred.backend.service.Service import Service
+from snapred.meta.Config import Config
+from snapred.meta.decorators.FromString import FromString
+from snapred.meta.decorators.Singleton import Singleton
+from snapred.meta.validator.RunNumberValidator import RunNumberValidator
+
+logger = snapredLogger.getLogger(__name__)
+
+
+@Singleton
+class MetadataLookupService(Service):
+    dataFactoryService = "DataFactoryService"
+
+    # register the service in ServiceFactory please!
+    def __init__(self):
+        super().__init__()
+        self.dataFactoryService = DataFactoryService()
+        self.registerPath("", self.verifyMultipleRuns)
+        return
+
+    @staticmethod
+    def name():
+        return "verifiedRuns"
+
+    @FromString
+    def verifyMultipleRuns(self, runs: str):
+        maxRuns = Config["instrument.maxNumberOfRuns"]
+        try:
+            allRuns = IntArrayProperty(name="RunList", values=runs).value
+        except Exception as e:
+            raise e
+        validRuns = []
+        for run in allRuns:
+            if RunNumberValidator.validateRunNumber(str(run)):
+                validRuns.append(run)
+        if len(validRuns) > maxRuns:
+            logger.warning(f"Maximum vale of {maxRuns} run numbers exceeded")
+            validRuns = []
+
+        return validRuns

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -43,6 +43,7 @@ instrument:
   startingRunNumber: 10000
   startingVersionNumber: 0
   minimumRunNumber: 46342
+  maxNumberOfRuns: 10
 
 nexus:
   lite:

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -49,6 +49,7 @@ instrument:
   startingRunNumber: 10000
   startingVersionNumber: 0
   minimumRunNumber: 46342
+  maxNumberOfRuns: 10
 
 nexus:
   lite:

--- a/tests/unit/backend/service/test_MetadataLookupService.py
+++ b/tests/unit/backend/service/test_MetadataLookupService.py
@@ -1,7 +1,12 @@
+import importlib
+import logging
 import unittest
 
 import pytest
 from snapred.backend.service.MetadataLookupService import MetadataLookupService
+from snapred.meta.Config import Config
+
+ServiceModule = importlib.import_module(MetadataLookupService.__module__)
 
 
 class TestMetadataLookupService(unittest.TestCase):
@@ -10,18 +15,21 @@ class TestMetadataLookupService(unittest.TestCase):
         cls.instance = MetadataLookupService()
         super().setUpClass()
 
-    def setUp(self):
-        return super().setUp()
-
     def test_verifyMultipleRuns(self):
         # Test valid number of runs
         runs = self.instance.verifyMultipleRuns("46342:46352")
         assert len(runs) == 10
 
         # Test exceeding max number of runs
-        runs = self.instance.verifyMultipleRuns("46342:46355")
-        assert len(runs) == 0
+        maxRuns = Config["instrument.maxNumberOfRuns"]
+        with self.assertLogs(logger=ServiceModule.logger, level=logging.WARNING) as cm:
+            runs = self.instance.verifyMultipleRuns("46342:46355")
+        assert f"Maximum value of {maxRuns} run numbers exceeded" in cm.output[0]
 
-        # Test bad input
+        # Test removing invalid runs from list
+        runs = self.instance.verifyMultipleRuns("1,2,46343")
+        assert len(runs) == 1
+
+        # Test invalid input
         with pytest.raises(Exception):  # noqa: PT011
             runs = self.instance.verifyMultipleRuns("46342, word, -1")

--- a/tests/unit/backend/service/test_MetadataLookupService.py
+++ b/tests/unit/backend/service/test_MetadataLookupService.py
@@ -1,0 +1,27 @@
+import unittest
+
+import pytest
+from snapred.backend.service.MetadataLookupService import MetadataLookupService
+
+
+class TestMetadataLookupService(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.instance = MetadataLookupService()
+        super().setUpClass()
+
+    def setUp(self):
+        return super().setUp()
+
+    def test_verifyMultipleRuns(self):
+        # Test valid number of runs
+        runs = self.instance.verifyMultipleRuns("46342:46352")
+        assert len(runs) == 10
+
+        # Test exceeding max number of runs
+        runs = self.instance.verifyMultipleRuns("46342:46355")
+        assert len(runs) == 0
+
+        # Test bad input
+        with pytest.raises(Exception):  # noqa: PT011
+            runs = self.instance.verifyMultipleRuns("46342, word, -1")


### PR DESCRIPTION
## Description of work

This new service takes in a list of run numbers that can be passed to a mantid IntArrayProperty, and then that list of runs is verified.

## Explanation of work

The new MetadataLookupService takes in a string of runs that can be accepted by an IntArrayProperty object. You can pass in a list several different ways, including by doing 100:200. When colon separated, it will return a list of all values in between. This list then gets verified by RunNumberValidator and then gets inserted into a list of valid runs. If the list is too big, the return list will be empty. The max size of run numbers is set in the application.yml file by instrument.maxNumberOfRuns. This value is currently set to an arbitrary value of 10.

## To test

### Dev testing

Make sure unit tests pass.

### CIS testing

None

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#5006](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=5006)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
