### PR TITLE
Don't cross the streams!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ conda.recipe/
 src/snapred/resources/dev.yml
 docs/source/developer/dao.rst
 docs/source/developer/snapred/*
+mantidlog.txt
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/src/snapred/backend/log/logger.py
+++ b/src/snapred/backend/log/logger.py
@@ -5,6 +5,7 @@ import socket
 import sys
 
 from mantid.api import Progress
+from mantid.kernel import ConfigService
 from mantid.utils.logging import log_to_python
 
 from snapred.meta.Config import Config
@@ -103,6 +104,10 @@ class _MantidLogger:
     _outputfile = Config["logging.mantid.file.output"]
 
     def __init__(self):
+        # remove any previous logging settings
+        # NOTE this step is necessary for dark and mysterious reasons
+        ConfigService.remove("logging.channels.consoleChannel.class")
+
         # Configure Mantid to send messages to Python
         log_to_python()
         logger = logging.getLogger("Mantid")

--- a/src/snapred/backend/log/logger.py
+++ b/src/snapred/backend/log/logger.py
@@ -5,8 +5,6 @@ import socket
 import sys
 
 from mantid.api import Progress
-from mantid.kernel import ConfigService
-from mantid.utils.logging import log_to_python
 
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Singleton import Singleton
@@ -97,38 +95,4 @@ class _SnapRedLogger:
         return logger
 
 
-@Singleton
-class _MantidLogger:
-    _streamlevel = Config["logging.mantid.stream.level"]
-    _filelevel = Config["logging.mantid.file.level"]
-    _outputfile = Config["logging.mantid.file.output"]
-
-    def __init__(self):
-        # remove any previous logging settings
-        # NOTE this step is necessary for dark and mysterious reasons
-        ConfigService.remove("logging.channels.consoleChannel.class")
-
-        # Configure Mantid to send messages to Python
-        log_to_python()
-        logger = logging.getLogger("Mantid")
-        # NOTE it is necessary to set the log to a nonzero level before adding handlers
-        logger.setLevel(logging.DEBUG)
-
-        # the stream handler will print alongside the SNAPRed logs
-        ch = logging.StreamHandler(sys.stdout)
-        streamformatter = CustomFormatter("mantid.stream")
-        ch.setLevel(self._streamlevel)
-        ch.setFormatter(streamformatter)
-
-        # the file handler will print to an external file
-        file = logging.FileHandler(self._outputfile, "w")
-        fileformatter = CustomFormatter("mantid.file")
-        file.setLevel(self._filelevel)
-        file.setFormatter(fileformatter)
-
-        logger.addHandler(file)
-        logger.addHandler(ch)
-
-
-mantidLogger = _MantidLogger()
 snapredLogger = _SnapRedLogger()

--- a/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
@@ -10,10 +10,13 @@ from mantid.api import (
     PropertyMode,
     PythonAlgorithm,
 )
-from mantid.kernel import Direction, logger
+from mantid.kernel import Direction
 
+from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
+
+logger = snapredLogger.getLogger(__name__)
 
 
 class LoadGroupingDefinition(PythonAlgorithm):

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -167,7 +167,7 @@ logging:
       format: 'MANTID %(levelname)-8s - %(asctime)s - %(message)s'
     file:
       level: "INFO"
-      format: ${logging.SNAP.format}
+      format: ${logging.SNAP.stream.format}
       output: "mantidlog.txt"
   SNAP:
     stream:

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -160,9 +160,19 @@ localdataservice:
     verifypaths: true
 
 logging:
-  level: 20
+  # log levels are NOTSET, DEBUG, INFO, WARNING, ERROR, CRITICAL
+  mantid:
+    stream:
+      level: "WARNING"
+      format: 'MANTID %(levelname)-8s - %(asctime)s - %(message)s'
+    file:
+      level: "INFO"
+      format: ${logging.SNAP.format}
+      output: "mantidlog.txt"
   SNAP:
-    format: '%(asctime)s - %(levelname)-8s - %(name)s - %(message)s'
+    stream:
+      level: "INFO"
+      format: '%(asctime)s - %(levelname)-8s - %(name)s - %(message)s'
 
 samples:
   home: ${instrument.calibration.sample.home}

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -168,11 +168,18 @@ localdataservice:
 
 logging:
   # logging.NOTSET: 0, logging.DEBUG: 10, logging.INFO: 20, logging:WARNING: 30, logging.ERROR: 40, logging.CRITICAL: 50
-  level:  40
   SNAP:
-    format: '%(asctime)s - %(levelname)-8s - %(name)s - %(message)s'
+    stream:
+      level: 40
+      format: '%(asctime)s - %(levelname)-8s - %(name)s - %(message)s'
   mantid:
-    format: '%Y-%m-%d %H:%M:%S,%i - %p - %s - %t'
+    stream:
+      level: 40
+      format: 'MANTID %(levelname)s - %(message)s'
+    file:
+      level: 40
+      format: 'MANTID FILE %(levelname)s - %(message)s'
+      output: '/dev/null'
 
 samples:
   home: ${instrument.calibration.sample.home}


### PR DESCRIPTION
## Description of work

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

SNAPRed is configured to log all of mantid's info, plus all of SNAPRed's info, which results in thousands of lines when even jsut starting up.

This splits the SNAPRed and mantid logger.  Everything from SNAPRed will be logged to the logging panel.  From mantid, only logs at WARNING or higher will be logged to the panel, while all logs at INFO or higher will go to an external file.

These level settings, and the name of the file, can be adjusted from the `application.yml`

This reduces the screen output from SNAPRed significantly.

## Explanation of work

The SNAPRed logger used to first setup the mantid logger to print similarly to the other logs.  It no longer does this.

A separate logger object is created for mantid logs.  It uses a `StreamHandler` and a `FileHandler` object to send the logs to both a file and to stdout.  The levels for these can be set independently, as can the output file.

One algorithm, `LoadGroupingDefinition`, was accidentally setup to use standard python logger, and not the SNAPRed logger.  That was fixed.

## To test

### Dev testing

~~See testing instructions on [mantid PR 37852](https://github.com/mantidproject/mantid/pull/37852) for setting this up to run with the new mantid feature.~~   No longer part of this PR.

Open the SNAPRed GUI.  On the terminal, you should only see the splash and a message "Welcome User!  Happy Reducing!"
![image](https://github.com/user-attachments/assets/b39aec1a-33b7-4816-b181-b64bbef97d3e)

Check the output log file (should be `mantidlog.txt`).  There should be some other messages there at the INFO level.  If this is empty, or contains DEBUG information, then this fails.

Try running calibration with 46680.  In the terminal logs, you will see a few mantid WARNING messages in yellow.  They should be obvious.  In the log file, there will be a bunch of information, some at INFO and some at WARNING level.  There should be nothing at the DEBUG level in the file.

Try changing the log levels in the  `application.yml` , and make sure mantid logs are printed at the correct level in the two places in a way that makes sense.

Open workbench and run SNAPRed from the interface.  Make sure the SNAPRed logs appear.  The mantid logs will also appear, and there just isn't anything we can do about that.

Close the SNAPRed interface and try running any algorithm in workbench, to make sure it is still writing logs.

### CIS testing

<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

``` python
# replace with your test script below
```

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#6257](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6257)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
