### PR TITLE
Fixed issue with threshold value not being set in certain cases

### DIFF
--- a/src/snapred/backend/dao/state/CalibrantSample/CalibrantSample.py
+++ b/src/snapred/backend/dao/state/CalibrantSample/CalibrantSample.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, field_validator
 from snapred.backend.dao.state.CalibrantSample.Crystallography import Crystallography
 from snapred.backend.dao.state.CalibrantSample.Geometry import Geometry
 from snapred.backend.dao.state.CalibrantSample.Material import Material
+from snapred.meta.Config import Config
 
 
 class CalibrantSample(BaseModel):
@@ -17,7 +18,7 @@ class CalibrantSample(BaseModel):
     geometry: Geometry
     material: Material
     crystallography: Optional[Crystallography] = None
-    peakIntensityFractionThreshold: float
+    peakIntensityFractionThreshold: Optional[float] = Config["constants.PeakIntensityFractionThreshold"]
 
     # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
     # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -292,7 +292,9 @@ class SousChef(Service):
         )
 
     def _getThresholdFromCalibrantSample(self, calibrantSamplePath: str) -> float:
-        if not os.path.exists(calibrantSamplePath):
+        if type(calibrantSamplePath) is None:
+            return Config["constants.PeakIntensityFractionThreshold"]
+        elif not os.path.exists(calibrantSamplePath):
             return Config["constants.PeakIntensityFractionThreshold"]
         else:
             calibrantSample = self.prepCalibrantSample(calibrantSamplePath)

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -292,7 +292,7 @@ class SousChef(Service):
         )
 
     def _getThresholdFromCalibrantSample(self, calibrantSamplePath: str) -> float:
-        if type(calibrantSamplePath) is None:
+        if calibrantSamplePath is None:
             return Config["constants.PeakIntensityFractionThreshold"]
         elif not os.path.exists(calibrantSamplePath):
             return Config["constants.PeakIntensityFractionThreshold"]

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -476,3 +476,7 @@ class TestSousChef(unittest.TestCase):
         path = self.ingredients.calibrantSamplePath
         result = self.instance._getThresholdFromCalibrantSample(path)
         assert result == calibrantSample.peakIntensityFractionThreshold
+
+    def test__getThresholdFromCalibrantSample_none_path(self):
+        result = self.instance._getThresholdFromCalibrantSample(None)
+        assert result == Config["constants.PeakIntensityFractionThreshold"]


### PR DESCRIPTION
## Description of work

This is to fix an issue with the PeakIntensityFractionThreshold in a CalibrantSample not correctly setting the default value in certain cases.

## Explanation of work

Updated the CalibrantSample DAO to set the default value from Config. Also updated SousChef to handle a case where the calibrant path might be None when getting the threshold value.

## To test

### Dev testing

Do full runs of DiffCal and Normalization and make sure nothing new is broken. You should be able to use calibrant sample files that don't have the threshold field set, and it should use the default value in application.yml.

### CIS testing

See dev testing.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#3146](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3146)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
