### PR TITLE
`unittest.mock.Mock.called_once` does not exist

### DIFF
--- a/src/snapred/backend/dao/indexing/CalculationParameters.py
+++ b/src/snapred/backend/dao/indexing/CalculationParameters.py
@@ -6,7 +6,7 @@ from snapred.backend.dao.state.InstrumentState import InstrumentState
 
 # NOTE: the request __init__ loads CalibrationExportRequest, which imports Calibration,
 #       which imports this module, which causes a circular import situation.
-#       In the future, need to remove the circualr import so that full set of ingredients
+#       In the future, need to remove the circular import so that full set of ingredients
 #       can be preserved
 # from snapred.backend.dao.request.FarmFreshIngredients import FarmFreshIngredients
 

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -3,6 +3,7 @@ import json
 import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from collections.abc import Iterable
 
 import numpy as np
 from mantid.dataobjects import MaskWorkspace
@@ -1022,7 +1023,7 @@ class GroceryService:
 
         return maskWSName
 
-    def fetchGroceryList(self, groceryList: List[GroceryListItem]) -> List[WorkspaceName]:
+    def fetchGroceryList(self, groceryList: Iterable[GroceryListItem]) -> List[WorkspaceName]:
         """
         :param groceryList: a list of GroceryListItems indicating the workspaces to create
         :type groceryList: List[GrocerListItem]

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -1,9 +1,9 @@
 # ruff: noqa: F811
 import json
 import os
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from collections.abc import Iterable
 
 import numpy as np
 from mantid.dataobjects import MaskWorkspace

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -199,7 +199,7 @@ class LocalDataService:
 
     @lru_cache
     def getIPTS(self, runNumber: str, instrumentName: str = Config["instrument.name"]) -> str:
-        ipts = GetIPTS(runNumber, instrumentName)
+        ipts = GetIPTS(RunNumber=runNumber, Instrument=instrumentName)
         return str(ipts)
 
     def workspaceIsInstance(self, wsName: str, wsType: Any) -> bool:
@@ -858,7 +858,7 @@ class LocalDataService:
 
     @validate_call
     @ExceptionHandler(StateValidationException)
-    # NOTE if you are debugigng and got here, coment out the ExceptionHandler and try again
+    # NOTE if you are debugging and got here, coment out the ExceptionHandler and try again
     def initializeState(self, runId: str, useLiteMode: bool, name: str = None):
         stateId, _ = self._generateStateId(runId)
 

--- a/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/SmoothDataExcludingPeaksAlgo.py
@@ -54,7 +54,7 @@ class SmoothDataExcludingPeaksAlgo(PythonAlgorithm):
                 PropertyMode.Mandatory,
                 validator=WorkspaceUnitValidator("dSpacing"),
             ),
-            doc="Hitogram Workspace with removed peaks",
+            doc="Histogram Workspace with removed peaks",
         )
         self.declareProperty("DetectorPeaks", defaultValue="", direction=Direction.Input)
         self.declareProperty("SmoothingParameter", defaultValue=-1.0, direction=Direction.Input)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,15 +23,15 @@ from snapred.meta.Config import (  # noqa: E402
 # PATCH the `unittest.mock.Mock` class: BANNED FUNCTIONS
 def banned_function(function_name: str):
   _error_message: str = f"`Mock.{function_name}` is a mock, it always evaluates to True. Use `Mock.assert_{function_name}` instead."
-  
+
   def _banned_function(self, *args, **kwargs):
       nonlocal _error_message # this line should not be necessary!
-      
+
       # Ensure that the complete message is in the pytest-captured output stream:
       print(_error_message)
-      
+
       raise RuntimeError(_error_message)
-  
+
   return _banned_function
 
 # `mock.Mock.called` is OK: it exists as a boolean attribute

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,27 @@ from snapred.meta.Config import (  # noqa: E402
 )
 
 
+# PATCH the `unittest.mock.Mock` class: BANNED FUNCTIONS
+def banned_function(function_name: str):
+  _error_message: str = f"`Mock.{function_name}` is a mock, it always evaluates to True. Use `Mock.assert_{function_name}` instead."
+  
+  def _banned_function(self, *args, **kwargs):
+      nonlocal _error_message # this line should not be necessary!
+      
+      # Ensure that the complete message is in the pytest-captured output stream:
+      print(_error_message)
+      
+      raise RuntimeError(_error_message)
+  
+  return _banned_function
+
+# `mock.Mock.called` is OK: it exists as a boolean attribute
+mock.Mock.called_once = banned_function("called_once")
+mock.Mock.called_once_with = banned_function("called_once_with")
+mock.Mock.called_with = banned_function("called_with")
+mock.Mock.not_called = banned_function("not_called")
+
+
 def mock_decorator(orig_cls):
     return orig_cls
 
@@ -55,7 +76,8 @@ def clear_loggers():  # noqa: PT004
             logger.removeHandler(handler)
 
 
-## Import `pytest.fixture` defined in separate `tests/util` modules:
+## Import various `pytest.fixture` defined in separate `tests/util` modules:
+#  -------------------------------------------------------------------------
 # *** IMPORTANT WARNING: these must be included _after_ the `Singleton` decorator is patched ! ***
 #   * Otherwise, the modules imported by these will not have the patched decorator applied to them.
 

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -1550,13 +1550,12 @@ class TestGroceryService(unittest.TestCase):
 
         res = self.instance.fetchGroceryDict(groceryDict)
         assert res == {"InputWorkspace": cleanWorkspace, "GroupingWorkspace": groupWorkspace}
-        
+
         assert self.instance.fetchGroceryList.call_count == 1
 
         # <dict>.values() compare as "NOT IMPLEMENTED", which evaluates to False
         #   => so we need to extract and compare the call args as lists.
         assert list(self.instance.fetchGroceryList.call_args[0][0]) == list(groceryDict.values())
-
 
     def test_fetch_grocery_dict_with_kwargs(self):
         # expected workspaces
@@ -1576,7 +1575,7 @@ class TestGroceryService(unittest.TestCase):
             "GroupingWorkspace": groupWorkspace,
             "OtherWorkspace": otherWorkspace,
         }
-        
+
         assert self.instance.fetchGroceryList.call_count == 1
 
         # <dict>.values() compare as "NOT IMPLEMENTED", which evaluates to False
@@ -1651,8 +1650,8 @@ class TestGroceryService(unittest.TestCase):
         #   `LiteDataService`.
         # The circular reference from `LiteDataService` back to `GroceryService.fetchLiteDataMap`
         #   (which should almost certainly be a service-to-service `InterfaceController` request)
-        #   should be checked in `test_LiteDataService`, _not_ here.        
-        
+        #   should be checked in `test_LiteDataService`, _not_ here.
+
         workspacename = self.instance._createNeutronWorkspaceName(self.runNumber, False)
         self.instance.convertToLiteMode(workspacename)
 

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -7,7 +7,6 @@ import unittest
 from pathlib import Path
 from random import randint
 from unittest import mock
-from unittest.mock import ANY
 
 import pytest
 import snapred.backend.recipe.algorithm  # noqa: F401
@@ -464,7 +463,7 @@ class TestGroceryService(unittest.TestCase):
         assert self.instance._loadedRuns == {}
         assert not mtd.doesExist(wsname)
         self.instance._updateNeutronCacheFromADS(runId, useLiteMode)
-        assert self.instance._createRawNeutronWorkspaceName.called_once_with(runId, useLiteMode)
+        self.instance._createRawNeutronWorkspaceName.assert_called_once_with(runId, useLiteMode)
         assert self.instance._loadedRuns == {}
         assert not mtd.doesExist(wsname)
 
@@ -478,7 +477,7 @@ class TestGroceryService(unittest.TestCase):
         self.create_dumb_workspace(wsname)
         assert mtd.doesExist(wsname)
         self.instance._updateNeutronCacheFromADS(runId, useLiteMode)
-        assert self.instance._createRawNeutronWorkspaceName.called_once_with(runId, useLiteMode)
+        self.instance._createRawNeutronWorkspaceName.assert_called_once_with(runId, useLiteMode)
         assert self.instance._loadedRuns == {(runId, useLiteMode): 1}
 
     def test_updateNeutronCacheFromADS_cache_no_ADS(self):
@@ -490,7 +489,7 @@ class TestGroceryService(unittest.TestCase):
         self.instance._loadedRuns[(runId, useLiteMode)] = 1
         assert not mtd.doesExist(wsname)
         self.instance._updateNeutronCacheFromADS(runId, useLiteMode)
-        assert self.instance._createRawNeutronWorkspaceName.called_once_with(runId, useLiteMode)
+        self.instance._createRawNeutronWorkspaceName.assert_called_once_with(runId, useLiteMode)
         assert self.instance._loadedRuns == {}
 
     def test_updateNeutronCacheFromADS_ADS_no_cache(self):
@@ -503,7 +502,7 @@ class TestGroceryService(unittest.TestCase):
         assert self.instance._loadedRuns == {}
         assert mtd.doesExist(wsname)
         self.instance._updateNeutronCacheFromADS(runId, useLiteMode)
-        assert self.instance._createRawNeutronWorkspaceName.called_once_with(runId, useLiteMode)
+        self.instance._createRawNeutronWorkspaceName.assert_called_once_with(runId, useLiteMode)
         assert self.instance._loadedRuns == {(runId, useLiteMode): 0}
 
     def test_updateGroupingCacheFromADS_noop(self):
@@ -517,7 +516,7 @@ class TestGroceryService(unittest.TestCase):
         assert self.instance._loadedGroupings == {}
         assert not mtd.doesExist(wsname)
         self.instance._updateGroupingCacheFromADS(key, wsname)
-        assert self.instance._createGroupingWorkspaceName.called_once_with(groupingScheme, wsname)
+        self.instance._createGroupingWorkspaceName.assert_not_called()
         assert self.instance._loadedGroupings == {}
         assert not mtd.doesExist(wsname)
 
@@ -533,7 +532,7 @@ class TestGroceryService(unittest.TestCase):
         self.create_dumb_workspace(wsname)
         assert mtd.doesExist(wsname)
         self.instance._updateGroupingCacheFromADS(key, wsname)
-        assert self.instance._createGroupingWorkspaceName.called_once_with(groupingScheme, wsname)
+        self.instance._createGroupingWorkspaceName.assert_not_called()
         assert self.instance._loadedGroupings == {key: wsname}
 
     def test_updateGroupingCacheFromADS_cache_no_ADS(self):
@@ -547,7 +546,7 @@ class TestGroceryService(unittest.TestCase):
         self.instance._loadedGroupings[key] = wsname
         assert not mtd.doesExist(wsname)
         self.instance._updateGroupingCacheFromADS(key, wsname)
-        assert self.instance._createGroupingWorkspaceName.called_once_with(groupingScheme, wsname)
+        self.instance._createGroupingWorkspaceName.assert_not_called()
         assert self.instance._loadedGroupings == {}
 
     def test_updateGroupingCacheFromADS_ADS_no_cache(self):
@@ -562,7 +561,7 @@ class TestGroceryService(unittest.TestCase):
         assert self.instance._loadedGroupings == {}
         assert mtd.doesExist(wsname)
         self.instance._updateGroupingCacheFromADS(key, wsname)
-        assert self.instance._createGroupingWorkspaceName.called_once_with(groupingScheme, wsname)
+        self.instance._createGroupingWorkspaceName.assert_not_called()
         assert self.instance._loadedGroupings == {key: wsname}
 
     def test_updateInstrumentCacheFromADS_noop(self):
@@ -696,7 +695,7 @@ class TestGroceryService(unittest.TestCase):
         self.instance.mantidSnapper.WashDishes = mockAlgo
         # wash the dish
         self.instance.deleteWorkspace(wsname)
-        assert mockAlgo.called_once_with(ANY, Workspace=wsname)
+        mockAlgo.assert_called_once_with(mock.ANY, Workspace=wsname)
 
     def test_deleteWorkspaceUnconditional(self):
         wsname = mtd.unique_name(prefix="_test_ws_")
@@ -704,12 +703,12 @@ class TestGroceryService(unittest.TestCase):
         self.instance.mantidSnapper.DeleteWorkspace = mockAlgo
         # if the workspace does not exist, then don't do anything
         self.instance.deleteWorkspaceUnconditional(wsname)
-        assert mockAlgo.not_called
+        mockAlgo.assert_not_called()
         # make the workspace
         self.create_dumb_workspace(wsname)
         # if the workspace does exist, then delete it
         self.instance.deleteWorkspaceUnconditional(wsname)
-        assert mockAlgo.called_once_with(ANY, Workspace=wsname)
+        mockAlgo.assert_called_once_with(mock.ANY, Workspace=wsname)
 
     ## TEST FETCH METHODS
 
@@ -736,7 +735,7 @@ class TestGroceryService(unittest.TestCase):
             "loader": "cached",
             "workspace": self.fetchedWSname,
         }
-        assert self.instance.grocer.executeRecipe.not_called
+        self.instance.grocer.executeRecipe.assert_not_called()
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
@@ -933,7 +932,8 @@ class TestGroceryService(unittest.TestCase):
             assert mtd.doesExist(ws)
         assert self.instance._loadedRuns == {testKey: 1, nativeKey: 0}
         # make sure it calls to convert to lite mode
-        assert self.instance.convertToLiteMode.called_once
+        self.instance.convertToLiteMode.assert_called_once()
+        self.instance.convertToLiteMode.reset_mock()
 
         # clear out the Lite workspaces from ADS and the cache
         self.instance._createNeutronFilename.side_effect = [fakeFilename, self.sampleWSFilePath]
@@ -955,7 +955,7 @@ class TestGroceryService(unittest.TestCase):
             assert mtd.doesExist(ws)
         assert self.instance._loadedRuns == {testKey: 1, nativeKey: 0}
         # make sure it calls to convert to lite mode
-        assert self.instance.convertToLiteMode.called_once
+        self.instance.convertToLiteMode.assert_called_once()
 
     def test_fetch_grouping(self):
         groupFilepath = Resource.getPath("inputs/testInstrument/fakeSNAPFocGroup_Natural.xml")
@@ -1034,12 +1034,12 @@ class TestGroceryService(unittest.TestCase):
         for i, fetchMethod in enumerate(
             [self.instance.fetchNeutronDataCached, self.instance.fetchNeutronDataSingleUse]
         ):
-            assert fetchMethod.called_once_with(
+            fetchMethod.assert_called_once_with(
                 groceryList[i].runNumber,
                 groceryList[i].useLiteMode,
                 groceryList[i].loader,
             )
-        assert self.instance.fetchGroupingDefinition.called_once_with(groceryList[2])
+        self.instance.fetchGroupingDefinition.assert_called_once_with(groceryList[2])
 
     def test_fetch_grocery_list_fails(self):
         self.instance.fetchNeutronDataSingleUse = mock.Mock(return_value={"result": False, "workspace": "unimportant"})
@@ -1352,8 +1352,8 @@ class TestGroceryService(unittest.TestCase):
 
         res = self.instance.fetchGroceryList(groceryList)
         assert res == [cleanWorkspace, groupWorkspace]
-        assert self.instance.fetchGroupingDefinition.called_with(groupItemWithSource)
-        assert self.instance.fetchNeutronDataCached.called_with(self.runNumber, False, "")
+        self.instance.fetchGroupingDefinition.assert_called_with(groupItemWithSource)
+        self.instance.fetchNeutronDataCached.assert_called_with(self.runNumber, False, "")
 
     def test_updateInstrumentParameters(self):
         wsName = mtd.unique_hidden_name()
@@ -1550,9 +1550,13 @@ class TestGroceryService(unittest.TestCase):
 
         res = self.instance.fetchGroceryDict(groceryDict)
         assert res == {"InputWorkspace": cleanWorkspace, "GroupingWorkspace": groupWorkspace}
-        assert self.instance.fetchGroceryList.called_once_with(
-            groceryDict["InputWorkspace"], groceryDict["GroupingWorkspace"]
-        )
+        
+        assert self.instance.fetchGroceryList.call_count == 1
+
+        # <dict>.values() compare as "NOT IMPLEMENTED", which evaluates to False
+        #   => so we need to extract and compare the call args as lists.
+        assert list(self.instance.fetchGroceryList.call_args[0][0]) == list(groceryDict.values())
+
 
     def test_fetch_grocery_dict_with_kwargs(self):
         # expected workspaces
@@ -1572,10 +1576,12 @@ class TestGroceryService(unittest.TestCase):
             "GroupingWorkspace": groupWorkspace,
             "OtherWorkspace": otherWorkspace,
         }
-        assert self.instance.fetchGroceryList.called_once_with(
-            groceryDict["InputWorkspace"],
-            groceryDict["GroupingWorkspace"],
-        )
+        
+        assert self.instance.fetchGroceryList.call_count == 1
+
+        # <dict>.values() compare as "NOT IMPLEMENTED", which evaluates to False
+        #   => so we need to extract and compare the call args as lists.
+        assert list(self.instance.fetchGroceryList.call_args[0][0]) == list(groceryDict.values())
 
     def test_fetch_default_diffcal_table(self):
         """
@@ -1640,19 +1646,19 @@ class TestGroceryService(unittest.TestCase):
         assert runNumber in str(e)
 
     @mock.patch("snapred.backend.service.LiteDataService.LiteDataService")
-    def test_make_lite(self, mockLDS):
-        # mock out the fetch grouping part to make it think it fetched the ltie data map
-        liteMapWorkspace = "unimportant"
-        self.instance.fetchGroupingDefinition = mock.MagicMock(return_value={"workspace": liteMapWorkspace})
-
-        # now call to make lite
+    def test_make_lite(self, mockLiteDataService):
+        # This test makes sure that `GroceryService.convertToLiteMode` appropriately calls
+        #   `LiteDataService`.
+        # The circular reference from `LiteDataService` back to `GroceryService.fetchLiteDataMap`
+        #   (which should almost certainly be a service-to-service `InterfaceController` request)
+        #   should be checked in `test_LiteDataService`, _not_ here.        
+        
         workspacename = self.instance._createNeutronWorkspaceName(self.runNumber, False)
         self.instance.convertToLiteMode(workspacename)
-        # assert the call to lite data mode fetched the lite data map
-        assert self.instance.fetchGroupingDefinition.called_once_with("Lite", False)
+
         # assert that the lite data service was created and called
-        assert mockLDS.called_once()
-        assert mockLDS.reduceLiteData.called_once_with(workspacename, workspacename)
+        mockLiteDataService.assert_called_once()
+        mockLiteDataService.return_value.reduceLiteData.assert_called_once_with(workspacename, workspacename)
 
     def test_getCachedWorkspaces(self):
         rawWsName = self.instance._createRawNeutronWorkspaceName("556854", False)
@@ -1751,7 +1757,7 @@ class TestGroceryService(unittest.TestCase):
             assert len(expected)
 
             actual = self.instance.getResidentWorkspaces(excludeCache=False)
-            assert mockGetCachedWorkspaces.not_called
+            mockGetCachedWorkspaces.assert_not_called()
             assert actual == expected
 
     def test_getResidentWorkspaces_exclude_cache(self):

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -147,6 +147,7 @@ def do_test_workflow_indexer(workflow):
         localDataService.indexer.assert_called_once_with("xyz", useLiteMode, IndexerType(workflow))
         localDataService.indexer.reset_mock()
 
+
 def do_test_read_index(workflow):
     # verify that calls to read index call out to the indexer
     mockIndex = ["nope"]

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -144,8 +144,8 @@ def do_test_workflow_indexer(workflow):
     localDataService.indexer = mock.Mock()
     for useLiteMode in [True, False]:
         getattr(localDataService, f"{workflow.lower()}Indexer")("xyz", useLiteMode)
-        assert localDataService.indexer.called_once_with("xyz", useLiteMode, workflow.upper())
-
+        localDataService.indexer.assert_called_once_with("xyz", useLiteMode, IndexerType(workflow))
+        localDataService.indexer.reset_mock()
 
 def do_test_read_index(workflow):
     # verify that calls to read index call out to the indexer
@@ -574,15 +574,15 @@ def test_getIPTS(mockGetIPTS):
     runNumber = "123456"
     res = localDataService.getIPTS(runNumber)
     assert res == mockGetIPTS.return_value
-    assert mockGetIPTS.called_with(
-        runNumber=runNumber,
-        instrumentName=Config["instrument.name"],
+    mockGetIPTS.assert_called_with(
+        RunNumber=runNumber,
+        Instrument=Config["instrument.name"],
     )
     res = localDataService.getIPTS(runNumber, "CRACKLE")
     assert res == mockGetIPTS.return_value
-    assert mockGetIPTS.called_with(
-        runNumber=runNumber,
-        instrumentName="CRACKLE",
+    mockGetIPTS.assert_called_with(
+        RunNumber=runNumber,
+        Instrument="CRACKLE",
     )
 
 
@@ -2049,7 +2049,9 @@ def test_initializeState():
         actual = localDataService.initializeState(runNumber, useLiteMode, "test")
         actual.creationDate = testCalibrationData.creationDate
     assert actual == testCalibrationData
-    assert localDataService._writeDefaultDiffCalTable.called_once_with(runNumber, useLiteMode)
+    assert localDataService._writeDefaultDiffCalTable.call_count == 2
+    localDataService._writeDefaultDiffCalTable.assert_any_call(runNumber, True)
+    localDataService._writeDefaultDiffCalTable.assert_any_call(runNumber, False)
 
 
 def test_initializeState_calls_prepareStateRoot():

--- a/tests/unit/backend/recipe/algorithm/test_FitMultiplePeaksAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FitMultiplePeaksAlgorithm.py
@@ -1,8 +1,10 @@
-import os
-import unittest.mock as mock
 from typing import List
-
+import os
 import pydantic
+
+from snapred.backend.dao.request.FarmFreshIngredients import FarmFreshIngredients
+
+import unittest.mock as mock
 
 with mock.patch.dict(
     "sys.modules",
@@ -24,7 +26,8 @@ with mock.patch.dict(
         """Test ability to initialize fit multiple peaks algo"""
         wsName = "testWS"
         CreateSingleValuedWorkspace(OutputWorkspace=wsName)
-        peaks = SculleryBoy().prepDetectorPeaks({})
+        mockFarmFresh = mock.Mock(spec_set=FarmFreshIngredients)
+        peaks = SculleryBoy().prepDetectorPeaks(mockFarmFresh)
         fmpAlgo = FitMultiplePeaksAlgorithm()
         fmpAlgo.initialize()
         fmpAlgo.setPropertyValue("InputWorkspace", wsName)
@@ -44,7 +47,8 @@ with mock.patch.dict(
             DataY=[1] * 6,
             NSpec=6,
         )
-        peaks = SculleryBoy().prepDetectorPeaks({"good": ""})
+        mockFarmFresh = mock.Mock(spec_set=FarmFreshIngredients)
+        peaks = SculleryBoy().prepDetectorPeaks(mockFarmFresh)
         fmpAlgo = FitMultiplePeaksAlgorithm()
         fmpAlgo.initialize()
         fmpAlgo.setPropertyValue("InputWorkspace", wsName)

--- a/tests/unit/backend/recipe/algorithm/test_FitMultiplePeaksAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FitMultiplePeaksAlgorithm.py
@@ -1,10 +1,9 @@
-from typing import List
 import os
-import pydantic
-
-from snapred.backend.dao.request.FarmFreshIngredients import FarmFreshIngredients
-
 import unittest.mock as mock
+from typing import List
+
+import pydantic
+from snapred.backend.dao.request.FarmFreshIngredients import FarmFreshIngredients
 
 with mock.patch.dict(
     "sys.modules",

--- a/tests/unit/backend/recipe/algorithm/test_SaveGroupingDefinition.py
+++ b/tests/unit/backend/recipe/algorithm/test_SaveGroupingDefinition.py
@@ -4,7 +4,6 @@ import socket
 import tempfile
 import unittest
 import unittest.mock as mock
-from unittest.mock import ANY
 
 import pytest
 from mantid.simpleapi import (
@@ -251,13 +250,15 @@ class TestSaveGroupingDefinition(unittest.TestCase):
             assert savingAlgo.execute()
 
             # assert that the mocked methods were called
-            assert savingAlgo.mantidSnapper.LoadGroupingDefinition.called_once_with(
-                ANY,
+            savingAlgo.mantidSnapper.LoadGroupingDefinition.assert_called_once_with(
+                mock.ANY,
                 GroupingFilename=groupingFile,
-                OutputWorkspace=ANY,
+                OutputWorkspace=mock.ANY,
+                InstrumentFileName="",
+                InstrumentName="",
                 InstrumentDonor=self.localIDFWorkspace,
             )
-            assert savingAlgo.mantidSnapper.WashDishes.called_once
+            savingAlgo.mantidSnapper.WashDishes.assert_called_once()
             # assert the save went through
             assert os.path.exists(outputFilePath)
 

--- a/tests/unit/backend/recipe/algorithm/test_SmoothDataExcludingPeaksAlgo.py
+++ b/tests/unit/backend/recipe/algorithm/test_SmoothDataExcludingPeaksAlgo.py
@@ -1,3 +1,5 @@
+import unittest
+from unittest import mock
 
 from mantid.simpleapi import (
     CreateWorkspace,
@@ -9,10 +11,6 @@ from snapred.backend.dao.request import FarmFreshIngredients
 from snapred.backend.recipe.algorithm.SmoothDataExcludingPeaksAlgo import SmoothDataExcludingPeaksAlgo as Algo
 from snapred.meta.Config import Resource
 from snapred.meta.redantic import list_to_raw
-
-import unittest
-from unittest import mock
-
 from util.SculleryBoy import SculleryBoy
 
 

--- a/tests/unit/backend/recipe/algorithm/test_SmoothDataExcludingPeaksAlgo.py
+++ b/tests/unit/backend/recipe/algorithm/test_SmoothDataExcludingPeaksAlgo.py
@@ -1,4 +1,3 @@
-import unittest
 
 from mantid.simpleapi import (
     CreateWorkspace,
@@ -6,9 +5,14 @@ from mantid.simpleapi import (
     LoadNexusProcessed,
     mtd,
 )
+from snapred.backend.dao.request import FarmFreshIngredients
 from snapred.backend.recipe.algorithm.SmoothDataExcludingPeaksAlgo import SmoothDataExcludingPeaksAlgo as Algo
 from snapred.meta.Config import Resource
 from snapred.meta.redantic import list_to_raw
+
+import unittest
+from unittest import mock
+
 from util.SculleryBoy import SculleryBoy
 
 
@@ -61,7 +65,8 @@ class TestSmoothDataAlgo(unittest.TestCase):
         )
 
         # populate ingredients
-        peaks = SculleryBoy().prepDetectorPeaks({"good": "yes"})
+        mockFarmFresh = mock.Mock(spec_set=FarmFreshIngredients)
+        peaks = SculleryBoy().prepDetectorPeaks(mockFarmFresh)
 
         # initialize and run smoothdata algo
         smoothDataAlgo = Algo()

--- a/tests/unit/backend/recipe/test_GenerateFocussedVanadiumRecipe.py
+++ b/tests/unit/backend/recipe/test_GenerateFocussedVanadiumRecipe.py
@@ -1,14 +1,17 @@
-import unittest
-from unittest import mock
 
-import pytest
 from mantid.simpleapi import (
     LoadNexusProcessed,
     mtd,
 )
+from snapred.backend.dao.request import FarmFreshIngredients
 from snapred.backend.dao.ingredients import GenerateFocussedVanadiumIngredients as Ingredients
 from snapred.backend.recipe.GenerateFocussedVanadiumRecipe import GenerateFocussedVanadiumRecipe as Recipe
 from snapred.meta.Config import Resource
+
+import unittest
+from unittest import mock
+import pytest
+
 from util.helpers import deleteWorkspaceNoThrow
 from util.SculleryBoy import SculleryBoy
 
@@ -26,7 +29,9 @@ class TestGenerateFocussedVanadiumRecipe(unittest.TestCase):
             Filename=Resource.getPath(testWorkspaceFile),
             outputWorkspace=self.fakeInputWorkspace,
         )
-        peaks = SculleryBoy().prepDetectorPeaks({})
+
+        mockFarmFresh = mock.Mock(spec_set=FarmFreshIngredients)
+        peaks = SculleryBoy().prepDetectorPeaks(mockFarmFresh)
 
         self.fakeIngredients = Ingredients(
             smoothingParameter=0.1,

--- a/tests/unit/backend/recipe/test_GenerateFocussedVanadiumRecipe.py
+++ b/tests/unit/backend/recipe/test_GenerateFocussedVanadiumRecipe.py
@@ -1,17 +1,15 @@
+import unittest
+from unittest import mock
 
+import pytest
 from mantid.simpleapi import (
     LoadNexusProcessed,
     mtd,
 )
-from snapred.backend.dao.request import FarmFreshIngredients
 from snapred.backend.dao.ingredients import GenerateFocussedVanadiumIngredients as Ingredients
+from snapred.backend.dao.request import FarmFreshIngredients
 from snapred.backend.recipe.GenerateFocussedVanadiumRecipe import GenerateFocussedVanadiumRecipe as Recipe
 from snapred.meta.Config import Resource
-
-import unittest
-from unittest import mock
-import pytest
-
 from util.helpers import deleteWorkspaceNoThrow
 from util.SculleryBoy import SculleryBoy
 

--- a/tests/unit/backend/recipe/test_PixelGroupingParametersCalculationRecipe.py
+++ b/tests/unit/backend/recipe/test_PixelGroupingParametersCalculationRecipe.py
@@ -1,5 +1,4 @@
 import unittest.mock as mock
-from typing import List
 
 import pytest
 from snapred.backend.dao.Limit import Limit
@@ -66,10 +65,10 @@ def test_resolve_callback(BinnedValue):
     parsePGPList = mock.Mock(return_value=[mock.Mock(dRelativeResolution=1.0)])
     recipe = PixelGroupingParametersCalculationRecipe()
     recipe.parsePGPList = parsePGPList
-        
+
     mockAlgo = mock.Mock(return_value=mock.Mock(get=mock.Mock(return_value="done")))
     recipe.mantidSnapper.PixelGroupingParametersCalculationAlgorithm = mockAlgo
-    
+
     ingredients = mock.Mock(nBinsAcrossPeakWidth=10)
     groceries = {
         "groupingWorkspace": "grouping workspace",

--- a/tests/unit/backend/recipe/test_PixelGroupingParametersCalculationRecipe.py
+++ b/tests/unit/backend/recipe/test_PixelGroupingParametersCalculationRecipe.py
@@ -62,12 +62,14 @@ def test_execute_unsuccessful():
 @mock.patch("snapred.backend.recipe.PixelGroupingParametersCalculationRecipe.BinnedValue")
 def test_resolve_callback(BinnedValue):
     BinnedValue.return_value = "tof"
-    parsePGPList = mock.Mock(return_value=[mock.Mock(dRelativeResolution=1.0)])
-    mockAlgo = mock.Mock(return_value=mock.Mock(get=mock.Mock(return_value="done")))
 
+    parsePGPList = mock.Mock(return_value=[mock.Mock(dRelativeResolution=1.0)])
     recipe = PixelGroupingParametersCalculationRecipe()
     recipe.parsePGPList = parsePGPList
+        
+    mockAlgo = mock.Mock(return_value=mock.Mock(get=mock.Mock(return_value="done")))
     recipe.mantidSnapper.PixelGroupingParametersCalculationAlgorithm = mockAlgo
+    
     ingredients = mock.Mock(nBinsAcrossPeakWidth=10)
     groceries = {
         "groupingWorkspace": "grouping workspace",
@@ -77,4 +79,4 @@ def test_resolve_callback(BinnedValue):
     assert data["result"]
     assert data["tof"] == BinnedValue.return_value
     assert data["parameters"] == parsePGPList.return_value
-    assert parsePGPList.called_once_with(List[PixelGroupingParameters], "done")
+    parsePGPList.assert_called_once_with("done")

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -2,12 +2,15 @@
 import json
 import tempfile
 import time
+import unittest
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
 from random import randint
 from typing import Dict, List
+from unittest import mock
 
+import pytest
 from mantid.simpleapi import (
     CloneWorkspace,
     CreateSingleValuedWorkspace,
@@ -28,20 +31,14 @@ from snapred.backend.dao.request import (
     InitializeStateRequest,
 )
 from snapred.backend.dao.RunConfig import RunConfig
-from snapred.backend.dao.StateConfig import StateConfig
 from snapred.backend.dao.state.FocusGroup import FocusGroup
-from snapred.meta.Config import Config
+from snapred.backend.dao.StateConfig import StateConfig
 from snapred.meta.builder.GroceryListBuilder import GroceryListBuilder
+from snapred.meta.Config import Config
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName, WorkspaceType
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceType as wngt
 from snapred.meta.redantic import parse_file_as
-
-
-import unittest
-from unittest import mock
-import pytest
-
 from util.dao import DAOFactory
 from util.state_helpers import state_root_redirect
 
@@ -329,7 +326,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             InputWorkspace=request.workspaces[wngt.DIFFCAL_OUTPUT][0],
             DetectorPeaks=self.instance.sousChef.prepDetectorPeaks(
                 FarmFreshIngredients.return_value,
-            )
+            ),
         )
         self.instance.dataFactoryService.getCifFilePath.assert_called_once_with("biscuit")
 
@@ -449,7 +446,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
                 version=calibRecord.version,
                 checkExistent=False,
             )
-            
+
             # Load the assessment workspaces:
             self.instance.loadQualityAssessment(mockRequest)
 
@@ -569,7 +566,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             useLiteMode=calibRecord.useLiteMode,
             version=calibRecord.version,
             checkExistent=False,
-        )        
+        )
         self.instance.loadQualityAssessment(mockRequest)
         calledWithDict = mockFetchGroceryDict.call_args[0][0]
         assert calledWithDict["diffCalOutput_0000"].unit == wng.Units.DSP
@@ -615,26 +612,24 @@ class TestCalibrationServiceMethods(unittest.TestCase):
 
     def test_fetchDiffractionCalibrationGroceries(self):
         self.instance.groceryClerk = mock.Mock(spec=GroceryListBuilder)
-        
-        runNumber="12345"
-        useLiteMode=True
-        focusGroup=FocusGroup(name="group1", definition="/any/path")
-        diffcalOutputName = (
-            wng.diffCalOutput().unit(wng.Units.DSP).runNumber(runNumber).group(focusGroup.name).build()
-        )
+
+        runNumber = "12345"
+        useLiteMode = True
+        focusGroup = FocusGroup(name="group1", definition="/any/path")
+        diffcalOutputName = wng.diffCalOutput().unit(wng.Units.DSP).runNumber(runNumber).group(focusGroup.name).build()
         diagnosticWorkspaceName = (
             wng.diffCalOutput().unit(wng.Units.DIAG).runNumber(runNumber).group(focusGroup.name).build()
         )
         calibrationTableName = wng.diffCalTable().runNumber(runNumber).build()
         calibrationMaskName = wng.diffCalMask().runNumber(runNumber).build()
-        
+
         self.instance.groceryService.fetchGroceryDict = mock.Mock(
             return_value={
                 "grocery1": "orange",
                 "outputWorkspace": diffcalOutputName,
                 "diagnosticWorkspace": diagnosticWorkspaceName,
                 "calibrationTable": calibrationTableName,
-                "maskWorkspace": calibrationMaskName,                           
+                "maskWorkspace": calibrationMaskName,
             }
         )
 
@@ -653,7 +648,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             outputWorkspace=diffcalOutputName,
             diagnosticWorkspace=diagnosticWorkspaceName,
             calibrationTable=calibrationTableName,
-            maskWorkspace=calibrationMaskName,           
+            maskWorkspace=calibrationMaskName,
         )
         assert result == self.instance.groceryService.fetchGroceryDict.return_value
 

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -2,16 +2,12 @@
 import json
 import tempfile
 import time
-import unittest
-import unittest.mock as mock
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
 from random import randint
 from typing import Dict, List
-from unittest.mock import MagicMock, patch
 
-import pytest
 from mantid.simpleapi import (
     CloneWorkspace,
     CreateSingleValuedWorkspace,
@@ -22,17 +18,30 @@ from mantid.simpleapi import (
     mtd,
 )
 from snapred.backend.dao.ingredients import CalibrationMetricsWorkspaceIngredients
-from snapred.backend.dao.request.CalibrationExportRequest import CalibrationExportRequest
-from snapred.backend.dao.request.CreateCalibrationRecordRequest import CreateCalibrationRecordRequest
-from snapred.backend.dao.request.CreateIndexEntryRequest import CreateIndexEntryRequest
-from snapred.backend.dao.request.InitializeStateRequest import InitializeStateRequest
+from snapred.backend.dao.request import (
+    CalibrationAssessmentRequest,
+    CalibrationExportRequest,
+    CalibrationLoadAssessmentRequest,
+    CreateCalibrationRecordRequest,
+    CreateIndexEntryRequest,
+    DiffractionCalibrationRequest,
+    InitializeStateRequest,
+)
 from snapred.backend.dao.RunConfig import RunConfig
 from snapred.backend.dao.StateConfig import StateConfig
+from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.meta.Config import Config
+from snapred.meta.builder.GroceryListBuilder import GroceryListBuilder
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName, WorkspaceType
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceType as wngt
 from snapred.meta.redantic import parse_file_as
+
+
+import unittest
+from unittest import mock
+import pytest
+
 from util.dao import DAOFactory
 from util.state_helpers import state_root_redirect
 
@@ -114,7 +123,7 @@ with mock.patch.dict(
         calibrationService.dataFactoryService.getCalibrationIndex = mock.Mock(
             return_value=IndexEntry(runNumber="1", useLiteMode=True, comments="", author="")
         )
-        calibrationService.getCalibrationIndex(MagicMock(run=MagicMock(runNumber="123")))
+        calibrationService.getCalibrationIndex(mock.MagicMock(run=mock.MagicMock(runNumber="123")))
         assert calibrationService.dataFactoryService.getCalibrationIndex.called
 
 
@@ -230,18 +239,18 @@ class TestCalibrationServiceMethods(unittest.TestCase):
                 maskWorkspaceName=self.sampleMaskWS if maskWSName else "",
             )
 
-    @patch(thisService + "CalibrationMetricExtractionRecipe")
-    @patch(thisService + "FocusGroupMetric")
+    @mock.patch(thisService + "CalibrationMetricExtractionRecipe")
+    @mock.patch(thisService + "FocusGroupMetric")
     def test_collectMetrics(
         self,
         FocusGroupMetric,
         CalibrationMetricExtractionRecipe,
     ):
         # mock the inputs to the function
-        focussedData = MagicMock(spec_set=str)
-        focusGroup = MagicMock(spec=FocusGroup)
+        focussedData = mock.MagicMock(spec_set=str)
+        focusGroup = mock.MagicMock(spec=FocusGroup)
         focusGroup.name = "group1"
-        pixelGroup = MagicMock(spec_set=PixelGroup)
+        pixelGroup = mock.MagicMock(spec=PixelGroup, json=lambda: "I'm a little teapot")
 
         # mock external method calls
         self.instance.parseCalibrationMetricList = mock.Mock(
@@ -254,37 +263,46 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         metric = self.instance._collectMetrics(focussedData, focusGroup, pixelGroup)
 
         # Assert correct behavior
-        assert CalibrationMetricExtractionRecipe.called_once_with(
+        CalibrationMetricExtractionRecipe.return_value.executeRecipe.assert_called_once_with(
             InputWorkspace=focussedData,
-            PixelGroup=pixelGroup,
+            PixelGroup=pixelGroup.json(),
         )
-        assert self.instance.parseCalibrationMetricList.called_once_with(mockMetric)
-        assert FocusGroupMetric.called_once_with(
+        self.instance.parseCalibrationMetricList.assert_called_once_with(mockMetric)
+        FocusGroupMetric.assert_called_once_with(
             focusGroupName=focusGroup.name,
             calibrationMetric=mockMetric,  # NOTE this is because of above lambda
         )
         assert metric == FocusGroupMetric.return_value
 
-    @patch(thisService + "FitMultiplePeaksRecipe")
+    @mock.patch(thisService + "FarmFreshIngredients")
+    @mock.patch(thisService + "FitMultiplePeaksRecipe")
     def test_assessQuality(
         self,
         FitMultiplePeaksRecipe,
+        FarmFreshIngredients,
     ):
         # Mock input data
+        timestamp = time.time()
+        mockFarmFreshIngredients = mock.Mock(
+            spec=FarmFreshIngredients,
+            runNumber="12345",
+            useLiteMode=True,
+            timestamp=timestamp,
+        )
+        FarmFreshIngredients.return_value = mockFarmFreshIngredients
         fakeMetrics = DAOFactory.focusGroupCalibrationMetric_Column
-        time = 123.123
         expectedRecord = DAOFactory.calibrationRecord()
         expectedWorkspaces = [
-            wng.diffCalTimedMetric().runNumber(expectedRecord.runNumber).timestamp(time).metricName(metric).build()
+            wng.diffCalTimedMetric().runNumber(expectedRecord.runNumber).timestamp(timestamp).metricName(metric).build()
             for metric in ["sigma", "strain"]
         ]
 
         # Mock the necessary method calls
         self.instance.sousChef = SculleryBoy()
-        self.instance.dataFactoryService.getCifFilePath = MagicMock(return_value="good/cif/path")
-        self.instance.dataFactoryService.createCalibrationRecord = MagicMock(return_value=expectedRecord)
-        self.instance.dataExportService.getUniqueTimestamp = MagicMock(return_value=time)
-        self.instance._collectMetrics = MagicMock(return_value=fakeMetrics)
+        self.instance.dataFactoryService.getCifFilePath = mock.Mock(return_value="good/cif/path")
+        self.instance.dataFactoryService.createCalibrationRecord = mock.Mock(return_value=expectedRecord)
+        self.instance.dataExportService.getUniqueTimestamp = mock.Mock(return_value=timestamp)
+        self.instance._collectMetrics = mock.Mock(return_value=fakeMetrics)
 
         # Call the method to test
         request = CalibrationAssessmentRequest(
@@ -307,8 +325,13 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         response = self.instance.assessQuality(request)
 
         # Assert correct method calls
-        assert FitMultiplePeaksRecipe.called_once_with(self.instance.sousChef.prepPeakIngredients({}))
-        assert self.instance.dataFactoryService.getCifFilePath.called_once_with("biscuit")
+        FitMultiplePeaksRecipe.return_value.executeRecipe.assert_called_once_with(
+            InputWorkspace=request.workspaces[wngt.DIFFCAL_OUTPUT][0],
+            DetectorPeaks=self.instance.sousChef.prepDetectorPeaks(
+                FarmFreshIngredients.return_value,
+            )
+        )
+        self.instance.dataFactoryService.getCifFilePath.assert_called_once_with("biscuit")
 
         # Assert the result is as expected
         assert response.model_dump() == {
@@ -374,7 +397,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
 
     def test_load_quality_assessment_no_calibration_record_exception(self):
         with state_root_redirect(self.localDataService):
-            mockRequest = MagicMock(
+            mockRequest = mock.Mock(
                 runId=self.runNumber,
                 useLiteMode=True,
                 version=self.version,
@@ -385,7 +408,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             assert str(mockRequest.runId) in str(excinfo.value)
             assert str(mockRequest.version) in str(excinfo.value)
 
-    @patch(thisService + "CalibrationMetricsWorkspaceIngredients")
+    @mock.patch(thisService + "CalibrationMetricsWorkspaceIngredients")
     def test_load_quality_assessment_no_calibration_metrics_exception(
         self,
         mockCalibrationMetricsWorkspaceIngredients,
@@ -407,20 +430,26 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         path = Resource.getPath("outputs")
         with tempfile.TemporaryDirectory(dir=path, suffix="/") as tmpDir:
             calibRecord = DAOFactory.calibrationRecord()
-            self.instance.dataFactoryService.getCalibrationRecord = MagicMock(return_value=calibRecord)
+            self.instance.dataFactoryService.getCalibrationRecord = mock.Mock(return_value=calibRecord)
 
             # Under a mocked calibration data path, create fake "persistent" workspace files
-            self.instance.dataFactoryService.getCalibrationDataPath = MagicMock(return_value=tmpDir)
-            self.instance.groceryService.dataService.readCalibrationRecord = MagicMock()
-            self.instance.groceryService.fetchCalibrationWorkspaces = MagicMock()
-            self.instance.groceryService._createDiffcalTableWorkspaceName = MagicMock()
-            self.instance.groceryService.fetchGroceryDict = MagicMock()
+            self.instance.dataFactoryService.getCalibrationDataPath = mock.Mock(return_value=tmpDir)
+            self.instance.groceryService.dataService.readCalibrationRecord = mock.Mock()
+            self.instance.groceryService.fetchCalibrationWorkspaces = mock.Mock()
+            self.instance.groceryService._createDiffcalTableWorkspaceName = mock.Mock()
+            self.instance.groceryService.fetchGroceryDict = mock.Mock()
             self.create_fake_diffcal_files(Path(tmpDir), calibRecord.workspaces, calibRecord.version)
 
-            mockRequest = MagicMock(runId=calibRecord.runNumber, version=calibRecord.version, checkExistent=False)
-            self.instance.groceryService._getCalibrationDataPath = MagicMock(return_value=tmpDir)
-            self.instance.groceryService._fetchInstrumentDonor = MagicMock(return_value=self.sampleWS)
-
+            self.instance.groceryService._getCalibrationDataPath = mock.Mock(return_value=tmpDir)
+            self.instance.groceryService._fetchInstrumentDonor = mock.Mock(return_value=self.sampleWS)
+            mockRequest = mock.Mock(
+                spec=CalibrationLoadAssessmentRequest,
+                runId=calibRecord.runNumber,
+                useLiteMode=calibRecord.useLiteMode,
+                version=calibRecord.version,
+                checkExistent=False,
+            )
+            
             # Load the assessment workspaces:
             self.instance.loadQualityAssessment(mockRequest)
 
@@ -430,7 +459,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
                     if mtd.doesExist(ws):
                         DeleteWorkspace(Workspace=ws)
 
-            mockRequest = MagicMock(runId=calibRecord.runNumber, version=calibRecord.version, checkExistent=True)
+            mockRequest = mock.Mock(runId=calibRecord.runNumber, version=calibRecord.version, checkExistent=True)
             with pytest.raises(RuntimeError) as excinfo:  # noqa: PT011
                 self.instance.loadQualityAssessment(mockRequest)
             assert "is already loaded" in str(excinfo.value)
@@ -454,7 +483,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
                 version=version,
                 checkExistent=False,
             )
-            self.instance.groceryService._fetchInstrumentDonor = MagicMock(return_value=self.sampleWS)
+            self.instance.groceryService._fetchInstrumentDonor = mock.Mock(return_value=self.sampleWS)
 
             # Load the assessment workspaces:
             self.instance.loadQualityAssessment(mockRequest)
@@ -483,13 +512,13 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             self.create_fake_diffcal_files(recordFilepath.parent, record.workspaces, version)
 
             # Call the method to test. Use a mocked run and a mocked version
-            mockRequest = MagicMock(
+            mockRequest = mock.Mock(
                 runId=record.runNumber,
                 useLiteMode=record.useLiteMode,
                 version=version,
                 checkExistent=False,
             )
-            self.instance.groceryService._fetchInstrumentDonor = MagicMock(return_value=self.sampleWS)
+            self.instance.groceryService._fetchInstrumentDonor = mock.Mock(return_value=self.sampleWS)
 
             self.instance.loadQualityAssessment(mockRequest)
 
@@ -513,10 +542,10 @@ class TestCalibrationServiceMethods(unittest.TestCase):
     def test_load_quality_assessment_no_units(self):
         calibRecord = DAOFactory.calibrationRecord(runNumber="57514", version=1)
         calibRecord.workspaces[wngt.DIFFCAL_OUTPUT] = ["_diffoc_057514_v0001"]  # NOTE no unit token
-        self.instance.dataFactoryService.getCalibrationRecord = MagicMock(return_value=calibRecord)
+        self.instance.dataFactoryService.getCalibrationRecord = mock.Mock(return_value=calibRecord)
 
         # Call the method to test. Use a mocked run and a mocked version
-        mockRequest = MagicMock(runId=calibRecord.runNumber, version=calibRecord.version, checkExistent=False)
+        mockRequest = mock.Mock(runId=calibRecord.runNumber, version=calibRecord.version, checkExistent=False)
         with pytest.raises(RuntimeError, match=r".*without a units token in its name.*"):
             self.instance.loadQualityAssessment(mockRequest)
 
@@ -534,8 +563,13 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         mockFetchGroceryDict = mock.Mock(return_value={})
         self.instance.groceryService.fetchGroceryDict = mockFetchGroceryDict
 
-        # Call the method to test. Use a mocked run and a mocked version
-        mockRequest = MagicMock(runId=calibRecord.runNumber, version=calibRecord.version, checkExistent=False)
+        mockRequest = mock.Mock(
+            spec=CalibrationLoadAssessmentRequest,
+            runId=calibRecord.runNumber,
+            useLiteMode=calibRecord.useLiteMode,
+            version=calibRecord.version,
+            checkExistent=False,
+        )        
         self.instance.loadQualityAssessment(mockRequest)
         calledWithDict = mockFetchGroceryDict.call_args[0][0]
         assert calledWithDict["diffCalOutput_0000"].unit == wng.Units.DSP
@@ -549,14 +583,19 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             "diffCalMask": ["_diffract_consts_mask_057514"],
             "rawVanadium": ["_unexpected_workspace_type"],
         }
-        self.instance.dataFactoryService.getCalibrationRecord = MagicMock(return_value=calibRecord)
+        self.instance.dataFactoryService.getCalibrationRecord = mock.Mock(return_value=calibRecord)
 
-        # Call the method to test. Use a mocked run and a mocked version
-        mockRequest = MagicMock(runId=calibRecord.runNumber, version=calibRecord.version, checkExistent=False)
+        mockRequest = mock.Mock(
+            spec=CalibrationLoadAssessmentRequest,
+            runId=calibRecord.runNumber,
+            useLiteMode=calibRecord.useLiteMode,
+            version=calibRecord.version,
+            checkExistent=False,
+        )
         with pytest.raises(RuntimeError, match=r".*not implemented: unable to load unexpected.*"):
             self.instance.loadQualityAssessment(mockRequest)
 
-    @patch(thisService + "FarmFreshIngredients", spec_set=FarmFreshIngredients)
+    @mock.patch(thisService + "FarmFreshIngredients", spec_set=FarmFreshIngredients)
     def test_prepDiffractionCalibrationIngredients(self, FarmFreshIngredients):
         mockFF = mock.Mock()
         FarmFreshIngredients.return_value = mockFF
@@ -571,26 +610,55 @@ class TestCalibrationServiceMethods(unittest.TestCase):
 
         # Perform assertions to check the result and method calls
         assert FarmFreshIngredients.call_count == 1
-        assert self.instance.dataFactoryService.getCifFilePath.called_once_with("cake_egg")
+        self.instance.dataFactoryService.getCifFilePath.assert_called_once_with("cake_egg")
         assert res == self.instance.sousChef.prepDiffractionCalibrationIngredients(mockFF)
 
     def test_fetchDiffractionCalibrationGroceries(self):
-        self.instance.groceryClerk = mock.Mock()
-        self.instance.groceryService.fetchGroceryDict = mock.Mock(return_value={"grocery1": "orange"})
+        self.instance.groceryClerk = mock.Mock(spec=GroceryListBuilder)
+        
+        runNumber="12345"
+        useLiteMode=True
+        focusGroup=FocusGroup(name="group1", definition="/any/path")
+        diffcalOutputName = (
+            wng.diffCalOutput().unit(wng.Units.DSP).runNumber(runNumber).group(focusGroup.name).build()
+        )
+        diagnosticWorkspaceName = (
+            wng.diffCalOutput().unit(wng.Units.DIAG).runNumber(runNumber).group(focusGroup.name).build()
+        )
+        calibrationTableName = wng.diffCalTable().runNumber(runNumber).build()
+        calibrationMaskName = wng.diffCalMask().runNumber(runNumber).build()
+        
+        self.instance.groceryService.fetchGroceryDict = mock.Mock(
+            return_value={
+                "grocery1": "orange",
+                "outputWorkspace": diffcalOutputName,
+                "diagnosticWorkspace": diagnosticWorkspaceName,
+                "calibrationTable": calibrationTableName,
+                "maskWorkspace": calibrationMaskName,                           
+            }
+        )
 
         # Call the method with the provided parameters
-        request = mock.Mock(runNumber="12345", focusGroup=mock.Mock(name="group1"))
-        res = self.instance.fetchDiffractionCalibrationGroceries(request)
-
-        # Perform assertions to check the result and method calls
-        assert self.instance.groceryClerk.buildDict.call_count == 1
-        assert self.instance.groceryService.fetchGroceryDict.called_once_with(
-            self.instance.groceryClerk.buildDict.return_value
+        request = mock.Mock(
+            spec=DiffractionCalibrationRequest,
+            runNumber=runNumber,
+            useLiteMode=useLiteMode,
+            focusGroup=focusGroup,
         )
-        assert res == self.instance.groceryService.fetchGroceryDict.return_value
+        result = self.instance.fetchDiffractionCalibrationGroceries(request)
 
-    @patch(thisService + "FarmFreshIngredients", spec_set=FarmFreshIngredients)
-    @patch(thisService + "DiffractionCalibrationRecipe", spec_set=DiffractionCalibrationRecipe)
+        assert self.instance.groceryClerk.buildDict.call_count == 1
+        self.instance.groceryService.fetchGroceryDict.assert_called_once_with(
+            self.instance.groceryClerk.buildDict.return_value,
+            outputWorkspace=diffcalOutputName,
+            diagnosticWorkspace=diagnosticWorkspaceName,
+            calibrationTable=calibrationTableName,
+            maskWorkspace=calibrationMaskName,           
+        )
+        assert result == self.instance.groceryService.fetchGroceryDict.return_value
+
+    @mock.patch(thisService + "FarmFreshIngredients", spec_set=FarmFreshIngredients)
+    @mock.patch(thisService + "DiffractionCalibrationRecipe", spec_set=DiffractionCalibrationRecipe)
     def test_diffractionCalibration(
         self,
         DiffractionCalibrationRecipe,
@@ -615,14 +683,14 @@ class TestCalibrationServiceMethods(unittest.TestCase):
 
         # Perform assertions to check the result and method calls
         assert FarmFreshIngredients.call_count == 1
-        assert DiffractionCalibrationRecipe().executeRecipe.called_once_with(
+        DiffractionCalibrationRecipe().executeRecipe.assert_called_once_with(
             self.instance.sousChef.prepDiffractionCalibrationIngredients(FarmFreshIngredients()),
             self.instance.groceryService.fetchGroceryDict.return_value,
         )
         assert res == {"calibrationTable": "fake"}
 
-    @patch(thisService + "FarmFreshIngredients", spec_set=FarmFreshIngredients)
-    @patch(thisService + "FocusSpectraRecipe")
+    @mock.patch(thisService + "FarmFreshIngredients", spec_set=FarmFreshIngredients)
+    @mock.patch(thisService + "FocusSpectraRecipe")
     def test_focusSpectra_not_exist(
         self,
         FocusSpectraRecipe,
@@ -654,9 +722,8 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         groupingItem = self.instance.groceryClerk.build.return_value
         groupingWorkspace = self.instance.groceryService.fetchGroupingDefinition.return_value["workspace"]
         assert FarmFreshIngredients.call_count == 1
-        # assert self.instance.sousChef.prepPixelGroup.called_once_with(FarmFreshIngredients.return_value)
-        assert self.instance.groceryService.fetchGroupingDefinition.called_once_with(groupingItem)
-        assert FocusSpectraRecipe().executeRecipe.called_once_with(
+        self.instance.groceryService.fetchGroupingDefinition.assert_called_once_with(groupingItem)
+        FocusSpectraRecipe().executeRecipe.assert_called_once_with(
             InputWorkspace=request.inputWorkspace,
             GroupingWorkspace=groupingWorkspace,
             Ingredients=self.instance.sousChef.prepPixelGroup(FarmFreshIngredients()),
@@ -664,8 +731,8 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         )
         assert res == (focusedWorkspace, groupingWorkspace)
 
-    @patch(thisService + "FarmFreshIngredients", spec_set=FarmFreshIngredients)
-    @patch(thisService + "FocusSpectraRecipe")
+    @mock.patch(thisService + "FarmFreshIngredients", spec_set=FarmFreshIngredients)
+    @mock.patch(thisService + "FocusSpectraRecipe")
     def test_focusSpectra_exists(self, FocusSpectraRecipe, FarmFreshIngredients):
         self.instance.sousChef = SculleryBoy()
 
@@ -691,13 +758,13 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         groupingItem = self.instance.groceryClerk.build.return_value
         groupingWorkspace = self.instance.groceryService.fetchGroupingDefinition.return_value["workspace"]
         assert FarmFreshIngredients.call_count == 1
-        assert self.instance.groceryService.fetchGroupingDefinition.called_once_with(groupingItem)
+        self.instance.groceryService.fetchGroupingDefinition.assert_called_once_with(groupingItem)
 
         # assert that the recipe is not called and the correct workspaces are returned
-        assert FocusSpectraRecipe().executeRecipe.call_count == 0
+        FocusSpectraRecipe().executeRecipe.assert_not_called()
         assert res == (focusedWorkspace, groupingWorkspace)
 
-    @patch(thisService + "FitMultiplePeaksRecipe")
+    @mock.patch(thisService + "FitMultiplePeaksRecipe")
     def test_fitPeaks(self, FitMultiplePeaksRecipe):
         request = mock.Mock()
         res = self.instance.fitPeaks(request)

--- a/tests/unit/backend/service/test_CrystallographicInfoService.py
+++ b/tests/unit/backend/service/test_CrystallographicInfoService.py
@@ -1,8 +1,10 @@
-import unittest
-from unittest.mock import patch
 
-import pytest
+from snapred.meta.Config import Config
 from snapred.backend.service.CrystallographicInfoService import CrystallographicInfoService
+
+import unittest
+from unittest import mock
+import pytest
 
 thisService = "snapred.backend.service.CrystallographicInfoService."
 
@@ -16,16 +18,20 @@ class TestXtalService(unittest.TestCase):
     def test_name(self):
         assert "ingestion" == self.instance.name()
 
-    @patch(thisService + "CrystallographicInfoRecipe")
+    @mock.patch(thisService + "CrystallographicInfoRecipe")
     def test_ingest_good(self, xtalRx):
+        D_MIN = Config["constants.CrystallographicInfo.crystalDMin"]
+        D_MAX = Config["constants.CrystallographicInfo.crystalDMax"]
         xtalRx.return_value.executeRecipe.return_value = {"good": "yup"}
         cifPath = "apples"
         data = self.instance.ingest(cifPath)
-        assert xtalRx.called_once
-        assert xtalRx.return_value.executeRecipe.called_once_with(cifPath)
+        xtalRx.assert_called_once()
+        xtalRx.return_value.executeRecipe.assert_called_once_with(
+            cifPath=cifPath, crystalDMin=D_MIN, crystalDMax=D_MAX
+        )
         assert data == xtalRx.return_value.executeRecipe.return_value
 
-    @patch(thisService + "CrystallographicInfoRecipe")
+    @mock.patch(thisService + "CrystallographicInfoRecipe")
     def test_ingest_bad(self, xtalRx):
         xtalRx.side_effect = RuntimeError("nope!")
         cifPath = "bananas"

--- a/tests/unit/backend/service/test_CrystallographicInfoService.py
+++ b/tests/unit/backend/service/test_CrystallographicInfoService.py
@@ -1,10 +1,9 @@
-
-from snapred.meta.Config import Config
-from snapred.backend.service.CrystallographicInfoService import CrystallographicInfoService
-
 import unittest
 from unittest import mock
+
 import pytest
+from snapred.backend.service.CrystallographicInfoService import CrystallographicInfoService
+from snapred.meta.Config import Config
 
 thisService = "snapred.backend.service.CrystallographicInfoService."
 
@@ -26,9 +25,7 @@ class TestXtalService(unittest.TestCase):
         cifPath = "apples"
         data = self.instance.ingest(cifPath)
         xtalRx.assert_called_once()
-        xtalRx.return_value.executeRecipe.assert_called_once_with(
-            cifPath=cifPath, crystalDMin=D_MIN, crystalDMax=D_MAX
-        )
+        xtalRx.return_value.executeRecipe.assert_called_once_with(cifPath=cifPath, crystalDMin=D_MIN, crystalDMax=D_MAX)
         assert data == xtalRx.return_value.executeRecipe.return_value
 
     @mock.patch(thisService + "CrystallographicInfoRecipe")

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -130,8 +130,7 @@ class TestNormalizationService(unittest.TestCase):
 
         res = self.instance.focusSpectra(mockRequest)
 
-        # assert self.instance.sousChef.prepPixelGroup.called_once_with(FarmFreshIngredients.return_value)
-        assert mockRecipeInst.executeRecipe.called_once_with(
+        mockRecipeInst.executeRecipe.assert_called_once_with(
             InputWorkspace=mockRequest.inputWorkspace,
             GroupingWorkspace=mockRequest.groupingWorkspace,
             Ingredients=self.instance.sousChef.prepPixelGroup(FarmFreshIngredients()),
@@ -162,8 +161,7 @@ class TestNormalizationService(unittest.TestCase):
         res = self.instance.vanadiumCorrection(mockRequest)
 
         mockRecipeInst = RawVanadiumCorrectionRecipe.return_value
-        # assert self.instance.sousChef.prepNormalizationIngredients.called_once_with(FarmFreshIngredients.return_value)
-        assert mockRecipeInst.executeRecipe.called_once_with(
+        mockRecipeInst.executeRecipe.assert_called_once_with(
             InputWorkspace=mockRequest.inputWorkspace,
             BackgroundWorkspace=mockRequest.backgroundWorkspace,
             Ingredients=self.instance.sousChef.prepNormalizationIngredients({}),
@@ -178,7 +176,7 @@ class TestNormalizationService(unittest.TestCase):
         mockRecipe,
         FarmFreshIngredients,
     ):
-        FarmFreshIngredients.return_value = {"good": ""}
+        FarmFreshIngredients.return_value = mock.Mock(spec=FarmFreshIngredients)
         mockRequest = SmoothDataExcludingPeaksRequest(
             runNumber="12345",
             useLiteMode=True,
@@ -192,17 +190,17 @@ class TestNormalizationService(unittest.TestCase):
 
         self.instance = NormalizationService()
         self.instance.sousChef = SculleryBoy()
-        self.instance.dataFactoryService.getCifFilePath = MagicMock(return_value="path/to/cif")
+        self.instance.dataFactoryService.getCifFilePath = mock.Mock(return_value="path/to/cif")
 
         mockRecipeInst = mockRecipe.return_value
 
         self.instance.smoothDataExcludingPeaks(mockRequest)
 
-        # assert self.instance.sousChef.prepDetectorPeaks.called_once_with(FarmFreshIngredients.return_value)
-        assert mockRecipeInst.executeRecipe.called_once_with(
+        mockRecipeInst.executeRecipe.assert_called_once_with(
             InputWorkspace=mockRequest.inputWorkspace,
             OutputWorkspace=mockRequest.outputWorkspace,
-            Ingredients=self.instance.sousChef.prepDetectorPeaks({}),
+            DetectorPeaks=self.instance.sousChef.prepDetectorPeaks(FarmFreshIngredients.return_value),
+            SmoothingParameter=mockRequest.smoothingParameter,
         )
 
     def test_normalizationAssessment(self):

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -1,13 +1,12 @@
 import os.path
 import tempfile
+import unittest
+from unittest import mock
 
 from mantid.simpleapi import DeleteWorkspace, mtd
 from snapred.backend.dao.request.FarmFreshIngredients import FarmFreshIngredients
 from snapred.backend.service.SousChef import SousChef
 from snapred.meta.Config import Config
-
-import unittest
-from unittest import mock
 
 thisService = "snapred.backend.service.SousChef."
 
@@ -88,7 +87,8 @@ class TestSousChef(unittest.TestCase):
         res = self.instance.prepCalibration(self.ingredients)
 
         self.instance.dataFactoryService.getCalibrationState.assert_called_once_with(
-            self.ingredients.runNumber, self.ingredients.useLiteMode,
+            self.ingredients.runNumber,
+            self.ingredients.useLiteMode,
         )
         assert res == self.instance.dataFactoryService.getCalibrationState.return_value
         assert res.instrumentState.fwhmMultipliers.dict() == Config["calibration.parameters.default.FWHMMultiplier"]
@@ -103,7 +103,8 @@ class TestSousChef(unittest.TestCase):
         res = self.instance.prepCalibration(self.ingredients)
 
         self.instance.dataFactoryService.getCalibrationState.assert_called_once_with(
-            self.ingredients.runNumber, self.ingredients.useLiteMode,
+            self.ingredients.runNumber,
+            self.ingredients.useLiteMode,
         )
         assert res == self.instance.dataFactoryService.getCalibrationState.return_value
         assert res.instrumentState.fwhmMultipliers == self.ingredients.fwhmMultipliers

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -1,12 +1,13 @@
 import os.path
 import tempfile
-import unittest
-from unittest import mock
 
 from mantid.simpleapi import DeleteWorkspace, mtd
 from snapred.backend.dao.request.FarmFreshIngredients import FarmFreshIngredients
 from snapred.backend.service.SousChef import SousChef
 from snapred.meta.Config import Config
+
+import unittest
+from unittest import mock
 
 thisService = "snapred.backend.service.SousChef."
 
@@ -37,7 +38,7 @@ class TestSousChef(unittest.TestCase):
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
         res = self.instance.prepManyDetectorPeaks(self.ingredients)
         assert res[0] == self.instance.prepDetectorPeaks.return_value
-        assert self.instance.prepDetectorPeaks.called_once_with(self.ingredients, purgePeaks=False)
+        self.instance.prepDetectorPeaks.assert_called_once_with(self.ingredients, purgePeaks=False)
 
     def test_prepManyDetectorPeaks_no_calibration(self):
         self.instance.prepDetectorPeaks = mock.Mock()
@@ -53,7 +54,7 @@ class TestSousChef(unittest.TestCase):
         self.instance.prepPixelGroup = mock.Mock()
         res = self.instance.prepManyPixelGroups(self.ingredients)
         assert res[0] == self.instance.prepPixelGroup.return_value
-        assert self.instance.prepPixelGroup.called_once_with(self.ingredients)
+        self.instance.prepPixelGroup.assert_called_once_with(self.ingredients)
 
     def test_prepFocusGroup_exists(self):
         # create a temp file to be used a the path for the focus group
@@ -86,7 +87,9 @@ class TestSousChef(unittest.TestCase):
 
         res = self.instance.prepCalibration(self.ingredients)
 
-        assert self.instance.dataFactoryService.getCalibrationState.called_once_with(self.ingredients)
+        self.instance.dataFactoryService.getCalibrationState.assert_called_once_with(
+            self.ingredients.runNumber, self.ingredients.useLiteMode,
+        )
         assert res == self.instance.dataFactoryService.getCalibrationState.return_value
         assert res.instrumentState.fwhmMultipliers.dict() == Config["calibration.parameters.default.FWHMMultiplier"]
 
@@ -99,7 +102,9 @@ class TestSousChef(unittest.TestCase):
 
         res = self.instance.prepCalibration(self.ingredients)
 
-        assert self.instance.dataFactoryService.getCalibrationState.called_once_with(self.ingredients)
+        self.instance.dataFactoryService.getCalibrationState.assert_called_once_with(
+            self.ingredients.runNumber, self.ingredients.useLiteMode,
+        )
         assert res == self.instance.dataFactoryService.getCalibrationState.return_value
         assert res.instrumentState.fwhmMultipliers == self.ingredients.fwhmMultipliers
         assert res.instrumentState.fwhmMultipliers.left == fakeLeft
@@ -112,18 +117,26 @@ class TestSousChef(unittest.TestCase):
         self.instance.prepCalibration = mock.Mock(return_value=mockCalibration)
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
         res = self.instance.prepInstrumentState(ingredients)
-        assert self.instance.prepCalibration.called_once_with(ingredients)
+        self.instance.prepCalibration.assert_called_once_with(ingredients)
         assert res == self.instance.prepCalibration.return_value.instrumentState
 
     def test_prepDefaultInstrumentState(self):
-        ingredients = mock.Mock()
-        mockCalibration = mock.Mock(instrumentState=mock.Mock())
-        self.instance.prepCalibration = mock.Mock(return_value=mockCalibration)
+        ingredients = mock.Mock(
+            spec=FarmFreshIngredients,
+            runNumber="12345",
+            useLiteMode=True,
+        )
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=False)
         self.instance.dataFactoryService.getDefaultInstrumentState = mock.Mock(return_value=mock.Mock())
-        res = self.instance.prepInstrumentState(ingredients)
-        assert self.instance.prepCalibration.called_once_with(ingredients)
-        assert res == self.instance.dataFactoryService.getDefaultInstrumentState.return_value
+        result = self.instance.prepInstrumentState(ingredients)
+        self.instance.dataFactoryService.calibrationExists.assert_called_once_with(
+            ingredients.runNumber,
+            ingredients.useLiteMode,
+        )
+        self.instance.dataFactoryService.getDefaultInstrumentState.assert_called_once_with(
+            ingredients.runNumber,
+        )
+        assert result == self.instance.dataFactoryService.getDefaultInstrumentState.return_value
 
     def test_prepRunConfig(self):
         self.instance.dataFactoryService.lookupService.readRunConfig = mock.Mock()
@@ -153,25 +166,27 @@ class TestSousChef(unittest.TestCase):
         # mock the calibration, which will give the instrument state
         mockCalibration = mock.Mock(instrumentState=mock.Mock())
         self.instance.prepCalibration = mock.Mock(return_value=mockCalibration)
-        self.instance.groceryService.fetchGroceryList = mock.Mock(return_value="banana")
+        self.instance.groceryService.fetchGroceryDict = mock.Mock(
+            return_value={"groupingWorkspace", self.ingredients.focusGroup.name},
+        )
 
         # call the method to be tested
         # make sure the focus group definition exists, by pointing it to a tmp file
         with tempfile.NamedTemporaryFile() as existent:
             self.ingredients.focusGroup.definition = existent.name
-            res = self.instance.prepPixelGroup(self.ingredients)
+            result = self.instance.prepPixelGroup(self.ingredients)
 
         # make necessary assertions
-        assert PixelGroupingIngredients.called_once_with(
+        PixelGroupingIngredients.assert_called_once_with(
             instrumentState=self.instance.prepCalibration.return_value.instrumentState,
             nBinsAcrossPeakWidth=self.ingredients.nBinsAcrossPeakWidth,
         )
-        assert PixelGroupingParametersCalculationRecipe.return_value.executeRecipe.called_once_with(
+        PixelGroupingParametersCalculationRecipe.return_value.executeRecipe.assert_called_once_with(
             PixelGroupingIngredients.return_value,
-            self.instance.groceryService.fetchGroceryList.return_value,
+            self.instance.groceryService.fetchGroceryDict.return_value,
         )
         assert self.instance._pixelGroupCache == {key: PixelGroup.return_value}
-        assert res == self.instance._pixelGroupCache[key]
+        assert result == self.instance._pixelGroupCache[key]
 
     @mock.patch(thisService + "PixelGroupingParametersCalculationRecipe")
     def test_prepPixelGroup_cache(self, PixelGroupingParametersCalculationRecipe):
@@ -200,7 +215,7 @@ class TestSousChef(unittest.TestCase):
 
         res = self.instance.prepCrystallographicInfo(self.ingredients)
 
-        assert XtalService.return_value.ingest.called_once_with(key)
+        XtalService.return_value.ingest.assert_called_once_with(*key)
         assert self.instance._xtalCache == {key: XtalService.return_value.ingest.return_value["crystalInfo"]}
         assert res == self.instance._xtalCache[key]
 
@@ -249,18 +264,18 @@ class TestSousChef(unittest.TestCase):
         self.instance.prepInstrumentState = mock.Mock()
         self.instance.prepPixelGroup = mock.Mock()
 
-        res = self.instance.prepPeakIngredients(self.ingredients)
+        result = self.instance.prepPeakIngredients(self.ingredients)
 
-        assert self.instance.prepCrystallographicInfo.called_once_with(self.ingredients)
-        assert self.instance.prepInstrumentState.called_once_with(self.ingredients.runNumber)
-        assert self.instance.prepPixelGroup.called_once_with(self.ingredients)
-        assert PeakIngredients.called_once_with(
+        self.instance.prepCrystallographicInfo.assert_called_once_with(self.ingredients)
+        self.instance.prepInstrumentState.assert_called_once_with(self.ingredients)
+        self.instance.prepPixelGroup.assert_called_once_with(self.ingredients)
+        PeakIngredients.assert_called_once_with(
             crystalInfo=self.instance.prepCrystallographicInfo.return_value,
             instrumentState=self.instance.prepInstrumentState.return_value,
             pixelGroup=self.instance.prepPixelGroup.return_value,
             peakIntensityThreshold=self.ingredients.peakIntensityThreshold,
         )
-        assert res == PeakIngredients.return_value
+        assert result == PeakIngredients.return_value
 
     @mock.patch(thisService + "DetectorPeakPredictorRecipe")
     @mock.patch(thisService + "GroupPeakList")
@@ -284,8 +299,10 @@ class TestSousChef(unittest.TestCase):
 
         res = self.instance.prepDetectorPeaks(self.ingredients, False)
 
-        assert self.instance.prepPeakIngredients.called_once_with(self.ingredients)
-        assert DetectorPeakPredictorRecipe.return_value.executeRecipe.called_once_with(Ingredients=self.ingredients)
+        self.instance.prepPeakIngredients.assert_called_once_with(self.ingredients)
+        DetectorPeakPredictorRecipe.return_value.executeRecipe.assert_called_once_with(
+            Ingredients=self.instance.prepPeakIngredients.return_value,
+        )
         assert res == [DetectorPeakPredictorRecipe.return_value.executeRecipe.return_value]
         assert self.instance._peaksCache == {key: [DetectorPeakPredictorRecipe.return_value.executeRecipe.return_value]}
 
@@ -317,8 +334,10 @@ class TestSousChef(unittest.TestCase):
 
         res = self.instance.prepDetectorPeaks(self.ingredients)
 
-        assert self.instance.prepPeakIngredients.called_once_with(self.ingredients)
-        assert DetectorPeakPredictorRecipe.return_value.executeRecipe.called_once_with(Ingredients=self.ingredients)
+        self.instance.prepPeakIngredients.assert_called_once_with(self.ingredients)
+        DetectorPeakPredictorRecipe.return_value.executeRecipe.assert_called_once_with(
+            Ingredients=self.instance.prepPeakIngredients.return_value,
+        )
         assert res == [PurgeOverlappingPeaksRecipe.return_value.executeRecipe.return_value]
         assert self.instance._peaksCache == {key: [PurgeOverlappingPeaksRecipe.return_value.executeRecipe.return_value]}
 
@@ -345,9 +364,12 @@ class TestSousChef(unittest.TestCase):
 
     @mock.patch(thisService + "ReductionIngredients")
     def test_prepReductionIngredients(self, ReductionIngredients):
+        calibrationCalibrantSamplePath = "a/sample.x"
         record = mock.Mock(
             smoothingParamter=1.0,
-            calculationParameters=mock.Mock(calibrantSamplePath="a/b.x"),
+            calculationParameters=mock.Mock(
+                calibrantSamplePath=calibrationCalibrantSamplePath,
+            ),
             peakIntensityThreshold=1.0e-5,
         )
         self.instance.prepRunConfig = mock.Mock()
@@ -358,16 +380,26 @@ class TestSousChef(unittest.TestCase):
         self.instance.dataFactoryService.getNormalizationRecord = mock.Mock(return_value=record)
         self.instance.dataFactoryService.getCalibrationRecord = mock.Mock(return_value=record)
 
-        res = self.instance.prepReductionIngredients(self.ingredients)
+        ingredients_ = self.ingredients.model_copy()
+        # ... from calibration record:
+        ingredients_.calibrantSamplePath = calibrationCalibrantSamplePath
+        ingredients_.cifPath = self.instance.dataFactoryService.getCifFilePath.return_value
+        # ... from normalization record:
+        ingredients_.peakIntensityThreshold = record.peakIntensityThreshold
+        result = self.instance.prepReductionIngredients(ingredients_)
 
-        assert self.instance.prepManyPixelGroups.called_once_with(self.ingredients)
-        assert self.instance.dataFactoryService.getCifFilePath.called_once_with("sample")
-        assert ReductionIngredients.called_once_with(
+        self.instance.prepManyPixelGroups.assert_called_once_with(ingredients_)
+        self.instance.dataFactoryService.getCifFilePath.assert_called_once_with("sample")
+        ReductionIngredients.assert_called_once_with(
             pixelGroups=self.instance.prepManyPixelGroups.return_value,
             smoothingParameter=record.smoothingParameter,
+            calibrantSamplePath=ingredients_.calibrantSamplePath,
+            peakIntensityThreshold=ingredients_.peakIntensityThreshold,
             detectorPeaksMany=self.instance.prepManyDetectorPeaks.return_value,
+            keepUnfocused=ingredients_.keepUnfocused,
+            convertUnitsTo=ingredients_.convertUnitsTo,
         )
-        assert res == ReductionIngredients.return_value
+        assert result == ReductionIngredients.return_value
 
     @mock.patch(thisService + "NormalizationIngredients")
     def test_prepNormalizationIngredients(self, NormalizationIngredients):
@@ -378,13 +410,13 @@ class TestSousChef(unittest.TestCase):
 
         res = self.instance.prepNormalizationIngredients(self.ingredients)
 
-        assert self.instance.prepCalibrantSample.called_once_with(self.ingredients.calibrantSamplePath)
-        assert self.instance.prepPixelGroup.called_once_with(self.ingredients)
-        assert self.instance.prepDetectorPeaks.called_once_with(self.ingredients)
-        assert NormalizationIngredients.called_once_with(
+        self.instance.prepCalibrantSample.assert_called_once_with(self.ingredients.calibrantSamplePath)
+        self.instance.prepPixelGroup.assert_called_once_with(self.ingredients)
+        self.instance.prepDetectorPeaks.assert_called_once_with(self.ingredients, purgePeaks=False)
+        NormalizationIngredients.assert_called_once_with(
             pixelGroup=self.instance.prepPixelGroup.return_value,
-            calibrantSamplePath=self.instance.prepCalibrantSample.return_value,
-            detectorPeakskLists=self.instance.prepDetectorPeaks.return_value,
+            calibrantSample=self.instance.prepCalibrantSample.return_value,
+            detectorPeaks=self.instance.prepDetectorPeaks.return_value,
         )
         assert res == NormalizationIngredients.return_value
 
@@ -395,19 +427,21 @@ class TestSousChef(unittest.TestCase):
         self.instance.prepDetectorPeaks = mock.Mock()
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
 
-        res = self.instance.prepDiffractionCalibrationIngredients(self.ingredients)
+        result = self.instance.prepDiffractionCalibrationIngredients(self.ingredients)
 
-        assert self.instance.prepRunConfig.called_once_with(self.ingredients.runNumber)
-        assert self.instance.prepPixelGroup.called_once_with(self.ingredients)
-        assert self.instance.prepDetectorPeaks.called_once_with(self.ingredients)
-        assert DiffractionCalibrationIngredients.called_once_with(
+        self.instance.prepRunConfig.assert_called_once_with(self.ingredients.runNumber)
+        self.instance.prepPixelGroup.assert_called_once_with(self.ingredients)
+        self.instance.prepDetectorPeaks.assert_called_once_with(self.ingredients)
+        DiffractionCalibrationIngredients.assert_called_once_with(
             runConfig=self.instance.prepRunConfig.return_value,
-            pixelGroup=self.instance.prepRunConfig.return_value,
+            pixelGroup=self.instance.prepPixelGroup.return_value,
             groupedPeakLists=self.instance.prepDetectorPeaks.return_value,
+            peakFunction=self.ingredients.peakFunction,
             convergenceThreshold=self.ingredients.convergenceThreshold,
             maxOffset=self.ingredients.maxOffset,
+            maxChiSq=self.ingredients.maxChiSq,
         )
-        assert res == DiffractionCalibrationIngredients.return_value
+        assert result == DiffractionCalibrationIngredients.return_value
 
     def test_pullManyCalibrationDetectorPeaks(self):
         mockDataFactory = mock.Mock()
@@ -421,7 +455,7 @@ class TestSousChef(unittest.TestCase):
 
         res = self.instance._pullManyCalibrationDetectorPeaks(self.ingredients, "12345", True)
         assert res == self.instance.prepManyDetectorPeaks.return_value
-        assert self.instance.prepManyDetectorPeaks.called_once_with(
+        self.instance.prepManyDetectorPeaks.assert_called_once_with(
             self.instance._pullCalibrationRecordFFI.return_value
         )
-        assert self.instance._pullCalibrationRecordFFI.called_once_with(self.ingredients, "12345", True)
+        self.instance._pullCalibrationRecordFFI.assert_called_once_with(self.ingredients, "12345", True)

--- a/tests/unit/backend/service/test_WorkspaceService.py
+++ b/tests/unit/backend/service/test_WorkspaceService.py
@@ -80,4 +80,4 @@ class TestWorkspaceService:
         service.groceryService = mockGroceryService
         request = ListWorkspacesRequest(excludeCache=True)
         service.getResidentWorkspaces(request)
-        assert mockGroceryService.getResidentWorkspaces.called_once_with(excludeCache=True)
+        mockGroceryService.getResidentWorkspaces.assert_called_once_with(excludeCache=True)

--- a/tests/unit/meta/test_Config.py
+++ b/tests/unit/meta/test_Config.py
@@ -135,13 +135,13 @@ def test_resource_packageMode_exists():
             assert rs._packageMode
             test_path = "any/path"
             rs.exists(test_path)
-            assert mockExistsInPackage.called_with(test_path)
+            mockExistsInPackage.assert_called_with(test_path)
 
 
 def test_resource_exists():
     with mock.patch.object(Resource, "_existsInPackage") as mockExistsInPackage:
         assert Resource.exists("application.yml")
-        assert mockExistsInPackage.not_called()
+        mockExistsInPackage.assert_not_called()
 
 
 def test_resource_exists_false():
@@ -157,7 +157,7 @@ def test_resource_open():
         assert not Resource._packageMode
         with Resource.open("application.yml", "r") as file:
             assert file is not None
-            assert mockResourcesPath.not_called()
+            mockResourcesPath.assert_not_called()
 
 
 def test_resource_packageMode_open():
@@ -174,7 +174,7 @@ def test_resource_packageMode_open():
         test_path = "application.yml"
         with Resource.open(test_path, "r") as file:
             assert file is not None
-            assert mockResourcesPath.called_once_with(test_path)
+            mockResourcesPath.assert_called_once_with("snapred.resources", test_path)
 
 
 def test_config_accessor():

--- a/tests/util/SculleryBoy.py
+++ b/tests/util/SculleryBoy.py
@@ -1,12 +1,6 @@
-# ruff: noqa: ARG002
-
-# TODO this needs to be setup to better handle inputs
-
-
-from typing import List
-from unittest import mock
-
+from typing import Dict, List
 import pydantic
+
 from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.ingredients import (
     DiffractionCalibrationIngredients,
@@ -29,6 +23,8 @@ from snapred.backend.dao.state.PixelGroupingParameters import PixelGroupingParam
 from snapred.backend.recipe.GenericRecipe import DetectorPeakPredictorRecipe
 from snapred.meta.Config import Resource
 from snapred.meta.redantic import parse_file_as
+
+from unittest import mock
 from util.dao import DAOFactory
 
 
@@ -40,8 +36,15 @@ class SculleryBoy:
     Should be able to mock out the SousChef.
     """
 
-    def __init__(self):
-        pass
+    def __init__(
+        self,
+        prepPeakIngredientsFlags: Dict[str, bool] = {"useFakePeakValues": False},
+        prepDetectorPeaksFlags: Dict[str, bool] = {"removeDuplicatePeaks": True},
+        ):
+        # Flag values were previously passed in using mocks:  this is not a recommended practice
+        #   as it causes the mock to deviate from its "spec" type.
+        self.prepPeakIngredientsFlags = prepPeakIngredientsFlags
+        self.prepDetectorPeaksFlags = prepDetectorPeaksFlags
 
     def prepCalibration(self, ingredients: FarmFreshIngredients):  # noqa ARG002
         return DAOFactory.calibrationParameters(ingredients.runNumber, ingredients.useLiteMode)
@@ -87,7 +90,7 @@ class SculleryBoy:
         return DAOFactory.default_xtal_info.copy()
 
     def prepPeakIngredients(self, ingredients: FarmFreshIngredients):  # noqa ARG002
-        if "good" in ingredients:
+        if not self.prepPeakIngredientsFlags["useFakePeakValues"]:
             return DAOFactory.good_peak_ingredients.copy()
         else:
             return DAOFactory.fake_peak_ingredients.copy()
@@ -96,7 +99,7 @@ class SculleryBoy:
         try:
             peakList = DetectorPeakPredictorRecipe().executeRecipe(
                 Ingredients=self.prepPeakIngredients(ingredients),
-                PurgeDuplicates=ingredients.get("purge", True),
+                PurgeDuplicates=self.prepDetectorPeaksFlags["removeDuplicatePeaks"],
             )
             return pydantic.TypeAdapter(List[GroupPeakList]).validate_json(peakList)
         except (TypeError, AttributeError):

--- a/tests/util/SculleryBoy.py
+++ b/tests/util/SculleryBoy.py
@@ -95,7 +95,7 @@ class SculleryBoy:
         else:
             return DAOFactory.fake_peak_ingredients.copy()
 
-    def prepDetectorPeaks(self, ingredients: FarmFreshIngredients, purgePeaks=False) -> List[GroupPeakList]:
+    def prepDetectorPeaks(self, ingredients: FarmFreshIngredients, purgePeaks=False) -> List[GroupPeakList]: # noqa: ARG002
         try:
             peakList = DetectorPeakPredictorRecipe().executeRecipe(
                 Ingredients=self.prepPeakIngredients(ingredients),

--- a/tests/util/SculleryBoy.py
+++ b/tests/util/SculleryBoy.py
@@ -1,6 +1,7 @@
 from typing import Dict, List
-import pydantic
+from unittest import mock
 
+import pydantic
 from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.ingredients import (
     DiffractionCalibrationIngredients,
@@ -23,8 +24,6 @@ from snapred.backend.dao.state.PixelGroupingParameters import PixelGroupingParam
 from snapred.backend.recipe.GenericRecipe import DetectorPeakPredictorRecipe
 from snapred.meta.Config import Resource
 from snapred.meta.redantic import parse_file_as
-
-from unittest import mock
 from util.dao import DAOFactory
 
 
@@ -40,7 +39,7 @@ class SculleryBoy:
         self,
         prepPeakIngredientsFlags: Dict[str, bool] = {"useFakePeakValues": False},
         prepDetectorPeaksFlags: Dict[str, bool] = {"removeDuplicatePeaks": True},
-        ):
+    ):
         # Flag values were previously passed in using mocks:  this is not a recommended practice
         #   as it causes the mock to deviate from its "spec" type.
         self.prepPeakIngredientsFlags = prepPeakIngredientsFlags
@@ -95,7 +94,7 @@ class SculleryBoy:
         else:
             return DAOFactory.fake_peak_ingredients.copy()
 
-    def prepDetectorPeaks(self, ingredients: FarmFreshIngredients, purgePeaks=False) -> List[GroupPeakList]: # noqa: ARG002
+    def prepDetectorPeaks(self, ingredients: FarmFreshIngredients, purgePeaks=False) -> List[GroupPeakList]:  # noqa: ARG002
         try:
             peakList = DetectorPeakPredictorRecipe().executeRecipe(
                 Ingredients=self.prepPeakIngredients(ingredients),


### PR DESCRIPTION
Throughout the SNAPRed test framework, assertions have been repeatedly constructed as `assert <mock>.called_once()`, and analogously for `called_once_with`, `not_called`, `called_with`.  Unfortunately, none of these functions exist, and the associated mock returns a mock function, which has a truth-value of True, and the associated assertions all pass.

This commit includes the following changes (for 52 unit tests, some requiring multiple substitutions):

  * Replace all occurrences of `called_once`, `called_once_with`, `not_called`, and `called_with` with the corresponding `assert_called_once` (and etc.) variants.

  * Make any required fixes to the resulting unit tests.

  * Patch the `unittest.mock.Mock` class so that these `call_once` (and etc.) functions are now defined, but are defined in such a manner that any application raises an exception.  To this end, an abstract-syntax-tree (AST) solution was also explored successfully, but it was considered overkill to meet the requirements of this PR.  This AST-approach is something we might want to look into in the future, if we implement a "SNAPRed coding style" commit check.

## Description of work

Throughout the SNAPRed test framework, assertions have been repeatedly constructed as `assert <mock>.called_once()`, and analogously for `called_once_with`, `not_called`, `called_with`.  Unfortunately, none of these functions exist, and the associated mock returns a mock function, which has a truth-value of True, and the associated assertions all pass.

## Explanation of work

This commit includes the following changes (for 52 unit tests, some requiring multiple substitutions):

  * Replace all occurrences of `called_once`, `called_once_with`, `not_called`, and `called_with` with the corresponding `assert_called_once` (and etc.) variants.

  * Make any required fixes to the resulting unit tests.

  * Patch the `unittest.mock.Mock` class so that these `call_once` (and etc.) functions are now defined, but are defined in such a manner that any use of the functions raises an exception.  To this end, an abstract-syntax-tree (AST) solution was also explored successfully, but it was considered overkill to meet the requirements of this PR.  This AST-approach is something we might want to look into in the future, if we implement a "SNAPRed coding style" commit check.
## To test

### Dev testing

These changes are to the **unit-test framework** itself, and to **specific unit tests**.
These changes are SNAPRed-internal.  No changes should be observed in terms of SNAPRed's functionality. 


### CIS testing

As mentioned above, these changes are SNAPRed-internal.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#6612](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6612)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
