### PR TITLE
Ewm6552 fix incorrect error

### DIFF
--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -185,6 +185,14 @@ class SousChef(Service):
         normalizationRecord = self.dataFactoryService.getNormalizationRecord(
             ingredients.runNumber, ingredients.useLiteMode, version
         )
+        if calibrationRecord is None:
+            raise ValueError(
+                f"No calibration record found for run {ingredients.runNumber}, please run a calibration for this run."
+            )
+        elif normalizationRecord is None:
+            raise ValueError(
+                f"No normalization record found for run {ingredients.runNumber}, please run a normalization for this run."  # noqa: E501
+            )
         # grab information from records
         ingredients.calibrantSamplePath = calibrationRecord.calibrationFittingIngredients.calibrantSamplePath
         ingredients.cifPath = self.dataFactoryService.getCifFilePath(Path(ingredients.calibrantSamplePath).stem)

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -185,6 +185,7 @@ class SousChef(Service):
         normalizationRecord = self.dataFactoryService.getNormalizationRecord(
             ingredients.runNumber, ingredients.useLiteMode, version
         )
+        #  check for records
         if calibrationRecord is None:
             raise ValueError(
                 f"No calibration record found for run {ingredients.runNumber}, please run a calibration for this run."

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -121,6 +121,7 @@ class TestGroceryService(unittest.TestCase):
         # each test, ensure a random version is drawn
         self.version = randint(1, 120)
         self.instance.dataService.latestVersion = self.version
+        self.rtolValue = 1.0e-10
         return super().setUp()
 
     def clearoutWorkspaces(self) -> None:
@@ -425,6 +426,7 @@ class TestGroceryService(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=wsname1,
             Workspace2=wsname2,
+            rtol=self.rtolValue,
         )
 
     def test_updateNeutronCacheFromADS_noop(self):
@@ -697,6 +699,7 @@ class TestGroceryService(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
+            rtol=self.rtolValue,
         )
 
         # make sure it won't load same workspace name again
@@ -712,6 +715,7 @@ class TestGroceryService(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
+            rtol=self.rtolValue,
         )
 
     def test_fetch_failed(self):
@@ -760,6 +764,7 @@ class TestGroceryService(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
+            rtol=self.rtolValue,
         )
 
         # test that it will use a raw workspace if one exists
@@ -783,6 +788,7 @@ class TestGroceryService(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
+            rtol=self.rtolValue,
         )
 
         # test calling with Lite data, that it will call to lite service
@@ -835,6 +841,7 @@ class TestGroceryService(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=workspaceNameCopy1,
+            rtol=self.rtolValue,
         )
 
         # run with a raw workspace in cache -- it will copy it
@@ -850,6 +857,7 @@ class TestGroceryService(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=workspaceNameCopy2,
+            rtol=self.rtolValue,
         )
 
     def test_fetch_cached_lite(self):

--- a/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
@@ -60,6 +60,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
             InputWorkspace=cls.sampleWS,
             Filename=cls.filepath,
         )
+        cls.rtolValue = 1.0e-10
         assert os.path.exists(cls.filepath)
 
     def tearDown(self) -> None:
@@ -159,6 +160,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.fetchedWS,
             Workspace2=self.sampleWS,
+            rtol=self.rtolValue,
         )
         assert "LoadNexusProcessed" == algo.getPropertyValue("LoaderType")
 
@@ -173,6 +175,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.fetchedWS,
             Workspace2=self.sampleWS,
+            rtol=self.rtolValue,
         )
         assert "LoadNexus" == algo.getPropertyValue("LoaderType")
 
@@ -196,6 +199,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.fetchedWS,
             Workspace2=self.sampleWS,
+            rtol=self.rtolValue,
         )
         assert "LoadNexusProcessed" == algo.getPropertyValue("LoaderType")
 
@@ -219,6 +223,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=f"_{self.runNumber}_grouping_file",
             Workspace2=f"_{self.runNumber}_grouping_name",
+            rtol=self.rtolValue,
         )
         algo.setProperty("InstrumentName", "")
 
@@ -228,6 +233,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=f"_{self.runNumber}_grouping_file",
             Workspace2=f"_{self.runNumber}_grouping_donor",
+            rtol=self.rtolValue,
         )
 
     def test_loadGroupingTwice(self):

--- a/tests/unit/backend/recipe/algorithm/test_SaveGroupingDefinition.py
+++ b/tests/unit/backend/recipe/algorithm/test_SaveGroupingDefinition.py
@@ -28,6 +28,9 @@ IS_ON_ANALYSIS_MACHINE = socket.gethostname().startswith("analysis")
 class TestSaveGroupingDefinition(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        # rtol value
+        cls.rtolValue = 1.0e-10
+
         # file location for instrument definition
         cls.localInstrumentFilename = Resource.getPath("inputs/testInstrument/fakeSNAP_Definition.xml")
         cls.localGroupingFilename = Resource.getPath("inputs/testInstrument/fakeSNAPFocGroup_Natural.xml")
@@ -222,7 +225,7 @@ class TestSaveGroupingDefinition(unittest.TestCase):
             assert loadingAlgo.execute()
 
             # retrieve the loaded workspace and compare it with the workspace created from the input grouping file
-            assert_wksp_almost_equal(loaded_ws_name, workspaceName)
+            assert_wksp_almost_equal(loaded_ws_name, workspaceName, rtol=self.rtolValue)
 
         def test_local_from_groupingfile_test(self):
             groupingFile = Resource.getPath("inputs/testInstrument/fakeSNAPFocGroup_Natural.xml")
@@ -272,6 +275,7 @@ class TestSaveGroupingDefinition(unittest.TestCase):
             assert_wksp_almost_equal(
                 loaded_ws_name,
                 self.localReferenceWorkspace["Natural"],
+                rtol=self.rtolValue,
             )
 
     def test_local_from_workspace_test_column(self):
@@ -280,6 +284,7 @@ class TestSaveGroupingDefinition(unittest.TestCase):
         assert_wksp_almost_equal(
             self.columnGroupingWorkspace,
             self.localReferenceWorkspace["Column"],
+            rtol=self.rtolValue,
         )
 
     def test_local_from_workspace_test_natural(self):
@@ -288,6 +293,7 @@ class TestSaveGroupingDefinition(unittest.TestCase):
         assert_wksp_almost_equal(
             self.columnGroupingWorkspace,
             self.localReferenceWorkspace["Natural"],
+            rtol=self.rtolValue,
         )
 
     ## REMOTE CHECKS WITH FULL INSTRUMENT

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -34,6 +34,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         cls.instrumentFilepath = Resource.getPath("inputs/testInstrument/fakeSNAP_Definition.xml")
         cls.fetchedWSname = "_fetched_grocery"
         cls.groupingScheme = "Native"
+        cls.rtolValue = 1.0e-10
         # create some sample data
         cls.sampleWS = "_grocery_to_fetch"
         CreateWorkspace(
@@ -102,6 +103,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
+            rtol=self.rtolValue,
         )
 
         # make sure it won't load same workspace name again
@@ -114,6 +116,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
+            rtol=self.rtolValue,
         )
 
     @mock.patch("snapred.backend.recipe.FetchGroceriesRecipe.FetchAlgo")

--- a/tests/unit/backend/recipe/test_GenericRecipe.py
+++ b/tests/unit/backend/recipe/test_GenericRecipe.py
@@ -170,7 +170,7 @@ class TestGenericRecipeInputsAndOutputs(unittest.TestCase):
         # run the recipe and make sure correct result is given
         CreateSingleValuedWorkspace(OutputWorkspace="okay")
         res = TestMatrixProp().executeRecipe(InputWorkspace="okay", OutputWorkspace="hurray")
-        assert_wksp_almost_equal(Workspace1="okay", Workspace2=res)
+        assert_wksp_almost_equal(Workspace1="okay", Workspace2=res, rtol=1.0e-10)
 
     def test_primitives(self):
         # register the algorithm and define the recipe


### PR DESCRIPTION
## Description of work
This work was to reproduce an error seen by Malcolm within the staging branch where if a normalization has not been performed on a run that is reduced, there is a confusing error that is displayed to the user on L199 in `SousChef` where SNAPRed is unable to retrieve a peak intensity threshold from a (non-existent) normalization record. This work is to fix the error as per request and change it to display something more meaningful like "Normalization Calibration has not been conducted for this state, normalization folder does not exist."
<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work
This took a bit of time in implementation, I tried looking at an implementation within `SousChef` within next to try and find ways to implement this fix within staging as a fix is present. After spending time trying to create something sensible with the 'old' way of handling records, I found it best to handle this fix in the simplest way possible to remove any added complexity. So the fix is a simple if elif statement for both normalization and calibration records.
<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing
1. Insure that your local state folders are all deleted.
2. Please open up SNAPRed within dev env
3. Run a calibration for run 46680 (any inputs, just has to run all the way through and save)
4. Run Reduction for run 46680
5. This error should occur:
![image](https://github.com/user-attachments/assets/f396ad62-61fe-4032-9002-906d0aa7fef0)

<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing
Same as above.
<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM # 6552](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6552)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
