### PR TITLE
Remove double difference in RawVanadiumCorrectionAlgorithm

### DIFF
--- a/src/snapred/backend/recipe/algorithm/RawVanadiumCorrectionAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/RawVanadiumCorrectionAlgorithm.py
@@ -135,13 +135,6 @@ class RawVanadiumCorrectionAlgorithm(PythonAlgorithm):
             Factor=protonCharge,
         )
 
-        self.mantidSnapper.Minus(
-            "Subtract off empty background",
-            LHSWorkspace=self.outputVanadiumWS,
-            RHSWorkspace=self.outputBackgroundWS,
-            OutputWorkspace=self.outputVanadiumWS,
-        )
-
         # take difference
         self.mantidSnapper.Minus(
             "Subtract off empty background",


### PR DESCRIPTION
## Description of work

Malcolm pointed out an apparent scribal error, where the command to subtract the background was repeated inside the algorithm.

## Explanation of work

Deleted the second copy.

## To test

### Dev testing

Not needed.

### CIS testing
Ensure this is what you want to do.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
