### PR TITLE
make sure the finalCalibrationTable is set to the expected table

### DIFF
--- a/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
@@ -349,6 +349,7 @@ class GroupDiffractionCalibration(PythonAlgorithm):
         # set the outputs
         self.setPropertyValue("DiagnosticWorkspace", self.diagnosticWS)
         self.setPropertyValue("OutputWorkspace", self.outputWSdSpacing)
+        self.setPropertyValue("FinalCalibrationTable", self.DIFCfinal)
 
     def convertAndFocusAndReturn(self, inputWS: str, outputWS: str, note: str, units: str):
         # Use workspace name generator

--- a/tests/unit/backend/recipe/algorithm/test_GroupDiffractionCalibration.py
+++ b/tests/unit/backend/recipe/algorithm/test_GroupDiffractionCalibration.py
@@ -284,3 +284,27 @@ class TestGroupDiffractionCalibration(unittest.TestCase):
                 assert maskWS.isMasked(int(det))
         deleteWorkspaceNoThrow(inputWSName)
         deleteWorkspaceNoThrow(maskWSName)
+
+    def test_final_calibration_table_set_correctly(self):
+        """Test that the final calibration table is set correctly"""
+
+        uniquePrefix = "test_fct_"
+        inputWS, maskWS = mutableWorkspaceClones((self.fakeRawData, self.fakeMaskWorkspace), uniquePrefix)
+        inputWSName, maskWSName = mutableWorkspaceClones(
+            (self.fakeRawData, self.fakeMaskWorkspace), uniquePrefix, name_only=True
+        )
+
+        algo = ThisAlgo()
+        algo.initialize()
+        algo.setProperty("Ingredients", self.fakeIngredients.json())
+        algo.setProperty("InputWorkspace", inputWSName)
+        algo.setProperty("GroupingWorkspace", self.fakeGroupingWorkspace)
+        algo.setProperty("FinalCalibrationTable", "_final_DIFc_table")
+        algo.setProperty("MaskWorkspace", maskWSName)
+        algo.setProperty("OutputWorkspace", f"_test_out_dsp_{self.fakeIngredients.runConfig.runNumber}")
+        algo.setProperty("PreviousCalibrationTable", self.difcWS)
+
+        algo.execute()
+        assert algo.DIFCfinal == algo.getPropertyValue("FinalCalibrationTable")
+        deleteWorkspaceNoThrow(inputWSName)
+        deleteWorkspaceNoThrow(maskWSName)


### PR DESCRIPTION
## Description of work

Bugfix to save the correct diffcal in the diffcal flow

## To test

cis_mode: true
use mantid workbench, we will need to run RebinRagged manually.

first, on `origin/next` run diffraction calibration

```
runnumber: 59039
peak intensity threshold: 0.01
calib samle: LA11b8

dmin: 1
max chi: 2000
```

save.

then run reduction also on `59039`
when it completes, execute rebinragged with the following params
```
InputWorkspace: sample_GroupProcessing_2
OutputWorkspace: sample_GroupProcessing_2_ragged
XMin: 0.3875133921571971, 0.41976370729918516, 0.4730401858597162, 0.4972527852740068, 0.5764138320442127, 0.7098143519415089
XMax: 2.138065985364488, 2.382583934013807, 2.7404543532708354, 2.9233779301234066, 3.702303149492925, 5.048818279947758
Delta: -0.0005285822142225365, -0.0006281306679209721, -0.0007730690425302434, -0.0008321708397955027, -0.0010649668648864828, -0.0014622431594735496
```
observe that `sample_GroupProcessing_2_ragged` has slightly misaligned peaks.
![image](https://github.com/neutrons/SNAPRed/assets/68125095/20c89160-fd91-42ba-8bed-7699f210a66f)

Now checkout this branch, repeat the above steps, and instead confirm that the peaks of `sample_GroupProcessing_2_ragged` are actually aligned.
![image](https://github.com/neutrons/SNAPRed/assets/68125095/dde64787-6ecd-4414-a9cd-860039e8f31e)

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#6039](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6039)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
