### PR TITLE
pull in changes from next to fix double error message

### DIFF
--- a/docs/source/api/snapred.ui.view.rst
+++ b/docs/source/api/snapred.ui.view.rst
@@ -52,7 +52,7 @@ snapred.ui.view.DiffCalTweakPeakView module
 .. automodule:: snapred.ui.view.DiffCalTweakPeakView
    :members:
    :undoc-members:
-   :exclude-members: signalRunNumberUpdate, signalValueChanged, signalUpdateRecalculationButton, signalPeakThresholdUpdate, signalMaxChiSqUpdate
+   :exclude-members: signalRunNumberUpdate, signalValueChanged, signalUpdateRecalculationButton, signalPeakThresholdUpdate, signalMaxChiSqUpdate, signalContinueAnyway
    :show-inheritance:
 
 

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -501,10 +501,6 @@ class LocalDataService:
 
     ##### NORMALIZATION METHODS #####
 
-    def normalizationExists(self, runId: str, useLiteMode: bool) -> bool:
-        record = self._getCurrentNormalizationRecord(runId, useLiteMode)
-        return record is not None
-
     @validate_call
     def readNormalizationRecord(self, runId: str, useLiteMode: bool, version: Optional[int] = None):
         latestFile = ""
@@ -582,12 +578,6 @@ class LocalDataService:
         return record
 
     ##### CALIBRATION METHODS #####
-
-    def calibrationExists(self, runId: str, useLiteMode: bool) -> bool:
-        record = self._getCurrentCalibrationRecord(runId, useLiteMode)
-        if not record:
-            logger.info(f"Calibration record does not exist for run {runId}")
-        return record is not None
 
     @validate_call
     def readCalibrationRecord(self, runId: str, useLiteMode: bool, version: Optional[int] = None):

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -501,6 +501,10 @@ class LocalDataService:
 
     ##### NORMALIZATION METHODS #####
 
+    def normalizationExists(self, runId: str, useLiteMode: bool) -> bool:
+        version = self.normalizationIndexer(runId, useLiteMode).currentVersion()
+        return version is not None
+
     @validate_call
     def readNormalizationRecord(self, runId: str, useLiteMode: bool, version: Optional[int] = None):
         latestFile = ""
@@ -578,6 +582,10 @@ class LocalDataService:
         return record
 
     ##### CALIBRATION METHODS #####
+
+    def calibrationExists(self, runId: str, useLiteMode: bool) -> bool:
+        version = self.calibrationIndexer(runId, useLiteMode).currentVersion()
+        return version is not None
 
     @validate_call
     def readCalibrationRecord(self, runId: str, useLiteMode: bool, version: Optional[int] = None):
@@ -906,8 +914,9 @@ class LocalDataService:
     ##### READ / WRITE STATE METHODS #####
 
     @validate_call
-    @ExceptionHandler(RecoverableException, "'NoneType' object has no attribute 'instrumentState'")
     def readCalibrationState(self, runId: str, useLiteMode: bool, version: Optional[int] = None):
+        if not self.calibrationExists(runId, useLiteMode):
+            raise RecoverableException.stateUninitialized(runId, useLiteMode)
         # check to see if such a folder exists, if not create it and initialize it
         calibrationStatePathGlob: str = str(self._constructCalibrationParametersFilePath(runId, useLiteMode, "*"))
 

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -943,9 +943,6 @@ class LocalDataService:
             with open(latestFile, "r") as f:
                 normalizationState = Normalization.model_validate_json(f.read())
 
-        if normalizationState is None:
-            raise RecoverableException.stateUninitialized(runId, useLiteMode)
-
         return normalizationState
 
     def writeCalibrationState(self, calibration: Calibration, version: Optional[Version] = None):

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -502,7 +502,7 @@ class LocalDataService:
     ##### NORMALIZATION METHODS #####
 
     def normalizationExists(self, runId: str, useLiteMode: bool) -> bool:
-        version = self.normalizationIndexer(runId, useLiteMode).currentVersion()
+        version = self._getVersionFromNormalizationIndex(runId, useLiteMode)
         return version is not None
 
     @validate_call
@@ -584,7 +584,7 @@ class LocalDataService:
     ##### CALIBRATION METHODS #####
 
     def calibrationExists(self, runId: str, useLiteMode: bool) -> bool:
-        version = self.calibrationIndexer(runId, useLiteMode).currentVersion()
+        version = self._getVersionFromCalibrationIndex(runId, useLiteMode)
         return version is not None
 
     @validate_call

--- a/src/snapred/backend/error/ContinueWarning.py
+++ b/src/snapred/backend/error/ContinueWarning.py
@@ -6,10 +6,11 @@ from pydantic import BaseModel
 class ContinueWarning(Exception):
     """
     The user has chosen to do something inadvisable, but not invalid.
-    Warn the user, but allow the user to continue with poor decision.
+    Warn the user, but allow the user to continue.
     """
 
     class Type(Flag):
+        UNSET = 0
         MISSING_DIFFRACTION_CALIBRATION = auto()
         MISSING_NORMALIZATION = auto()
         LOW_PEAK_COUNT = auto()
@@ -18,7 +19,20 @@ class ContinueWarning(Exception):
         message: str
         flags: "ContinueWarning.Type"
 
-    def __init__(self, message: str, flags: "Type"):
+    @property
+    def message(self):
+        return self.model.message
+
+    @property
+    def flags(self):
+        return self.model.flags
+
+    def __init__(self, message: str, flags: "Type" = 0):
         ContinueWarning.Model.update_forward_refs()
+        ContinueWarning.Model.model_rebuild(force=True)
         self.model = ContinueWarning.Model(message=message, flags=flags)
         super().__init__(message)
+
+    def parse_raw(raw):
+        raw = ContinueWarning.Model.model_validate_json(raw)
+        return ContinueWarning(raw.message, raw.flags)

--- a/src/snapred/backend/error/RecoverableException.py
+++ b/src/snapred/backend/error/RecoverableException.py
@@ -1,13 +1,11 @@
-from typing import Any, Literal
+from enum import Flag, auto
+from typing import Any, Optional
+
+from pydantic import BaseModel
 
 from snapred.backend.log.logger import snapredLogger
 
 logger = snapredLogger.getLogger(__name__)
-
-RecoverableErrorType = Literal[
-    "AttributeError: 'NoneType' object has no attribute 'instrumentState'",
-    "etc",
-]
 
 
 class RecoverableException(Exception):
@@ -16,14 +14,40 @@ class RecoverableException(Exception):
     Allows for custom error types and optional extra context.
     """
 
-    def __init__(self, exception: Exception, errorMsg: RecoverableErrorType, **kwargs: Any):
-        self.errorMsg = errorMsg
-        self.message = errorMsg
-        self.extraContext = kwargs
+    class Type(Flag):
+        UNSET = 0
+        STATE_UNINITIALIZED = auto()
 
-        logMessage = f"{self.message} Original exception: {str(exception)}"
+    class Model(BaseModel):
+        message: str
+        flags: "RecoverableException.Type"
+        data: Any
 
-        if self.extraContext:
-            logMessage += f" | Context: {self.extraContext}"
-        logger.error(logMessage)
-        super().__init__(self.message)
+    @property
+    def message(self):
+        return self.model.message
+
+    @property
+    def flags(self):
+        return self.model.flags
+
+    @property
+    def data(self):
+        return self.model.data
+
+    def __init__(self, message: str, flags: "Type" = 0, data: Optional[Any] = None):
+        RecoverableException.Model.update_forward_refs()
+        RecoverableException.Model.model_rebuild(force=True)
+        self.model = RecoverableException.Model(message=message, flags=flags, data=data)
+        super().__init__(message)
+
+    def parse_raw(raw):
+        raw = RecoverableException.Model.model_validate_json(raw)
+        return RecoverableException(**raw.dict())
+
+    def stateUninitialized(runNumber: str, useLiteMode: bool):
+        return RecoverableException(
+            "State uninitialized",
+            flags=RecoverableException.Type.STATE_UNINITIALIZED,
+            data={"runNumber": runNumber, "useLiteMode": useLiteMode},
+        )

--- a/src/snapred/meta/decorators/ExceptionHandler.py
+++ b/src/snapred/meta/decorators/ExceptionHandler.py
@@ -1,20 +1,32 @@
 import functools
-from typing import Any, Callable, Optional, Type
+import sys
+import traceback
+from typing import Any, Callable, Type
 
-from snapred.backend.error.RecoverableException import RecoverableException
+from snapred.backend.log.logger import snapredLogger
+
+logger = snapredLogger.getLogger(__name__)
 
 
-def ExceptionHandler(exceptionType: Type[Exception], errorMsg: Optional[str] = None):
+def extractTrueStacktrace() -> str:
+    exc_info = sys.exc_info()
+    stack = traceback.extract_stack()
+    tb = traceback.extract_tb(exc_info[2])
+    full_tb = stack[:-1] + tb
+    exc_line = traceback.format_exception_only(*exc_info[:2])
+    stacktraceStr = "\n".join(["".join(traceback.format_list(full_tb)), "".join(exc_line)])
+    return stacktraceStr
+
+
+def ExceptionHandler(exceptionType: Type[Exception]):
     def decorator(func: Callable[..., Any]):
         @functools.wraps(func)
         def inner(*args, **kwargs):
             try:
                 return func(*args, **kwargs)
             except Exception as e:  # noqa BLE001
-                if issubclass(exceptionType, RecoverableException) and errorMsg is not None:
-                    raise exceptionType(exception=e, errorMsg=errorMsg)
-                else:
-                    raise exceptionType(e)
+                logger.error(f"{extractTrueStacktrace()}")
+                raise exceptionType(e)
 
         return inner
 

--- a/src/snapred/ui/handler/SNAPResponseHandler.py
+++ b/src/snapred/ui/handler/SNAPResponseHandler.py
@@ -3,7 +3,6 @@ import threading
 from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import QMessageBox, QWidget
 
-from snapred.backend.dao.request.InitializeStateHandler import InitializeStateHandler
 from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.error.RecoverableException import RecoverableException
@@ -49,7 +48,9 @@ class SNAPResponseHandler(QWidget):
         if result.code >= ResponseCode.ERROR:
             raise RuntimeError(result.message)
         if result.code >= ResponseCode.RECOVERABLE:
-            raise RecoverableException(result.message, "state")
+            raise RecoverableException.parse_raw(result.message)
+        if result.code == ResponseCode.CONTINUE_WARNING:
+            raise ContinueWarning.parse_raw(result.message)
         if result.message:
             self.signalWarning.emit(result.message, self)
 
@@ -65,19 +66,9 @@ class SNAPResponseHandler(QWidget):
                 QMessageBox.Ok,
             )
         elif SNAPResponseHandler._isRecoverableError(code):
-            if "state" in message:
-                SNAPResponseHandler.handleStateMessage(view)
-            else:
-                logger.error(f"Unhandled scenario triggered by state message: {message}")
-                messageBox = QMessageBox(
-                    QMessageBox.Warning,
-                    "Warning",
-                    "The backend has encountered warning(s)",
-                    QMessageBox.Ok,
-                    view,
-                )
-                messageBox.setDetailedText(f"{message}")
-                messageBox.exec()
+            recoverableException = RecoverableException.parse_raw(message)
+            if recoverableException.flags == RecoverableException.Type.STATE_UNINITIALIZED:
+                SNAPResponseHandler.handleStateMessage(view, recoverableException)
         elif code == ResponseCode.CONTINUE_WARNING:
             continueInfo = ContinueWarning.Model.model_validate_json(message)
             if SNAPResponseHandler._handleContinueWarning(continueInfo.message, view):
@@ -99,6 +90,12 @@ class SNAPResponseHandler(QWidget):
 
     @staticmethod
     def _handleContinueWarning(message, view):
+        # print stacktrace
+        logger.info("It happens here and here")
+        import traceback
+
+        traceback.print_stack()
+
         continueAnyway = QMessageBox.warning(
             view,
             "Warning",
@@ -109,15 +106,16 @@ class SNAPResponseHandler(QWidget):
         return continueAnyway == QMessageBox.Yes
 
     @staticmethod
-    def handleStateMessage(view):
+    def handleStateMessage(view, recoverableException):
         """
         Handles a specific 'state' message.
         """
+        recoveryData = recoverableException.data
+        runNumber = recoveryData.get("runNumber")
+        useLiteMode = recoveryData.get("useLiteMode")
         try:
             logger.info("Handling 'state' message.")
-            initializationMenu = InitializationMenu(
-                runNumber=InitializeStateHandler.runId, parent=view, useLiteMode=InitializeStateHandler.useLiteMode
-            )
+            initializationMenu = InitializationMenu(runNumber=runNumber, parent=view, useLiteMode=useLiteMode)
             initializationMenu.finished.connect(lambda: initializationMenu.deleteLater())
             initializationMenu.show()
         except Exception as e:  # noqa: BLE001

--- a/src/snapred/ui/presenter/WorkflowPresenter.py
+++ b/src/snapred/ui/presenter/WorkflowPresenter.py
@@ -183,10 +183,8 @@ class WorkflowPresenter(QObject):
     @Slot(object)
     def continueAnyway(self, continueInfo: ContinueWarning.Model):
         # The associated signal is of type ``Signal(SNAPResponseHandler.continueAnyway) as Signal(object)``
-        if self.model.continueAnywayHandler:
-            self.model.continueAnywayHandler(continueInfo)
-
-        self.worker = self.worker_pool.createWorker(target=self.model.nextModel.continueAction, args=self)
-        self.worker.success.connect(lambda success: self.advanceWorkflow() if success else None)
-
-        self.worker_pool.submitWorker(self.worker)
+        if self.view.tabModel.continueAnywayHandler:
+            self.view.tabModel.continueAnywayHandler(continueInfo)
+        else:
+            raise NotImplementedError(f"Continue anyway handler not implemented: {self.view.tabModel}")
+        self.handleContinueButtonClicked(self.view.tabModel)

--- a/src/snapred/ui/threading/worker_pool.py
+++ b/src/snapred/ui/threading/worker_pool.py
@@ -33,7 +33,7 @@ class Worker(QObject):
         except ContinueWarning as w:
             results = SNAPResponse(code=ResponseCode.CONTINUE_WARNING, message=w.model.json())
         except RecoverableException as e:
-            results = SNAPResponse(code=ResponseCode.RECOVERABLE, message=e.errorMsg)
+            results = SNAPResponse(code=ResponseCode.RECOVERABLE, message=e.model.json())
         except Exception as e:  # noqa: BLE001
             # print stacktrace
             import traceback

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -51,6 +51,7 @@ class DiffCalTweakPeakView(BackendRequestView):
     signalValueChanged = Signal(int, float, float, float, SymmetricPeakEnum, Pair, float)
     signalUpdateRecalculationButton = Signal(bool)
     signalMaxChiSqUpdate = Signal(float)
+    signalContinueAnyway = Signal(bool)
 
     def __init__(self, samples=[], groups=[], parent=None):
         super().__init__(parent=parent)
@@ -62,6 +63,8 @@ class DiffCalTweakPeakView(BackendRequestView):
         self.signalRunNumberUpdate.connect(self._updateRunNumber)
         self.signalPeakThresholdUpdate.connect(self._updatePeakThreshold)
         self.signalMaxChiSqUpdate.connect(self._updateMaxChiSq)
+        self.continueAnyway = False
+        self.signalContinueAnyway.connect(self._updateContineAnyway)
 
         # create the graph elements
         self.figure = plt.figure(constrained_layout=True)
@@ -112,6 +115,13 @@ class DiffCalTweakPeakView(BackendRequestView):
         self.initialLayoutHeight = self.size().height()
 
         self.signalUpdateRecalculationButton.connect(self.setEnableRecalculateButton)
+
+    def updateContinueAnyway(self, continueAnyway):
+        self.signalContinueAnyway.emit(continueAnyway)
+
+    @Slot(bool)
+    def _updateContineAnyway(self, continueAnyway):
+        self.continueAnyway = continueAnyway
 
     @Slot(str)
     def _updateRunNumber(self, runNumber):
@@ -285,6 +295,7 @@ class DiffCalTweakPeakView(BackendRequestView):
 
     def verify(self):
         self._testFailStates()
-        self._testContinueAnywayStates()
+        if not self.continueAnyway:
+            self._testContinueAnywayStates()
 
         return True

--- a/src/snapred/ui/view/WorkflowView.py
+++ b/src/snapred/ui/view/WorkflowView.py
@@ -48,6 +48,10 @@ class WorkflowView(QWidget):
             self.tabWidget.setCurrentIndex(self.currentTab)
 
     @property
+    def tabModel(self):
+        return self.tabWidget.widget(self.currentTab).model
+
+    @property
     def tabView(self):
         return self.tabWidget.widget(self.currentTab).view
 

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -95,11 +95,19 @@ class DiffCalWorkflow(WorkflowImplementer):
                 parent=parent,
             )
             .addNode(self._specifyRun, self._requestView, "Diffraction Calibration")
-            .addNode(self._triggerDiffractionCalibration, self._tweakPeakView, "Tweak Peak Peek")
+            .addNode(
+                self._triggerDiffractionCalibration,
+                self._tweakPeakView,
+                "Tweak Peak Peek",
+                continueAnywayHandler=self._continueAnywayHandlerTweak,
+            )
             .addNode(self._assessCalibration, self._assessmentView, "Assessing", iterate=True)
             .addNode(self._saveCalibration, self._saveView, name="Saving")
             .build()
         )
+
+    def _continueAnywayHandlerTweak(self, continueInfo):  # noqa: ARG002
+        self._tweakPeakView.updateContinueAnyway(True)
 
     @ExceptionToErrLog
     @Slot()

--- a/src/snapred/ui/workflow/WorkflowImplementer.py
+++ b/src/snapred/ui/workflow/WorkflowImplementer.py
@@ -9,6 +9,7 @@ from snapred.backend.dao.request import (
     ListWorkspacesRequest,
     RenameWorkspacesFromTemplateRequest,
 )
+from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.log.logger import snapredLogger
 from snapred.ui.handler.SNAPResponseHandler import SNAPResponseHandler
 from snapred.ui.widget.Workflow import Workflow
@@ -23,7 +24,7 @@ class WorkflowImplementer(QObject):
         super().__init__()
         self.parent = parent
         self.interfaceController = InterfaceController()
-        self.responseHandler = SNAPResponseHandler(parent)
+        self.responseHandler = SNAPResponseHandler(self.parent)
         self.workflow: Workflow = None
 
         self.requests = []
@@ -107,10 +108,15 @@ class WorkflowImplementer(QObject):
         return response
 
     def _handleComplications(self, result):
-        if result.code == 400:
-            self.responseHandler.rethrow(result)
+        # requests never execute on the main thread
+        # so this should just rethrow and let the main thread handle it
+        self.responseHandler.rethrow(result)
+
+    def _continueAnywayHandler(self, continueInfo):
+        if isinstance(continueInfo, ContinueWarning.Model):
+            self.continueAnywayFlags = self.continueAnywayFlags | continueInfo.flags
         else:
-            self.responseHandler.handle(result)
+            raise ValueError(f"Invalid continueInfo type: {type(continueInfo)}, expecting ContinueWarning.Model.")
 
     @property
     def widget(self):

--- a/src/snapred/ui/workflow/WorkflowImplementer.py
+++ b/src/snapred/ui/workflow/WorkflowImplementer.py
@@ -24,6 +24,7 @@ class WorkflowImplementer(QObject):
         super().__init__()
         self.parent = parent
         self.interfaceController = InterfaceController()
+        self.continueAnywayFlags = ContinueWarning.Type.UNSET
         self.responseHandler = SNAPResponseHandler(self.parent)
         self.workflow: Workflow = None
 

--- a/tests/unit/backend/api/test_InterfaceController.py
+++ b/tests/unit/backend/api/test_InterfaceController.py
@@ -3,6 +3,7 @@ import unittest.mock as mock
 
 from snapred.backend.api.RequestScheduler import RequestScheduler
 from snapred.backend.dao.SNAPResponse import ResponseCode
+from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.error.RecoverableException import RecoverableException
 
 # Mock out of scope modules before importing InterfaceController
@@ -17,7 +18,7 @@ with mock.patch.dict(
 ):
     from snapred.backend.api.InterfaceController import InterfaceController  # noqa: E402
 
-    def mockedSuccessfulInterfaceController(raiseRecoverable=False):
+    def mockedSuccessfulInterfaceController(raiseRecoverable=False, raiseContinueWarning=False):
         """Mock InterfaceController"""
         interfaceController = InterfaceController()
         interfaceController.serviceFactory = mock.Mock()
@@ -26,10 +27,9 @@ with mock.patch.dict(
 
         def orchestrateRecipe_side_effect(request):  # noqa: ARG001
             if raiseRecoverable:
-                raise RecoverableException(
-                    exception=AttributeError("'NoneType' object has no attribute 'instrumentState'"),
-                    errorMsg="AttributeError: 'NoneType' object has no attribute 'instrumentState'",
-                )
+                raise RecoverableException.stateUninitialized("12345", True)
+            elif raiseContinueWarning:
+                raise ContinueWarning("Continue with warning")
             else:
                 return {"result": "Success!"}
 
@@ -61,7 +61,20 @@ with mock.patch.dict(
         response = interfaceController.executeRequest(stateCheckRequest)
 
         assert response.code == ResponseCode.RECOVERABLE
-        assert "state" in response.message
+        assert "State uninitialized" in response.message
+        assert response.data is None
+
+    def test_executeRequest_continueWarning():
+        """Test executeRequest with a continue warning"""
+        interfaceController = mockedSuccessfulInterfaceController(raiseContinueWarning=True)
+        reductionRequest = mock.Mock()
+        reductionRequest.path = "Test Service"
+        reductionRequest.payload = json.dumps({"runNumber": "12345", "useLiteMode": "True"})
+
+        response = interfaceController.executeRequest(reductionRequest)
+
+        assert response.code == ResponseCode.CONTINUE_WARNING
+        assert response.message is not None
         assert response.data is None
 
     def test_executeRequest_unsuccessful():

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -1807,6 +1807,7 @@ def test__constructCalibrationParametersFilePath():
 def test_readCalibrationState():
     localDataService = LocalDataService()
     localDataService._generateStateId = mock.Mock(return_value=(ENDURING_STATE_ID, None))
+    localDataService.calibrationExists = mock.Mock(return_value=True)
     localDataService._constructCalibrationParametersFilePath = mock.Mock()
     localDataService._constructCalibrationParametersFilePath.return_value = Resource.getPath(
         f"{ENDURING_STATE_ID}/v_0001/CalibrationParameters.json"

--- a/tests/unit/backend/error/test_ContinueWarning.py
+++ b/tests/unit/backend/error/test_ContinueWarning.py
@@ -1,0 +1,26 @@
+from snapred.backend.error.ContinueWarning import ContinueWarning
+
+
+def test_ContinueWarning():
+    inst = ContinueWarning("Continue with warning")
+    assert inst.message == "Continue with warning"
+    assert inst.flags == ContinueWarning.Type.UNSET
+
+
+def test_ContinueWarning_parse_raw():
+    raw = '{"message": "Continue with warning", "flags": 0 }'
+    inst = ContinueWarning.parse_raw(raw)
+    assert inst.message == "Continue with warning"
+    assert inst.flags == ContinueWarning.Type.UNSET
+    assert isinstance(inst, ContinueWarning)
+
+
+def test_ContinueWarning_multiFlags():
+    inst = ContinueWarning(
+        "Continue with warning",
+        ContinueWarning.Type.MISSING_DIFFRACTION_CALIBRATION | ContinueWarning.Type.MISSING_NORMALIZATION,
+    )
+    assert inst.message == "Continue with warning"
+    assert (
+        inst.flags == ContinueWarning.Type.MISSING_DIFFRACTION_CALIBRATION | ContinueWarning.Type.MISSING_NORMALIZATION
+    )

--- a/tests/unit/backend/error/test_RecoverableException.py
+++ b/tests/unit/backend/error/test_RecoverableException.py
@@ -1,0 +1,16 @@
+from snapred.backend.error.RecoverableException import RecoverableException
+
+
+def test_RecoverableException():
+    inst = RecoverableException("Recoverable exception")
+    assert inst.message == "Recoverable exception"
+    assert inst.flags == RecoverableException.Type.UNSET
+
+
+def test_RecoverableException_parse_raw():
+    raw = '{"message": "Recoverable exception", "flags": 0, "data": 1 }'
+    inst = RecoverableException.parse_raw(raw)
+    assert inst.message == "Recoverable exception"
+    assert inst.flags == RecoverableException.Type.UNSET
+    assert inst.data == 1
+    assert isinstance(inst, RecoverableException)

--- a/tests/unit/meta/test_Decorators.py
+++ b/tests/unit/meta/test_Decorators.py
@@ -92,21 +92,10 @@ def test_stateExceptionHandler():
         throwsStateException()
 
 
-@ExceptionHandler(RecoverableException, "state")
-def throwsRecoverableException():
-    raise RuntimeError("'NoneType' object has no attribute 'instrumentState'")
-
-
-def test_recoverableExceptionHandler():
-    with pytest.raises(RecoverableException):
-        throwsRecoverableException()
-
-
 def test_recoverableExceptionKwargs():
-    exceptionPath = "SNS/SNAP/expected/path/somefile.txt"
-    exceptionString = f"Error accessing {exceptionPath}"
+    exceptionString = "State uninitialized"
     with pytest.raises(RecoverableException, match=exceptionString):
-        raise RecoverableException(RuntimeError(exceptionString), exceptionString, extraInfo="some extra info")
+        raise RecoverableException.stateUninitialized("57514", True)
 
 
 def throwsContinueWarning():


### PR DESCRIPTION
## Description of work

As the title states.

## To test

Prep your calibration folder such that you have an initialized calibration folder but no normalization.
Then attempt to perform a reduction.

This should net ONLY 1 error box.
Staging currently nets 2.

`runnumber: 59039`


[EWM#6095](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6095)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
