### PR TITLE
Configure mypy so it can pass

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -41,10 +41,10 @@ jobs:
       with:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }} # required
-    - name: mypy checks
-      shell: bash -l {0}
-      run: |
-        python -m mypy --config-file $(pwd)/pyproject.toml $(pwd)
+#    - name: mypy checks
+#      shell: bash -l {0}
+#      run: |
+#        python -m mypy --config-file=$(pwd)/pyproject.toml $(pwd)
     - name: Gui tests
       run: |
         python -m pip install -e . # install the application in editable mode

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -26,10 +26,6 @@ jobs:
             - mantid/label/nightly
         cache-environment-key: ${{ runner.os }}-env-${{ hashFiles('**/environment.yml') }}
         cache-downloads-key: ${{ runner.os }}-downloads-${{ hashFiles('**/environment.yml') }}
-    - name: mypy checks
-      shell: bash -l {0}
-      run: |
-        python -m mypy --config-file $(pwd)/pyproject.toml $(pwd)
     - name: Apt install deps
       run: |
         sudo apt update
@@ -45,6 +41,10 @@ jobs:
       with:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }} # required
+    - name: mypy checks
+      shell: bash -l {0}
+      run: |
+        python -m mypy --config-file $(pwd)/pyproject.toml $(pwd)
     - name: Gui tests
       run: |
         python -m pip install -e . # install the application in editable mode

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -26,6 +26,8 @@ jobs:
             - mantid/label/nightly
         cache-environment-key: ${{ runner.os }}-env-${{ hashFiles('**/environment.yml') }}
         cache-downloads-key: ${{ runner.os }}-downloads-${{ hashFiles('**/environment.yml') }}
+    - name: mypy checks
+      run: mypy .
     - name: Apt install deps
       run: |
         sudo apt update

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -27,7 +27,9 @@ jobs:
         cache-environment-key: ${{ runner.os }}-env-${{ hashFiles('**/environment.yml') }}
         cache-downloads-key: ${{ runner.os }}-downloads-${{ hashFiles('**/environment.yml') }}
     - name: mypy checks
-      run: mypy .
+      shell: bash -l {0}
+      run: |
+        python -m mypy --config-file $(pwd)/pyproject.toml $(pwd)
     - name: Apt install deps
       run: |
         sudo apt update

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,6 @@ repos:
       exclude: "tests/cis_tests/.*"
 # disable for now
 #- repo: https://github.com/pre-commit/mirrors-mypy
-#  rev: v1.1.1
+#  rev: v1.10.1
 #  hooks:
 #  - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,10 @@ repos:
     - id: ruff-format
       exclude: "tests/cis_tests/.*"
 # disable for now
-#- repo: https://github.com/pre-commit/mirrors-mypy
-#  rev: v1.10.1
-#  hooks:
-#  - id: mypy
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.10.1
+  hooks:
+  - id: mypy
+    additional_dependencies: [ pydantic, types-PyYAML ]
+    types: [python]
+    args: [--config-file=pyproject.toml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,10 +24,7 @@ repos:
     - id: ruff-format
       exclude: "tests/cis_tests/.*"
 # disable for now
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.10.1
-  hooks:
-  - id: mypy
-    additional_dependencies: [ pydantic, types-PyYAML ]
-    types: [python]
-    args: [--config-file=pyproject.toml]
+#- repo: https://github.com/pre-commit/mirrors-mypy
+#  rev: v1.1.1
+#  hooks:
+#  - id: mypy

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,8 +18,11 @@ except ImportError:
 import unittest.mock as mock
 
 from mantid.api import PythonAlgorithm
-from qtpy.QtCore import Property, Signal
-from qtpy.QtCore import QThread  # type: ignore
+from qtpy.QtCore import (
+    Property,
+    QThread,  # type: ignore
+    Signal,
+)
 
 # Store original __import__
 orig_import = __import__
@@ -44,8 +47,6 @@ def import_mock(name, *args):
 
 with mock.patch("builtins.__import__", side_effect=import_mock):
     from mantid.api import PythonAlgorithm  # noqa: F811
-    from qtpy.QtCore import Property, Signal
-    from qtpy.QtCore import QThread  # type: ignore
 
     autodoc_mock_imports = [
         "mantid",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,7 @@ except ImportError:
 import unittest.mock as mock
 
 from mantid.api import PythonAlgorithm
-from qtpy.QtCore import (Property, QThread, Signal)  # type: ignore
+from qtpy.QtCore import Property, QThread, Signal  # type: ignore
 
 # Store original __import__
 orig_import = __import__

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,7 +18,8 @@ except ImportError:
 import unittest.mock as mock
 
 from mantid.api import PythonAlgorithm
-from qtpy.QtCore import Property, QThread, Signal
+from qtpy.QtCore import Property, Signal
+from qtpy.QtCore import QThread  # type: ignore
 
 # Store original __import__
 orig_import = __import__
@@ -43,7 +44,8 @@ def import_mock(name, *args):
 
 with mock.patch("builtins.__import__", side_effect=import_mock):
     from mantid.api import PythonAlgorithm  # noqa: F811
-    from qtpy.QtCore import Property, QThread, Signal  # noqa: F811
+    from qtpy.QtCore import Property, Signal
+    from qtpy.QtCore import QThread  # type: ignore
 
     autodoc_mock_imports = [
         "mantid",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,11 +18,7 @@ except ImportError:
 import unittest.mock as mock
 
 from mantid.api import PythonAlgorithm
-from qtpy.QtCore import (
-    Property,
-    QThread,  # type: ignore
-    Signal,
-)
+from qtpy.QtCore import (Property, QThread, Signal)  # type: ignore
 
 # Store original __import__
 orig_import = __import__

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
 - pip
 - pydantic>=2.7.3,<3
 - mantidworkbench>=6.8.20231213
+- mypy
 - qtpy
 - pre-commit
 - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,10 +57,10 @@ plugins = [
 ]
 ignore_missing_imports = true # gets around mantid imports
 exclude = [
-"tests/.*",
-"src/snapred/backend/.*",
-"src/snapred/meta/.*",
-"src/snapred/ui/.*"
+"tests/",
+"src/snapred/backend/",
+"src/snapred/meta/",
+"src/snapred/ui/"
 ]
 
 [tool.pydantic-mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,10 +57,10 @@ plugins = [
 ]
 ignore_missing_imports = true # gets around mantid imports
 exclude = [
-"^tests/.*",
-"^src/snapred/backend/.*",
-"^src/snapred/meta/.*",
-"^src/snapred/ui/.*"
+"tests/.*",
+"src/snapred/backend/.*",
+"src/snapred/meta/.*",
+"src/snapred/ui/.*"
 ]
 
 [tool.pydantic-mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,19 @@ ignore = ["F403", "F405", # wild imports and  unknown names
 ]
 extend-exclude = ["conftest.py"]
 
-[[tool.mypy.overrides]]
-module = [
-    "yaml",
+[tool.mypy]
+plugins = [
+  "pydantic.mypy"
 ]
-ignore_missing_imports = true
+ignore_missing_imports = true # gets around mantid imports
+exclude = [
+"^tests/.*",
+"^src/snapred/backend/.*",
+"^src/snapred/meta/.*",
+"^src/snapred/ui/.*"
+]
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true

--- a/src/snapred/__main__.py
+++ b/src/snapred/__main__.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from mantid.kernel import amend_config
 
@@ -30,7 +30,7 @@ def _bool_to_mtd_str(arg: bool) -> str:
     return "1" if arg else "0"
 
 
-def _prepend_datasearch_directories() -> List[str]:
+def _prepend_datasearch_directories() -> Optional[List[str]]:
     """data-search directories to prepend to
     mantid.kernel.ConfigService 'datasearch.directories'
     """


### PR DESCRIPTION
## Description of work

This configures mypy and fixes a couple of minor issues. Unfortunately, I was unable to convince the build server to use the configuration file.

The intent is to start here and slowly remove ignored directories until everything passes. At that point the mypy pre-commit hook should work similar to [here](https://github.com/pre-commit/pre-commit/blob/main/.pre-commit-config.yaml#L39-L44).

## Dev testing

```sh
python -m mypy .
```
Should run without issue

### CIS testing

Not applicable

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM6080](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6080)

This is an alternative attempt at #83.

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
