### PR TITLE
Reduce data output for Diffcal and Reduction

### DIFF
--- a/src/snapred/backend/recipe/ApplyNormalizationRecipe.py
+++ b/src/snapred/backend/recipe/ApplyNormalizationRecipe.py
@@ -66,6 +66,7 @@ class ApplyNormalizationRecipe(Recipe[Ingredients]):
             NumberBins=self.NUM_BINS,
             LogBinning=self.LOG_BINNING,
             OutputWorkspace=self.sampleWs,
+            PreserveEvents=False,
         )
 
     # NOTE: Metaphorically, would ingredients better have been called Spices?

--- a/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/GroupDiffractionCalibration.py
@@ -328,7 +328,7 @@ class GroupDiffractionCalibration(PythonAlgorithm):
             InstrumentWorkspace=self.originalWStof,
             CalibrationWorkspace=self.DIFCfinal,
         )
-        self.convertAndFocusAndReturn(self.originalWStof, self.outputWSdSpacing, "after", "dSpacing")
+        self.convertAndFocusAndReturn(self.originalWStof, self.outputWSdSpacing, "after", "dSpacing", False)
 
         # add the TOF-spacing workspace to the diagnostic workspace group
         self.mantidSnapper.CloneWorkspace(
@@ -351,7 +351,7 @@ class GroupDiffractionCalibration(PythonAlgorithm):
         self.setPropertyValue("OutputWorkspace", self.outputWSdSpacing)
         self.setPropertyValue("FinalCalibrationTable", self.DIFCfinal)
 
-    def convertAndFocusAndReturn(self, inputWS: str, outputWS: str, note: str, units: str):
+    def convertAndFocusAndReturn(self, inputWS: str, outputWS: str, note: str, units: str, keepEvents: bool = True):
         # Use workspace name generator
         tmpWStof = f"_TOF_{self.runNumber}_diffoc_{note}"
         tmpWSdsp = f"_DSP_{self.runNumber}_diffoc_{note}"
@@ -380,6 +380,7 @@ class GroupDiffractionCalibration(PythonAlgorithm):
             XMin=self.dMin,
             XMax=self.dMax,
             Delta=self.dBin,
+            preserveEvents=keepEvents,
         )
 
         if units == "TOF":


### PR DESCRIPTION
## Description of work

Added flag to not preserve events for DiffCal and Reduction workflows. This prevents file/workspace size from getting too big.

## To test

### Dev testing

On analysis, make sure you are on the staging branch. Run the diffcal workflow with the following parameters: 

Run Number: 59039
Sample: La11B6_NIST_660c_001
Grouping File: Column
Peak Intensity Threshold: 0.01

Click continue. On the Tweak Peak Peek tab, set MaxChiSq to 2000, click Recalculate, and continue on all the way to the Saving tab. Before saving, inspect the output workspaces. You should see that the main output workspace takes up about 3000 MB of space. Complete the save step and verify there that the tar file and diagnostic .nxs file are at least 3 GB.

Run Normalization with the following:

Both run numbers: 59039
Sample: La11B6_NIST_660c_001
Grouping File: Column

Complete and save the results.

Run reduction with the 59039 run number and verify the workspaces with "output" in the name are about 3 GB or more.

Now repeat everything but on the reduce-data-size branch.  You should not have to repeat the Normalization step. When inspecting the workspace/file size, you should see that they no longer take up 3 GB of space. The workspaces should show something like 50 MB and the tar file will be about 300 MB. 

### CIS testing

Same as the dev testing, just make sure all workspaces are still as expected.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#6101](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6101)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
