### PR TITLE
defect: user pixel mask: incomplete `WorkspaceName`

### DIFF
--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -1001,12 +1001,13 @@ class LocalDataService:
                 if not self.isCompatibleMask(ws, runNumber, useLiteMode):
                     excludedCount += 1
                     continue
-                
+
                 # Convert to a `WorkspaceName`
-                maskName = wng\
-                    .reductionUserPixelMask()\
-                    .numberTag(int(match_.group(2)) if match_.group(2) is not None else 1)\
+                maskName = (
+                    wng.reductionUserPixelMask()
+                    .numberTag(int(match_.group(2)) if match_.group(2) is not None else 1)
                     .build()
+                )
                 masks.add(maskName)
 
         if excludedCount > 0:

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -993,14 +993,21 @@ class LocalDataService:
                     masks.add(maskName)
 
         # Next: add compatible user-created masks that are already resident in the ADS
-        mantidMaskName = re.compile(r"MaskWorkspace(_[0-9]+)?")
+        mantidMaskName = re.compile(r"MaskWorkspace(_([0-9]+))?")
         wsNames = mtd.getObjectNames()
         for ws in wsNames:
-            if mantidMaskName.match(ws):
+            match_ = mantidMaskName.match(ws)
+            if match_:
                 if not self.isCompatibleMask(ws, runNumber, useLiteMode):
                     excludedCount += 1
                     continue
-                masks.add(ws)
+                
+                # Convert to a `WorkspaceName`
+                maskName = wng\
+                    .reductionUserPixelMask()\
+                    .numberTag(int(match_.group(2)) if match_.group(2) is not None else 1)\
+                    .build()
+                masks.add(maskName)
 
         if excludedCount > 0:
             logger.warning(

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -1,5 +1,3 @@
-import typing
-from typing import List, Literal, Set
 import functools
 import importlib
 import json
@@ -9,10 +7,12 @@ import re
 import socket
 import tempfile
 import time
+import typing
 import unittest.mock as mock
 from contextlib import ExitStack
 from pathlib import Path
 from random import randint, shuffle
+from typing import List, Literal, Set
 
 import h5py
 import pydantic
@@ -57,10 +57,16 @@ from snapred.backend.data.LocalDataService import LocalDataService
 from snapred.backend.data.NexusHDF5Metadata import NexusHDF5Metadata as n5m
 from snapred.meta.Config import Config, Resource
 from snapred.meta.mantid.WorkspaceNameGenerator import (
-    WorkspaceName,
-    WorkspaceNameGenerator as wng,
-    WorkspaceType as wngt,
     ValueFormatter as wnvf,
+)
+from snapred.meta.mantid.WorkspaceNameGenerator import (
+    WorkspaceName,
+)
+from snapred.meta.mantid.WorkspaceNameGenerator import (
+    WorkspaceNameGenerator as wng,
+)
+from snapred.meta.mantid.WorkspaceNameGenerator import (
+    WorkspaceType as wngt,
 )
 from snapred.meta.redantic import parse_file_as, parse_raw_as, write_model_pretty
 from util.Config_helpers import Config_override
@@ -2599,7 +2605,7 @@ class TestReductionPixelMasks:
                 continue
             # Be careful here: `masks: List[WorkspaceName]` not `masks: List[str]`
             # => iterate over the `WorkspaceName`, not over the `str`.
-            
+
             assert name in ["MaskWorkspace"]
             # somewhat complicated: `WorkspaceName` is an annotated type
             assert isinstance(name, typing.get_args(WorkspaceName)[0])
@@ -2613,7 +2619,6 @@ class TestReductionPixelMasks:
             # somewhat complicated: `WorkspaceName` is an annotated type
             assert isinstance(name, typing.get_args(WorkspaceName)[0])
             assert name.tokens("workspaceType") == wngt.REDUCTION_USER_PIXEL_MASK
-
 
     def test_getCompatibleReductionMasks_resident_pixel(self):
         # Check that any _resident_ pixel masks are compatible:


### PR DESCRIPTION

## Description of work

When the list of compatible pixel masks is assembled for use in the reduction process, it's important that each assembled mask name is a complete `WorkspaceName` (with builder).  This defect was caused by the fact that there was no conversion from `str` to `WorkspaceName` in the location step for resident user pixel masks (e.g. "MaskWorkspace_\<nn\>")

## Explanation of work

This commit includes the following changes:

  * When locating compatible resident user pixel masks, make sure that the name is converted to a complete `WorkspaceName` (with builder) before adding it to the `compatibleMasks` list;

  * Add unit tests to make sure that both `WorkspaceType.reductionPixelMask` and `WorkspaceType.reductionUserPixelMask` are loaded to the compatible-masks list as complete `WorkspaceName` (with builder).

## To test

### Dev testing

New unit tests are added to catch the case that triggered this defect.

### CIS testing
CIS testing as for [EWM#4801](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/4801) and [EWM#5912](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/5912)


## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#6340](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6340)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
