### PR TITLE
write correct calibrant to norm record and then use it in reduction

### DIFF
--- a/src/snapred/backend/dao/normalization/NormalizationRecord.py
+++ b/src/snapred/backend/dao/normalization/NormalizationRecord.py
@@ -28,6 +28,7 @@ class NormalizationRecord(BaseModel):
     workspaceNames: List[WorkspaceName] = []
     version: int = Config["instrument.startingVersionNumber"]
     crystalDBounds: Limit[float]
+    normalizationCalibrantSamplePath: str
 
     @field_validator("runNumber", "backgroundRunNumber", mode="before")
     @classmethod

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -169,6 +169,7 @@ class NormalizationService(Service):
             peakIntensityThreshold=request.peakIntensityThreshold,
             backgroundRunNumber=request.backgroundRunNumber,
             smoothingParameter=request.smoothingParameter,
+            normalizationCalibrantSamplePath=request.calibrantSamplePath,
             calibration=calibration,
             crystalDBounds=request.crystalDBounds,
         )

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -194,7 +194,7 @@ class SousChef(Service):
             )
         # grab information from records
         ingredients_ = ingredients.model_copy()
-        ingredients_.calibrantSamplePath = calibrationRecord.calibrationFittingIngredients.calibrantSamplePath
+        ingredients_.calibrantSamplePath = normalizationRecord.normalizationCalibrantSamplePath
         ingredients_.cifPath = self.dataFactoryService.getCifFilePath(Path(ingredients_.calibrantSamplePath).stem)
         ingredients_.peakIntensityThreshold = normalizationRecord.peakIntensityThreshold
         return ReductionIngredients(

--- a/tests/resources/inputs/normalization/NormalizationRecord.json
+++ b/tests/resources/inputs/normalization/NormalizationRecord.json
@@ -4,6 +4,7 @@
     "backgroundRunNumber": 58813,
     "smoothingParameter": 0.5,
     "peakIntensityThreshold": 0.05,
+    "normalizationCalibrantSamplePath": "/path/to/sample",
     "calibration":{
         "instrumentState": {
             "id": "ab8704b0bc2a2342",

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -324,17 +324,18 @@ class TestSousChef(unittest.TestCase):
 
     @mock.patch(thisService + "ReductionIngredients")
     def test_prepReductionIngredients(self, ReductionIngredients):
-        record = mock.Mock(
-            smoothingParamter=1.0,
-            calibrationFittingIngredients=mock.Mock(calibrantSamplePath="a/b.x"),
+        calibrationRecord = mock.Mock()
+        normalizationRecord = mock.Mock(
+            smoothingParameter=1.0,
+            normalizationCalibrantSamplePath="a/b.x",
         )
         self.instance.prepRunConfig = mock.Mock()
         self.instance.prepManyPixelGroups = mock.Mock()
         self.instance.prepManyDetectorPeaks = mock.Mock()
         self.instance.dataFactoryService.getCifFilePath = mock.Mock()
         self.instance.dataFactoryService.getReductionState = mock.Mock()
-        self.instance.dataFactoryService.getNormalizationRecord = mock.Mock(return_value=record)
-        self.instance.dataFactoryService.getCalibrationRecord = mock.Mock(return_value=record)
+        self.instance.dataFactoryService.getNormalizationRecord = mock.Mock(return_value=normalizationRecord)
+        self.instance.dataFactoryService.getCalibrationRecord = mock.Mock(return_value=calibrationRecord)
 
         res = self.instance.prepReductionIngredients(self.ingredients)
 
@@ -343,7 +344,7 @@ class TestSousChef(unittest.TestCase):
         assert ReductionIngredients.called_once_with(
             maskList=[],
             pixelGroups=self.instance.prepManyPixelGroups.return_value,
-            smoothingParameter=record.smoothingParameter,
+            smoothingParameter=normalizationRecord.smoothingParameter,
             detectorPeaksMany=self.instance.prepManyDetectorPeaks.return_value,
         )
         assert res == ReductionIngredients.return_value


### PR DESCRIPTION
## Description of work

Pretty simple fix, we need to record the calibrant sample used in normalization and use that in reduction instead of the one use during Calibration.

This is because it is used in preparing the Normalization as part of reduction, and no where else, thus it should be the calibrant from normalization.

## To test

Tests pass, the workflows complete as normal.

I used the typical inputs
```
For reduction/calib
Runnumber: 59039 

for calib:
sample: LA11b6
Grouping: Column
Peak Intensity Thresh: 0.01
Chi: 2000
dmin: 1

for norm:
rnunumber: 58810
bgrunnumber: 58813
```
## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#6898](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6898)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
