### PR TITLE
`ReductionRecipe` code cleanup

### DIFF
--- a/src/snapred/backend/dao/SNAPRequest.py
+++ b/src/snapred/backend/dao/SNAPRequest.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel
 
@@ -13,4 +13,4 @@ class SNAPRequest(BaseModel):
     """
 
     path: str
-    payload: Optional[str] = None
+    payload: Optional[Any] = None

--- a/src/snapred/backend/dao/ingredients/PreprocessReductionIngredients.py
+++ b/src/snapred/backend/dao/ingredients/PreprocessReductionIngredients.py
@@ -9,6 +9,7 @@ class PreprocessReductionIngredients(BaseModel):
     maskList: Optional[List[WorkspaceName]] = None
 
     model_config = ConfigDict(
+        extra="forbid",
         # required in order to use 'WorkspaceName'
         arbitrary_types_allowed=True,
     )

--- a/src/snapred/backend/dao/ingredients/ReductionGroupProcessingIngredients.py
+++ b/src/snapred/backend/dao/ingredients/ReductionGroupProcessingIngredients.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel, ConfigDict
+
+from snapred.backend.dao.state.PixelGroup import PixelGroup
+
+
+class ReductionGroupProcessingIngredients(BaseModel):
+    pixelGroup: PixelGroup
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )

--- a/src/snapred/backend/dao/ingredients/ReductionIngredients.py
+++ b/src/snapred/backend/dao/ingredients/ReductionIngredients.py
@@ -1,8 +1,15 @@
-from typing import List, Optional
+from typing import List
 
 from pydantic import BaseModel, ConfigDict
 
 from snapred.backend.dao.GroupPeakList import GroupPeakList
+
+# These are from the same `__init__` module, so for the moment, we require the full import specifications.
+# (That is, not just "from snapred.backend.dao.ingredients import ...".)
+from snapred.backend.dao.ingredients.ApplyNormalizationIngredients import ApplyNormalizationIngredients
+from snapred.backend.dao.ingredients.GenerateFocussedVanadiumIngredients import GenerateFocussedVanadiumIngredients
+from snapred.backend.dao.ingredients.PreprocessReductionIngredients import PreprocessReductionIngredients
+from snapred.backend.dao.ingredients.ReductionGroupProcessingIngredients import ReductionGroupProcessingIngredients
 from snapred.backend.dao.state.PixelGroup import PixelGroup
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
@@ -19,9 +26,27 @@ class ReductionIngredients(BaseModel):
     calibrantSamplePath: str
     peakIntensityThreshold: float
 
-    # These are just to interface with child recipes easier
-    pixelGroup: Optional[PixelGroup] = None
-    detectorPeaks: Optional[List[GroupPeakList]] = None
+    #
+    # FACTORY methods to create sub-recipe ingredients:
+    #
+    def preprocess(self) -> PreprocessReductionIngredients:
+        # Note: at present, there are no required parameters.
+        return PreprocessReductionIngredients(maskList=None)
+
+    def groupProcessing(self, groupingIndex: int) -> ReductionGroupProcessingIngredients:
+        return ReductionGroupProcessingIngredients(pixelGroup=self.pixelGroups[groupingIndex])
+
+    def generateFocussedVanadium(self, groupingIndex: int) -> GenerateFocussedVanadiumIngredients:
+        return GenerateFocussedVanadiumIngredients(
+            smoothingParameter=self.smoothingParameter,
+            pixelGroup=self.pixelGroups[groupingIndex],
+            detectorPeaks=self.detectorPeaksMany[groupingIndex],
+        )
+
+    def applyNormalization(self, groupingIndex: int) -> ApplyNormalizationIngredients:
+        return ApplyNormalizationIngredients(
+            pixelGroup=self.pixelGroups[groupingIndex],
+        )
 
     model_config = ConfigDict(
         extra="forbid",

--- a/src/snapred/backend/dao/request/ReductionRequest.py
+++ b/src/snapred/backend/dao/request/ReductionRequest.py
@@ -9,7 +9,7 @@ from snapred.backend.error.ContinueWarning import ContinueWarning
 class ReductionRequest(BaseModel):
     runNumber: Union[str, List[str]]
     useLiteMode: bool
-    focusGroup: Union[Optional[FocusGroup], List[FocusGroup]]
+    focusGroups: List[FocusGroup] = []
     userSelectedMaskPath: Optional[str] = None
     version: Union[int, Literal["*"]] = "*"
 

--- a/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
+++ b/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
@@ -1,10 +1,11 @@
 from typing import Any, Dict, List, Tuple
 
-from snapred.backend.dao.state.PixelGroup import PixelGroup as Ingredients
+from snapred.backend.dao.ingredients import ReductionGroupProcessingIngredients as Ingredients
 from snapred.backend.error.AlgorithmException import AlgorithmException
 from snapred.backend.log.logger import snapredLogger
-from snapred.backend.recipe.Recipe import Recipe, WorkspaceName
+from snapred.backend.recipe.Recipe import Recipe
 from snapred.meta.decorators.Singleton import Singleton
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
 logger = snapredLogger.getLogger(__name__)
 
@@ -25,7 +26,7 @@ class ReductionGroupProcessingRecipe(Recipe[Ingredients]):
 
     def queueAlgos(self):
         """
-        Queues up the procesing algorithms for the recipe.
+        Queues up the processing algorithms for the recipe.
         Requires: unbagged groceries.
         """
         # TODO: This is all subject to change based on EWM 4798

--- a/src/snapred/backend/recipe/ReductionRecipe.py
+++ b/src/snapred/backend/recipe/ReductionRecipe.py
@@ -72,19 +72,18 @@ class ReductionRecipe(Recipe[Ingredients]):
         )
         self.mantidSnapper.executeQueue()
 
-    def _applyRecipe(self, recipe: Type[Recipe], inputWorkspace: str):
-        if inputWorkspace:
-            self.groceries["inputWorkspace"] = inputWorkspace
-            recipe().cook(self.ingredients, self.groceries)
+    def _applyRecipe(self, recipe: Type[Recipe], ingredients_, **kwargs):
+        if "inputWorkspace" in kwargs:
+            self.groceries.update(kwargs)
+            recipe().cook(ingredients_, self.groceries)
 
-    def _prepGroupWorkspaces(self, index: int):
+    def _prepGroupWorkspaces(self, groupingIndex: int):
         # TODO:  We need the wng to be able to deconstruct the workspace name
         # so that we can appropriately name the cloned workspaces
         # For now we are just appending it to the end, probably preferable
         # as it keeps the output colocated.
-        self.ingredients.pixelGroup = self.ingredients.pixelGroups[index]
-        self.ingredients.detectorPeaks = self.ingredients.detectorPeaksMany[index]
-        groupName = self.ingredients.pixelGroup.focusGroup.name
+
+        groupName = self.ingredients.pixelGroups[groupingIndex].focusGroup.name
         sampleClone = self._cloneWorkspace(self.sampleWs, f"output_{self.sampleWs}_{groupName}")
         self.groceries["inputWorkspace"] = sampleClone
         normalizationClone = None
@@ -101,36 +100,59 @@ class ReductionRecipe(Recipe[Ingredients]):
     def queueAlgos(self):
         pass
 
-    def _applyNormalization(self, sampleWorkspace: str, normalizationWorkspace: str):
-        self.groceries["inputWorkspace"] = sampleWorkspace
-        self.groceries["normalizationWorkspace"] = normalizationWorkspace
-        ApplyNormalizationRecipe().cook(self.ingredients, self.groceries)
-
     def execute(self):
         # 1. PreprocessReductionRecipe
         outputs = []
-        self._applyRecipe(PreprocessReductionRecipe, self.sampleWs)
+        self._applyRecipe(
+            PreprocessReductionRecipe,
+            self.ingredients.preprocess(),
+            inputWorkspace=self.sampleWs,
+        )
         self._cloneIntermediateWorkspace(self.sampleWs, "sample_preprocessed")
-        self._applyRecipe(PreprocessReductionRecipe, self.normalizationWs)
+        self._applyRecipe(
+            PreprocessReductionRecipe,
+            self.ingredients.preprocess(),
+            inputWorkspace=self.normalizationWs,
+        )
         self._cloneIntermediateWorkspace(self.normalizationWs, "normalization_preprocessed")
-        for i, groupWs in enumerate(self.groupWorkspaces):
+
+        for groupingIndex, groupWs in enumerate(self.groupWorkspaces):
             self.groceries["groupingWorkspace"] = groupWs
 
             # Clone
-            sampleClone, normalizationClone = self._prepGroupWorkspaces(i)
+            sampleClone, normalizationClone = self._prepGroupWorkspaces(groupingIndex)
             # TODO: Set pixel group specific stuff
 
-            # Apply Calculations
-            self._applyRecipe(ReductionGroupProcessingRecipe, sampleClone)
-            self._cloneIntermediateWorkspace(sampleClone, f"sample_GroupProcessing_{i}")
-            self._applyRecipe(ReductionGroupProcessingRecipe, normalizationClone)
-            self._cloneIntermediateWorkspace(normalizationClone, f"normalization_GroupProcessing_{i}")
+            # 2. ReductionGroupProcessingRecipe
+            self._applyRecipe(
+                ReductionGroupProcessingRecipe,
+                self.ingredients.groupProcessing(groupingIndex),
+                inputWorkspace=sampleClone,
+            )
+            self._cloneIntermediateWorkspace(sampleClone, f"sample_GroupProcessing_{groupingIndex}")
+            self._applyRecipe(
+                ReductionGroupProcessingRecipe,
+                self.ingredients.groupProcessing(groupingIndex),
+                inputWorkspace=normalizationClone,
+            )
+            self._cloneIntermediateWorkspace(normalizationClone, f"normalization_GroupProcessing_{groupingIndex}")
 
-            self._applyRecipe(GenerateFocussedVanadiumRecipe, normalizationClone)
-            self._cloneIntermediateWorkspace(normalizationClone, f"normalization_FoocussedVanadium_{i}")
+            # 3. GenerateFocussedVanadiumRecipe
+            self._applyRecipe(
+                GenerateFocussedVanadiumRecipe,
+                self.ingredients.generateFocussedVanadium(groupingIndex),
+                inputWorkspace=normalizationClone,
+            )
+            self._cloneIntermediateWorkspace(normalizationClone, f"normalization_FoocussedVanadium_{groupingIndex}")
 
-            self._applyNormalization(sampleClone, normalizationClone)
-            self._cloneIntermediateWorkspace(sampleClone, f"sample_ApplyNormalization_{i}")
+            # 4. ApplyNormalizationRecipe
+            self._applyRecipe(
+                ApplyNormalizationRecipe,
+                self.ingredients.applyNormalization(groupingIndex),
+                inputWorkspace=sampleClone,
+                normalizationWorkspace=normalizationClone,
+            )
+            self._cloneIntermediateWorkspace(sampleClone, f"sample_ApplyNormalization_{groupingIndex}")
 
             # Cleanup
             outputs.append(sampleClone)

--- a/src/snapred/backend/service/ReductionService.py
+++ b/src/snapred/backend/service/ReductionService.py
@@ -76,7 +76,7 @@ class ReductionService(Service):
         groupResults = self.fetchReductionGroupings(request)
         focusGroups = groupResults["focusGroups"]
         groupingWorkspaces = groupResults["groupingWorkspaces"]
-        request.focusGroup = focusGroups
+        request.focusGroups = focusGroups
 
         ingredients = self.prepReductionIngredients(request)
 
@@ -90,7 +90,6 @@ class ReductionService(Service):
     def fetchReductionGroupings(self, request: ReductionRequest) -> Dict[str, Any]:
         """
         Load all groupings that are valid for a specific state using a ReductionRequest.
-        Will attach the focus group list to the request.
 
         :param request: a reduction request with at minimum a run number and lite mode flag
         :type request: ReductionRequest
@@ -103,7 +102,6 @@ class ReductionService(Service):
         """
         # fetch all valid groups for this run state
         res = self.loadAllGroupings(request.runNumber, request.useLiteMode)
-        request.focusGroup = res["focusGroups"]
         return res
 
     @FromString
@@ -154,7 +152,7 @@ class ReductionService(Service):
         farmFresh = FarmFreshIngredients(
             runNumber=request.runNumber,
             useLiteMode=request.useLiteMode,
-            focusGroup=request.focusGroup,
+            focusGroup=request.focusGroups,
         )
         return self.sousChef.prepReductionIngredients(farmFresh)
 

--- a/src/snapred/meta/Config.py
+++ b/src/snapred/meta/Config.py
@@ -20,7 +20,7 @@ def _find_root_dir():
     env = os.environ.get("env")
     if env and "test" in env and "conftest" in sys.modules:
         ROOT_MODULE = sys.modules["conftest"].__file__
-    else:
+    elif "snapred" in sys.modules:
         ROOT_MODULE = sys.modules["snapred"].__file__
 
     if ROOT_MODULE is None:

--- a/src/snapred/ui/view/reduction/ReductionView.py
+++ b/src/snapred/ui/view/reduction/ReductionView.py
@@ -61,7 +61,9 @@ class ReductionView(QWidget):
     def addRunNumber(self):
         runNumberList = self.parseInputRunNumbers()
         if runNumberList is not None:
-            self.runNumbers.extend(runNumberList)
+            noDuplicates = set(self.runNumbers)
+            noDuplicates.update(runNumberList)
+            self.runNumbers = list(noDuplicates)
             self.updateRunNumberList()
             self.runNumberInput.clear()
 
@@ -69,7 +71,7 @@ class ReductionView(QWidget):
         runNumberString = self.runNumberInput.text().strip()
         if runNumberString:
             try:
-                runNumberList = [int(num.strip()) for num in runNumberString.split(",") if num.strip().isdigit()]
+                runNumberList = [num.strip() for num in runNumberString.split(",") if num.strip().isdigit()]
                 return runNumberList
             except ValueError:
                 raise ValueError(

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -72,12 +72,14 @@ class ReductionWorkflow(WorkflowImplementer):
 
         for runNumber in runNumbers:
             payload = ReductionRequest(
-                runNumber=str(runNumber),
+                runNumber=runNumber,
                 useLiteMode=self._reductionView.liteModeToggle.field.getState(),
                 continueFlags=self.continueAnywayFlags,
             )
             # TODO: Handle Continue Anyway
             self.request(path="reduction/", payload=payload.json())
+
+            # Note: the run number is deliberately not deleted from the run numbers list.
 
         return self.responses[-1]
 

--- a/tests/unit/backend/recipe/test_ReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionRecipe.py
@@ -3,6 +3,7 @@ from unittest import TestCase, mock
 import pytest
 from mantid.simpleapi import CreateSingleValuedWorkspace, mtd
 from snapred.backend.recipe.ReductionRecipe import (
+    ApplyNormalizationRecipe,
     GenerateFocussedVanadiumRecipe,
     PreprocessReductionRecipe,
     ReductionGroupProcessingRecipe,
@@ -78,7 +79,7 @@ class ReductionRecipeTest(TestCase):
 
         mockRecipe = mock.Mock()
         inputWS = "input"
-        recipe._applyRecipe(mockRecipe, inputWS)
+        recipe._applyRecipe(mockRecipe, recipe.ingredients, inputWorkspace=inputWS)
 
         assert recipe.groceries["inputWorkspace"] == inputWS
         assert mockRecipe.cook.called_once_with(recipe.ingredients, recipe.groceries)
@@ -101,8 +102,6 @@ class ReductionRecipeTest(TestCase):
 
         assert recipe.groceries["inputWorkspace"] == "cloned"
         assert recipe.groceries["normalizationWorkspace"] == "cloned"
-        assert recipe.ingredients.pixelGroup == recipe.ingredients.pixelGroups[0]
-        assert recipe.ingredients.detectorPeaks == ["peaks"]
         assert sampleClone == "cloned"
         assert normClone == "cloned"
 
@@ -116,10 +115,16 @@ class ReductionRecipeTest(TestCase):
         recipe = ReductionRecipe()
         recipe.groceries = {}
         recipe.ingredients = mock.Mock()
-        recipe.ingredients.pixelGroup = "group"
-        recipe.ingredients.detectorPeaks = ["peaks"]
+        recipe.ingredients.pixelGroups = ["group"]
+        recipe.ingredients.detectorPeaksMany = [["peaks"]]
 
-        recipe._applyNormalization("sample", "norm")
+        groupingIndex = 0
+        recipe._applyRecipe(
+            mockApplyNormalizationRecipe,
+            recipe.ingredients.applyNormalization(groupingIndex),
+            inputWorkspace="sample",
+            normalizationWorkspace="norm",
+        )
 
         assert mockApplyNormalizationRecipe.cook.called_once_with(recipe.ingredients, recipe.groceries)
         assert recipe.groceries["inputWorkspace"] == "sample"
@@ -137,9 +142,20 @@ class ReductionRecipeTest(TestCase):
     def test_execute(self):
         recipe = ReductionRecipe()
         recipe.groceries = {}
+
+        recipe.ingredients = mock.Mock()
+        recipe.ingredients.groupProcessing = mock.Mock(
+            return_value=lambda groupingIndex: f"groupProcessing_{groupingIndex}"
+        )
+        recipe.ingredients.generateFocussedVanadium = mock.Mock(
+            return_value=lambda groupingIndex: f"generateFocussedVanadium_{groupingIndex}"
+        )
+        recipe.ingredients.applyNormalization = mock.Mock(
+            return_value=lambda groupingIndex: f"applyNormalization_{groupingIndex}"
+        )
+
         recipe._applyRecipe = mock.Mock()
         recipe._cloneIntermediateWorkspace = mock.Mock()
-        recipe._applyNormalization = mock.Mock()
         recipe._deleteWorkspace = mock.Mock()
         recipe._prepGroupWorkspaces = mock.Mock()
         recipe._prepGroupWorkspaces.return_value = ("sample_grouped", "norm_grouped")
@@ -149,15 +165,30 @@ class ReductionRecipeTest(TestCase):
 
         output = recipe.execute()
 
+        ingredients = recipe.ingredients()
         assert recipe._applyRecipe.called_once_with(PreprocessReductionRecipe, recipe.sampleWs)
         assert recipe._applyRecipe.called_once_with(PreprocessReductionRecipe, recipe.normalizationWs)
 
-        assert recipe._applyRecipe.called_once_with(ReductionGroupProcessingRecipe, "sample_grouped")
-        assert recipe._applyRecipe.called_once_with(ReductionGroupProcessingRecipe, "norm_grouped")
+        assert recipe._applyRecipe.called_once_with(
+            ReductionGroupProcessingRecipe, ingredients.groupProcessing(0), "sample_grouped"
+        )
+        assert recipe._applyRecipe.called_once_with(
+            ReductionGroupProcessingRecipe, ingredients.groupProcessing(1), "norm_grouped"
+        )
 
-        assert recipe._applyRecipe.called_once_with(GenerateFocussedVanadiumRecipe, "norm_grouped")
+        assert recipe._applyRecipe.called_once_with(
+            GenerateFocussedVanadiumRecipe, ingredients.generateFocussedVanadium(0), "norm_grouped"
+        )
+        assert recipe._applyRecipe.called_once_with(
+            GenerateFocussedVanadiumRecipe, ingredients.generateFocussedVanadium(1), "norm_grouped"
+        )
 
-        assert recipe._applyNormalization.called_once_with("sample_grouped", "norm_grouped")
+        assert recipe._applyRecipe.called_once_with(
+            ApplyNormalizationRecipe, ingredients.applyNormalization(0), "sample_grouped", "norm_grouped"
+        )
+        assert recipe._applyRecipe.called_once_with(
+            ApplyNormalizationRecipe, ingredients.applyNormalization(1), "sample_grouped", "norm_grouped"
+        )
 
         assert recipe._deleteWorkspace.called_once_with("norm_grouped")
 

--- a/tests/unit/backend/service/test_ReductionService.py
+++ b/tests/unit/backend/service/test_ReductionService.py
@@ -51,7 +51,7 @@ class TestReductionService(unittest.TestCase):
         self.request = ReductionRequest(
             runNumber="123",
             useLiteMode=False,
-            focusGroup=FocusGroup(name="apple", definition="path/to/grouping"),
+            focusGroups=[FocusGroup(name="apple", definition="path/to/grouping")],
         )
         ## Mock out the assistant services
         self.instance.sousChef = self.sculleryBoy
@@ -75,7 +75,6 @@ class TestReductionService(unittest.TestCase):
 
     def test_fetchReductionGroupings(self):
         data = self.instance.fetchReductionGroupings(self.request)
-        assert self.request.focusGroup == data["focusGroups"]
         assert data == self.instance.loadAllGroupings(self.request.runNumber, self.request.useLiteMode)
 
     def test_prepReductionIngredients(self):

--- a/tests/unit/meta/test_config.py
+++ b/tests/unit/meta/test_config.py
@@ -99,7 +99,7 @@ def test_resource_not_packageMode(caplog):
     assert "Not in package mode" in caplog.text
 
 
-def test_resource_packageMode_exists(caplog):
+def test_resource_packageMode_exists():
     # Test that the "exists" method in package mode implements <exists in the package> functionality.
     
     ROOT_MODULE = Path(sys.modules["snapred"].__file__).parent

--- a/tests/unit/meta/test_config.py
+++ b/tests/unit/meta/test_config.py
@@ -1,13 +1,47 @@
-import pytest
+from contextlib import contextmanager
+import importlib
+from pathlib import Path
+import logging
+import os
+import shutil
+import sys
+from tempfile import TemporaryDirectory
+
+import snapred.meta.Config as Config_module
 from snapred.meta.Config import Config, Resource, _find_root_dir
+
+from unittest import mock
+import pytest
 
 
 def test_environment():
     assert Config["environment"] == "test"
 
 
-def test_find_root_dir():
+def test_find_root_dir_test_env():
+    # Test that a test environment's `MODULE_ROOT` is set to the `tests` directory.
     assert _find_root_dir().endswith("/tests")
+
+
+@mock.patch.dict(os.environ, values={"env": "dev"}, clear=True)
+def test_find_root_dir_non_test_env():
+    # Test that a non-test environment's `MODULE_ROOT` is set to the SNAPRed module directory
+    assert Path(_find_root_dir()) == Path(sys.modules["snapred"].__file__).parent
+
+
+@mock.patch.dict(os.environ, values={"env": "dev_test"}, clear=True)
+def test_find_root_dir_special_test_env():
+    # Test that a special test environment's (any "env" with "test" in the name)
+    #   `MODULE_ROOT` is set to the `tests` directory.
+    assert _find_root_dir().endswith("/tests")
+
+
+@mock.patch.dict(os.environ, values={"env": "dev"}, clear=True)
+@mock.patch.dict(sys.modules, clear=True)
+def test_find_root_dir_failure():
+    # Test that not being able to define the `MODULE_ROOT` raises an exception.
+    with pytest.raises(Exception, match="Unable to determine root directory"):
+        _find_root_dir()
 
 
 def test_instrument_home():
@@ -16,11 +50,96 @@ def test_instrument_home():
     assert Config["instrument.home"].endswith(correctPathEnding)
 
 
+def test_resource_packageMode(caplog):
+    # Test that "package mode" is recognized appropriately.
+    
+    # TODO: At present, 'Config' has a _redundant_ '@Singleton' =>  It is also initialized
+    #   explicitly as a singleton.  This needs to be fixed!
+    
+    ROOT_MODULE = Path(sys.modules["snapred"].__file__).parent
+    ymlPath = ROOT_MODULE / "resources" / "application.yml"
+    
+    # In the below, we need to trigger a fresh import for the 'Config' module.
+    # AND, we need an absolute path for an "application.yml" which is _outside_ of "snapred/resources". 
+    with (
+        mock.patch.dict(os.environ),
+        mock.patch.dict(sys.modules),
+        TemporaryDirectory() as tmpdir,
+        ):
+        # An absolute path for "application.yml" _outside_ of "snapred/resources".
+        nonModuleEnvPath = Path(tmpdir) / "application.yml"
+        shutil.copy2(ymlPath, nonModuleEnvPath)
+        os.environ["env"] = str(nonModuleEnvPath)
+        
+        # Trigger a fresh import for the "Config" module.
+        del sys.modules["snapred.meta.Config"]
+        from snapred.meta.Config import _Resource
+        with (
+            mock.patch.object(_Resource, "_existsInPackage") as mockExistsInPackage,
+            caplog.at_level(logging.DEBUG, logger="snapred.meta.Config.Resource"),
+            ):
+            # This mock bypasses the fact that "application.yml" actually does exist
+            #   under "snapred/resources".  Probably there's a better way to do this!
+            mockExistsInPackage.return_value = False
+            rs = _Resource()
+            assert rs._packageMode
+        assert "In package mode" in caplog.text
+
+
+def test_resource_not_packageMode(caplog):
+    # Test that a test env is recognized as non-"package mode".
+
+    with (mock.patch.dict(sys.modules)):        
+        # Trigger a fresh import for the "Config" module.
+        del sys.modules["snapred.meta.Config"]
+        with (caplog.at_level(logging.DEBUG, logger="snapred.meta.Config.Resource")):
+            from snapred.meta.Config import _Resource
+            rs = _Resource()
+            assert not rs._packageMode
+    assert "Not in package mode" in caplog.text
+
+
+def test_resource_packageMode_exists(caplog):
+    # Test that the "exists" method in package mode implements <exists in the package> functionality.
+    
+    ROOT_MODULE = Path(sys.modules["snapred"].__file__).parent
+    ymlPath = ROOT_MODULE / "resources" / "application.yml"
+    
+    # In the below, we need to trigger a fresh import for the 'Config' module.
+    # AND, we need an absolute path for an "application.yml" which is _outside_ of "snapred/resources". 
+    with (
+        mock.patch.dict(os.environ),
+        mock.patch.dict(sys.modules),
+        TemporaryDirectory() as tmpdir,
+        ):
+        # An absolute path for "application.yml" _outside_ of "snapred/resources".
+        nonModuleEnvPath = Path(tmpdir) / "application.yml"
+        shutil.copy2(ymlPath, nonModuleEnvPath)
+        os.environ["env"] = str(nonModuleEnvPath)
+        
+        # Trigger a fresh import for the "Config" module.
+        del sys.modules["snapred.meta.Config"]
+        from snapred.meta.Config import _Resource
+        with (
+            mock.patch.object(_Resource, "_existsInPackage") as mockExistsInPackage,
+            ):
+            # This mock bypasses the fact that "application.yml" actually does exist
+            #   under "snapred/resources".  Probably there's a better way to do this!
+            mockExistsInPackage.return_value = False
+            rs = _Resource()
+            assert rs._packageMode
+            test_path = "any/path"
+            rs.exists(test_path)
+            assert mockExistsInPackage.called_with(test_path)
+
+
 def test_resource_exists():
-    assert Resource.exists("application.yml")
+    with mock.patch.object(Resource, "_existsInPackage") as mockExistsInPackage:
+        assert Resource.exists("application.yml")
+        assert mockExistsInPackage.not_called()
 
 
-def test_resource_not_exists():
+def test_resource_exists_false():
     assert not Resource.exists("not_a_real_file.yml")
 
 
@@ -29,8 +148,28 @@ def test_resource_read():
 
 
 def test_resource_open():
-    with Resource.open("application.yml", "r") as file:
-        assert file is not None
+    with mock.patch.object(Config_module.resources, "path") as mockResourcesPath:
+        assert not Resource._packageMode
+        with Resource.open("application.yml", "r") as file:
+            assert file is not None
+            assert mockResourcesPath.not_called()
+
+
+def test_resource_packageMode_open():
+    actual_path = Resource.getPath("application.yml")
+    with (
+        mock.patch.object(Config_module.resources, "path") as mockResourcesPath,
+        mock.patch.object(Resource, "_packageMode") as mockPackageMode,
+        ):
+        mockResourcesPath.return_value = mock.Mock(
+            __enter__=mock.Mock(return_value=actual_path),
+            __exit__=mock.Mock(),
+        )
+        mockPackageMode.return_value = True
+        test_path = "application.yml"
+        with Resource.open(test_path, "r") as file:
+            assert file is not None
+            assert mockResourcesPath.called_once_with(test_path)
 
 
 def test_config_accessor():


### PR DESCRIPTION
## Description of work

Mostly, these changes are required in order to get the reduction panel to work with Pydantic v2.  In addition, this commit includes several changes to clean up the code, and to enhance readability.

## Explanation of work

This commit includes the following changes:

  * Add factory methods to `ReductionIngredients` to produce any required sub-recipe ingredients.  This fix allows sub-recipes in `ReductionRecipe` to be called with their correct argument types.  This behavior is now required by Pydantic v2, but in general should be required when typed arguments are used.

  * Remove temporary attributes from `ReductionRequest`.  This includes removing the "ambiguous plural"  for `focusGroup`, which is now simply `focusGroups: List[FocusGroup]`, and always will be accessed as a list.

  * Modify `SNAPRequest.payload: str` to `SNAPRequest.payload: Optional[Any]`.  As such this now matches `SNAPResponse.data`.  With respect to this change, note that previously the type of this argument was generally ignored, and `Request...` types were passed as the payload without stringification.  Pydantic v2 will no longer allow this.

  * Remove the erroneous conversion of run numbers to `int` in `ReductionView`.  Note that for compatibility with Mantid, `runNumber: str` is still the correct parameter type, as "ISIS" uses `str` suffixes to integer 'runNumber'.
  
  * In `ReductionView`: dissallow the entry of duplicate run numbers in the run numbers list.

  * Omit `runNumber` removal from the run-numbers list at the end of the reduction workflow.  For the moment, it is desirable to retain the list of run numbers so that the user can easily see what has actually been reduced.  Note that there actually was a defect associated with this removal operation, which has been bypassed by omitting this call.  However, since the removal method works in other cases, any further work on this issue will be deferred to a later date.


## To test

### Dev testing

Existing unit tests should be sufficient to cover these changes.  However in addition, it is _extremely_ important that the _calibration_, _normalization_, and _reduction_ panels work as they are supposed to.

### CIS testing
As mentioned previously,  _calibration_, _normalization_, and _reduction_ panels work as they are supposed to, including any required file-system behavior.  It will probably be most useful to test this code _without_ any existing state directory.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#5898](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=5898)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
