### PR TITLE
Utilize request scheduler

### DIFF
--- a/src/snapred/backend/api/InterfaceController.py
+++ b/src/snapred/backend/api/InterfaceController.py
@@ -71,7 +71,8 @@ class InterfaceController:
         # verify all requests have same path
         for request in requests:
             if not requests[0].path == request.path:
-                self.logger.exception("Mismatch of paths in list of requests")
+                self.logger.error("Mismatch of paths in list of requests")
+                return None
 
         # reorder the list of requests
         service = self.serviceFactory.getService(requests[0].path)

--- a/tests/unit/backend/api/test_InterfaceController.py
+++ b/tests/unit/backend/api/test_InterfaceController.py
@@ -1,6 +1,7 @@
 import json
 import unittest.mock as mock
 
+from snapred.backend.api.RequestScheduler import RequestScheduler
 from snapred.backend.dao.SNAPResponse import ResponseCode
 from snapred.backend.error.RecoverableException import RecoverableException
 
@@ -74,3 +75,27 @@ with mock.patch.dict(
         assert response.code == ResponseCode.ERROR
         assert response.message is not None
         assert response.data is None
+
+    @mock.patch.object(RequestScheduler, "handle")
+    def test_executeBatchRequests_successful(mockRequestScheduler):
+        """Test executeBatchRequest with good requests"""
+        interfaceController = mockedSuccessfulInterfaceController()
+        reductionRequest = mock.Mock()
+        reductionRequest.path = "Test Service"
+        mockRequestScheduler.return_value = [reductionRequest, reductionRequest]
+        responses = interfaceController.executeBatchRequests([reductionRequest, reductionRequest])
+        assert responses[0].code == ResponseCode.OK
+        assert responses[0].message is None
+        assert responses[0].data["result"] == "Success!"
+        assert len(responses) == 2
+
+    def test_executeBatchRequests_unsuccessful():
+        """Test executeBatchRequest with bad requests"""
+        interfaceController = mockedSuccessfulInterfaceController()
+        reductionRequest = mock.Mock()
+        reductionRequest.path = "Test Service"
+        # executeBatchRequest fails due to path mismatch
+        badRequest = mock.Mock()
+        badRequest.path = "Not same Path"
+        responses = interfaceController.executeBatchRequests([reductionRequest, badRequest])
+        assert responses is None


### PR DESCRIPTION
## Description of work

This adds a function to the InterfaceController to be able to execute multiple requests using the RequestScheduler.

## Explanation of work

The new function executeBatchRequests()  validates  that the paths are all the same, utilizes RequestScheduler to order the requests, then executes the requests. 

## To test

### Dev testing

Make sure unit tests pass.

### CIS testing

None

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#5287](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=5287)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
