### PR TITLE
Retain diagnostic workspace on iterate.

### DIFF
--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -1031,9 +1031,14 @@ class GroceryService:
         :param cache: whether or not to clear cached workspaces (True = yes, clear the cache), optional (defaults to False)
         :type cache: bool
         """  # noqa E501
-        workspacesToClear = mtd.getObjectNames()
+        workspacesToClear = set(mtd.getObjectNames())
         # filter exclude
-        workspacesToClear = [w for w in workspacesToClear if w not in exclude]
+        workspacesToClear = workspacesToClear - set(exclude)
+        # properly handle workspace groups -- also exclude deleting their constituents
+        for ws in exclude:
+            if mtd[ws].isGroup():
+                workspacesToClear = workspacesToClear - set(mtd[ws].getNames())
+
         # filter caches
         if not cache:
             workspaceCache = self.getCachedWorkspaces()

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -1033,14 +1033,14 @@ class GroceryService:
         """  # noqa E501
         workspacesToClear = set(mtd.getObjectNames())
         # filter exclude
-        workspacesToClear = workspacesToClear - set(exclude)
+        workspacesToClear = workspacesToClear.difference(exclude)
         # properly handle workspace groups -- also exclude deleting their constituents
         for ws in exclude:
             if self.workspaceDoesExist(ws) and mtd[ws].isGroup():
-                workspacesToClear = workspacesToClear - set(mtd[ws].getNames())
+                workspacesToClear = workspacesToClear.difference(mtd[ws].getNames())
         # filter caches
         if not cache:
-            workspacesToClear = workspacesToClear - set(self.getCachedWorkspaces())
+            workspacesToClear = workspacesToClear.difference(self.getCachedWorkspaces())
         # clear the workspaces
         for workspace in workspacesToClear:
             self.deleteWorkspaceUnconditional(workspace)

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -1036,9 +1036,8 @@ class GroceryService:
         workspacesToClear = workspacesToClear - set(exclude)
         # properly handle workspace groups -- also exclude deleting their constituents
         for ws in exclude:
-            if mtd[ws].isGroup():
+            if ws in workspacesToClear and mtd[ws].isGroup():
                 workspacesToClear = workspacesToClear - set(mtd[ws].getNames())
-
         # filter caches
         if not cache:
             workspaceCache = self.getCachedWorkspaces()

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -1036,12 +1036,11 @@ class GroceryService:
         workspacesToClear = workspacesToClear - set(exclude)
         # properly handle workspace groups -- also exclude deleting their constituents
         for ws in exclude:
-            if ws in workspacesToClear and mtd[ws].isGroup():
+            if self.workspaceDoesExist(ws) and mtd[ws].isGroup():
                 workspacesToClear = workspacesToClear - set(mtd[ws].getNames())
         # filter caches
         if not cache:
-            workspaceCache = self.getCachedWorkspaces()
-            workspacesToClear = [w for w in workspacesToClear if w not in workspaceCache]
+            workspacesToClear = workspacesToClear - set(self.getCachedWorkspaces())
         # clear the workspaces
         for workspace in workspacesToClear:
             self.deleteWorkspaceUnconditional(workspace)

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -16,6 +16,7 @@ from mantid.simpleapi import (
     CreateWorkspace,
     DeleteWorkspace,
     GenerateTableWorkspaceFromListOfDict,
+    GroupWorkspaces,
     LoadEmptyInstrument,
     SaveDiffCal,
     SaveNexusProcessed,
@@ -1576,3 +1577,41 @@ class TestGroceryService(unittest.TestCase):
         assert mtd.doesExist(rawWsName) is True
         self.instance.rebuildCache.assert_called()
         self.instance.rebuildCache = rebuildCache
+
+    def test_clearADS_group(self):
+        # create a workspace that will be removed
+        dumbws = mtd.unique_name(prefix="_dumb_")
+        self.create_dumb_workspace(dumbws)
+        assert mtd.doesExist(dumbws)
+        # create a workspace group
+        groupws = mtd.unique_name(prefix="_groupws_")
+        subws1 = mtd.unique_name(prefix="a")
+        subws2 = mtd.unique_name(prefix="b")
+        self.create_dumb_workspace(subws1)
+        self.create_dumb_workspace(subws2)
+        GroupWorkspaces(
+            OutputWorkspace=groupws,
+            InputWorkspaces=[subws1, subws2],
+        )
+        assert mtd.doesExist(groupws)
+        assert mtd.doesExist(subws1)
+        assert mtd.doesExist(subws2)
+        assert mtd[groupws].isGroup()
+        assert set(mtd[groupws].getNames()) == {subws1, subws2}
+
+        # exclude the group from clearing
+        exclude = self.exclude.copy()
+        exclude.append(groupws)
+
+        # clear the ADS with this excluded
+        self.instance.clearADS(exclude=exclude)
+
+        # ensure the workspace group and its sub still exist
+        assert mtd.doesExist(groupws)
+        assert mtd.doesExist(subws1)
+        assert mtd.doesExist(subws2)
+        # assert the workspace not in the exclude is removed
+        assert not mtd.doesExist(dumbws)
+
+        # delete these specially
+        mtd.remove(groupws)


### PR DESCRIPTION
## Description of work

The diffcal process was recently changed to output a diagnostic workspace with information about the peak fits.

However, if the user elected to iterate, this workspace would be deleted, and could create errors if the user tried to save this older iteration.

The issue was, while the diagnostic workspace group itself was being retained, all of the constituents were deleted, and this signaled to mantid to delete the group as well.

## Explanation of work

The simplest and most elegant solution was to fix `clearADS` inside `GroceryService`, so that if a workspace in the exclude list is also a workspace group, all of the constituents are also excluded.

That was achieved as follows:
``` python
        workspacesToClear = set(mtd.getObjectNames())
        # filter exclude
        workspacesToClear = workspacesToClear - set(exclude)
        # properly handle workspace groups -- also exclude deleting their constituents
        for ws in exclude:
            if mtd[ws].isGroup():
                workspacesToClear = workspacesToClear - set(mtd[ws].getNames())
```
I used sets because it seemed less likely to get in a situation of double-deleting a workspace name from `workspacesToClear`.

## To test

### Dev testing

1. **reproduce the error**.  On `next`, run diffcal to assessment stage.  Observe the light-blue workspace group, click the arrow next to it, observe the four workspaces inside it.  Now click to iterate.  It's gone!  Go back through to save and try to save iteration 1.  The program will fail.
2. Switch to this branch, and reproduce the above behavior.  When iterating, the workspace will remain!
3. Iterate a few times for good measure.
4. Save iteration 1.  It should complete fine.
5. After save, continue.  Make sure the *entire* workspace list is cleared.
6. Check that the workspaces saved in the corresponding version folder, and that there is no iteration counter on the workspace names.
7. Run normalization and make sure it saves.

### CIS testing

As above, but use a real run like 58882.

Make sure the workspaces inside the diagnostic workspace group are valuable and make sense.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#5668](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=5668)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
