### PR TITLE
Automerge staging into next

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,22 @@
+# this uses the action to merge special branches on push
+# https://github.com/marketplace/actions/merge-branch
+name: Merge protected branches
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [staging]
+
+jobs:
+  merge-staging-into-next:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref_name == 'staging' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Merge staging into next
+        uses: devmasx/merge-branch@1.4.0
+        with:
+          type: now
+          target_branch: next
+          message: Merge staging into next
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description of work

Every time that there is a commit to `staging`, that is merged directly into `next`. This will ensure that bigfixes for the next release get into the development branch. The workflow is [adapted from mantid](https://github.com/mantidproject/mantid/blob/main/.github/workflows/automerge.yml).

## To test

### Dev testing

The run that passed is [here](https://github.com/neutrons/SNAPRed/actions/runs/10011806364/job/27675995499?pr=407).

### CIS testing

N/A

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM6082](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6082)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
