### PR TITLE
Properly iterate diagnostics :repeat_one: 

### DIFF
--- a/src/snapred/backend/dao/request/RenameWorkspaceFromTemplateRequest.py
+++ b/src/snapred/backend/dao/request/RenameWorkspaceFromTemplateRequest.py
@@ -1,0 +1,23 @@
+from typing import List
+
+from pydantic import BaseModel, field_validator
+
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
+
+
+class RenameWorkspaceFromTemplateRequest(BaseModel, arbitrary_types_allowed=True):
+    """
+    Rename a list of workspaces according to a template.
+    The template must be a formattable string with a placeholder labeled `workspaceName`.
+    In the new workspace names, the old workspace name will appear at this label.
+    """
+
+    workspaces: List[WorkspaceName]
+    renameTemplate: str
+
+    @field_validator("renameTemplate")
+    @classmethod
+    def renameTemplate_has_workspaceName(cls, v: str) -> str:
+        if "{workspaceName}" not in v:
+            raise ValueError("Rename template must contain a placeholder labeled 'workspaceName'")
+        return v

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -333,6 +333,22 @@ class GroceryService:
         )
         self.mantidSnapper.executeQueue()
 
+    def renameWorkspaces(self, oldNames: List[WorkspaceName], newNames: List[WorkspaceName]):
+        """
+        Renames a list of workspaces in Mantid's ADS.
+
+        :param oldNames: the original names of the workspaces in the ADS
+        :type oldNames: List[WorkspaceName]
+        :param newNames: the names to replace the workspace names in the ADS
+        :type newNames: List[WorkspaceName]
+        """
+        self.mantidSnapper.RenameWorkspaces(
+            "Renaming several workspaces",
+            InputWorkspaces=oldNames,
+            WorkspaceNames=newNames,
+        )
+        self.mantidSnapper.executeQueue()
+
     def getWorkspaceForName(self, name: WorkspaceName):
         """
         Simple wrapper of mantid's ADS for the service layer.

--- a/tests/unit/backend/dao/test_RenameWorkspaceFromTemplateRequest.py
+++ b/tests/unit/backend/dao/test_RenameWorkspaceFromTemplateRequest.py
@@ -1,0 +1,20 @@
+import pytest
+from pydantic import ValidationError
+from snapred.backend.dao.request import RenameWorkspaceFromTemplateRequest
+
+
+def test_good():
+    request = RenameWorkspaceFromTemplateRequest(workspaces=[], renameTemplate="{workspaceName}_X")
+    assert request.renameTemplate.format(workspaceName="mike") == "mike_X"
+
+
+def test_insufficient():
+    with pytest.raises(ValidationError) as e:
+        RenameWorkspaceFromTemplateRequest(workspaces=[], renameTemplate="workspaceName_X")
+    assert "workspaceName" in str(e.value)
+
+
+def test_bad():
+    with pytest.raises(ValidationError) as e:
+        RenameWorkspaceFromTemplateRequest(workspaces=[], renameTemplate="{bad_label}_X")
+    assert "workspaceName" in str(e.value)

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -1557,6 +1557,18 @@ class TestGroceryService(unittest.TestCase):
         assert not mtd.doesExist(oldName)
         assert mtd.doesExist(newName)
 
+    def test_renameWorkspaces(self):
+        oldNames = ["old1", "old2"]
+        newNames = ["new1", "new2"]
+        for oldName in oldNames:
+            self.create_dumb_workspace(oldName)
+            assert mtd.doesExist(oldName)
+        self.instance.renameWorkspaces(oldNames, newNames)
+        for oldName in oldNames:
+            assert not mtd.doesExist(oldName)
+        for newName in newNames:
+            assert mtd.doesExist(newName)
+
     def test_clearADS(self):
         rawWsName = self.instance._createRawNeutronWorkspaceName(0, "a")
         self.instance._loadedRuns = {(0, "a"): rawWsName}

--- a/tests/unit/backend/service/test_WorkspaceService.py
+++ b/tests/unit/backend/service/test_WorkspaceService.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+from mantid.simpleapi import CreateSingleValuedWorkspace, GroupWorkspaces, mtd
+from snapred.backend.dao.request import RenameWorkspaceFromTemplateRequest
 from snapred.backend.service.WorkspaceService import WorkspaceService
 
 
@@ -13,6 +15,53 @@ class TestWorkspaceService:
         service.groceryService = mockGroceryService
         service.rename('{"oldName": "oldName", "newName": "newName"}')
         mockGroceryService.renameWorkspace.assert_called_once_with("oldName", "newName")
+
+    def test_renameFromTemplate(self):
+        mockGroceryService = MagicMock()
+        service = WorkspaceService()
+        service.groceryService = mockGroceryService
+        # must mock out the isGroup function to return false, so that it does not look for child workspaces
+        service.groceryService.getWorkspaceForName.return_value = MagicMock(isGroup=MagicMock(return_value=False))
+        oldNames = ["old1", "old2"]
+        renameTemplate = "{workspaceName}_X"
+        newNames = [renameTemplate.format(workspaceName=ws) for ws in oldNames]
+        request = RenameWorkspaceFromTemplateRequest(
+            workspaces=oldNames,
+            renameTemplate=renameTemplate,
+        )
+        res = service.renameFromTemplate(request.model_dump_json())
+        assert newNames == res
+        mockGroceryService.renameWorkspaces.assert_called_once_with(oldNames, newNames)
+
+    def test_renameFromTemplate_group(self):
+        """
+        Create a grouped workspace with one child.
+        Make sure that a call to this endpoint will rename BOTH parent and child.
+        """
+        service = WorkspaceService()
+        oldNames = ["parent", "child"]
+        # create the needed workspaces
+        CreateSingleValuedWorkspace(OutputWorkspace="child")
+        GroupWorkspaces(
+            InputWorkspaces=["child"],
+            OutputWorkspace="parent",
+        )
+        # create the expected new names
+        renameTemplate = "{workspaceName}_X"
+        newNames = [renameTemplate.format(workspaceName=ws) for ws in oldNames]
+        for old, new in zip(oldNames, newNames):
+            assert mtd.doesExist(old)
+            assert not mtd.doesExist(new)
+        # perform the request
+        request = RenameWorkspaceFromTemplateRequest(
+            workspaces=["parent"],
+            renameTemplate=renameTemplate,
+        )
+        service.renameFromTemplate(request.model_dump_json())
+        # check names changed
+        for new in newNames:
+            assert not mtd.doesExist(old)
+            assert mtd.doesExist(new)
 
     def test_clear(self):
         mockGroceryService = MagicMock()

--- a/tests/unit/ui/workflow/test_WorkflowImplementer.py
+++ b/tests/unit/ui/workflow/test_WorkflowImplementer.py
@@ -2,15 +2,13 @@ from random import randint
 from unittest.mock import MagicMock
 
 from mantid.simpleapi import CreateSingleValuedWorkspace, GroupWorkspaces, mtd
-from qtpy.QtWidgets import QApplication
 from snapred.ui.workflow.WorkflowImplementer import WorkflowImplementer
 
 
-def test_rename_on_iterate_list():
+def test_rename_on_iterate_list(qtbot):  # noqa: ARG001
     """
     Test that on iteration, a list of workspaces will be renamed according to the iteration template.
     """
-    test_app = QApplication(["nuffink"])  # noqa
     # setup a list of workspaces to be renamed
     oldNames = ["old1", "old2"]
     for name in oldNames:
@@ -23,14 +21,12 @@ def test_rename_on_iterate_list():
     instance.outputs = oldNames
     instance._iterate(mockPresenter)
     assert instance.collectiveOutputs == newNames
-    del test_app
 
 
-def test_rename_on_iterate_group():
+def test_rename_on_iterate_group(qtbot):  # noqa: ARG001
     """
     Test that on iteration, a workspace group has all of its members renamed.
     """
-    test_app = QApplication(["nuffink"])  # noqa
     # setup a list of workspaces to be renamed
     oldNames = ["parent", "child1", "child2"]
     CreateSingleValuedWorkspace(OutputWorkspace=oldNames[-1])
@@ -51,4 +47,3 @@ def test_rename_on_iterate_group():
     for old, new in zip(oldNames, newNames):
         assert not mtd.doesExist(old)
         assert mtd.doesExist(new)
-    del test_app

--- a/tests/unit/ui/workflow/test_WorkflowImplementer.py
+++ b/tests/unit/ui/workflow/test_WorkflowImplementer.py
@@ -1,0 +1,54 @@
+from random import randint
+from unittest.mock import MagicMock
+
+from mantid.simpleapi import CreateSingleValuedWorkspace, GroupWorkspaces, mtd
+from qtpy.QtWidgets import QApplication
+from snapred.ui.workflow.WorkflowImplementer import WorkflowImplementer
+
+
+def test_rename_on_iterate_list():
+    """
+    Test that on iteration, a list of workspaces will be renamed according to the iteration template.
+    """
+    test_app = QApplication(["nuffink"])  # noqa
+    # setup a list of workspaces to be renamed
+    oldNames = ["old1", "old2"]
+    for name in oldNames:
+        CreateSingleValuedWorkspace(OutputWorkspace=name)
+
+    mockPresenter = MagicMock(iteration=randint(1, 120))
+
+    instance = WorkflowImplementer()
+    newNames = [instance.renameTemplate.format(workspaceName=ws, iteration=mockPresenter.iteration) for ws in oldNames]
+    instance.outputs = oldNames
+    instance._iterate(mockPresenter)
+    assert instance.collectiveOutputs == newNames
+    del test_app
+
+
+def test_rename_on_iterate_group():
+    """
+    Test that on iteration, a workspace group has all of its members renamed.
+    """
+    test_app = QApplication(["nuffink"])  # noqa
+    # setup a list of workspaces to be renamed
+    oldNames = ["parent", "child1", "child2"]
+    CreateSingleValuedWorkspace(OutputWorkspace=oldNames[-1])
+    CreateSingleValuedWorkspace(OutputWorkspace=oldNames[-2])
+    GroupWorkspaces(InputWorkspaces=oldNames[-2:], OutputWorkspace=oldNames[0])
+
+    mockPresenter = MagicMock(iteration=randint(1, 120))
+
+    instance = WorkflowImplementer()
+    newNames = [instance.renameTemplate.format(workspaceName=ws, iteration=mockPresenter.iteration) for ws in oldNames]
+    for old, new in zip(oldNames, newNames):
+        assert mtd.doesExist(old)
+        assert not mtd.doesExist(new)
+
+    instance.outputs = [oldNames[0]]
+    instance._iterate(mockPresenter)
+    assert instance.collectiveOutputs == [newNames[0]]
+    for old, new in zip(oldNames, newNames):
+        assert not mtd.doesExist(old)
+        assert mtd.doesExist(new)
+    del test_app

--- a/tests/util_tests/test_state_helpers.py
+++ b/tests/util_tests/test_state_helpers.py
@@ -90,12 +90,17 @@ def initPVFileMock() -> mock.Mock:
     return mock_
 
 
+@mock.patch.object(LocalDataService, "_writeDefaultDiffCalTable")
 @mock.patch.object(LocalDataService, "_generateStateId")
 @mock.patch.object(LocalDataService, "_defaultGroupingMapPath")
 @mock.patch.object(LocalDataService, "readInstrumentConfig")
 @mock.patch.object(LocalDataService, "_readPVFile")
 def test_state_root_override_enter(
-    mockReadPVFile, mockReadInstrumentConfig, mockDefaultGroupingMapPath, mockGenerateStateId
+    mockReadPVFile,
+    mockReadInstrumentConfig,
+    mockDefaultGroupingMapPath,
+    mockGenerateStateId,
+    mockWriteDefaultDiffCalTable,  # noqa ARG001
 ):
     # see `test_LocalDataService::test_initializeState`
     mockReadPVFile.return_value = initPVFileMock()
@@ -119,10 +124,16 @@ def test_state_root_override_enter(
         assert (Path(stateRootPath) / "lite" / "diffraction" / versionString / "CalibrationParameters.json").exists()
 
 
+@mock.patch.object(LocalDataService, "_writeDefaultDiffCalTable")
 @mock.patch.object(LocalDataService, "_defaultGroupingMapPath")
 @mock.patch.object(LocalDataService, "readInstrumentConfig")
 @mock.patch.object(LocalDataService, "_readPVFile")
-def test_state_root_override_exit(mockReadPVFile, mockReadInstrumentConfig, mockDefaultGroupingMapPath):
+def test_state_root_override_exit(
+    mockReadPVFile,
+    mockReadInstrumentConfig,
+    mockDefaultGroupingMapPath,
+    mockWriteDefaultDiffCalTable,  # noqa ARG001
+):
     # see `test_LocalDataService::test_initializeState`
     mockReadPVFile.return_value = initPVFileMock()
 
@@ -143,10 +154,16 @@ def test_state_root_override_exit(mockReadPVFile, mockReadInstrumentConfig, mock
     assert not Path(stateRootPath).exists()
 
 
+@mock.patch.object(LocalDataService, "_writeDefaultDiffCalTable")
 @mock.patch.object(LocalDataService, "_defaultGroupingMapPath")
 @mock.patch.object(LocalDataService, "readInstrumentConfig")
 @mock.patch.object(LocalDataService, "_readPVFile")
-def test_state_root_override_exit_no_delete(mockReadPVFile, mockReadInstrumentConfig, mockDefaultGroupingMapPath):
+def test_state_root_override_exit_no_delete(
+    mockReadPVFile,
+    mockReadInstrumentConfig,
+    mockDefaultGroupingMapPath,
+    mockWriteDefaultDiffCalTable,  # noqa ARG001
+):
     # see `test_LocalDataService::test_initializeState`
     mockReadPVFile.return_value = initPVFileMock()
 


### PR DESCRIPTION
## Description of work

In PR #295, the diffcal workflow was refactored to output a `WorkspaceGroup` containign diagnostic information from the peak fitting that takes place inside `PDCalibration`.  This being a `WorkspaceGroup`, and not simply a `Workspace`, has led to a few unexpected behaviors when handling it.

One unexpected behavior was solved in PR #390, where child workspaces were being accidentally deleted and needed to be added to a retain list.

In this case, child workspaces are not being renamed when the parent is.  This means the diagnostic `WorkspaceGroup`s for each iteration all contain references to the same set of workspaces, as opposed to the workspaces made in that iteration.

The work is to add a new endpoint which more effectively handles renaming workspaces on an iteration.

## Explanation of work

Adding the new endpoint inside the `WorkspaceService`.

This required a new DAO request object.

This could be handled with a single call to `RenameWorkspaces` for the whole list of workspaces, so a new method was added to `GroceryService`.

## To test

### Dev testing

Check the unit tests and make sure they cover the situations meant to be fixed here.

Run diffcal.  At the assess screen, open the diagnostic workspace group (it has a light blue icon) and make sure the names have no iteration label on them.

Click iterate.  Now the parent and all children should have a `_1` on the end.

Iterate a few times until you are satisfied that the workspaces are being renamed.


### CIS testing

Do as above, but using differences in each calibration, and make sure the values in each iteration are different.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#6018](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6018)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
