### PR TITLE
Reconcile diffraction-calibration output sections.  Check for possible regression.

### DIFF
--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -7,7 +7,7 @@ from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as
 
 logger = snapredLogger.getLogger(__name__)
 
-KnownUnits = Literal[wng.Units.TOF, wng.Units.DSP, wng.Units.DIAG]
+KnownUnits = Literal[wng.Units.TOF, wng.Units.DSP]
 known_units = list(get_args(KnownUnits))
 
 

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -209,7 +209,7 @@ class GroceryService:
         ext = Config["calibration.diffraction.diagnostic.extension"]
         return str(
             Path(self._getCalibrationDataPath(item.runNumber, item.useLiteMode, item.version))
-            / (self._createDiffcalOutputWorkspaceName(item) + ext)
+            / (self._createDiffcalDiagnosticWorkspaceName(item) + ext)
         )
 
     @validate_call
@@ -256,6 +256,15 @@ class GroceryService:
     def _createDiffcalInputWorkspaceName(self, runNumber: str) -> WorkspaceName:
         return wng.diffCalInput().runNumber(runNumber).build()
 
+    def _createDiffcalDiagnosticWorkspaceName(self, item: GroceryListItem) -> WorkspaceName:
+        return (
+            wng.diffCalDiagnostic()
+            .runNumber(item.runNumber)
+            .version(item.version)
+            .group(item.groupingScheme)
+            .build()
+        )
+
     def _createDiffcalOutputWorkspaceName(self, item: GroceryListItem) -> WorkspaceName:
         return (
             wng.diffCalOutput()
@@ -265,7 +274,7 @@ class GroceryService:
             .group(item.groupingScheme)
             .build()
         )
-
+        
     @validate_call
     def _createDiffcalTableWorkspaceName(
         self,
@@ -894,7 +903,7 @@ class GroceryService:
                 case "diffcal_diagnostic":
                     self.fetchWorkspace(
                         self._createDiffcalDiagnosticWorkspaceFilename(item),
-                        self._createDiffcalOutputWorkspaceName(item),
+                        self._createDiffcalDiagnosticWorkspaceName(item),
                         loader="LoadNexusProcessed",
                     )
                 case "diffcal_table":

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -133,7 +133,7 @@ class CalibrationService(Service):
             wng.diffCalOutput().unit(wng.Units.DSP).runNumber(request.runNumber).group(request.focusGroup.name).build()
         )
         diagnosticWorkspaceName = (
-            wng.diffCalOutput().unit(wng.Units.DIAG).runNumber(request.runNumber).group(request.focusGroup.name).build()
+            wng.diffCalDiagnostic().runNumber(request.runNumber).group(request.focusGroup.name).build()
         )
         calibrationTableName = wng.diffCalTable().runNumber(request.runNumber).build()
         calibrationMaskName = wng.diffCalMask().runNumber(request.runNumber).build()
@@ -318,10 +318,9 @@ class CalibrationService(Service):
                 )
         for n, wsName in enumerate(workspaces.pop(wngt.DIFFCAL_DIAG, [])):
             self.groceryClerk.name(wngt.DIFFCAL_DIAG + "_" + str(n).zfill(4))
-            if wng.Units.DIAG.lower() in wsName:
-                self.groceryClerk.diffcal_diagnostic(runId, version).unit(wng.Units.DIAG).group(
-                    calibrationRecord.focusGroupCalibrationMetrics.focusGroupName
-                ).add()
+            self.groceryClerk.diffcal_diagnostic(runId, version).group(
+                calibrationRecord.focusGroupCalibrationMetrics.focusGroupName
+            ).add()
         for n, (tableWSName, maskWSName) in enumerate(
             zip(
                 workspaces.pop(wngt.DIFFCAL_TABLE, []),

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -163,7 +163,6 @@ class _WorkspaceNameGenerator:
         _templateRoot = "mantid.workspace.nameTemplate.units"
         DSP = Config[f"{_templateRoot}.dSpacing"]
         TOF = Config[f"{_templateRoot}.timeOfFlight"]
-        DIAG = Config[f"{_templateRoot}.diagnostic"]
 
     class Groups:
         _templateRoot = "mantid.workspace.nameTemplate.groups"
@@ -205,6 +204,15 @@ class _WorkspaceNameGenerator:
             version="",
         )
 
+    def diffCalDiagnostic(self):
+        return NameBuilder(
+            self._diffCalDiagnosticTemplate,
+            self._diffCalDiagnosticTemplateKeys,
+            self._delimiter,
+            group=self.Groups.UNFOC,
+            version="",
+        )
+        
     def diffCalOutput(self):
         return NameBuilder(
             self._diffCalOutputTemplate,

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -106,6 +106,7 @@ mantid:
         diffCal:
           input: "{unit},{runNumber},raw"
           table: "diffract_consts,{runNumber},{version}"
+          diagnostic: "diagnostic,{group},{runNumber},{version}"
           output: "{unit},{group},{runNumber},{version}"
           mask: "diffract_consts,mask,{runNumber},{version}"
           metric: "calib_metrics,{metricName},{runNumber},{version}"
@@ -120,7 +121,6 @@ mantid:
       units:
         dSpacing: DSP
         timeOfFlight: TOF
-        diagnostic: diagnostic
       groups:
         unfocussed: Unfoc
         all: All

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -113,6 +113,7 @@ mantid:
           diffCal:
             input: "_{unit},{runNumber},raw"
             table: "_diffract_consts,{runNumber},{version}"
+            diagnostic: "_diagnostic,{group},{runNumber},{version}"
             output: "_{unit},{group},{runNumber},{version}"
             mask: "_diffract_consts,mask,{runNumber},{version}"
             metric: "_calib_metrics,{metricName},{runNumber},{version}"
@@ -127,7 +128,6 @@ mantid:
         units:
           dSpacing: dsp
           timeOfFlight: tof
-          diagnostic: diagnostic
         groups:
           unfocussed: unfoc
           all: all

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -451,10 +451,13 @@ class TestCalibrationServiceMethods(unittest.TestCase):
 
         # Call the method to test. Use a mocked run and a mocked version
         mockRequest = MagicMock(runId=calibRecord.runNumber, version=calibRecord.version, checkExistent=False)
+        
         self.instance.loadQualityAssessment(mockRequest)
         calledWithDict = mockFetchGroceryDict.call_args[0][0]
         assert calledWithDict["diffCalOutput_0000"].unit == wng.Units.DSP
-        assert calledWithDict["diffCalDiagnostic_0000"].unit == wng.Units.DIAG
+        assert calledWithDict["diffCalOutput_0000"].workspaceType == "diffcal_output"
+        assert calledWithDict["diffCalDiagnostic_0000"].unit is None
+        assert calledWithDict["diffCalDiagnostic_0000"].workspaceType == "diffcal_diagnostic"
 
     def test_load_quality_assessment_unexpected_type(self):
         with pytest.raises(RuntimeError, match=r"not implemented: unable to load unexpected"):  # noqa: PT012

--- a/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
+++ b/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
@@ -34,6 +34,13 @@ def testDiffCalOutputName():
         == wng.diffCalOutput().runNumber(runNumber).unit(wng.Units.TOF).version(version).build()
     )
 
+def testDiffCalDiagnosticName():
+    assert f"_diagnostic_unfoc_{fRunNumber}" == wng.diffCalDiagnostic().runNumber(runNumber).build()
+    assert (
+        f"_diagnostic_unfoc_{fRunNumber}_{fVersion}"
+        == wng.diffCalDiagnostic().runNumber(runNumber).version(version).build()
+    )
+
 
 def testDiffCalTableName():
     assert f"_diffract_consts_{fRunNumber}" == wng.diffCalTable().runNumber(runNumber).build()


### PR DESCRIPTION

## Explanation of work

This commit includes the following changes:

  * Remove 'WorkspaceNameGenerator.Units.DIAG' as a possible unit in favor of simply using the `WorkspaceNameGenerator.DIFFCAL_DIAG` workspace type and its associated naming template (in 'application.yml').

  * Reconcile (and explain) the implementation treatment in `LocalDataService.writeCalibrationRecord` and `LocalDataService.writeCalibrationWorkspaces`.  Interestingly, there was actually no regression in the current implementation, it was just difficult to understand due to the way that SNAPRed uses "lazy versioning" and "iterations" when naming workspaces in the ADS.

  * Unfortunately, the implementation is still difficult to understand and it could be simplified.  However, any modification is deferred as being irrelevent, due to the upcoming "indexer centralization" changes. After those changes, most of these code sections will be obsolete.

### Dev testing

All unit tests should pass.  All panels (with the exception of the _reduction_ panel), should work correctly.  No changes should be observed (in comparison to "next") with respect to _workspace_ or _filenames_ on the file system.

### CIS testing

The changes of this PR are internal to SNAPRed.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#5611](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=5611)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
