### PR TITLE
Retain reduction-workflow output workspaces

### DIFF
--- a/docs/source/api/snapred.backend.dao.request.rst
+++ b/docs/source/api/snapred.backend.dao.request.rst
@@ -36,10 +36,18 @@ snapred.backend.dao.request.CalibrationLoadAssessmentRequest module
    :undoc-members:
    :show-inheritance:
 
-snapred.backend.dao.request.ClearWorkspaceRequest module
+snapred.backend.dao.request.ClearWorkspacesRequest module
+---------------------------------------------------------
+
+.. automodule:: snapred.backend.dao.request.ClearWorkspacesRequest
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+snapred.backend.dao.request.ListWorkspacesRequest module
 --------------------------------------------------------
 
-.. automodule:: snapred.backend.dao.request.ClearWorkspaceRequest
+.. automodule:: snapred.backend.dao.request.ListWorkspacesRequest
    :members:
    :undoc-members:
    :show-inheritance:
@@ -104,6 +112,14 @@ snapred.backend.dao.request.RenameWorkspaceRequest module
 ---------------------------------------------------------
 
 .. automodule:: snapred.backend.dao.request.RenameWorkspaceRequest
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+snapred.backend.dao.request.RenameWorkspacesFromTemplateRequest module
+----------------------------------------------------------------------
+
+.. automodule:: snapred.backend.dao.request.RenameWorkspacesFromTemplateRequest
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/api/snapred.ui.presenter.rst
+++ b/docs/source/api/snapred.ui.presenter.rst
@@ -61,20 +61,13 @@ snapred.ui.presenter.ToolBarPresenter module
    :undoc-members:
    :show-inheritance:
 
-snapred.ui.presenter.WorkflowNodePresenter module
--------------------------------------------------
-
-.. automodule:: snapred.ui.presenter.WorkflowNodePresenter
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 snapred.ui.presenter.WorkflowPresenter module
 ---------------------------------------------
 
 .. automodule:: snapred.ui.presenter.WorkflowPresenter
    :members:
    :undoc-members:
+   :exclude-members: actionCompleted, disableOtherWorkflows, enableAllWorkflows
    :show-inheritance:
 
 Module contents

--- a/docs/source/api/snapred.ui.widget.rst
+++ b/docs/source/api/snapred.ui.widget.rst
@@ -76,10 +76,10 @@ snapred.ui.widget.SmoothingSlider module
    :undoc-members:
    :show-inheritance:
 
-snapred.ui.widget.SuccessDialog module
+snapred.ui.widget.SuccessPrompt module
 --------------------------------------
 
-.. automodule:: snapred.ui.widget.SuccessDialog
+.. automodule:: snapred.ui.widget.SuccessPrompt
    :members:
    :undoc-members:
    :show-inheritance:
@@ -120,14 +120,6 @@ snapred.ui.widget.Workflow module
 ---------------------------------
 
 .. automodule:: snapred.ui.widget.Workflow
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-snapred.ui.widget.WorkflowNode module
--------------------------------------
-
-.. automodule:: snapred.ui.widget.WorkflowNode
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/api/snapred.ui.workflow.rst
+++ b/docs/source/api/snapred.ui.workflow.rst
@@ -41,6 +41,7 @@ snapred.ui.workflow.WorkflowImplementer module
 .. automodule:: snapred.ui.workflow.WorkflowImplementer
    :members:
    :undoc-members:
+   :exclude-members: enableAllWorkflows
    :show-inheritance:
 
 Module contents

--- a/docs/source/developer/architecture/frontend/index.rst
+++ b/docs/source/developer/architecture/frontend/index.rst
@@ -13,7 +13,7 @@ TODO
    normalization/normalization_tweak_peak_view
    normalization/normalization_workflow
    normalization/smoothing_slider
-   success_dialog
+   success_prompt
    calibration/calibration_assessment_presenter
    calibration/diffcal_assessment_view
    calibration/diffcal_request_view

--- a/docs/source/developer/architecture/frontend/success_prompt.rst
+++ b/docs/source/developer/architecture/frontend/success_prompt.rst
@@ -1,7 +1,7 @@
-SuccessDialog Class Documentation
+SuccessPrompt Class Documentation
 =================================
 
-SuccessDialog is a qt dialog constructed to deliver succinct and clear feedback to users following successful operations, such as the completion
+SuccessPrompt is a qt dialog constructed to deliver succinct and clear feedback to users following successful operations, such as the completion
 of a setup process or state initialization. It adheres to GUI design principles emphasizing straightforward communication, offering a minimalistic
 yet effective interface for conveying success messages. This approach serves to enhance the user experience within applications by affirmatively
 acknowledging positive action outcomes in a clear and uncomplicated manner.
@@ -31,6 +31,6 @@ Layout and Content:
   functionality streamlines the user's task progression, emphasizing efficiency and ease of use.
 
 
-SuccessDialog exemplifies an effective method of delivering essential feedback to users in GUI applications, by focusing on delivering key
+SuccessPrompt exemplifies an effective method of delivering essential feedback to users in GUI applications, by focusing on delivering key
 information without unnecessary complexity. Through its well-considered design and functionality, it significantly contributes to a positive and
 streamlined user experience, affirming the successful completion of actions within the application.

--- a/src/snapred/backend/dao/request/ClearWorkspaceRequest.py
+++ b/src/snapred/backend/dao/request/ClearWorkspaceRequest.py
@@ -1,8 +1,0 @@
-from typing import List
-
-from pydantic import BaseModel
-
-
-class ClearWorkspaceRequest(BaseModel):
-    exclude: List[str] = []
-    cache: bool = False

--- a/src/snapred/backend/dao/request/ClearWorkspacesRequest.py
+++ b/src/snapred/backend/dao/request/ClearWorkspacesRequest.py
@@ -1,0 +1,11 @@
+from typing import List
+
+from pydantic import BaseModel
+
+
+class ClearWorkspacesRequest(BaseModel):
+    # List of workspaces to retain
+    exclude: List[str]
+
+    # True => also clear cached workspaces
+    clearCache: bool

--- a/src/snapred/backend/dao/request/ListWorkspacesRequest.py
+++ b/src/snapred/backend/dao/request/ListWorkspacesRequest.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pydantic import BaseModel
 
 

--- a/src/snapred/backend/dao/request/ListWorkspacesRequest.py
+++ b/src/snapred/backend/dao/request/ListWorkspacesRequest.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from pydantic import BaseModel
+
+
+class ListWorkspacesRequest(BaseModel):
+    # True => exclude the cached workspaces from the list
+    excludeCache: bool

--- a/src/snapred/backend/dao/request/RenameWorkspacesFromTemplateRequest.py
+++ b/src/snapred/backend/dao/request/RenameWorkspacesFromTemplateRequest.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, field_validator
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
 
-class RenameWorkspaceFromTemplateRequest(BaseModel, arbitrary_types_allowed=True):
+class RenameWorkspacesFromTemplateRequest(BaseModel, arbitrary_types_allowed=True):
     """
     Rename a list of workspaces according to a template.
     The template must be a formattable string with a placeholder labeled `workspaceName`.

--- a/src/snapred/backend/dao/response/ReductionResponse.py
+++ b/src/snapred/backend/dao/response/ReductionResponse.py
@@ -1,0 +1,15 @@
+from typing import List
+
+from pydantic import BaseModel, ConfigDict
+
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
+
+
+class ReductionResponse(BaseModel):
+    workspaces: List[WorkspaceName]
+
+    model_config = ConfigDict(
+        extra="forbid",
+        # required in order to use 'WorkspaceName'
+        arbitrary_types_allowed=True,
+    )

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -1219,7 +1219,7 @@ class GroceryService:
     def getResidentWorkspaces(self, excludeCache: bool):
         """
         Get the list of ADS-resident workspaces:
-        
+
         - optionally exclude the cached workspaces from this list.
         """
         workspaces = set(mtd.getObjectNames())

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -1190,14 +1190,14 @@ class GroceryService:
         else:
             pass
 
-    def clearADS(self, exclude: List[WorkspaceName] = [], cache: bool = False):
+    def clearADS(self, exclude: List[WorkspaceName] = [], clearCache: bool = False):
         """
         Clears ADS of all workspaces except those in the exclude list and cache.
 
         :param exclude: a list of workspaces to retain in the ADS after clear
         :type exclude: List[WorkspaceName]
-        :param cache: whether or not to clear cached workspaces (True = yes, clear the cache), optional (defaults to False)
-        :type cache: bool
+        :param clearCache: whether or not to clear cached workspaces
+        :type clearCache: bool
         """  # noqa E501
         workspacesToClear = set(mtd.getObjectNames())
         # filter exclude
@@ -1207,10 +1207,22 @@ class GroceryService:
             if self.workspaceDoesExist(ws) and mtd[ws].isGroup():
                 workspacesToClear = workspacesToClear.difference(mtd[ws].getNames())
         # filter caches
-        if not cache:
+        if not clearCache:
             workspacesToClear = workspacesToClear.difference(self.getCachedWorkspaces())
         # clear the workspaces
         for workspace in workspacesToClear:
             self.deleteWorkspaceUnconditional(workspace)
 
-        self.rebuildCache()
+        if clearCache:
+            self.rebuildCache()
+
+    def getResidentWorkspaces(self, excludeCache: bool):
+        """
+        Get the list of ADS-resident workspaces:
+        
+        - optionally exclude the cached workspaces from this list.
+        """
+        workspaces = set(mtd.getObjectNames())
+        if excludeCache:
+            workspaces = workspaces.difference(self.getCachedWorkspaces())
+        return list(workspaces)

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -8,12 +8,12 @@ from errno import ENOENT as NOT_FOUND
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
-import h5py
-from pydantic import validate_call
 
+import h5py
 from mantid.dataobjects import MaskWorkspace
 from mantid.kernel import PhysicalConstants
 from mantid.simpleapi import GetIPTS, mtd
+from pydantic import validate_call
 
 from snapred.backend.dao import (
     GSASParameters,
@@ -53,8 +53,14 @@ from snapred.meta.decorators.ExceptionHandler import ExceptionHandler
 from snapred.meta.decorators.Singleton import Singleton
 from snapred.meta.mantid.WorkspaceNameGenerator import (
     ValueFormatter as wnvf,
+)
+from snapred.meta.mantid.WorkspaceNameGenerator import (
     WorkspaceName,
+)
+from snapred.meta.mantid.WorkspaceNameGenerator import (
     WorkspaceNameGenerator as wng,
+)
+from snapred.meta.mantid.WorkspaceNameGenerator import (
     WorkspaceType as wngt,
 )
 from snapred.meta.redantic import parse_file_as, write_model_pretty

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -8,12 +8,12 @@ from errno import ENOENT as NOT_FOUND
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
-
 import h5py
+from pydantic import validate_call
+
 from mantid.dataobjects import MaskWorkspace
 from mantid.kernel import PhysicalConstants
 from mantid.simpleapi import GetIPTS, mtd
-from pydantic import validate_call
 
 from snapred.backend.dao import (
     GSASParameters,
@@ -53,14 +53,8 @@ from snapred.meta.decorators.ExceptionHandler import ExceptionHandler
 from snapred.meta.decorators.Singleton import Singleton
 from snapred.meta.mantid.WorkspaceNameGenerator import (
     ValueFormatter as wnvf,
-)
-from snapred.meta.mantid.WorkspaceNameGenerator import (
     WorkspaceName,
-)
-from snapred.meta.mantid.WorkspaceNameGenerator import (
     WorkspaceNameGenerator as wng,
-)
-from snapred.meta.mantid.WorkspaceNameGenerator import (
     WorkspaceType as wngt,
 )
 from snapred.meta.redantic import parse_file_as, write_model_pretty

--- a/src/snapred/backend/recipe/ReductionRecipe.py
+++ b/src/snapred/backend/recipe/ReductionRecipe.py
@@ -14,7 +14,6 @@ logger = snapredLogger.getLogger(__name__)
 Pallet = Tuple[Ingredients, Dict[str, str]]
 
 
-# @Singleton
 class ReductionRecipe(Recipe[Ingredients]):
     """
     Currently requires:
@@ -130,6 +129,7 @@ class ReductionRecipe(Recipe[Ingredients]):
         pass
 
     def execute(self):
+        data: Dict[str, Any] = {"result": False}
         # 1. PreprocessReductionRecipe
         outputs = []
         self._applyRecipe(
@@ -195,7 +195,9 @@ class ReductionRecipe(Recipe[Ingredients]):
         if self.maskWs:
             outputs.append(self.maskWs)
 
-        return outputs
+        data["result"] = True
+        data["outputs"] = outputs
+        return data
 
     def cook(self, ingredients: Ingredients, groceries: Dict[str, str]) -> Dict[str, Any]:
         """

--- a/src/snapred/backend/service/ReductionService.py
+++ b/src/snapred/backend/service/ReductionService.py
@@ -9,6 +9,7 @@ from snapred.backend.dao.request import (
     ReductionRequest,
 )
 from snapred.backend.dao.request.ReductionRequest import Versions
+from snapred.backend.dao.response.ReductionResponse import ReductionResponse
 from snapred.backend.dao.SNAPRequest import SNAPRequest
 from snapred.backend.data.DataExportService import DataExportService
 from snapred.backend.data.DataFactoryService import DataFactoryService
@@ -22,11 +23,7 @@ from snapred.meta.decorators.FromString import FromString
 from snapred.meta.decorators.Singleton import Singleton
 from snapred.meta.mantid.WorkspaceNameGenerator import (
     WorkspaceName,
-)
-from snapred.meta.mantid.WorkspaceNameGenerator import (
     WorkspaceNameGenerator as wng,
-)
-from snapred.meta.mantid.WorkspaceNameGenerator import (
     WorkspaceType as wngt,
 )
 from snapred.meta.validator.RunNumberValidator import RunNumberValidator
@@ -86,7 +83,10 @@ class ReductionService(Service):
         # attach the list of grouping workspaces to the grocery dictionary
         groceries["groupingWorkspaces"] = groupingResults["groupingWorkspaces"]
 
-        return ReductionRecipe().cook(ingredients, groceries)
+        data = ReductionRecipe().cook(ingredients, groceries)
+        return ReductionResponse(
+            workspaces=data["outputs"],
+        )
 
     @FromString
     def fetchReductionGroupings(self, request: ReductionRequest) -> Dict[str, Any]:

--- a/src/snapred/backend/service/ReductionService.py
+++ b/src/snapred/backend/service/ReductionService.py
@@ -23,7 +23,11 @@ from snapred.meta.decorators.FromString import FromString
 from snapred.meta.decorators.Singleton import Singleton
 from snapred.meta.mantid.WorkspaceNameGenerator import (
     WorkspaceName,
+)
+from snapred.meta.mantid.WorkspaceNameGenerator import (
     WorkspaceNameGenerator as wng,
+)
+from snapred.meta.mantid.WorkspaceNameGenerator import (
     WorkspaceType as wngt,
 )
 from snapred.meta.validator.RunNumberValidator import RunNumberValidator

--- a/src/snapred/backend/service/Service.py
+++ b/src/snapred/backend/service/Service.py
@@ -23,7 +23,7 @@ class Service(ABC):
     def getPaths(self):
         return self._paths
 
-    def registerPath(self, path, route):
+    def registerPath(self, path, route: Callable):
         self._paths[path] = route
 
     def parsePath(self, path):

--- a/src/snapred/backend/service/ServiceFactory.py
+++ b/src/snapred/backend/service/ServiceFactory.py
@@ -1,12 +1,10 @@
-# import regex
-
 from snapred.backend.error.UserException import UserException
 from snapred.backend.service.ApiService import ApiService
 from snapred.backend.service.CalibrantSampleService import CalibrantSampleService
 from snapred.backend.service.CalibrationService import CalibrationService
 
-# cant think of a good way around requireing the services to be imported
-# here in order to autoregister them
+# I can't think of a good way around requiring the services to be imported
+#   here in order to auto-register them.
 from snapred.backend.service.ConfigLookupService import ConfigLookupService
 from snapred.backend.service.CrystallographicInfoService import CrystallographicInfoService
 from snapred.backend.service.LiteDataService import LiteDataService
@@ -20,7 +18,7 @@ from snapred.meta.Config import Config
 from snapred.meta.decorators.Singleton import Singleton
 
 
-# singleton ServiceFactory class
+# Singleton ServiceFactory class
 @Singleton
 class ServiceFactory:
     serviceDirectory: ServiceDirectory = ServiceDirectory()

--- a/src/snapred/backend/service/WorkspaceService.py
+++ b/src/snapred/backend/service/WorkspaceService.py
@@ -3,8 +3,8 @@ from typing import List
 from snapred.backend.dao.request import (
     ClearWorkspacesRequest,
     ListWorkspacesRequest,
-    RenameWorkspacesFromTemplateRequest,
     RenameWorkspaceRequest,
+    RenameWorkspacesFromTemplateRequest,
 )
 from snapred.backend.data.GroceryService import GroceryService
 from snapred.backend.service.Service import Service
@@ -66,7 +66,7 @@ class WorkspaceService(Service):
     def getResidentWorkspaces(self, request: ListWorkspacesRequest):
         """
         Gets the list of workspaces resident in the ADS:
-        
+
         - optionally excludes the cached workspaces from this list.
         """
         return self.groceryService.getResidentWorkspaces(excludeCache=request.excludeCache)

--- a/src/snapred/backend/service/WorkspaceService.py
+++ b/src/snapred/backend/service/WorkspaceService.py
@@ -1,8 +1,9 @@
 from typing import List
 
 from snapred.backend.dao.request import (
-    ClearWorkspaceRequest,
-    RenameWorkspaceFromTemplateRequest,
+    ClearWorkspacesRequest,
+    ListWorkspacesRequest,
+    RenameWorkspacesFromTemplateRequest,
     RenameWorkspaceRequest,
 )
 from snapred.backend.data.GroceryService import GroceryService
@@ -23,6 +24,7 @@ class WorkspaceService(Service):
         self.registerPath("rename", self.rename)
         self.registerPath("renameFromTemplate", self.renameFromTemplate)
         self.registerPath("clear", self.clear)
+        self.registerPath("getResidentWorkspaces", self.getResidentWorkspaces)
         return
 
     @staticmethod
@@ -37,7 +39,7 @@ class WorkspaceService(Service):
         self.groceryService.renameWorkspace(request.oldName, request.newName)
 
     @FromString
-    def renameFromTemplate(self, request: RenameWorkspaceFromTemplateRequest) -> List[WorkspaceName]:
+    def renameFromTemplate(self, request: RenameWorkspacesFromTemplateRequest) -> List[WorkspaceName]:
         """
         Renames workspaces by applying a template to them.
         """
@@ -46,7 +48,7 @@ class WorkspaceService(Service):
         for workspace in request.workspaces:
             ws = self.groceryService.getWorkspaceForName(workspace)
             if ws.isGroup():
-                subRequest = RenameWorkspaceFromTemplateRequest(
+                subRequest = RenameWorkspacesFromTemplateRequest(
                     workspaces=ws.getNames(),
                     renameTemplate=request.renameTemplate,
                 )
@@ -55,8 +57,16 @@ class WorkspaceService(Service):
         return newWorkspaces
 
     @FromString
-    def clear(self, request: ClearWorkspaceRequest):
+    def clear(self, request: ClearWorkspacesRequest):
         """
         Clears the workspaces, excluding the given list of items and cache.
         """
-        self.groceryService.clearADS(request.exclude, request.cache)
+        self.groceryService.clearADS(request.exclude, request.clearCache)
+
+    def getResidentWorkspaces(self, request: ListWorkspacesRequest):
+        """
+        Gets the list of workspaces resident in the ADS:
+        
+        - optionally excludes the cached workspaces from this list.
+        """
+        return self.groceryService.getResidentWorkspaces(excludeCache=request.excludeCache)

--- a/src/snapred/ui/handler/SNAPResponseHandler.py
+++ b/src/snapred/ui/handler/SNAPResponseHandler.py
@@ -1,12 +1,14 @@
 import threading
 
-from qtpy.QtCore import Signal
+from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import QMessageBox, QWidget
 
-from snapred.backend.dao.SNAPResponse import ResponseCode
+from snapred.backend.dao.request.InitializeStateHandler import InitializeStateHandler
+from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.error.RecoverableException import RecoverableException
 from snapred.backend.log.logger import snapredLogger
+from snapred.ui.view.InitializeStateCheckView import InitializationMenu
 
 logger = snapredLogger.getLogger(__name__)
 
@@ -24,6 +26,7 @@ class SNAPResponseHandler(QWidget):
     def handle(self, result):
         self.signal.emit(result)
 
+    @Slot(SNAPResponse)
     def _handle(self, result):
         # if no complications, do nothing here (program will continue)
         # if errors, do nothing here (program will halt)
@@ -110,9 +113,6 @@ class SNAPResponseHandler(QWidget):
         """
         Handles a specific 'state' message.
         """
-        from snapred.backend.dao.request.InitializeStateHandler import InitializeStateHandler
-        from snapred.ui.view.InitializeStateCheckView import InitializationMenu
-
         try:
             logger.info("Handling 'state' message.")
             initializationMenu = InitializationMenu(

--- a/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
+++ b/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
@@ -1,4 +1,4 @@
-from qtpy.QtCore import QObject
+from qtpy.QtCore import QObject, Slot
 
 from snapred.backend.api.InterfaceController import InterfaceController
 from snapred.backend.dao import RunConfig, SNAPRequest
@@ -31,6 +31,7 @@ class CalibrationAssessmentPresenter(QObject):
         super().__init__()
         self.view = view
 
+    @Slot()
     def loadSelectedCalibrationAssessment(self):
         if self.view.getCalibrationRecordCount() < 1:
             self.view.onError("No calibration records available.")
@@ -57,10 +58,12 @@ class CalibrationAssessmentPresenter(QObject):
         self.worker.result.connect(self.handleLoadAssessmentResult)
         self.worker_pool.submitWorker(self.worker)
 
+    @Slot(SNAPResponse)
     def handleLoadAssessmentResult(self, response: SNAPResponse):
         if response.code == ResponseCode.ERROR:
             self.view.onError(response.message)
 
+    @Slot(str, bool)
     def loadCalibrationIndex(self, runNumber: str, useLiteMode: bool):
         payload = CalibrationIndexRequest(
             run=RunConfig(runNumber=runNumber, useLiteMode=useLiteMode),
@@ -73,6 +76,7 @@ class CalibrationAssessmentPresenter(QObject):
         self.worker.result.connect(self.handleLoadCalibrationIndexResult)
         self.worker_pool.submitWorker(self.worker)
 
+    @Slot(SNAPResponse)
     def handleLoadCalibrationIndexResult(self, response: SNAPResponse):
         if response.code == ResponseCode.ERROR:
             self.view.onError(response.message)

--- a/src/snapred/ui/presenter/InitializeStatePresenter.py
+++ b/src/snapred/ui/presenter/InitializeStatePresenter.py
@@ -6,7 +6,7 @@ from snapred.backend.dao.request.InitializeStateRequest import InitializeStateRe
 from snapred.backend.dao.SNAPRequest import SNAPRequest
 from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.ui.widget.LoadingCursor import LoadingCursor
-from snapred.ui.widget.SuccessDialog import SuccessDialog
+from snapred.ui.widget.SuccessPrompt import SuccessPrompt
 
 
 class InitializeStatePresenter(QObject):
@@ -53,5 +53,4 @@ class InitializeStatePresenter(QObject):
         else:
             self.stateInitialized.emit(response)
             self.loadingCursor.close()
-            successDialog = SuccessDialog(self.view)
-            successDialog.exec_()
+            SuccessPrompt.prompt(self.view)

--- a/src/snapred/ui/presenter/TestPanelPresenter.py
+++ b/src/snapred/ui/presenter/TestPanelPresenter.py
@@ -17,29 +17,27 @@ class TestPanelPresenter(object):
     def __init__(self, view):
         self.view = view
 
-        self.diffractionCalibrationWidget = self._createWorkflowWidget(self._createDiffCalWorkflow)
-        self.calibrationNormalizationWidget = self._createWorkflowWidget(self._createNormalizationWorkflow)
-        self.reductionWidget = self._createWorkflowWidget(self._createReductionWorkflow)
+        # For testing purposes:
+        #   here we retain references to the workflows themselves, and not just their widgets,
+        #   so that we can access their signals.
+        self.diffractionCalibrationWorkflow = DiffCalWorkflow(parent=self.view)
+        self.normalizationCalibrationWorkflow = NormalizationWorkflow(parent=self.view)
+        self.reductionWorkflow = ReductionWorkflow(parent=self.view)
+
+        self.diffractionCalibrationWidget = self._addWorkflowWidget(self.diffractionCalibrationWorkflow.widget)
+        self.normalizationCalibrationWidget = self._addWorkflowWidget(self.normalizationCalibrationWorkflow.widget)
+        self.reductionWidget = self._addWorkflowWidget(self.reductionWorkflow.widget)
 
         self.view.tabWidget.addTab(self.diffractionCalibrationWidget, "Diffraction Calibration")
-        self.view.tabWidget.addTab(self.calibrationNormalizationWidget, "Normalization")
+        self.view.tabWidget.addTab(self.normalizationCalibrationWidget, "Normalization")
         self.view.tabWidget.addTab(self.reductionWidget, "Reduction")
 
-    def _createWorkflowWidget(self, method):
+    def _addWorkflowWidget(self, widget_):
         layout = QGridLayout()
         widget = QWidget()
         widget.setLayout(layout)
-        layout.addWidget(method())
+        layout.addWidget(widget_)
         return widget
-
-    def _createDiffCalWorkflow(self):
-        return DiffCalWorkflow(parent=self.view).widget
-
-    def _createNormalizationWorkflow(self):
-        return NormalizationWorkflow(parent=self.view).widget
-
-    def _createReductionWorkflow(self):
-        return ReductionWorkflow(parent=self.view).widget
 
     @property
     def widget(self):

--- a/src/snapred/ui/presenter/WorkflowNodePresenter_.py
+++ b/src/snapred/ui/presenter/WorkflowNodePresenter_.py
@@ -1,5 +1,7 @@
 from time import sleep
 
+from qtpy.QtCore import QObject, Signal, Slot
+
 from snapred.ui.threading.worker_pool import WorkerPool
 
 
@@ -15,10 +17,14 @@ class _Spinner:
         return symbol
 
 
-class WorkflowPresenter(object):
+class WorkflowNodePresenter(QObject):
     worker_pool = WorkerPool()
 
+    # Allow an observer (e.g. `qtbot`) to monitor action completion.
+    actionCompleted = Signal()
+
     def __init__(self, view, model):
+        super().__init__()
         self.view = view
         self.model = model
 
@@ -32,9 +38,11 @@ class WorkflowPresenter(object):
     def show(self):
         self.view.show()
 
+    @Slot()
     def updateSubview(self):
         self.view.updateSubview(self.model.view)
 
+    @Slot()
     def handleContinueButtonClicked(self):
         self.view.continueButton.setEnabled(False)
         self.view.quitButton.setEnabled(False)
@@ -62,10 +70,13 @@ class WorkflowPresenter(object):
 
         self.worker_pool.submitWorker(self.infworker)
         self.worker_pool.submitWorker(self.worker)
+        self.actionCompleted.emit()
 
+    @Slot()
     def handleQuitButtonClicked(self):
         self.view.close()
 
+    @Slot()
     def _updateButton(self, text):
         self.view.button.setText(text)
 

--- a/src/snapred/ui/presenter/WorkflowPresenter.py
+++ b/src/snapred/ui/presenter/WorkflowPresenter.py
@@ -1,8 +1,9 @@
+from typing import Callable, List
+
+from qtpy.QtCore import QObject, Signal, Slot
 from qtpy.QtWidgets import QMainWindow
 
 from snapred.backend.api.InterfaceController import InterfaceController
-from snapred.backend.dao import SNAPRequest
-from snapred.backend.dao.request import ClearWorkspaceRequest
 from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.log.logger import snapredLogger
 from snapred.ui.handler.SNAPResponseHandler import SNAPResponseHandler
@@ -14,19 +15,51 @@ from snapred.ui.widget.ActionPrompt import ActionPrompt
 logger = snapredLogger.getLogger(__name__)
 
 
-class WorkflowPresenter(object):
+class WorkflowPresenter(QObject):
+    enableAllWorkflows = Signal()
+    disableOtherWorkflows = Signal()
     worker_pool = WorkerPool()
 
-    def __init__(self, model: WorkflowNodeModel, cancelLambda=None, iterateLambda=None, parent=None):
+    actionCompleted = Signal()  # Allow an observer (e.g. ``qtbot``) to monitor action completion.
+
+    def __init__(
+        self,
+        model: WorkflowNodeModel,
+        startLambda=None,
+        iterateLambda=None,
+        resetLambda=None,
+        cancelLambda=None,
+        parent=None,
+    ):
+        super().__init__()
         self.view = WorkflowView(model, parent)
         self._iteration = 1
         self.model = model
-        self._cancelLambda = cancelLambda
-        self._iterateLambda = iterateLambda
-        self.resetLambda = self.resetAndClear
+
+        # All workflow "hook" methods must be initialized, either to a bound method
+        #   or to an equivalent lambda function taking arguments as specified.
+        self._startLambda: Callable[[], None] = startLambda if startLambda is not None else self._NOP
+        self._iterateLambda: Callable[[WorkflowPresenter], None] = (
+            iterateLambda if iterateLambda is not None else self._NOP
+        )
+        self._resetLambda: Callable[[], None] = resetLambda if resetLambda is not None else self.reset
+        self._cancelLambda: Callable[[], None] = cancelLambda if cancelLambda is not None else self.resetWithPermission
+
+        self.externalWorkspaces: List[str] = []
+        # Retain list of ADS-resident workspaces at start of workflow
+
+        self.interfaceController = InterfaceController()
+
         self._hookupSignals()
         self.responseHandler = SNAPResponseHandler(self.view)
         self.responseHandler.continueAnyway.connect(self.continueAnyway)
+
+        if self.view.parent() is not None:
+            self.enableAllWorkflows.connect(self.view.parent().enableAllWorkflows)
+            self.disableOtherWorkflows.connect(self.view.parent().disableOtherWorkflows)
+
+    def _NOP(self):
+        pass
 
     @property
     def widget(self):
@@ -45,29 +78,27 @@ class WorkflowPresenter(object):
     def resetSoft(self):
         self.widget.reset(hard=False)
 
-    def clearWorkspacesRequest(self):
-        interfaceController = InterfaceController()
-        clearWorkspacesRequest = ClearWorkspaceRequest(cache=True, exclude=[])
-        snapRequest = SNAPRequest(path="workspace/clear", payload=clearWorkspacesRequest.json())
-        interfaceController.executeRequest(snapRequest)
-
     def resetHard(self):
         self.widget.reset(hard=True)
 
-    def resetAndClear(self):
+    def reset(self):
+        self._resetLambda()
         self.resetSoft()
-        self.clearWorkspacesRequest()
         self._iteration = 1
 
-    def cancel(self):
-        ActionPrompt(
+        # Workflow is complete: enable the other workflow tabs.
+        self.enableAllWorkflows.emit()
+
+    def resetWithPermission(self):
+        ActionPrompt.prompt(
             "Are you sure?",
             "Are you sure you want to cancel the workflow? This will clear all workspaces.",
-            self.resetAndClear,
+            self.reset,
             self.view,
         )
 
     def iterate(self):
+        self._iterateLambda(self)
         self._iteration += 1
         self.resetSoft()
 
@@ -91,14 +122,9 @@ class WorkflowPresenter(object):
                 widget.enableIterate()
 
             widget.onContinueButtonClicked(self.handleContinueButtonClicked)
-
-            if self._cancelLambda:
-                widget.onCancelButtonClicked(self._cancelLambda)
-            else:
-                widget.onCancelButtonClicked(self.cancel)
+            widget.onCancelButtonClicked(self._cancelLambda)
 
     def handleIterateButtonClicked(self):
-        self._iterateLambda(self)
         self.iterate()
 
     def handleSkipButtonClicked(self):
@@ -106,47 +132,57 @@ class WorkflowPresenter(object):
 
     def advanceWorkflow(self):
         if self.view.currentTab >= self.view.totalNodes - 1:
-            ActionPrompt(
+            ActionPrompt.prompt(
                 "‧₊Workflow Complete‧₊",
                 "‧₊‧₊The workflow has been completed successfully!‧₊‧₊",
                 lambda: None,
                 self.view,
             )
-            self.resetLambda()
+            self.reset()
         else:
             self.view.advanceWorkflow()
 
-    def setResetLambda(self, resetLambda):
-        self.resetLambda = resetLambda
-
     def handleContinueButtonClicked(self, model):
+        if self.view.currentTab == 0:
+            self._startLambda()
+
+            # disable other workflow-tabs during workflow execution
+            self.disableOtherWorkflows.emit()
+
         # disable navigation buttons during run
         self._enableButtons(False)
 
         # scoped action to verify before running
         def verifyAndContinue():
-            # This will toss any exceptions and stop the continue
+            # On verification failure: this will raise an exception and abort the continue.
             self.view.tabView.verify()
-            # this will handle the request if no verification failed, getting the true snapresponse
+
+            # On verification success: this will return the correct SNAPResponse.
             return model.continueAction(self)
 
         # do action
         self.worker = self.worker_pool.createWorker(target=verifyAndContinue, args=None)
-        self.worker.finished.connect(lambda: self._enableButtons(True))  # renable buttons on finish
+        self.worker.finished.connect(lambda: self._enableButtons(True))  # re-enable panel buttons on finish
         self.worker.result.connect(self._handleComplications)
         self.worker.success.connect(lambda success: self.advanceWorkflow() if success else None)
         self.worker_pool.submitWorker(self.worker)
+        self.actionCompleted.emit()
 
+    @Slot(bool)
     def _enableButtons(self, enable):
-        # NOTE this is necessary in order for the buttons to actually be updated from worker
+        # This slot is necessary in order for the buttons to actually be updated from the worker.
         buttons = [self.view.continueButton, self.view.cancelButton, self.view.skipButton]
         for button in buttons:
             button.setEnabled(enable)
 
+    @Slot(object)
     def _handleComplications(self, result):
+        # The associated signal is of type ``Signal(Worker.result) as Signal(object)``
         self.responseHandler.handle(result)
 
+    @Slot(object)
     def continueAnyway(self, continueInfo: ContinueWarning.Model):
+        # The associated signal is of type ``Signal(SNAPResponseHandler.continueAnyway) as Signal(object)``
         if self.model.continueAnywayHandler:
             self.model.continueAnywayHandler(continueInfo)
 

--- a/src/snapred/ui/threading/worker_pool.py
+++ b/src/snapred/ui/threading/worker_pool.py
@@ -1,6 +1,6 @@
 from typing import Dict, List
 
-from qtpy.QtCore import QObject, QThread, Signal
+from qtpy.QtCore import QObject, QThread, Signal, Slot
 
 from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.backend.error.ContinueWarning import ContinueWarning
@@ -21,6 +21,7 @@ class Worker(QObject):
         self.target = target
         self.args = args
 
+    @Slot()
     def run(self):
         """Long-running task."""
         try:
@@ -67,9 +68,11 @@ class InfiniteWorker(QObject):
         self.target = target
         self.args = args
 
+    @Slot()
     def stop(self):
         self._kill = True
 
+    @Slot()
     def run(self):
         """inf running task."""
         while not self._kill:
@@ -101,7 +104,7 @@ class WorkerPool:
         else:
             # spawn thread and deligate
             thread = QThread()
-            # WARN: maybe the worker shouldnt be a key, not sure how equivelence is solved
+            # WARN: maybe the worker shouldn't be a key, not sure how equivelence is solved
             self.threads[worker] = thread
             worker.moveToThread(thread)
             # Step 5: Connect signals and slots

--- a/src/snapred/ui/view/ActionPromptView.py
+++ b/src/snapred/ui/view/ActionPromptView.py
@@ -1,3 +1,4 @@
+from qtpy.QtCore import Slot
 from qtpy.QtWidgets import QDesktopWidget, QGridLayout, QLabel, QMainWindow, QPushButton, QWidget
 
 
@@ -37,6 +38,7 @@ class ActionPromptView(QMainWindow):
         self.move(qtRectangle.topLeft())
 
     def onContinueButtonClicked(self, slot):
+        @Slot()
         def slotAndClose():
             slot()
             self.close()

--- a/src/snapred/ui/view/DiffCalAssessmentView.py
+++ b/src/snapred/ui/view/DiffCalAssessmentView.py
@@ -1,7 +1,6 @@
 from typing import List
 
-# from qtpy import signals and widgets
-from qtpy.QtCore import Signal
+from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import QComboBox, QGridLayout, QLabel, QMessageBox, QPushButton, QWidget
 
 from snapred.backend.dao.indexing.IndexEntry import IndexEntry
@@ -83,13 +82,15 @@ class DiffCalAssessmentView(QWidget):
     def onError(self, msg: str):
         self.signalError.emit(msg)
 
+    @Slot()
     def _displayError(self, msg: str):
-        msgBox = QMessageBox()
-        msgBox.setWindowTitle("Error")
-        msgBox.setIcon(QMessageBox.Critical)
-        msgBox.setText(msg)
-        msgBox.setFixedSize(500, 200)
-        msgBox.exec()
+        # Note: specifically using the static method `QMessageBox.critical` here helps with automated testing.
+        # (That is, we can "mock.patch" just that method, and not patch the entire `QMessageBox` class.)
+        QMessageBox.critical(
+            self,
+            "Error",
+            msg,
+        )
 
     def updateRunNumber(self, runNumber, useLiteMode):
         self.signalRunNumberUpdate.emit(runNumber, useLiteMode)

--- a/src/snapred/ui/view/DiffCalSaveView.py
+++ b/src/snapred/ui/view/DiffCalSaveView.py
@@ -1,4 +1,4 @@
-from qtpy.QtCore import Signal
+from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import QComboBox, QGridLayout, QLabel, QLineEdit, QWidget
 
 from snapred.meta.decorators.Resettable import Resettable
@@ -62,6 +62,7 @@ class DiffCalSaveView(QWidget):
 
     # This signal boilerplate mumbo jumbo is necessary because worker threads cant update the gui directly
     # So we have to send a signal to the main thread to update the gui, else we get an unhelpful segfault
+    @Slot(str)
     def _updateRunNumber(self, runNumber):
         self.fieldRunNumber.setText(runNumber)
 

--- a/src/snapred/ui/view/InitializeStateCheckView.py
+++ b/src/snapred/ui/view/InitializeStateCheckView.py
@@ -1,3 +1,4 @@
+from qtpy.QtCore import Slot
 from qtpy.QtWidgets import (
     QDialog,
     QGridLayout,
@@ -65,6 +66,7 @@ class InitializationMenu(QDialog):
     def getMode(self):
         return self.useLiteMode
 
+    @Slot()
     def handleButtonClicked(self):
         runNumber = self.getRunNumber()
         stateName = self.getStateName()

--- a/src/snapred/ui/view/NormalizationSaveView.py
+++ b/src/snapred/ui/view/NormalizationSaveView.py
@@ -1,4 +1,4 @@
-from qtpy.QtCore import Signal
+from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import QLabel
 
 from snapred.meta.decorators.Resettable import Resettable
@@ -56,16 +56,18 @@ class NormalizationSaveView(BackendRequestView):
         self.layout.addWidget(self.fieldComments)
         self.layout.addWidget(self.fieldAuthor)
 
-    def _updateRunNumber(self, runNumber):
+    @Slot(str)
+    def _updateRunNumber(self, runNumber: str):
         self.fieldRunNumber.setText(runNumber)
 
-    def updateRunNumber(self, runNumber):
+    def updateRunNumber(self, runNumber: str):
         self.signalRunNumberUpdate.emit(runNumber)
 
-    def _updateBackgroundRunNumber(self, backgroundRunNumber):
+    @Slot(str)
+    def _updateBackgroundRunNumber(self, backgroundRunNumber: str):
         self.fieldBackgroundRunNumber.setText(backgroundRunNumber)
 
-    def updateBackgroundRunNumber(self, backgroundRunNumber):
+    def updateBackgroundRunNumber(self, backgroundRunNumber: str):
         self.signalBackgroundRunNumberUpdate.emit(backgroundRunNumber)
 
     def verify(self):

--- a/src/snapred/ui/view/NormalizationTweakPeakView.py
+++ b/src/snapred/ui/view/NormalizationTweakPeakView.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import pydantic
 from mantid.plots.datafunctions import get_spectrum
 from mantid.simpleapi import mtd
-from qtpy.QtCore import Signal
+from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import (
     QHBoxLayout,
     QLineEdit,
@@ -105,18 +105,21 @@ class NormalizationTweakPeakView(BackendRequestView):
         self.signalUpdateFields.connect(self._updateFields)
         self.signalPopulateGroupingDropdown.connect(self._populateGroupingDropdown)
 
+    @Slot(str)
     def _updateRunNumber(self, runNumber):
         self.fieldRunNumber.setText(runNumber)
 
     def updateRunNumber(self, runNumber):
         self.signalRunNumberUpdate.emit(runNumber)
 
+    @Slot(str)
     def _updateBackgroundRunNumber(self, backgroundRunNumber):
         self.fieldBackgroundRunNumber.setText(backgroundRunNumber)
 
     def updateBackgroundRunNumber(self, backgroundRunNumber):
         self.signalBackgroundRunNumberUpdate.emit(backgroundRunNumber)
 
+    @Slot(int, int, float)
     def _updateFields(self, sampleIndex, groupingIndex, smoothingParameter):
         self.sampleDropdown.setCurrentIndex(sampleIndex)
         self.groupingFileDropdown.setCurrentIndex(groupingIndex)
@@ -125,6 +128,7 @@ class NormalizationTweakPeakView(BackendRequestView):
     def updateFields(self, sampleIndex, groupingIndex, smoothingParameter):
         self.signalUpdateFields.emit(sampleIndex, groupingIndex, smoothingParameter)
 
+    @Slot()
     def emitValueChange(self):
         # verify the fields before recalculation
         try:
@@ -212,6 +216,7 @@ class NormalizationTweakPeakView(BackendRequestView):
             colSize = sqrtSize + 1
         return rowSize, colSize
 
+    @Slot(bool)
     def setEnableRecalculateButton(self, enable):
         self.recalculationButton.setEnabled(enable)
 
@@ -221,6 +226,7 @@ class NormalizationTweakPeakView(BackendRequestView):
     def enableRecalculateButton(self):
         self.signalUpdateRecalculationButton.emit(True)
 
+    @Slot(list)
     def _populateGroupingDropdown(self, groups=["Enter a Run Number"]):
         self.groupingFileDropdown.setItems(groups)
         self.groupingFileDropdown.setEnabled(True)

--- a/src/snapred/ui/view/PromptUserforCalibrationInputView.py
+++ b/src/snapred/ui/view/PromptUserforCalibrationInputView.py
@@ -1,4 +1,4 @@
-from qtpy.QtCore import Qt, Signal
+from qtpy.QtCore import Qt, Signal, Slot
 from qtpy.QtWidgets import QDialog, QLabel, QLineEdit, QPushButton, QVBoxLayout
 
 
@@ -30,6 +30,7 @@ class PromptUserforCalibrationInputView(QDialog):
     def getName(self):
         return self.name_input.text()
 
+    @Slot()
     def handle_continue_click(self):
         run_number = self.getRunNumber()
         state_name = self.getName()

--- a/src/snapred/ui/view/TestPanelView.py
+++ b/src/snapred/ui/view/TestPanelView.py
@@ -1,3 +1,4 @@
+from qtpy.QtCore import Slot
 from qtpy.QtWidgets import QGridLayout, QMainWindow, QTabWidget, QWidget
 
 
@@ -17,3 +18,17 @@ class TestPanelView(QMainWindow):
         self.tabWidget.setTabPosition(QTabWidget.West)
         self.grid.addWidget(self.tabWidget)
         self.adjustSize()
+
+    @Slot()
+    def enableAllWorkflows(self):
+        for n in range(self.tabWidget.count()):
+            self.tabWidget.setTabEnabled(n, True)
+
+    @Slot()
+    def disableOtherWorkflows(self):
+        # Once a workflow-tab has been clicked, disable the others
+        #   until that workflow has been completed (or reset).
+        currentTab = self.tabWidget.currentIndex()
+        for n in range(self.tabWidget.count()):
+            if n != currentTab:
+                self.tabWidget.setTabEnabled(n, False)

--- a/src/snapred/ui/view/WorkflowView.py
+++ b/src/snapred/ui/view/WorkflowView.py
@@ -1,3 +1,4 @@
+from qtpy.QtCore import Slot
 from qtpy.QtWidgets import QGridLayout, QTabWidget, QWidget
 
 from snapred.ui.model.WorkflowNodeModel import WorkflowNodeModel
@@ -16,6 +17,7 @@ class WorkflowView(QWidget):
 
         # add a tab widget
         self.tabWidget = QTabWidget()
+        self.tabWidget.setObjectName("nodeTabs")
         self.tabWidget.tabBarClicked.connect(self.handleTabClicked)
         self.layout.addWidget(self.tabWidget)
 
@@ -27,16 +29,19 @@ class WorkflowView(QWidget):
         for i in range(1, self.tabWidget.count()):
             self.tabWidget.setTabEnabled(i, False)
 
+    @Slot(int)
     def handleTabClicked(self, index):
         # if clicked tab is enabled, set current tab to clicked tab
         if self.tabWidget.isTabEnabled(index):
             self.currentTab = index
 
+    @Slot()
     def goBack(self):
         if self.currentTab > 0:
             self.currentTab -= 1
             self.tabWidget.setCurrentIndex(self.currentTab)
 
+    @Slot()
     def goForward(self):
         if self.currentTab < self.position:
             self.currentTab += 1

--- a/src/snapred/ui/view/reduction/ReductionRequestView.py
+++ b/src/snapred/ui/view/reduction/ReductionRequestView.py
@@ -1,7 +1,8 @@
 from typing import Callable, List, Optional
 
-from qtpy.QtCore import Signal
-from qtpy.QtWidgets import QHBoxLayout, QLineEdit, QPushButton, QTextEdit, QVBoxLayout
+from qtpy.QtCore import Signal, Slot
+from qtpy.QtWidgets import QHBoxLayout, QLineEdit, QPushButton, QTextEdit, QVBoxLayout, QWidget
+
 from snapred.backend.log.logger import snapredLogger
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.view.BackendRequestView import BackendRequestView
@@ -64,6 +65,7 @@ class ReductionRequestView(BackendRequestView):
 
         self.signalRemoveRunNumber.connect(self._removeRunNumber)
 
+    @Slot()
     def addRunNumber(self):
         runNumberList = self.parseInputRunNumbers()
         if runNumberList is not None:
@@ -89,9 +91,11 @@ class ReductionRequestView(BackendRequestView):
                     "Please enter a valid run number or list of run numbers. (e.g. 46680, 46685, 46686, etc...)"
                 )
 
+    @Slot()
     def removeRunNumber(self, runNumber):
         self.signalRemoveRunNumber.emit(runNumber)
 
+    @Slot()
     def _removeRunNumber(self, runNumber):
         if runNumber not in self.runNumbers:
             logger.warning(
@@ -130,11 +134,3 @@ class ReductionRequestView(BackendRequestView):
     def getPixelMasks(self):
         return self.pixelMaskDropdown.checkedItems()
 
-    # Placeholder for checkBox logic
-    """
-    def onCheckBoxChecked(self, checked):
-        if checked:
-
-        else:
-            pass
-    """

--- a/src/snapred/ui/view/reduction/ReductionRequestView.py
+++ b/src/snapred/ui/view/reduction/ReductionRequestView.py
@@ -1,8 +1,7 @@
 from typing import Callable, List, Optional
 
 from qtpy.QtCore import Signal, Slot
-from qtpy.QtWidgets import QHBoxLayout, QLineEdit, QPushButton, QTextEdit, QVBoxLayout, QWidget
-
+from qtpy.QtWidgets import QHBoxLayout, QLineEdit, QPushButton, QTextEdit, QVBoxLayout
 from snapred.backend.log.logger import snapredLogger
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.view.BackendRequestView import BackendRequestView
@@ -133,4 +132,3 @@ class ReductionRequestView(BackendRequestView):
 
     def getPixelMasks(self):
         return self.pixelMaskDropdown.checkedItems()
-

--- a/src/snapred/ui/widget/ActionPrompt.py
+++ b/src/snapred/ui/widget/ActionPrompt.py
@@ -14,3 +14,8 @@ class ActionPrompt:
     @property
     def widget(self):
         return self.view
+
+    # A static "factory" method to facilitate testing.
+    @staticmethod
+    def prompt(title, message, action, parent=None):
+        ActionPrompt(title, message, action, parent)

--- a/src/snapred/ui/widget/LabeledCheckBox.py
+++ b/src/snapred/ui/widget/LabeledCheckBox.py
@@ -1,9 +1,9 @@
-from qtpy.QtCore import Signal as pyqtSignal
+from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import QCheckBox, QHBoxLayout, QLabel, QWidget
 
 
 class LabeledCheckBox(QWidget):
-    checkedChanged = pyqtSignal(bool)
+    checkedChanged = Signal(bool)
 
     def __init__(self, label, parent=None):
         super(LabeledCheckBox, self).__init__(parent)
@@ -21,6 +21,7 @@ class LabeledCheckBox(QWidget):
 
         self._checkBox.stateChanged.connect(self.emitCheckedState)
 
+    @Slot()
     def emitCheckedState(self, state):
         self.checkedChanged.emit(state == QCheckBox.isChecked)
 

--- a/src/snapred/ui/widget/Section.py
+++ b/src/snapred/ui/widget/Section.py
@@ -118,6 +118,7 @@ class Section(wd.QWidget):
         self.updateAnimationHeight(self.contentHeight)
         self.toggleAnimation.start()
 
+    @cr.Slot()
     def toggle(self, collapsed):
         height = self.contentArea.layout().sizeHint().height() + self.collapsedHeight * 2
         if collapsed:

--- a/src/snapred/ui/widget/SmoothingSlider.py
+++ b/src/snapred/ui/widget/SmoothingSlider.py
@@ -1,6 +1,6 @@
 import math
 
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import QHBoxLayout, QLineEdit, QMessageBox, QSlider, QWidget
 
 
@@ -50,11 +50,13 @@ class SmoothingSlider(QWidget):
         self._slider.valueChanged.connect(self._updateNumberFromSlider)
         self._number.editingFinished.connect(self._updateSliderFromNumber)
 
+    @Slot()
     def _updateNumberFromSlider(self):
         v = self._slider.value() / 100.0
         s = 10**v
         self._number.setText("{:.2e}".format(s))
 
+    @Slot()
     def _updateSliderFromNumber(self):
         text = self._number.text()
         try:

--- a/src/snapred/ui/widget/SuccessPrompt.py
+++ b/src/snapred/ui/widget/SuccessPrompt.py
@@ -1,8 +1,8 @@
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import QDialog, QLabel, QPushButton, QVBoxLayout
 
 
-class SuccessDialog(QDialog):
+class SuccessPrompt(QDialog):
     """
 
     This qt dialog is crafted to provide users with immediate, clear feedback on successful operations,
@@ -17,6 +17,7 @@ class SuccessDialog(QDialog):
 
     def __init__(self, parent=None):
         super().__init__(parent, Qt.WindowCloseButtonHint | Qt.WindowTitleHint)
+        self.setWindowModality(Qt.ApplicationModal)
         self.setWindowTitle("Success")
         self.setFixedSize(300, 120)
         layout = QVBoxLayout()
@@ -24,13 +25,21 @@ class SuccessDialog(QDialog):
         label = QLabel("State initialized successfully.")
         layout.addWidget(label)
 
-        okButton = QPushButton("OK")
-        layout.addWidget(okButton)
-        okButton.clicked.connect(self.accept)
+        self.okButton = QPushButton("OK")
+        layout.addWidget(self.okButton)
+        self.okButton.clicked.connect(self.accept)
 
         self.setLayout(layout)
 
+    @Slot()
     def accept(self):
         super().accept()
         if self.parent():
             self.parent().close()
+
+    # A static "factory" method to facilitate testing.
+    @staticmethod
+    def prompt(parent=None):
+        # Use of `setWindowModality(Qt.ApplicationModal)` with `open`
+        #   allows synchronous tasks.  Use of `exec_` does not, and should be avoided.
+        SuccessPrompt(parent).open()

--- a/src/snapred/ui/widget/UserDocsButton.py
+++ b/src/snapred/ui/widget/UserDocsButton.py
@@ -1,4 +1,4 @@
-from qtpy.QtCore import QUrl
+from qtpy.QtCore import QUrl, Slot
 from qtpy.QtWebEngineWidgets import QWebEngineView
 from qtpy.QtWidgets import QHBoxLayout, QPushButton, QWidget
 
@@ -26,6 +26,7 @@ class UserDocsButton(QWidget):
         self.button.clicked.connect(self.launchWebView)
         layout.addWidget(self.button)
 
+    @Slot()
     def launchWebView(self):
         # Create and configure the web view
         self.webView = QWebEngineView()

--- a/src/snapred/ui/widget/Workflow.py
+++ b/src/snapred/ui/widget/Workflow.py
@@ -3,10 +3,24 @@ from snapred.ui.presenter.WorkflowPresenter import WorkflowPresenter
 
 
 class Workflow:
-    def __init__(self, model: WorkflowNodeModel, cancelLambda=None, iterateLambda=None, parent=None):
+    def __init__(
+        self,
+        model: WorkflowNodeModel,
+        *,
+        startLambda=None,
+        iterateLambda=None,
+        resetLambda=None,
+        cancelLambda=None,
+        parent=None,
+    ):
         # default loading subview
         self._presenter = WorkflowPresenter(
-            model, cancelLambda=cancelLambda, iterateLambda=iterateLambda, parent=parent
+            model,
+            startLambda=startLambda,
+            iterateLambda=iterateLambda,
+            resetLambda=resetLambda,
+            cancelLambda=cancelLambda,
+            parent=parent,
         )
 
     @property

--- a/src/snapred/ui/widget/WorkflowNode_.py
+++ b/src/snapred/ui/widget/WorkflowNode_.py
@@ -1,4 +1,4 @@
-from snapred.ui.presenter.WorkflowNodePresenter import WorkflowPresenter
+from snapred.ui.presenter.WorkflowNodePresenter import WorkflowNodePresenter
 from snapred.ui.view.WorkflowNodeView import WorkflowNodeView
 
 
@@ -7,7 +7,7 @@ class WorkflowNode:
         # default loading subview
         subview = model.view
         view = WorkflowNodeView(subview, parent)
-        self._presenter = WorkflowPresenter(view, model)
+        self._presenter = WorkflowNodePresenter(view, model)
 
     @property
     def presenter(self):

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -1,9 +1,9 @@
 from qtpy.QtCore import Slot
 
 from snapred.backend.dao import RunConfig
-from snapred.backend.dao.Limit import Pair
 from snapred.backend.dao.indexing.IndexEntry import IndexEntry
 from snapred.backend.dao.indexing.Versioning import VersionedObject
+from snapred.backend.dao.Limit import Pair
 from snapred.backend.dao.request import (
     CalibrationAssessmentRequest,
     CalibrationExportRequest,

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -1,4 +1,7 @@
+from qtpy.QtCore import Slot
+
 from snapred.backend.dao import RunConfig
+from snapred.backend.dao.Limit import Pair
 from snapred.backend.dao.indexing.IndexEntry import IndexEntry
 from snapred.backend.dao.indexing.Versioning import VersionedObject
 from snapred.backend.dao.request import (
@@ -11,10 +14,13 @@ from snapred.backend.dao.request import (
     FocusSpectraRequest,
     HasStateRequest,
 )
+from snapred.backend.dao.SNAPResponse import SNAPResponse
 from snapred.backend.log.logger import snapredLogger
 from snapred.meta.Config import Config
 from snapred.meta.decorators.ExceptionToErrLog import ExceptionToErrLog
+from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceType as wngt
+from snapred.ui.presenter.WorkflowPresenter import WorkflowPresenter
 from snapred.ui.view.DiffCalAssessmentView import DiffCalAssessmentView
 from snapred.ui.view.DiffCalRequestView import DiffCalRequestView
 from snapred.ui.view.DiffCalSaveView import DiffCalSaveView
@@ -84,16 +90,22 @@ class DiffCalWorkflow(WorkflowImplementer):
         # 4. user assesses calibration and chooses to iterate, or continue
         # 5. user may elect to save the calibration
         self.workflow = (
-            WorkflowBuilder(cancelLambda=self.resetWithPermission, iterateLambda=self._iterate, parent=parent)
+            WorkflowBuilder(
+                startLambda=self.start,
+                iterateLambda=self.iterate,
+                # Any implicit reset will retain output workspaces (at present: meaning reduction-output only).
+                resetLambda=self.reset,
+                parent=parent,
+            )
             .addNode(self._specifyRun, self._requestView, "Diffraction Calibration")
             .addNode(self._triggerDiffractionCalibration, self._tweakPeakView, "Tweak Peak Peek")
             .addNode(self._assessCalibration, self._assessmentView, "Assessing", iterate=True)
             .addNode(self._saveCalibration, self._saveView, name="Saving")
             .build()
         )
-        self.workflow.presenter.setResetLambda(self.reset)
 
     @ExceptionToErrLog
+    @Slot()
     def _populateGroupingDropdown(self):
         # when the run number is updated, freeze the drop down to populate it
         runNumber = self._requestView.runNumberField.text()
@@ -115,7 +127,7 @@ class DiffCalWorkflow(WorkflowImplementer):
                 self.groupingMap = self.defaultGroupingMap
             self.focusGroups = self.groupingMap.getMap(useLiteMode)
 
-            # populate and reenable the drop down
+            # populate and re-enable the drop down
             self._requestView.populateGroupingDropdown(list(self.focusGroups.keys()))
         except Exception as e:  # noqa BLE001
             print(e)
@@ -124,6 +136,7 @@ class DiffCalWorkflow(WorkflowImplementer):
         self._requestView.litemodeToggle.setEnabled(True)
 
     @ExceptionToErrLog
+    @Slot()
     def _switchLiteNativeGroups(self):
         # when the run number is updated, freeze the drop down to populate it
         useLiteMode = self._requestView.litemodeToggle.field.getState()
@@ -138,6 +151,7 @@ class DiffCalWorkflow(WorkflowImplementer):
 
         self._requestView.groupingFileDropdown.setEnabled(True)
 
+    @Slot(WorkflowPresenter, result=SNAPResponse)
     def _specifyRun(self, workflowPresenter):
         view = workflowPresenter.widget.tabView
 
@@ -204,6 +218,7 @@ class DiffCalWorkflow(WorkflowImplementer):
         return response
 
     @ExceptionToErrLog
+    @Slot(int, float, float, float, SymmetricPeakEnum, Pair, float)
     def onValueChange(self, groupingIndex, xtalDMin, xtalDMax, peakThreshold, peakFunction, fwhm, maxChiSq):
         self._tweakPeakView.disableRecalculateButton()
         # TODO: This is a temporary solution,
@@ -299,6 +314,7 @@ class DiffCalWorkflow(WorkflowImplementer):
         )
         return self.request(path="calibration/fitpeaks", payload=payload.json())
 
+    @Slot(WorkflowPresenter, result=SNAPResponse)
     def _triggerDiffractionCalibration(self, workflowPresenter):
         view = workflowPresenter.widget.tabView
 
@@ -355,6 +371,7 @@ class DiffCalWorkflow(WorkflowImplementer):
         self._assessmentView.updateRunNumber(self.runNumber, self.useLiteMode)
         return response
 
+    @Slot(WorkflowPresenter, result=SNAPResponse)
     def _assessCalibration(self, workflowPresenter):  # noqa: ARG002
         if workflowPresenter.iteration > 1:
             self._saveView.enableIterationDropdown()
@@ -373,6 +390,7 @@ class DiffCalWorkflow(WorkflowImplementer):
             for wsKey, wsNames in self.calibrationRecord.workspaces.items()
         }
 
+    @Slot(WorkflowPresenter, result=SNAPResponse)
     def _saveCalibration(self, workflowPresenter):
         view = workflowPresenter.widget.tabView
         runNumber = view.fieldRunNumber.get()

--- a/src/snapred/ui/workflow/WorkflowBuilder.py
+++ b/src/snapred/ui/workflow/WorkflowBuilder.py
@@ -3,10 +3,12 @@ from snapred.ui.widget.Workflow import Workflow
 
 
 class WorkflowBuilder:
-    def __init__(self, cancelLambda=None, iterateLambda=None, parent=None):
+    def __init__(self, *, startLambda=None, iterateLambda=None, resetLambda=None, cancelLambda=None, parent=None):
         self.parent = parent
-        self._cancelLambda = cancelLambda
+        self._startLambda = startLambda
         self._iterateLambda = iterateLambda
+        self._resetLambda = resetLambda
+        self._cancelLambda = cancelLambda
         self._workflow = None
 
     def addNode(
@@ -38,4 +40,11 @@ class WorkflowBuilder:
         return self
 
     def build(self):
-        return Workflow(self._workflow, self._cancelLambda, self._iterateLambda, self.parent)
+        return Workflow(
+            self._workflow,
+            startLambda=self._startLambda,
+            iterateLambda=self._iterateLambda,
+            resetLambda=self._resetLambda,
+            cancelLambda=self._cancelLambda,
+            parent=self.parent,
+        )

--- a/tests/resources/integration_test.yml
+++ b/tests/resources/integration_test.yml
@@ -7,4 +7,4 @@ IPTS:
   # Eventually, for SNAPRed's test framework:
   #   this should be a shared location on "analysis.sns.gov".
   # For the moment, each developer needs to set this individually to their local path.
-  root: /SNS/users/ux0/workspaces/SNAPRed/SNS_root
+  root: /mnt/data0/workspaces/ORNL-work/SNAPRed/SNS_root

--- a/tests/resources/outputs/APIServicePaths.json
+++ b/tests/resources/outputs/APIServicePaths.json
@@ -1,7 +1,7 @@
 {
   "mockService": {
     "": {
-      "mockObject": "{\n  \"properties\": {\n    \"m_list\": {\n      \"items\": {\n        \"type\": \"number\"\n      },\n      \"title\": \"M List\",\n      \"type\": \"array\"\n    },\n    \"m_float\": {\n      \"title\": \"M Float\",\n      \"type\": \"number\"\n    },\n    \"m_int\": {\n      \"title\": \"M Int\",\n      \"type\": \"integer\"\n    },\n    \"m_string\": {\n      \"title\": \"M String\",\n      \"type\": \"string\"\n    }\n  },\n  \"required\": [\n    \"m_list\",\n    \"m_float\",\n    \"m_int\",\n    \"m_string\"\n  ],\n  \"title\": \"<class 'test_APIService.MockObject'>\",\n  \"type\": \"object\"\n}"
+      "mockObject": "{\n  \"properties\": {\n    \"m_list\": {\n      \"items\": {\n        \"type\": \"number\"\n      },\n      \"title\": \"M List\",\n      \"type\": \"array\"\n    },\n    \"m_float\": {\n      \"title\": \"M Float\",\n      \"type\": \"number\"\n    },\n    \"m_int\": {\n      \"title\": \"M Int\",\n      \"type\": \"integer\"\n    },\n    \"m_string\": {\n      \"title\": \"M String\",\n      \"type\": \"string\"\n    }\n  },\n  \"required\": [\n    \"m_list\",\n    \"m_float\",\n    \"m_int\",\n    \"m_string\"\n  ],\n  \"title\": \"<class 'test_APIService.TestAPIService.test_getValidPaths.<locals>.MockObject'>\",\n  \"type\": \"object\"\n}"
     }
   }
 }

--- a/tests/unit/backend/api/test_APIService.py
+++ b/tests/unit/backend/api/test_APIService.py
@@ -1,46 +1,56 @@
 import json
+import sys
 import unittest.mock as mock
 from typing import List
 
 from pydantic import BaseModel
 
-# Mock out of scope modules before importing DataExportService
 
-with mock.patch.dict(
-    "sys.modules",
-    {"snapred.backend.data.DataExportService": mock.Mock(), "snapred.backend.data.DataFactoryService": mock.Mock()},
-):
-    from snapred.backend.service.ApiService import ApiService
-    from snapred.backend.service.Service import Service
-    from snapred.backend.service.ServiceDirectory import ServiceDirectory
-    from snapred.meta.Config import Resource
+class TestAPIService:
+    """
+    THIS initialization mocks the imported modules AT the time the test is actually RUN.
+    NOT AT the time the MODULE LOAD is triggered during the pytest-setup phase.
+    The effect of the latter is difficult to predict when considering modules which may
+    contain shallow references to other modules.
+    """
 
-    class MockObject(BaseModel):
-        m_list: List[float]
-        m_float: float
-        m_int: int
-        m_string: str
+    @mock.patch.dict(sys.modules)
+    def test_getValidPaths(self):
+        sys.modules.pop("snapred.backend.service.ApiService", None)
+        sys.modules.pop("snapred.backend.service.Service", None)
+        sys.modules.pop("snapred.backend.service.ServiceDirectory", None)
+        from snapred.backend.service.ApiService import ApiService
+        from snapred.backend.service.Service import Service
+        from snapred.backend.service.ServiceDirectory import ServiceDirectory
+        from snapred.meta.Config import Resource
 
-    class MockService(Service):
-        _name = "mockService"
+        class MockObject(BaseModel):
+            m_list: List[float]
+            m_float: float
+            m_int: int
+            m_string: str
 
-        def __init__(self):
-            super().__init__()
-            self.registerPath("", self.testMethod)
-            return
+        class MockService(Service):
+            _name = "mockService"
 
-        def name(self):
-            return self._name
+            def __init__(self):
+                super().__init__()
+                self.registerPath("", self.testMethod)
+                return
 
-        def testMethod(self, mockObject: MockObject):
-            return mockObject
+            def name(self):
+                return self._name
 
-    def test_getValidPaths():
+            def testMethod(self, mockObject: MockObject):
+                return mockObject
+
         apiService = ApiService()
         serviceDirectory = ServiceDirectory()
         mockService = MockService()
         serviceDirectory.registerService(mockService)
         validPaths = apiService.getValidPaths()
+        with Resource.open("/outputs/APIServicePaths.json.new", "w") as f:
+            f.write(json.dumps(validPaths, indent=2))
         with Resource.open("/outputs/APIServicePaths.json", "r") as f:
             actualValidPaths = json.load(f)
             assert validPaths == actualValidPaths

--- a/tests/unit/backend/dao/test_RenameWorkspaceFromTemplateRequest.py
+++ b/tests/unit/backend/dao/test_RenameWorkspaceFromTemplateRequest.py
@@ -1,20 +1,20 @@
 import pytest
 from pydantic import ValidationError
-from snapred.backend.dao.request import RenameWorkspaceFromTemplateRequest
+from snapred.backend.dao.request import RenameWorkspacesFromTemplateRequest
 
 
 def test_good():
-    request = RenameWorkspaceFromTemplateRequest(workspaces=[], renameTemplate="{workspaceName}_X")
+    request = RenameWorkspacesFromTemplateRequest(workspaces=[], renameTemplate="{workspaceName}_X")
     assert request.renameTemplate.format(workspaceName="mike") == "mike_X"
 
 
 def test_insufficient():
     with pytest.raises(ValidationError) as e:
-        RenameWorkspaceFromTemplateRequest(workspaces=[], renameTemplate="workspaceName_X")
+        RenameWorkspacesFromTemplateRequest(workspaces=[], renameTemplate="workspaceName_X")
     assert "workspaceName" in str(e.value)
 
 
 def test_bad():
     with pytest.raises(ValidationError) as e:
-        RenameWorkspaceFromTemplateRequest(workspaces=[], renameTemplate="{bad_label}_X")
+        RenameWorkspacesFromTemplateRequest(workspaces=[], renameTemplate="{bad_label}_X")
     assert "workspaceName" in str(e.value)

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -1,7 +1,6 @@
 # ruff: noqa: E722, PT011, PT012, F811
 import json
 import os
-import sys
 import shutil
 import time
 import unittest
@@ -1695,9 +1694,9 @@ class TestGroceryService(unittest.TestCase):
         self.instance._loadedGroupings = {(1, "c"): "d"}
 
         with mock.patch.object(self.instance, "rebuildCache") as mockRebuildCache:
-            self.create_dumb_workspace(rawWsName) # in the cache
-            self.create_dumb_workspace("b")       # not in the cache
-            self.instance.clearADS(exclude=self.exclude) # default => don't clear cache
+            self.create_dumb_workspace(rawWsName)  # in the cache
+            self.create_dumb_workspace("b")  # not in the cache
+            self.instance.clearADS(exclude=self.exclude)  # default => don't clear cache
             assert not mtd.doesExist("b")
             assert mtd.doesExist(rawWsName)
 
@@ -1711,7 +1710,7 @@ class TestGroceryService(unittest.TestCase):
         dumbws = mtd.unique_name(prefix="_dumb_")
         self.create_dumb_workspace(dumbws)
         assert mtd.doesExist(dumbws)
-        
+
         # create a workspace group
         groupws = mtd.unique_name(prefix="_groupws_")
         subws1 = mtd.unique_name(prefix="a")
@@ -1746,12 +1745,10 @@ class TestGroceryService(unittest.TestCase):
         mtd.remove(groupws)
 
     def test_getResidentWorkspaces(self):
-        with (
-            mock.patch.object(self.instance, "getCachedWorkspaces") as mockGetCachedWorkspaces
-            ):
-            expected = list(set(mtd.getObjectNames())) # note: re-ordering is required
+        with mock.patch.object(self.instance, "getCachedWorkspaces") as mockGetCachedWorkspaces:
+            expected = list(set(mtd.getObjectNames()))  # note: re-ordering is required
             assert len(expected)
-            
+
             actual = self.instance.getResidentWorkspaces(excludeCache=False)
             assert mockGetCachedWorkspaces.not_called
             assert actual == expected
@@ -1761,7 +1758,6 @@ class TestGroceryService(unittest.TestCase):
         self.instance._loadedRuns = {(0, "a"): rawWsName}
         expected = list(set(mtd.getObjectNames()).difference([rawWsName]))
         assert len(expected)
-        
+
         actual = self.instance.getResidentWorkspaces(excludeCache=True)
         assert actual == expected
-    

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -1,6 +1,7 @@
 # ruff: noqa: E722, PT011, PT012, F811
 import json
 import os
+import sys
 import shutil
 import time
 import unittest
@@ -1693,27 +1694,24 @@ class TestGroceryService(unittest.TestCase):
         self.instance._loadedRuns = {(0, "a"): rawWsName}
         self.instance._loadedGroupings = {(1, "c"): "d"}
 
-        rebuildCache = self.instance.rebuildCache
-        self.instance.rebuildCache = mock.Mock()
+        with mock.patch.object(self.instance, "rebuildCache") as mockRebuildCache:
+            self.create_dumb_workspace(rawWsName) # in the cache
+            self.create_dumb_workspace("b")       # not in the cache
+            self.instance.clearADS(exclude=self.exclude) # default => don't clear cache
+            assert not mtd.doesExist("b")
+            assert mtd.doesExist(rawWsName)
 
-        self.create_dumb_workspace("b")
-        self.instance.clearADS(exclude=self.exclude)
-
-        assert mtd.doesExist(rawWsName) is False
-        self.create_dumb_workspace(rawWsName)
-        assert mtd.doesExist(rawWsName) is True
-
-        self.instance.clearADS(exclude=self.exclude, cache=False)
-
-        assert mtd.doesExist(rawWsName) is True
-        self.instance.rebuildCache.assert_called()
-        self.instance.rebuildCache = rebuildCache
+            assert mtd.doesExist(rawWsName)
+            self.instance.clearADS(exclude=self.exclude, clearCache=True)
+            assert not mtd.doesExist(rawWsName)
+            mockRebuildCache.assert_called()
 
     def test_clearADS_group(self):
         # create a workspace that will be removed
         dumbws = mtd.unique_name(prefix="_dumb_")
         self.create_dumb_workspace(dumbws)
         assert mtd.doesExist(dumbws)
+        
         # create a workspace group
         groupws = mtd.unique_name(prefix="_groupws_")
         subws1 = mtd.unique_name(prefix="a")
@@ -1746,3 +1744,24 @@ class TestGroceryService(unittest.TestCase):
 
         # delete these specially
         mtd.remove(groupws)
+
+    def test_getResidentWorkspaces(self):
+        with (
+            mock.patch.object(self.instance, "getCachedWorkspaces") as mockGetCachedWorkspaces
+            ):
+            expected = list(set(mtd.getObjectNames())) # note: re-ordering is required
+            assert len(expected)
+            
+            actual = self.instance.getResidentWorkspaces(excludeCache=False)
+            assert mockGetCachedWorkspaces.not_called
+            assert actual == expected
+
+    def test_getResidentWorkspaces_exclude_cache(self):
+        rawWsName = self.instance._createRawNeutronWorkspaceName(0, "a")
+        self.instance._loadedRuns = {(0, "a"): rawWsName}
+        expected = list(set(mtd.getObjectNames()).difference([rawWsName]))
+        assert len(expected)
+        
+        actual = self.instance.getResidentWorkspaces(excludeCache=True)
+        assert actual == expected
+    

--- a/tests/unit/backend/recipe/test_ReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionRecipe.py
@@ -183,7 +183,7 @@ class ReductionRecipeTest(TestCase):
         recipe.keepUnfocused = True
         recipe.convertUnitsTo = "dSpacing"
 
-        output = recipe.execute()
+        result = recipe.execute()
 
         ingredients = recipe.ingredients()
         assert recipe._applyRecipe.called_once_with(PreprocessReductionRecipe, recipe.sampleWs)
@@ -211,8 +211,7 @@ class ReductionRecipeTest(TestCase):
         )
 
         assert recipe._deleteWorkspace.called_once_with("norm_grouped")
-
-        assert output[0] == "sample_grouped"
+        assert result["outputs"][0] == "sample_grouped"
 
     def test_cook(self):
         recipe = ReductionRecipe()

--- a/tests/unit/backend/service/test_ReductionService.py
+++ b/tests/unit/backend/service/test_ReductionService.py
@@ -1,13 +1,11 @@
 import time
+import unittest
+import unittest.mock as mock
 from typing import List
 
 import numpy as np
 import pydantic
-
-import unittest
-import unittest.mock as mock
 import pytest
-
 from mantid.simpleapi import (
     DeleteWorkspace,
     mtd,
@@ -110,7 +108,7 @@ class TestReductionService(unittest.TestCase):
         mockReductionRecipe.return_value.cook = mock.Mock(return_value=mockResult)
         self.instance.dataFactoryService.getThisOrLatestCalibrationVersion = mock.Mock(return_value=1)
         self.instance.dataFactoryService.getThisOrLatestNormalizationVersion = mock.Mock(return_value=1)
-        
+
         result = self.instance.reduction(self.request)
         groupings = self.instance.fetchReductionGroupings(self.request)
         ingredients = self.instance.prepReductionIngredients(self.request)

--- a/tests/unit/backend/service/test_WorkspaceService.py
+++ b/tests/unit/backend/service/test_WorkspaceService.py
@@ -3,8 +3,8 @@ from unittest.mock import MagicMock
 
 from mantid.simpleapi import CreateSingleValuedWorkspace, GroupWorkspaces, mtd
 from snapred.backend.dao.request import (
-    RenameWorkspacesFromTemplateRequest,
     ListWorkspacesRequest,
+    RenameWorkspacesFromTemplateRequest,
 )
 from snapred.backend.service.WorkspaceService import WorkspaceService
 
@@ -81,5 +81,3 @@ class TestWorkspaceService:
         request = ListWorkspacesRequest(excludeCache=True)
         service.getResidentWorkspaces(request)
         assert mockGroceryService.getResidentWorkspaces.called_once_with(excludeCache=True)
-        
-        

--- a/tests/unit/backend/service/test_WorkspaceService.py
+++ b/tests/unit/backend/service/test_WorkspaceService.py
@@ -1,7 +1,11 @@
+from unittest import mock
 from unittest.mock import MagicMock
 
 from mantid.simpleapi import CreateSingleValuedWorkspace, GroupWorkspaces, mtd
-from snapred.backend.dao.request import RenameWorkspaceFromTemplateRequest
+from snapred.backend.dao.request import (
+    RenameWorkspacesFromTemplateRequest,
+    ListWorkspacesRequest,
+)
 from snapred.backend.service.WorkspaceService import WorkspaceService
 
 
@@ -25,7 +29,7 @@ class TestWorkspaceService:
         oldNames = ["old1", "old2"]
         renameTemplate = "{workspaceName}_X"
         newNames = [renameTemplate.format(workspaceName=ws) for ws in oldNames]
-        request = RenameWorkspaceFromTemplateRequest(
+        request = RenameWorkspacesFromTemplateRequest(
             workspaces=oldNames,
             renameTemplate=renameTemplate,
         )
@@ -53,7 +57,7 @@ class TestWorkspaceService:
             assert mtd.doesExist(old)
             assert not mtd.doesExist(new)
         # perform the request
-        request = RenameWorkspaceFromTemplateRequest(
+        request = RenameWorkspacesFromTemplateRequest(
             workspaces=["parent"],
             renameTemplate=renameTemplate,
         )
@@ -67,5 +71,15 @@ class TestWorkspaceService:
         mockGroceryService = MagicMock()
         service = WorkspaceService()
         service.groceryService = mockGroceryService
-        service.clear('{"exclude": ["name"]}')
+        service.clear('{"exclude": ["name"], "clearCache": false}')
         mockGroceryService.clearADS.assert_called_once_with(["name"], False)
+
+    def test_getResidentWorkspaces(self):
+        mockGroceryService = mock.Mock()
+        service = WorkspaceService()
+        service.groceryService = mockGroceryService
+        request = ListWorkspacesRequest(excludeCache=True)
+        service.getResidentWorkspaces(request)
+        assert mockGroceryService.getResidentWorkspaces.called_once_with(excludeCache=True)
+        
+        

--- a/tests/unit/ui/presenter/test_InitializeStatePresenter.py
+++ b/tests/unit/ui/presenter/test_InitializeStatePresenter.py
@@ -58,10 +58,10 @@ def test__initializeState(setup_view_and_workflow):
     mock_response = SNAPResponse(code=ResponseCode.OK)
 
     with patch.object(workflow.interfaceController, "executeRequest", return_value=mock_response), patch(
-        "snapred.ui.widget.SuccessDialog.SuccessDialog.exec_"
-    ) as mock_dialog_exec_:
+        "snapred.ui.widget.SuccessPrompt.SuccessPrompt.prompt"
+    ) as mock_dialog_showSuccess:
         workflow._initializeState("12345", "Test State", True)
-        mock_dialog_exec_.assert_called_once()
+        mock_dialog_showSuccess.assert_called_once()
 
 
 def test__handleResponse_error(setup_view_and_workflow):
@@ -83,6 +83,6 @@ def test__handleResponse_success(setup_view_and_workflow):
     # Initialize loadingCursor
     workflow.loadingCursor = LoadingCursor(view)
 
-    with patch("snapred.ui.widget.SuccessDialog.SuccessDialog.exec_") as mock_dialog_exec:
+    with patch("snapred.ui.widget.SuccessPrompt.SuccessPrompt.prompt") as mock_dialog_showSuccess:
         workflow._handleResponse(success_response)
-        mock_dialog_exec.assert_called_once()
+        mock_dialog_showSuccess.assert_called_once()

--- a/tests/unit/ui/widget/test_Workflow.py
+++ b/tests/unit/ui/widget/test_Workflow.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, Slot
 from qtpy.QtWidgets import QGridLayout, QPushButton, QWidget
 from snapred.ui.model.WorkflowNodeModel import WorkflowNodeModel
 from snapred.ui.workflow.WorkflowBuilder import WorkflowBuilder
@@ -20,6 +20,7 @@ class _TestView(QWidget):
         self.layout = QGridLayout()
         self.setLayout(self.layout)
 
+    @Slot()
     def handleContinueButtonClicked(self):
         pass
 
@@ -35,7 +36,7 @@ def _generateWorkflow():
         return None
 
     WorkflowNodeModel(view, continueAction, None)
-    return WorkflowBuilder(None).addNode(continueAction, view, "Test").build()
+    return WorkflowBuilder().addNode(continueAction, view, "Test").build()
 
 
 def test_workflowPresenterHandleContinueButtonClicked(qtbot):

--- a/tests/unit/ui/workflow/test_WorkflowImplementer.py
+++ b/tests/unit/ui/workflow/test_WorkflowImplementer.py
@@ -19,8 +19,8 @@ def test_rename_on_iterate_list(qtbot):  # noqa: ARG001
     instance = WorkflowImplementer()
     newNames = [instance.renameTemplate.format(workspaceName=ws, iteration=mockPresenter.iteration) for ws in oldNames]
     instance.outputs = oldNames
-    instance._iterate(mockPresenter)
-    assert instance.collectiveOutputs == newNames
+    instance.iterate(mockPresenter)
+    assert instance.collectedOutputs == newNames
 
 
 def test_rename_on_iterate_group(qtbot):  # noqa: ARG001
@@ -42,8 +42,8 @@ def test_rename_on_iterate_group(qtbot):  # noqa: ARG001
         assert not mtd.doesExist(new)
 
     instance.outputs = [oldNames[0]]
-    instance._iterate(mockPresenter)
-    assert instance.collectiveOutputs == [newNames[0]]
+    instance.iterate(mockPresenter)
+    assert instance.collectedOutputs == [newNames[0]]
     for old, new in zip(oldNames, newNames):
         assert not mtd.doesExist(old)
         assert mtd.doesExist(new)


### PR DESCRIPTION
# PR from "staging" (PR#416) onto "next"

## Description of work

This PR includes changes added to facilitate `qtbot`-based testing, **which also happen to satisfy the requirements of this "3.0.1 defect" regarding retention of reduction-workflow output workspaces**.  The changes of this commit are relatively minor, and will be merged to "next" almost immediately.  For this reason, no attempt has been made to separate out the "staging" changes specific to the present defect.

## Explanation of work

This PR includes the following changes:

  * Identify ADS-resident workspaces before the start of each workflow, and do not delete these workspaces at exit.  This allows users to go back-and-forth between the SNAPRed panel, and the Mantid workbench, and not to have their workspaces unexpectedly deleted by SNAPRed.  In addition, simply extending this workspace list where required allowed retention of final result workspaces from the reduction workflow.

  * Lock out other workflow tabs once a workflow has started; 
  
  * Use `@Slot` decorator where appropriate, throughout the codebase.  This allows `pyqt` to check `Signal` argument types, but in addition, it also allows clear identification of which methods are being employed as slots;

  * Add missing `QObject` derivation for several classes with methods that are used as Qt slots.
    
  * Add several new signals specifically to help during testing: these include a signal at the start of each workflow, and a signal when any `Worker` task completes.  By default, connecting these `Signal` to `lambda *args: None` allows `qtbot` to intercept them when required;
  
  * All `QMessageBox` and `ActionPrompt`-style dialogs, including `SuccessPrompt` (formerly `SuccessDialog`) are now called only via static `warning`, `critical`, and `prompt` methods.  This allows these dialogs to be easily mocked without requiring mocking their entire classes;
  
  * Remove 'WorkflowNodePresenter' as _dead_ code.  This removal is in an _interim_ state, now marked by retaining the source file, but renaming it to `WorkflowNodePresenter_.py`.  The reason for this approach is that most probably we _do_ want to distinguish between `WorkflowPresenter` and `WorkflowNodePresenter`, and although it's not being used at present, this issue should probably be fixed.

## To test

### Dev testing

Existing unit tests cover these changes, with a few minor modifications.
In addition, the best way to test these changes is to completely run the diffraction-calibration, normalization, and reduction workflow tabs, and observe that the _other_ workflow tabs are disabled once a given workflow has been started.  **Additionally observe that the reduction output-workspaces are retained at the end of the complete process.** 

### CIS testing
Same as above, for Dev testing.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#6093](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6093)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
