### PR TITLE
Update Test Fixture

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - python=3.10
 - pip
 - pydantic>=2.7.3,<3
-- mantidworkbench>=6.10.20240816
+- mantidworkbench>=6.10.20240909
 - qtpy
 - pre-commit
 - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - python=3.10
 - pip
 - pydantic>=2.7.3,<3
-- mantidworkbench>=6.10.20240705
+- mantidworkbench>=6.10.20240816
 - qtpy
 - pre-commit
 - pytest

--- a/tests/unit/backend/recipe/algorithm/data/test_Leftovers.py
+++ b/tests/unit/backend/recipe/algorithm/data/test_Leftovers.py
@@ -10,8 +10,8 @@ from mantid.simpleapi import (
     ResampleX,
     WrapLeftovers,
 )
+from mantid.testing import assert_almost_equal
 from snapred.meta.Config import Config
-from util.helpers import workspacesEqual
 
 NUM_BINS = Config["constants.ResampleX.NumberBins"]
 LOG_BINNING = True
@@ -62,7 +62,11 @@ def test_saveLoad():
         LogBinning=LOG_BINNING,
         OutputWorkspace="expected",
     )
-    assert workspacesEqual(mtd["expected"], mtd["reheated"])
+    assert_almost_equal(
+        Workspace1=mtd["expected"],
+        Workspace2=mtd["reheated"],
+        atol=1e-10,
+    )
     DeleteWorkspace("raw")
     DeleteWorkspace("expected")
     DeleteWorkspace("reheated")

--- a/tests/unit/backend/recipe/algorithm/data/test_Leftovers.py
+++ b/tests/unit/backend/recipe/algorithm/data/test_Leftovers.py
@@ -65,7 +65,7 @@ def test_saveLoad():
     assert_almost_equal(
         Workspace1=mtd["expected"],
         Workspace2=mtd["reheated"],
-        atol=1e-10,
+        atol=0.0,
     )
     DeleteWorkspace("raw")
     DeleteWorkspace("expected")

--- a/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
+++ b/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
@@ -2,10 +2,10 @@ import socket
 import unittest.mock as mock
 
 import pytest
+from mantid.testing import assert_almost_equal
 from snapred.backend.dao import CrystallographicPeak, DetectorPeak, GroupPeakList
 from snapred.meta.redantic import list_to_raw
 from util.diffraction_calibration_synthetic_data import SyntheticData
-from util.helpers import workspacesEqual
 
 with mock.patch.dict(
     "sys.modules",
@@ -94,9 +94,10 @@ with mock.patch.dict(
         algo.unbagGroceries()
 
         # verify result
-        assert workspacesEqual(
-            input_ws_name,
-            weight_ws_name,
+        assert_almost_equal(
+            Workspace1=input_ws_name,
+            Workspace2=weight_ws_name,
+            atol=1e-10,
         )
 
     def test_unbag_ingredients_converts_events():
@@ -130,9 +131,10 @@ with mock.patch.dict(
         algo.unbagGroceries()
 
         # verify result: the weight ws should converted back to histogram data
-        assert workspacesEqual(
-            input_ws_name,
-            weight_ws_name,
+        assert_almost_equal(
+            Workspace1=input_ws_name,
+            Workspace2=weight_ws_name,
+            atol=1e-10,
         )
 
     def test_validate_fail_wrong_sizes():
@@ -254,7 +256,11 @@ with mock.patch.dict(
         assert weightCalculatorAlgo.execute()
 
         # verify the weight workspace matches expectations
-        assert workspacesEqual(output_ws_name, weight_ws_name)
+        assert_almost_equal(
+            Workspace1=output_ws_name,
+            Workspace2=weight_ws_name,
+            atol=1e-10,
+        )
 
     def test_with_predicted_peaks():
         """
@@ -292,8 +298,9 @@ with mock.patch.dict(
         assert weightCalculatorAlgo.execute()
 
         # assert the weights are as expected
-        assert workspacesEqual(
+        assert_almost_equal(
             Workspace1=weight_ws_name,
             Workspace2=ref_weight_ws_name,
+            atol=1e-10,
             CheckInstrument=False,
         )

--- a/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
+++ b/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
@@ -97,7 +97,6 @@ with mock.patch.dict(
         assert_almost_equal(
             Workspace1=input_ws_name,
             Workspace2=weight_ws_name,
-            atol=1e-10,
         )
 
     def test_unbag_ingredients_converts_events():
@@ -134,7 +133,6 @@ with mock.patch.dict(
         assert_almost_equal(
             Workspace1=input_ws_name,
             Workspace2=weight_ws_name,
-            atol=1e-10,
         )
 
     def test_validate_fail_wrong_sizes():
@@ -259,7 +257,6 @@ with mock.patch.dict(
         assert_almost_equal(
             Workspace1=output_ws_name,
             Workspace2=weight_ws_name,
-            atol=1e-10,
         )
 
     def test_with_predicted_peaks():
@@ -301,6 +298,5 @@ with mock.patch.dict(
         assert_almost_equal(
             Workspace1=weight_ws_name,
             Workspace2=ref_weight_ws_name,
-            atol=1e-10,
             CheckInstrument=False,
         )

--- a/tests/unit/backend/recipe/algorithm/test_FocusSpectraAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FocusSpectraAlgorithm.py
@@ -140,7 +140,6 @@ class TestFocusSpectra(unittest.TestCase):
         assert_almost_equal(
             Workspace1=outputWs,
             Workspace2=outputWs + "_loaded",
-            atol=1e-10,
             CheckAllData=True,
         )
 

--- a/tests/unit/backend/recipe/algorithm/test_FocusSpectraAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FocusSpectraAlgorithm.py
@@ -4,6 +4,7 @@ from mantid.simpleapi import (
     DeleteWorkspace,
     mtd,
 )
+from mantid.testing import assert_almost_equal
 
 # the algorithm to test
 from snapred.backend.recipe.algorithm.FocusSpectraAlgorithm import (
@@ -11,7 +12,6 @@ from snapred.backend.recipe.algorithm.FocusSpectraAlgorithm import (
 )
 from snapred.meta.Config import Resource
 from util.dao import DAOFactory
-from util.helpers import workspacesEqual
 
 
 class TestFocusSpectra(unittest.TestCase):
@@ -137,7 +137,12 @@ class TestFocusSpectra(unittest.TestCase):
         assert mtd[outputWs].getNumberHistograms() == mtd[outputWs + "_loaded"].getNumberHistograms()
         # check block size
         assert mtd[outputWs].blocksize() == mtd[outputWs + "_loaded"].blocksize()
-        assert workspacesEqual(outputWs, outputWs + "_loaded", CheckAllData=True)
+        assert_almost_equal(
+            Workspace1=outputWs,
+            Workspace2=outputWs + "_loaded",
+            atol=1e-10,
+            CheckAllData=True,
+        )
 
     def test_chopIngredients(self):
         algo = ThisAlgo()

--- a/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
+++ b/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
@@ -253,7 +253,7 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=outputWorkspace,
             Workspace2=self.localReferenceWorkspace,
-            atol=1e-10,
+            atol=0.0,
         )
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
@@ -279,7 +279,7 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=outputWorkspace,
             Workspace2=self.localReferenceWorkspace,
-            atol=1e-10,
+            atol=0.0,
         )
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
@@ -300,7 +300,7 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         assert_wksp_almost_equal(
             Workspace1=outputWorkspace,
             Workspace2=self.localReferenceWorkspace,
-            atol=1e-10,
+            atol=0.0,
         )
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]

--- a/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
+++ b/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
@@ -14,7 +14,6 @@ from mantid.simpleapi import (
 from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
 from snapred.backend.recipe.algorithm.LoadGroupingDefinition import LoadGroupingDefinition as LoadingAlgo
 from snapred.meta.Config import Resource
-from util.helpers import workspacesEqual
 
 IS_ON_ANALYSIS_MACHINE = socket.gethostname().startswith("analysis")
 
@@ -251,7 +250,11 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         loadingAlgo.setProperty("OutputWorkspace", outputWorkspace)
         assert loadingAlgo.execute()
         assert mtd.doesExist(outputWorkspace)
-        assert workspacesEqual(outputWorkspace, self.localReferenceWorkspace)
+        assert_wksp_almost_equal(
+            Workspace1=outputWorkspace,
+            Workspace2=self.localReferenceWorkspace,
+            atol=1e-10,
+        )
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
         # check used correct cals
@@ -273,7 +276,11 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         ConfigService.updateFacilities("")
         ConfigService.reset()
         assert mtd.doesExist(outputWorkspace)
-        assert workspacesEqual(outputWorkspace, self.localReferenceWorkspace)
+        assert_wksp_almost_equal(
+            Workspace1=outputWorkspace,
+            Workspace2=self.localReferenceWorkspace,
+            atol=1e-10,
+        )
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
         # check used correct cals
@@ -290,7 +297,11 @@ class TestLoadGroupingDefinition(unittest.TestCase):
         loadingAlgo.setProperty("OutputWorkspace", outputWorkspace)
         assert loadingAlgo.execute()
         assert mtd.doesExist(outputWorkspace)
-        assert workspacesEqual(outputWorkspace, self.localReferenceWorkspace)
+        assert_wksp_almost_equal(
+            Workspace1=outputWorkspace,
+            Workspace2=self.localReferenceWorkspace,
+            atol=1e-10,
+        )
         # check the function calls made
         calls = [call[0] for call in loadingAlgo.mantidSnapper._algorithmQueue]
         # check used correct cals

--- a/tests/unit/backend/recipe/algorithm/test_MaskDetectorFlags.py
+++ b/tests/unit/backend/recipe/algorithm/test_MaskDetectorFlags.py
@@ -4,6 +4,7 @@ from mantid.simpleapi import (
     LoadEmptyInstrument,
     mtd,
 )
+from mantid.testing import assert_almost_equal
 from snapred.backend.log.logger import snapredLogger
 
 # the algorithm to test
@@ -12,7 +13,6 @@ from snapred.meta.Config import Resource
 from util.helpers import (
     createCompatibleMask,
     deleteWorkspaceNoThrow,
-    workspacesEqual,
 )
 
 logger = snapredLogger.getLogger(__name__)
@@ -132,9 +132,10 @@ class TestMaskDetectorFlags:
         algo.setProperty("OutputWorkspace", self.testInstrumentWS)
 
         algo.execute()
-        assert workspacesEqual(
+        assert_almost_equal(
             Workspace1=self.testInstrumentWS,
             Workspace2=self.instrumentWS,
+            atol=1e-10,
             CheckInstrument=False,
         )
 
@@ -196,9 +197,10 @@ class TestMaskDetectorFlags:
         algo.setProperty("OutputWorkspace", self.testGroupingWS)
 
         algo.execute()
-        assert workspacesEqual(
+        assert_almost_equal(
             Workspace1=self.testGroupingWS,
             Workspace2=self.groupingWS,
+            atol=1e-10,
             CheckInstrument=False,
         )
 
@@ -274,8 +276,9 @@ class TestMaskDetectorFlags:
         algo.setProperty("OutputWorkspace", testOtherMaskWS)
 
         algo.execute()
-        assert workspacesEqual(
+        assert_almost_equal(
             Workspace1=testOtherMaskWS,
             Workspace2=self.maskWS,
+            atol=1e-10,
             CheckInstrument=False,
         )

--- a/tests/unit/backend/recipe/algorithm/test_MaskDetectorFlags.py
+++ b/tests/unit/backend/recipe/algorithm/test_MaskDetectorFlags.py
@@ -135,7 +135,7 @@ class TestMaskDetectorFlags:
         assert_almost_equal(
             Workspace1=self.testInstrumentWS,
             Workspace2=self.instrumentWS,
-            atol=1e-10,
+            atol=0.0,
             CheckInstrument=False,
         )
 
@@ -200,7 +200,7 @@ class TestMaskDetectorFlags:
         assert_almost_equal(
             Workspace1=self.testGroupingWS,
             Workspace2=self.groupingWS,
-            atol=1e-10,
+            atol=0.0,
             CheckInstrument=False,
         )
 
@@ -279,6 +279,6 @@ class TestMaskDetectorFlags:
         assert_almost_equal(
             Workspace1=testOtherMaskWS,
             Workspace2=self.maskWS,
-            atol=1e-10,
+            atol=0.0,
             CheckInstrument=False,
         )

--- a/tests/util/helpers.py
+++ b/tests/util/helpers.py
@@ -211,31 +211,6 @@ def deleteWorkspaceNoThrow(wsName: str):
         pass
 
 
-def workspacesEqual(Workspace1: str, Workspace2: str, **other_options):
-    """
-    Meant to be called as
-    ``` python
-    assert workspacesEqual(ws1, ws2)
-    ```
-    Parameters:
-    - Workspace1: str -- one of the workspaces to compare
-    - Workspace2: str -- one of the workspaces to compare
-    - other_options: kwargs dict -- other options available to CompareWorkspaces
-    Returns: if the workspaces are equal, will return True
-    Otherwise, will raise an assertion error containing the result of CompareWorkspaces in description
-    """
-    # NOTE this can be re-worked to call `assert_wksp_almost_equal` when that
-    # has been fixed to allow exact comparisons.
-    equal, message = CompareWorkspaces(
-        Workspace1=Workspace1,
-        Workspace2=Workspace2,
-        **other_options,
-    )
-    if not equal:
-        raise AssertionError(message.column("Message"))
-    return equal
-
-
 def workspacesNotEqual(Workspace1: str, Workspace2: str, **other_options):
     """
     Meant to be called as


### PR DESCRIPTION
## Description of work

This was to update a snapred defined test fixture that used mantid's CompareWorkspaces to now use assert_almost_equal(). assert_almost_equal now has the functionality we need.

## Explanation of work

Unit tests were updated to now use assert_almost_equal(). `atol=1e-10` was added as argument because either atol or rtol args are required for the assertion.


## To test

### Dev testing

Just make sure unit tests pass

### CIS testing

None, this only affects unit tests.


## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#5044](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=5044)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
