### PR TITLE
Fixes to the iteration dropdown menu.

### DIFF
--- a/src/snapred/ui/view/DiffCalSaveView.py
+++ b/src/snapred/ui/view/DiffCalSaveView.py
@@ -74,7 +74,7 @@ class DiffCalSaveView(QWidget):
         self.layout.addWidget(self.iterationWidget)
 
     def setIterationDropdown(self, iterations):
-        self.iterationDropdown.clear()
+        self.resetIterationDropdown()
         self.iterationDropdown.addItems(iterations)
         self.iterationDropdown.setItemText(0, self.currentIterationText)
 
@@ -84,3 +84,9 @@ class DiffCalSaveView(QWidget):
         if self.fieldComments.text() == "":
             raise ValueError("You must add comments")
         return True
+
+    def hideIterationDropdown(self):
+        self.iterationWidget.setVisible(False)
+
+    def resetIterationDropdown(self):
+        self.iterationDropdown.clear()

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -62,6 +62,8 @@ class DiffCalWorkflow(WorkflowImplementer):
         self.groupingMap = self.defaultGroupingMap
         self.focusGroups = self.groupingMap.lite
 
+        self.addResetHook(self._resetSaveView)
+
         self._requestView = DiffCalRequestView(
             samples=self.samplePaths,
             groups=list(self.focusGroups.keys()),
@@ -397,6 +399,10 @@ class DiffCalWorkflow(WorkflowImplementer):
             wsKey: [self.renameTemplate.format(workspaceName=wsName, iteration=iteration) for wsName in wsNames]
             for wsKey, wsNames in self.calibrationRecord.workspaces.items()
         }
+
+    def _resetSaveView(self):
+        self._saveView.hideIterationDropdown()
+        self._saveView.resetIterationDropdown()
 
     @Slot(WorkflowPresenter, result=SNAPResponse)
     def _saveCalibration(self, workflowPresenter):

--- a/src/snapred/ui/workflow/WorkflowImplementer.py
+++ b/src/snapred/ui/workflow/WorkflowImplementer.py
@@ -52,7 +52,7 @@ class WorkflowImplementer(QObject):
 
         self.resetHooks = []
 
-    def addResetHook(self, hook):
+    def addResetHook(self, hook: callable[[], None]):
         self.resetHooks.append(hook)
 
     def iterate(self, workflowPresenter):

--- a/src/snapred/ui/workflow/WorkflowImplementer.py
+++ b/src/snapred/ui/workflow/WorkflowImplementer.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Callable, List
 
 from qtpy.QtCore import QObject, Signal
 
@@ -52,7 +52,7 @@ class WorkflowImplementer(QObject):
 
         self.resetHooks = []
 
-    def addResetHook(self, hook: callable[[], None]):
+    def addResetHook(self, hook: Callable[[], None]):
         self.resetHooks.append(hook)
 
     def iterate(self, workflowPresenter):

--- a/src/snapred/ui/workflow/WorkflowImplementer.py
+++ b/src/snapred/ui/workflow/WorkflowImplementer.py
@@ -50,6 +50,11 @@ class WorkflowImplementer(QObject):
         self.continueAnywayFlags = ContinueWarning.Type.UNSET
         self.responseHandler = SNAPResponseHandler(self.parent)
 
+        self.resetHooks = []
+
+    def addResetHook(self, hook):
+        self.resetHooks.append(hook)
+
     def iterate(self, workflowPresenter):
         # rename output workspaces
         payload = RenameWorkspacesFromTemplateRequest(
@@ -91,6 +96,9 @@ class WorkflowImplementer(QObject):
         self.outputs = []
         self.collectedOutputs = []
 
+        for hook in self.resetHooks:
+            hook()
+
     def _clearWorkspaces(self, *, exclude: List[str], clearCachedWorkspaces: bool):
         # Always exclude any external workspaces.
         exclude_ = set(self.externalWorkspaces)
@@ -98,6 +106,10 @@ class WorkflowImplementer(QObject):
         payload = ClearWorkspacesRequest(exclude=list(exclude_), clearCache=clearCachedWorkspaces)
         response = self.request(path="workspace/clear", payload=payload.json())
         return response
+
+    def complete(self):
+        for hook in self.resetHooks:
+            hook()
 
     def _request(self, request: SNAPRequest):
         response = self.interfaceController.executeRequest(request)

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -70,6 +70,8 @@ class TestGroceryService(unittest.TestCase):
         # create some sample data
         cls.sampleWS = "_grocery_to_fetch"
 
+        cls.rtolValue = 1.0e-10
+
         CreateWorkspace(
             OutputWorkspace=cls.sampleWS,
             DataX=[0.5, 1.5] * 16,
@@ -452,6 +454,7 @@ class TestGroceryService(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=wsname1,
             Workspace2=wsname2,
+            rtol=self.rtolValue,
         )
 
     def test_updateNeutronCacheFromADS_noop(self):
@@ -724,6 +727,7 @@ class TestGroceryService(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
+            rtol=self.rtolValue,
         )
 
         # make sure it won't load same workspace name again
@@ -739,6 +743,7 @@ class TestGroceryService(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
+            rtol=self.rtolValue,
         )
 
     def test_fetch_failed(self):
@@ -787,6 +792,7 @@ class TestGroceryService(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
+            rtol=self.rtolValue,
         )
 
         # test that it will use a raw workspace if one exists
@@ -810,6 +816,7 @@ class TestGroceryService(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
+            rtol=self.rtolValue,
         )
 
         # test calling with Lite data, that it will call to lite service
@@ -862,6 +869,7 @@ class TestGroceryService(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=workspaceNameCopy1,
+            rtol=self.rtolValue,
         )
 
         # run with a raw workspace in cache -- it will copy it
@@ -877,6 +885,7 @@ class TestGroceryService(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=workspaceNameCopy2,
+            rtol=self.rtolValue,
         )
 
     def test_fetch_cached_lite(self):

--- a/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
@@ -39,6 +39,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         cls.filepath = Resource.getPath(f"inputs/test_{cls.runNumber}_fetchgroceriesalgo.nxs")
         cls.instrumentFilepath = Resource.getPath("inputs/testInstrument/fakeSNAP_Definition.xml")
         cls.fetchedWS = f"_{cls.runNumber}_fetched"
+        cls.rtolValue = 1.0e-10
         # create some sample data
         cls.sampleWS = f"_{cls.runNumber}_grocery_to_fetch"
         # create some sample data
@@ -159,6 +160,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.fetchedWS,
             Workspace2=self.sampleWS,
+            rtol=self.rtolValue,
         )
         assert "LoadNexusProcessed" == algo.getPropertyValue("LoaderType")
 
@@ -173,6 +175,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.fetchedWS,
             Workspace2=self.sampleWS,
+            rtol=self.rtolValue,
         )
         assert "LoadNexus" == algo.getPropertyValue("LoaderType")
 
@@ -196,6 +199,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.fetchedWS,
             Workspace2=self.sampleWS,
+            rtol=self.rtolValue,
         )
         assert "LoadNexusProcessed" == algo.getPropertyValue("LoaderType")
 
@@ -219,6 +223,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=f"_{self.runNumber}_grouping_file",
             Workspace2=f"_{self.runNumber}_grouping_name",
+            rtol=self.rtolValue,
         )
         algo.setProperty("InstrumentName", "")
 
@@ -228,6 +233,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=f"_{self.runNumber}_grouping_file",
             Workspace2=f"_{self.runNumber}_grouping_donor",
+            rtol=self.rtolValue,
         )
 
     def test_loadGroupingTwice(self):

--- a/tests/unit/backend/recipe/algorithm/test_SaveGroupingDefinition.py
+++ b/tests/unit/backend/recipe/algorithm/test_SaveGroupingDefinition.py
@@ -39,7 +39,7 @@ class TestSaveGroupingDefinition(unittest.TestCase):
             OutputWorkspace=cls.localIDFWorkspace,
             Filename=cls.localInstrumentFilename,
         )
-
+        cls.rtolValue = 1.0e-10
         # NOTE: the below do not need to match the actual grouping workspaces,
         #  and can be arbitary for these tests to still work
         cls.localReferenceWorkspace = {
@@ -221,7 +221,11 @@ class TestSaveGroupingDefinition(unittest.TestCase):
             assert loadingAlgo.execute()
 
             # retrieve the loaded workspace and compare it with the workspace created from the input grouping file
-            assert_wksp_almost_equal(loaded_ws_name, workspaceName)
+            assert_wksp_almost_equal(
+                loaded_ws_name,
+                workspaceName,
+                rtol=self.rtolValue,
+            )
 
         def test_local_from_groupingfile_test(self):
             groupingFile = Resource.getPath("inputs/testInstrument/fakeSNAPFocGroup_Natural.xml")
@@ -273,6 +277,7 @@ class TestSaveGroupingDefinition(unittest.TestCase):
             assert_wksp_almost_equal(
                 loaded_ws_name,
                 self.localReferenceWorkspace["Natural"],
+                rtol=self.rtolValue,
             )
 
     def test_local_from_workspace_test_column(self):
@@ -281,6 +286,7 @@ class TestSaveGroupingDefinition(unittest.TestCase):
         assert_wksp_almost_equal(
             self.columnGroupingWorkspace,
             self.localReferenceWorkspace["Column"],
+            rtol=self.rtolValue,
         )
 
     def test_local_from_workspace_test_natural(self):
@@ -289,6 +295,7 @@ class TestSaveGroupingDefinition(unittest.TestCase):
         assert_wksp_almost_equal(
             self.columnGroupingWorkspace,
             self.localReferenceWorkspace["Natural"],
+            rtol=self.rtolValue,
         )
 
     ## REMOTE CHECKS WITH FULL INSTRUMENT
@@ -325,7 +332,11 @@ class TestSaveGroupingDefinition(unittest.TestCase):
 
             lnp_ws_name = "lnp_ws_name"
             original_ws = LoadNexusProcessed(Filename=groupingFile, OutputWorkspace=lnp_ws_name)
-            assert_wksp_almost_equal(original_ws, saved_and_loaded_ws)
+            assert_wksp_almost_equal(
+                original_ws,
+                saved_and_loaded_ws,
+                rtol=self.rtolValue,
+            )
 
         @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
         def test_with_xml_grouping_file(self):
@@ -358,7 +369,11 @@ class TestSaveGroupingDefinition(unittest.TestCase):
             ldgf_ws_name = "ldgf_ws_name"
             original_ws = LoadDetectorsGroupingFile(InputFile=groupingFile, OutputWorkspace=ldgf_ws_name)
 
-            assert_wksp_almost_equal(original_ws, saved_and_loaded_ws)
+            assert_wksp_almost_equal(
+                original_ws,
+                saved_and_loaded_ws,
+                rtol=self.rtolValue,
+            )
 
         @pytest.mark.skipif(not IS_ON_ANALYSIS_MACHINE, reason="requires analysis datafiles")
         def test_with_grouping_workspace(self):
@@ -391,4 +406,8 @@ class TestSaveGroupingDefinition(unittest.TestCase):
 
             # retrieve the loaded workspace and compare it with the workspace created from the input grouping file
             saved_and_loaded_ws = mtd[loaded_ws_name]
-            assert_wksp_almost_equal(original_ws, saved_and_loaded_ws)
+            assert_wksp_almost_equal(
+                original_ws,
+                saved_and_loaded_ws,
+                rtol=self.rtolValue,
+            )

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -34,6 +34,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         cls.instrumentFilepath = Resource.getPath("inputs/testInstrument/fakeSNAP_Definition.xml")
         cls.fetchedWSname = "_fetched_grocery"
         cls.groupingScheme = "Native"
+        cls.rtolValue = 1.0e-10
         # create some sample data
         cls.sampleWS = "_grocery_to_fetch"
         CreateWorkspace(
@@ -102,6 +103,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
+            rtol=self.rtolValue,
         )
 
         # make sure it won't load same workspace name again
@@ -114,6 +116,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
             Workspace2=res["workspace"],
+            rtol=self.rtolValue,
         )
 
     @mock.patch("snapred.backend.recipe.FetchGroceriesRecipe.FetchAlgo")

--- a/tests/unit/backend/recipe/test_GenericRecipe.py
+++ b/tests/unit/backend/recipe/test_GenericRecipe.py
@@ -170,7 +170,7 @@ class TestGenericRecipeInputsAndOutputs(unittest.TestCase):
         # run the recipe and make sure correct result is given
         CreateSingleValuedWorkspace(OutputWorkspace="okay")
         res = TestMatrixProp().executeRecipe(InputWorkspace="okay", OutputWorkspace="hurray")
-        assert_wksp_almost_equal(Workspace1="okay", Workspace2=res)
+        assert_wksp_almost_equal(Workspace1="okay", Workspace2=res, rtol=1.0e-10)
 
     def test_primitives(self):
         # register the algorithm and define the recipe


### PR DESCRIPTION
## Description of work
This work encapsulate a fix for the iteration dropdown. It was found that when a calibration was performed iterated and completed and then a subsequent calibration was started, the iteration dropdown menu would still be present with filled values. This work implements some hooks as stated within the solution on the EWM post to fix this issue. 
<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work
Given above.
<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing
With a clean state directory, please run through the calibration workflow on `next` and reproduce the issue stated above. 
Following this, rerun the calibration workflow with another clean state directory on this branch and insure that the iteration dropdown issue has been resolve.

Ensure all pytests pass.
<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing
Same as dev testing.
<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM # 6388](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6388)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
