### PR TITLE
Added ability to keep unfocused data for reduction

### DIFF
--- a/src/snapred/backend/dao/ingredients/ReductionIngredients.py
+++ b/src/snapred/backend/dao/ingredients/ReductionIngredients.py
@@ -26,6 +26,9 @@ class ReductionIngredients(BaseModel):
     calibrantSamplePath: str
     peakIntensityThreshold: float
 
+    keepUnfocused: bool
+    convertUnitsTo: str
+
     #
     # FACTORY methods to create sub-recipe ingredients:
     #

--- a/src/snapred/backend/dao/request/FarmFreshIngredients.py
+++ b/src/snapred/backend/dao/request/FarmFreshIngredients.py
@@ -27,6 +27,10 @@ class FarmFreshIngredients(BaseModel, extra="forbid"):
     ## needs to be mandatory for normcal
     calibrantSamplePath: Optional[str] = None
 
+    ## needs to be mandatory for reduction
+    keepUnfocused: Optional[bool] = None
+    convertUnitsTo: Optional[str] = None
+
     ## the below are not-so-fresh, being fiddly optional parameters with defaults
     convergenceThreshold: float = Config["calibration.diffraction.convergenceThreshold"]
     nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]

--- a/src/snapred/backend/dao/request/ReductionRequest.py
+++ b/src/snapred/backend/dao/request/ReductionRequest.py
@@ -12,6 +12,8 @@ class ReductionRequest(BaseModel):
     focusGroups: List[FocusGroup] = []
     userSelectedMaskPath: Optional[str] = None
     version: Union[int, Literal["*"]] = "*"
+    keepUnfocused: bool = False
+    convertUnitsTo: str = None
 
     # TODO: Move to SNAPRequest
     continueFlags: Optional[ContinueWarning.Type] = None

--- a/src/snapred/backend/recipe/ReductionRecipe.py
+++ b/src/snapred/backend/recipe/ReductionRecipe.py
@@ -86,7 +86,6 @@ class ReductionRecipe(Recipe[Ingredients]):
         elif units == "dSpacing":
             unitsAbrev = wng.Units.DSP
         outWS = workspace.replace("tof", unitsAbrev.lower())
-        print(outWS)
         self.mantidSnapper.ConvertUnits(
             "Convert the clone of the final output back to TOFl",
             InputWorkspace=workspace,

--- a/src/snapred/backend/recipe/ReductionRecipe.py
+++ b/src/snapred/backend/recipe/ReductionRecipe.py
@@ -8,6 +8,7 @@ from snapred.backend.recipe.PreprocessReductionRecipe import PreprocessReduction
 from snapred.backend.recipe.Recipe import Recipe, WorkspaceName
 from snapred.backend.recipe.ReductionGroupProcessingRecipe import ReductionGroupProcessingRecipe
 from snapred.meta.decorators.Singleton import Singleton
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 
 logger = snapredLogger.getLogger(__name__)
 
@@ -37,6 +38,8 @@ class ReductionRecipe(Recipe[Ingredients]):
         Chops off the needed elements of the ingredients.
         """
         self.ingredients = ingredients.copy()
+        self.keepUnfocused = self.ingredients.keepUnfocused
+        self.convertUnitsTo = self.ingredients.convertUnitsTo
 
     def unbagGroceries(self, groceries: Dict[str, Any]):
         """
@@ -70,6 +73,28 @@ class ReductionRecipe(Recipe[Ingredients]):
             "Deleting workspace...",
             Workspace=workspace,
         )
+        self.mantidSnapper.executeQueue()
+
+    def _convertWorkspace(self, workspace: str, units: str):
+        unitsAbrev = ""
+        if units == "TOF":
+            unitsAbrev = wng.Units.TOF
+        elif units == "Wavelength":
+            unitsAbrev = wng.Units.LAM
+        elif units == "MomentumTransfer":
+            unitsAbrev = wng.Units.QSP
+        elif units == "dSpacing":
+            unitsAbrev = wng.Units.DSP
+        outWS = workspace.replace("tof", unitsAbrev.lower())
+        print(outWS)
+        self.mantidSnapper.ConvertUnits(
+            "Convert the clone of the final output back to TOFl",
+            InputWorkspace=workspace,
+            OutputWorkspace=outWS,
+            Target=units,
+        )
+        if outWS != workspace:
+            self._deleteWorkspace(workspace)
         self.mantidSnapper.executeQueue()
 
     def _applyRecipe(self, recipe: Type[Recipe], ingredients_, **kwargs):
@@ -156,7 +181,12 @@ class ReductionRecipe(Recipe[Ingredients]):
 
             # Cleanup
             outputs.append(sampleClone)
-            self._deleteWorkspace(normalizationClone)
+
+            if self.keepUnfocused:
+                self._convertWorkspace(normalizationClone, self.convertUnitsTo)
+            else:
+                self._deleteWorkspace(normalizationClone)
+
         return outputs
 
     def cook(self, ingredients: Ingredients, groceries: Dict[str, str]) -> Dict[str, Any]:

--- a/src/snapred/backend/service/ReductionService.py
+++ b/src/snapred/backend/service/ReductionService.py
@@ -153,6 +153,8 @@ class ReductionService(Service):
             runNumber=request.runNumber,
             useLiteMode=request.useLiteMode,
             focusGroup=request.focusGroups,
+            keepUnfocused=request.keepUnfocused,
+            convertUnitsTo=request.convertUnitsTo,
         )
         return self.sousChef.prepReductionIngredients(farmFresh)
 

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -196,6 +196,8 @@ class SousChef(Service):
             calibrantSamplePath=ingredients.calibrantSamplePath,
             peakIntensityThreshold=ingredients.peakIntensityThreshold,
             detectorPeaksMany=self.prepManyDetectorPeaks(ingredients),
+            keepUnfocused=ingredients.keepUnfocused,
+            convertUnitsTo=ingredients.convertUnitsTo,
         )
 
     def prepNormalizationIngredients(self, ingredients: FarmFreshIngredients) -> NormalizationIngredients:

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -163,6 +163,8 @@ class _WorkspaceNameGenerator:
         _templateRoot = "mantid.workspace.nameTemplate.units"
         DSP = Config[f"{_templateRoot}.dSpacing"]
         TOF = Config[f"{_templateRoot}.timeOfFlight"]
+        QSP = Config[f"{_templateRoot}.momentumTransfer"]
+        LAM = Config[f"{_templateRoot}.wavelength"]
         DIAG = Config[f"{_templateRoot}.diagnostic"]
 
     class Groups:

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -120,6 +120,8 @@ mantid:
       units:
         dSpacing: DSP
         timeOfFlight: TOF
+        momentumTransfer: QSP
+        wavelength: LAM
         diagnostic: diagnostic
       groups:
         unfocussed: Unfoc

--- a/src/snapred/ui/view/reduction/ReductionView.py
+++ b/src/snapred/ui/view/reduction/ReductionView.py
@@ -37,7 +37,7 @@ class ReductionView(QWidget):
 
         # Lite mode toggle, pixel masks dropdown, and retain unfocused data checkbox
         self.liteModeToggle = LabeledField("Lite Mode", Toggle(parent=self, state=True))
-        self.retainUnfocusedDataCheckbox = LabeledCheckBox("Retain Unfocussed Data")
+        self.retainUnfocusedDataCheckbox = LabeledCheckBox("Retain Unfocused Data")
         self.pixelMaskDropdown = SampleDropDown("Pixel Masks", pixelMasks)
         self.convertUnitsDropdown = SampleDropDown(
             "Convert Units", ["TOF", "dSpacing", "Wavelength", "MomentumTransfer"]

--- a/src/snapred/ui/view/reduction/ReductionView.py
+++ b/src/snapred/ui/view/reduction/ReductionView.py
@@ -39,11 +39,15 @@ class ReductionView(QWidget):
         self.liteModeToggle = LabeledField("Lite Mode", Toggle(parent=self, state=True))
         self.retainUnfocusedDataCheckbox = LabeledCheckBox("Retain Unfocussed Data")
         self.pixelMaskDropdown = SampleDropDown("Pixel Masks", pixelMasks)
+        self.convertUnitsDropdown = SampleDropDown(
+            "Convert Units", ["TOF", "dSpacing", "Wavelength", "MomentumTransfer"]
+        )
 
         # Set field properties
         self.liteModeToggle.setEnabled(False)
         self.retainUnfocusedDataCheckbox.setEnabled(False)
         self.pixelMaskDropdown.setEnabled(False)
+        self.convertUnitsDropdown.setEnabled(False)
 
         # Add widgets to layout
         self.layout.addLayout(self.runNumberLayout)
@@ -51,6 +55,7 @@ class ReductionView(QWidget):
         self.layout.addWidget(self.liteModeToggle)
         self.layout.addWidget(self.pixelMaskDropdown)
         self.layout.addWidget(self.retainUnfocusedDataCheckbox)
+        self.layout.addWidget(self.convertUnitsDropdown)
 
         # Connect buttons to methods
         self.enterRunNumberButton.clicked.connect(self.addRunNumber)
@@ -103,16 +108,10 @@ class ReductionView(QWidget):
         # They dont need to select a pixel mask
         # if self.pixelMaskDropdown.currentIndex() < 0:
         #     raise ValueError("Please select a pixel mask.")
+        if self.retainUnfocusedDataCheckbox.isChecked():
+            if self.convertUnitsDropdown.currentIndex() < 0:
+                raise ValueError("Please select units to convert to")
         return True
 
     def getRunNumbers(self):
         return self.runNumbers
-
-    # Placeholder for checkBox logic
-    """
-    def onCheckBoxChecked(self, checked):
-        if checked:
-
-        else:
-            pass
-    """

--- a/src/snapred/ui/widget/LabeledCheckBox.py
+++ b/src/snapred/ui/widget/LabeledCheckBox.py
@@ -22,7 +22,7 @@ class LabeledCheckBox(QWidget):
         self._checkBox.stateChanged.connect(self.emitCheckedState)
 
     def emitCheckedState(self, state):
-        self.checkedChanged.emit(state == QCheckBox.Checked)
+        self.checkedChanged.emit(state == QCheckBox.isChecked)
 
     @property
     def checkBox(self):

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -36,6 +36,12 @@ class ReductionWorkflow(WorkflowImplementer):
         )
         self.workflow.presenter.setResetLambda(self.reset)
 
+        self._reductionView.retainUnfocusedDataCheckbox.checkedChanged.connect(self._enableConvertToUnits)
+
+    def _enableConvertToUnits(self):
+        state = self._reductionView.retainUnfocusedDataCheckbox.isChecked()
+        self._reductionView.convertUnitsDropdown.setEnabled(state)
+
     def _nothing(self, workflowPresenter):  # noqa: ARG002
         return SNAPResponse(code=200)
 
@@ -55,6 +61,7 @@ class ReductionWorkflow(WorkflowImplementer):
 
         self._reductionView.liteModeToggle.setEnabled(False)
         self._reductionView.pixelMaskDropdown.setEnabled(False)
+        self._reductionView.retainUnfocusedDataCheckbox.setEnabled(False)
 
         for runNumber in runNumbers:
             try:
@@ -64,6 +71,8 @@ class ReductionWorkflow(WorkflowImplementer):
 
         self._reductionView.liteModeToggle.setEnabled(True)
         self._reductionView.pixelMaskDropdown.setEnabled(True)
+        self._reductionView.retainUnfocusedDataCheckbox.setEnabled(True)
+        # self._reductionView.convertUnitsDropdown.setEnabled(True)
 
     def _triggerReduction(self, workflowPresenter):
         view = workflowPresenter.widget.tabView  # noqa: F841
@@ -75,6 +84,8 @@ class ReductionWorkflow(WorkflowImplementer):
                 runNumber=runNumber,
                 useLiteMode=self._reductionView.liteModeToggle.field.getState(),
                 continueFlags=self.continueAnywayFlags,
+                keepUnfocused=self._reductionView.retainUnfocusedDataCheckbox.isChecked(),
+                convertUnitsTo=self._reductionView.convertUnitsDropdown.currentText(),
             )
             # TODO: Handle Continue Anyway
             self.request(path="reduction/", payload=payload.json())

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -127,6 +127,8 @@ mantid:
         units:
           dSpacing: dsp
           timeOfFlight: tof
+          momentumTransfer: qsp
+          wavelength: lam
           diagnostic: diagnostic
         groups:
           unfocussed: unfoc

--- a/tests/resources/inputs/calibration/ReductionIngredients.json
+++ b/tests/resources/inputs/calibration/ReductionIngredients.json
@@ -4271,5 +4271,7 @@
   ],
   "smoothingParameter": 0.5,
   "peakIntensityThreshold": 0.05,
-  "calibrantSamplePath": "path/to/sample"
+  "calibrantSamplePath": "path/to/sample",
+  "keepUnfocused": false,
+  "convertUnitsTo": "TOF"
 }

--- a/tests/unit/backend/recipe/test_ReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionRecipe.py
@@ -78,6 +78,12 @@ class ReductionRecipeTest(TestCase):
         workspace = "input_tof"
         units = "dSpacing"
         recipe._convertWorkspace(workspace, units)
+        units = "TOF"
+        recipe._convertWorkspace(workspace, units)
+        units = "MomentumTransfer"
+        recipe._convertWorkspace(workspace, units)
+        units = "Wavelength"
+        recipe._convertWorkspace(workspace, units)
 
         assert recipe.mantidSnapper.ConvertUnits.called_once_with(mock.ANY, Workspace=workspace)
         assert recipe.mantidSnapper.executeQueue.called

--- a/tests/unit/backend/recipe/test_ReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionRecipe.py
@@ -157,12 +157,14 @@ class ReductionRecipeTest(TestCase):
         recipe._applyRecipe = mock.Mock()
         recipe._cloneIntermediateWorkspace = mock.Mock()
         recipe._deleteWorkspace = mock.Mock()
+        recipe._convertWorkspace = mock.Mock()
         recipe._prepGroupWorkspaces = mock.Mock()
         recipe._prepGroupWorkspaces.return_value = ("sample_grouped", "norm_grouped")
         recipe.sampleWs = "sample"
         recipe.normalizationWs = "norm"
         recipe.groupWorkspaces = ["group1", "group2"]
-        recipe.keepUnfocused = False
+        recipe.keepUnfocused = True
+        recipe.convertUnitsTo = "dSpacing"
 
         output = recipe.execute()
 

--- a/tests/unit/backend/recipe/test_ReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionRecipe.py
@@ -72,6 +72,16 @@ class ReductionRecipeTest(TestCase):
         assert recipe.mantidSnapper.DeleteWorkspace.called_once_with(mock.ANY, Workspace=workspace)
         assert recipe.mantidSnapper.executeQueue.called
 
+    def test_convertWorkspace(self):
+        recipe = ReductionRecipe()
+        recipe.mantidSnapper = mock.Mock()
+        workspace = "input_tof"
+        units = "dSpacing"
+        recipe._convertWorkspace(workspace, units)
+
+        assert recipe.mantidSnapper.ConvertUnits.called_once_with(mock.ANY, Workspace=workspace)
+        assert recipe.mantidSnapper.executeQueue.called
+
     def test_applyRecipe(self):
         recipe = ReductionRecipe()
         recipe.groceries = {}

--- a/tests/unit/backend/recipe/test_ReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionRecipe.py
@@ -162,6 +162,7 @@ class ReductionRecipeTest(TestCase):
         recipe.sampleWs = "sample"
         recipe.normalizationWs = "norm"
         recipe.groupWorkspaces = ["group1", "group2"]
+        recipe.keepUnfocused = False
 
         output = recipe.execute()
 


### PR DESCRIPTION
## Description of work

User can now keep unfocused data during Reduction and can convert workspace to user specified units.

## Explanation of work

The reduction frontend was modified so that the Keep Unfocused Data checkbox is enabled and connected to the backend.  There is also a dropdown box so that the user can select what the units of the workspace should be in.

For the backend, 2 new fields were added to the ReductionIngredients: `keepUnfocused` and `convertUnitsTo`. The first is a bool and the second is a string that determines what the units should be. The ReductionRecipe was updated to process these new variables and make sure the intended outcome happens.

## To test

### Dev testing

1. Make sure you have a run that you are able to run Reduction on. 
2. On the Reduction tab, enter a run number. Make sure the `ConvertUnits` dropdown is still disabled. 
3. Now click the `Retain Unfocused Data` box. The dropdown should be enabled. 
4. Try to continue. You should see an error message saying to select units. 
5. Select TOF from the drop and click continue. 
6. When reduction finishes, look at the main SNAPRed window that has all the workspaces. You should now see several workspaces that start `output_tof_unfoc_<run number>...`.  Verify those workspaces have units of TOF. 
7. Rerun reduction but make sure `Retain Unfocused Data` is not checked this time. Make sure those workspaces do not exist anymore. 
8. To be really thorough, verify all units work. Here's what the dropdown should match to:

TOF                         = tof
dSpacing                 = dsp
Wavelength             = lam
MomentumTransfer = qsp

### CIS testing

Do the above, but verify the unfocused workspaces is the correct data that you are expecting.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#793](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=793)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
