### PR TITLE
Fix SNAPRed Launch within Mantid

### DIFF
--- a/src/snapred/meta/Config.py
+++ b/src/snapred/meta/Config.py
@@ -5,10 +5,9 @@ import re
 import sys
 from glob import glob
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, TypeVar
 
 import yaml
-from pydantic.utils import deep_update
 
 from snapred.meta.decorators.Singleton import Singleton
 
@@ -75,6 +74,19 @@ class _Resource:
 
 
 Resource = _Resource()
+
+KeyType = TypeVar("KeyType")
+
+
+def deep_update(mapping: Dict[KeyType, Any], *updating_mappings: Dict[KeyType, Any]) -> Dict[KeyType, Any]:
+    updated_mapping = mapping.copy()
+    for updating_mapping in updating_mappings:
+        for k, v in updating_mapping.items():
+            if k in updated_mapping and isinstance(updated_mapping[k], dict) and isinstance(v, dict):
+                updated_mapping[k] = deep_update(updated_mapping[k], v)
+            else:
+                updated_mapping[k] = v
+    return updated_mapping
 
 
 @Singleton

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -18,7 +18,12 @@ from snapred.meta.Config import Resource
 from snapred.ui.widget.LogTable import LogTable
 from snapred.ui.widget.TestPanel import TestPanel
 from snapred.ui.widget.ToolBar import ToolBar
-from snapred.ui.widget.UserDocsButton import UserDocsButton
+
+# Conditionally import UserDocsButton (temporary)
+try:
+    from snapred.ui.widget.UserDocsButton import UserDocsButton
+except ImportError:
+    UserDocsButton = None
 
 
 class SNAPRedGUI(QMainWindow):
@@ -67,8 +72,11 @@ class SNAPRedGUI(QMainWindow):
         self.statusBar = QStatusBar()
         self.setStatusBar(self.statusBar)
 
-        self.userDocButton = UserDocsButton(self)
-        splitter.addWidget(self.userDocButton)
+        if UserDocsButton:
+            self.userDocButton = UserDocsButton(self)
+            splitter.addWidget(self.userDocButton)
+        else:
+            print("UserDocsButton is not available. Skipping its initialization.")
 
     def openNewWindow(self):
         try:


### PR DESCRIPTION
## Description of work
This fix should allow SNAPRed to be launched once again through mantid workbench.
<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work
There was an issue originally with a method within pydantic V1 called `deep_update`. This was fixed by following Reece's suggestion and just pulling the method from within pydantic V1's implementation. This allows the removal of dependence on this constantly changing codebase within `Config.py`. The issue following this had to do with an error with `QtWebEngineWidgets`. The trace had the following message:
```python
Error: QCoreApplication instance already exists.
QtWebEngineWidgets must be imported before a QCoreApplication instance is created
SNAPRed is not available
SNAPRed is not available
Traceback (most recent call last):
  File "<string>", line 25, in <module>
  File "/SNS/users/dzj/SNAPRed/src/snapred/ui/main.py", line 15, in <module>
    from qtpy.QtWebEngineWidgets import QWebEngineView
  File "/SNS/users/dzj/miniforge3/envs/SNAPRed/lib/python3.10/site-packages/qtpy/QtWebEngineWidgets.py", line 28, in <module>
    from PyQt5.QtWebEngineWidgets import (
ImportError: QtWebEngineWidgets must be imported before a QCoreApplication instance is created
```
Pete suggested to implement conditional imports with SNAPRed and Mantid until `QtWebEngineWidgets` is fully implemented within Mantid later on. This takes care of the SNAPRed side of things.
<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing
Please launch mantid workbench within analysis and insure that SNAPRed launches successfully. Ensure all pytests pass.
<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing
Not needed.
<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM # 5890](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=5890)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
