### PR TITLE
(Resolve Staging->Next Conflict) Properly iterate diagnostics :repeat_one:  (#412)

### DIFF
--- a/src/snapred/backend/dao/request/RenameWorkspaceFromTemplateRequest.py
+++ b/src/snapred/backend/dao/request/RenameWorkspaceFromTemplateRequest.py
@@ -1,0 +1,23 @@
+from typing import List
+
+from pydantic import BaseModel, field_validator
+
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
+
+
+class RenameWorkspaceFromTemplateRequest(BaseModel, arbitrary_types_allowed=True):
+    """
+    Rename a list of workspaces according to a template.
+    The template must be a formattable string with a placeholder labeled `workspaceName`.
+    In the new workspace names, the old workspace name will appear at this label.
+    """
+
+    workspaces: List[WorkspaceName]
+    renameTemplate: str
+
+    @field_validator("renameTemplate")
+    @classmethod
+    def renameTemplate_has_workspaceName(cls, v: str) -> str:
+        if "{workspaceName}" not in v:
+            raise ValueError("Rename template must contain a placeholder labeled 'workspaceName'")
+        return v

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -357,6 +357,22 @@ class GroceryService:
         )
         self.mantidSnapper.executeQueue()
 
+    def renameWorkspaces(self, oldNames: List[WorkspaceName], newNames: List[WorkspaceName]):
+        """
+        Renames a list of workspaces in Mantid's ADS.
+
+        :param oldNames: the original names of the workspaces in the ADS
+        :type oldNames: List[WorkspaceName]
+        :param newNames: the names to replace the workspace names in the ADS
+        :type newNames: List[WorkspaceName]
+        """
+        self.mantidSnapper.RenameWorkspaces(
+            "Renaming several workspaces",
+            InputWorkspaces=oldNames,
+            WorkspaceNames=newNames,
+        )
+        self.mantidSnapper.executeQueue()
+
     def getWorkspaceForName(self, name: WorkspaceName):
         """
         Simple wrapper of mantid's ADS for the service layer.

--- a/tests/integration/test_versions_in_order.py
+++ b/tests/integration/test_versions_in_order.py
@@ -256,7 +256,11 @@ class TestVersioning(TestCase):
 
         # create an InterfaceController
         self.api = InterfaceController()
+        self.old_self = self.api.serviceFactory.getService
         self.api.serviceFactory.getService = lambda x: self.instance  # noqa: ARG005
+
+    def tearDown(self):
+        self.api.serviceFactory.getService = self.old_self
 
     def test_calibration_versioning(self):
         """

--- a/tests/unit/backend/dao/test_RenameWorkspaceFromTemplateRequest.py
+++ b/tests/unit/backend/dao/test_RenameWorkspaceFromTemplateRequest.py
@@ -1,0 +1,20 @@
+import pytest
+from pydantic import ValidationError
+from snapred.backend.dao.request import RenameWorkspaceFromTemplateRequest
+
+
+def test_good():
+    request = RenameWorkspaceFromTemplateRequest(workspaces=[], renameTemplate="{workspaceName}_X")
+    assert request.renameTemplate.format(workspaceName="mike") == "mike_X"
+
+
+def test_insufficient():
+    with pytest.raises(ValidationError) as e:
+        RenameWorkspaceFromTemplateRequest(workspaces=[], renameTemplate="workspaceName_X")
+    assert "workspaceName" in str(e.value)
+
+
+def test_bad():
+    with pytest.raises(ValidationError) as e:
+        RenameWorkspaceFromTemplateRequest(workspaces=[], renameTemplate="{bad_label}_X")
+    assert "workspaceName" in str(e.value)

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -1679,6 +1679,18 @@ class TestGroceryService(unittest.TestCase):
         assert not mtd.doesExist(oldName)
         assert mtd.doesExist(newName)
 
+    def test_renameWorkspaces(self):
+        oldNames = ["old1", "old2"]
+        newNames = ["new1", "new2"]
+        for oldName in oldNames:
+            self.create_dumb_workspace(oldName)
+            assert mtd.doesExist(oldName)
+        self.instance.renameWorkspaces(oldNames, newNames)
+        for oldName in oldNames:
+            assert not mtd.doesExist(oldName)
+        for newName in newNames:
+            assert mtd.doesExist(newName)
+
     def test_clearADS(self):
         rawWsName = self.instance._createRawNeutronWorkspaceName(0, "a")
         self.instance._loadedRuns = {(0, "a"): rawWsName}

--- a/tests/unit/backend/service/test_WorkspaceService.py
+++ b/tests/unit/backend/service/test_WorkspaceService.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+from mantid.simpleapi import CreateSingleValuedWorkspace, GroupWorkspaces, mtd
+from snapred.backend.dao.request import RenameWorkspaceFromTemplateRequest
 from snapred.backend.service.WorkspaceService import WorkspaceService
 
 
@@ -13,6 +15,53 @@ class TestWorkspaceService:
         service.groceryService = mockGroceryService
         service.rename('{"oldName": "oldName", "newName": "newName"}')
         mockGroceryService.renameWorkspace.assert_called_once_with("oldName", "newName")
+
+    def test_renameFromTemplate(self):
+        mockGroceryService = MagicMock()
+        service = WorkspaceService()
+        service.groceryService = mockGroceryService
+        # must mock out the isGroup function to return false, so that it does not look for child workspaces
+        service.groceryService.getWorkspaceForName.return_value = MagicMock(isGroup=MagicMock(return_value=False))
+        oldNames = ["old1", "old2"]
+        renameTemplate = "{workspaceName}_X"
+        newNames = [renameTemplate.format(workspaceName=ws) for ws in oldNames]
+        request = RenameWorkspaceFromTemplateRequest(
+            workspaces=oldNames,
+            renameTemplate=renameTemplate,
+        )
+        res = service.renameFromTemplate(request.model_dump_json())
+        assert newNames == res
+        mockGroceryService.renameWorkspaces.assert_called_once_with(oldNames, newNames)
+
+    def test_renameFromTemplate_group(self):
+        """
+        Create a grouped workspace with one child.
+        Make sure that a call to this endpoint will rename BOTH parent and child.
+        """
+        service = WorkspaceService()
+        oldNames = ["parent", "child"]
+        # create the needed workspaces
+        CreateSingleValuedWorkspace(OutputWorkspace="child")
+        GroupWorkspaces(
+            InputWorkspaces=["child"],
+            OutputWorkspace="parent",
+        )
+        # create the expected new names
+        renameTemplate = "{workspaceName}_X"
+        newNames = [renameTemplate.format(workspaceName=ws) for ws in oldNames]
+        for old, new in zip(oldNames, newNames):
+            assert mtd.doesExist(old)
+            assert not mtd.doesExist(new)
+        # perform the request
+        request = RenameWorkspaceFromTemplateRequest(
+            workspaces=["parent"],
+            renameTemplate=renameTemplate,
+        )
+        service.renameFromTemplate(request.model_dump_json())
+        # check names changed
+        for new in newNames:
+            assert not mtd.doesExist(old)
+            assert mtd.doesExist(new)
 
     def test_clear(self):
         mockGroceryService = MagicMock()

--- a/tests/unit/ui/workflow/test_WorkflowImplementer.py
+++ b/tests/unit/ui/workflow/test_WorkflowImplementer.py
@@ -1,0 +1,49 @@
+from random import randint
+from unittest.mock import MagicMock
+
+from mantid.simpleapi import CreateSingleValuedWorkspace, GroupWorkspaces, mtd
+from snapred.ui.workflow.WorkflowImplementer import WorkflowImplementer
+
+
+def test_rename_on_iterate_list(qtbot):  # noqa: ARG001
+    """
+    Test that on iteration, a list of workspaces will be renamed according to the iteration template.
+    """
+    # setup a list of workspaces to be renamed
+    oldNames = ["old1", "old2"]
+    for name in oldNames:
+        CreateSingleValuedWorkspace(OutputWorkspace=name)
+
+    mockPresenter = MagicMock(iteration=randint(1, 120))
+
+    instance = WorkflowImplementer()
+    newNames = [instance.renameTemplate.format(workspaceName=ws, iteration=mockPresenter.iteration) for ws in oldNames]
+    instance.outputs = oldNames
+    instance._iterate(mockPresenter)
+    assert instance.collectiveOutputs == newNames
+
+
+def test_rename_on_iterate_group(qtbot):  # noqa: ARG001
+    """
+    Test that on iteration, a workspace group has all of its members renamed.
+    """
+    # setup a list of workspaces to be renamed
+    oldNames = ["parent", "child1", "child2"]
+    CreateSingleValuedWorkspace(OutputWorkspace=oldNames[-1])
+    CreateSingleValuedWorkspace(OutputWorkspace=oldNames[-2])
+    GroupWorkspaces(InputWorkspaces=oldNames[-2:], OutputWorkspace=oldNames[0])
+
+    mockPresenter = MagicMock(iteration=randint(1, 120))
+
+    instance = WorkflowImplementer()
+    newNames = [instance.renameTemplate.format(workspaceName=ws, iteration=mockPresenter.iteration) for ws in oldNames]
+    for old, new in zip(oldNames, newNames):
+        assert mtd.doesExist(old)
+        assert not mtd.doesExist(new)
+
+    instance.outputs = [oldNames[0]]
+    instance._iterate(mockPresenter)
+    assert instance.collectiveOutputs == [newNames[0]]
+    for old, new in zip(oldNames, newNames):
+        assert not mtd.doesExist(old)
+        assert mtd.doesExist(new)


### PR DESCRIPTION
* fix problem

* add test of workflow implementer renaming on iteration

* update workflow implementer test to use qtbot

## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work

<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing

<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing

<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

``` python
# replace with your test script below
```

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
