### PR TITLE
Reduction save panel

### DIFF
--- a/src/snapred/backend/dao/reduction/ReductionRecord.py
+++ b/src/snapred/backend/dao/reduction/ReductionRecord.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -24,8 +24,8 @@ class ReductionRecord(BaseModel):
     timestamp: float = Field(frozen=True, default=None)
 
     # specific to reduction records
-    calibration: CalibrationRecord
-    normalization: NormalizationRecord
+    calibration: Optional[CalibrationRecord] = None
+    normalization: Optional[NormalizationRecord] = None
     pixelGroupingParameters: Dict[str, List[PixelGroupingParameters]]
 
     workspaceNames: List[WorkspaceName]

--- a/src/snapred/backend/dao/request/CalibrationWritePermissionsRequest.py
+++ b/src/snapred/backend/dao/request/CalibrationWritePermissionsRequest.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+from snapred.backend.error.ContinueWarning import ContinueWarning
+
+
+class CalibrationWritePermissionsRequest(BaseModel):
+    runNumber: str
+    continueFlags: ContinueWarning.Type

--- a/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
+++ b/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, ConfigDict, field_validator
 
 from snapred.backend.dao.Limit import Pair
 from snapred.backend.dao.state.FocusGroup import FocusGroup
+from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.meta.Config import Config
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
 
@@ -35,6 +36,8 @@ class DiffractionCalibrationRequest(BaseModel, extra="forbid"):
     fwhmMultipliers: Pair[float] = Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
     maxChiSq: float = Config["constants.GroupDiffractionCalibration.MaxChiSq"]
     removeBackground: Optional[bool]
+
+    continueFlags: Optional[ContinueWarning.Type] = ContinueWarning.Type.UNSET
 
     @field_validator("fwhmMultipliers", mode="before")
     @classmethod

--- a/src/snapred/backend/dao/request/NormalizationRequest.py
+++ b/src/snapred/backend/dao/request/NormalizationRequest.py
@@ -1,7 +1,10 @@
+from typing import Optional
+
 from pydantic import BaseModel
 
 from snapred.backend.dao.Limit import Limit, Pair
 from snapred.backend.dao.state.FocusGroup import FocusGroup
+from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.meta.Config import Config
 
 
@@ -27,3 +30,5 @@ class NormalizationRequest(BaseModel, extra="forbid"):
     )
     nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]
     fwhmMultipliers: Pair[float] = Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
+
+    continueFlags: Optional[ContinueWarning.Type] = ContinueWarning.Type.UNSET

--- a/src/snapred/backend/dao/request/ReductionExportRequest.py
+++ b/src/snapred/backend/dao/request/ReductionExportRequest.py
@@ -7,11 +7,11 @@ class ReductionExportRequest(BaseModel):
     """
 
     Sent from reduction workflow to reduction service, requesting
-    the reduction service save the data for the reduction.
+    the reduction service to save the data for the reduction.
 
     """
 
-    reductionRecord: ReductionRecord
+    record: ReductionRecord
 
     model_config = ConfigDict(
         # required in order to use 'WorkspaceName'

--- a/src/snapred/backend/dao/response/ReductionResponse.py
+++ b/src/snapred/backend/dao/response/ReductionResponse.py
@@ -1,12 +1,13 @@
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import BaseModel, ConfigDict
 
+from snapred.backend.dao.reduction.ReductionRecord import ReductionRecord
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
 
 class ReductionResponse(BaseModel):
-    workspaces: List[WorkspaceName]
+    record: ReductionRecord
     unfocusedData: Optional[WorkspaceName] = None
 
     model_config = ConfigDict(

--- a/src/snapred/backend/data/DataExportService.py
+++ b/src/snapred/backend/data/DataExportService.py
@@ -49,6 +49,9 @@ class DataExportService:
     def checkFileandPermission(self, filePath: Path) -> Tuple[bool, bool]:
         return self.dataService.checkFileandPermission(filePath)
 
+    def checkWritePermissions(self, path: Path) -> bool:
+        return self.dataService.checkWritePermissions(path)
+
     ##### CALIBRATION METHODS #####
 
     @validate_call
@@ -78,6 +81,10 @@ class DataExportService:
         Calibration must have correct version set.
         """
         self.dataService.writeCalibrationState(calibration)
+
+    def getCalibrationStateRoot(self, runNumber: str) -> Path:
+        stateId, _ = self.dataService.generateStateId(runNumber)
+        return self.dataService.constructCalibrationStateRoot(stateId)
 
     ##### NORMALIZATION METHODS #####
 
@@ -120,6 +127,9 @@ class DataExportService:
         - 'exportReductionRecord' must have been called previously.
         """
         self.dataService.writeReductionData(record)
+
+    def getReductionStateRoot(self, runNumber: str) -> Path:
+        return self.dataService._constructReductionStateRoot(runNumber)
 
     ##### WORKSPACE METHODS #####
 

--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -51,7 +51,7 @@ class DataFactoryService:
         return self.lookupService.readStateConfig(runId, useLiteMode)
 
     def constructStateId(self, runId: str):
-        return self.lookupService._generateStateId(runId)
+        return self.lookupService.generateStateId(runId)
 
     def getCalibrantSample(self, filePath):
         return self.lookupService.readCalibrantSample(filePath)

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -2,8 +2,8 @@ import datetime
 import glob
 import json
 import os
-import stat
 import re
+import stat
 import time
 from errno import ENOENT as NOT_FOUND
 from functools import lru_cache
@@ -174,10 +174,10 @@ class LocalDataService:
     @staticmethod
     def _hasWritePermissionstoPath(filePath: Path) -> bool:
         # WARNING: `os.access` does not work correctly on the `/SNS` shared filesystem.
-        
+
         # formerly:
         #   `return os.access(filePath, os.W_OK) if filePath.exists() else False`
-        
+
         # alternative implementation (LINUX specific):
         hasPermissions = False
         if filePath.exists():
@@ -198,9 +198,9 @@ class LocalDataService:
             #   checking the user-bits, if the current user is the owner;
             #   then checking the group-bits, if the user belongs to the file-owner's group;
             #   and finally checking the other-bits.
-            hasPermissions = (uid == fuid) and bool(mode & 0o200)\
-                or (fgid in gids) and bool(mode & 0o020)\
-                or bool(mode & 0o002)
+            hasPermissions = (
+                (uid == fuid) and bool(mode & 0o200) or (fgid in gids) and bool(mode & 0o020) or bool(mode & 0o002)
+            )
         return hasPermissions
 
     @staticmethod

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -2,6 +2,7 @@ import datetime
 import glob
 import json
 import os
+import stat
 import re
 import time
 from errno import ENOENT as NOT_FOUND
@@ -172,7 +173,43 @@ class LocalDataService:
 
     @staticmethod
     def _hasWritePermissionstoPath(filePath: Path) -> bool:
-        return os.access(filePath, os.W_OK) if filePath.exists() else False
+        # WARNING: `os.access` does not work correctly on the `/SNS` shared filesystem.
+        
+        # formerly:
+        #   `return os.access(filePath, os.W_OK) if filePath.exists() else False`
+        
+        # alternative implementation (LINUX specific):
+        hasPermissions = False
+        if filePath.exists():
+            stat_ = os.stat(filePath)
+
+            # Get the path's permissions mode bits.
+            mode = stat.S_IMODE(stat_.st_mode)
+
+            # Get the path owner's user-id, and group-id.
+            fuid = stat_.st_uid
+            fgid = stat_.st_gid
+
+            # Get the current user's user-id and group-ids
+            uid = os.getuid()
+            gids = os.getgroups()
+
+            # Check for any overlap with the write permission's mode bits:
+            #   checking the user-bits, if the current user is the owner;
+            #   then checking the group-bits, if the user belongs to the file-owner's group;
+            #   and finally checking the other-bits.
+            hasPermissions = (uid == fuid) and bool(mode & 0o200)\
+                or (fgid in gids) and bool(mode & 0o020)\
+                or bool(mode & 0o002)
+        return hasPermissions
+
+    @staticmethod
+    def checkWritePermissions(path: Path) -> bool:
+        """Check if the user has permissions to write to, or to create, the specified path."""
+        path_ = path
+        while path_ and not path_.exists():
+            path_ = path_.parent
+        return LocalDataService._hasWritePermissionstoPath(path_) if (path_ and path_.exists()) else False
 
     @staticmethod
     def getUniqueTimestamp() -> float:
@@ -244,7 +281,7 @@ class LocalDataService:
     # NOTE `lru_cache` decorator needs to be on the outside
     @lru_cache
     @ExceptionHandler(StateValidationException)
-    def _generateStateId(self, runId: str) -> Tuple[str, str]:
+    def generateStateId(self, runId: str) -> Tuple[str, str]:
         detectorState = self.readDetectorState(runId)
         SHA = self._stateIdFromDetectorState(detectorState)
         return SHA.hex, SHA.decodedKey
@@ -287,22 +324,22 @@ class LocalDataService:
         # Append a timestamp directory to a data path
         return root / wnvf.pathTimestamp(timestamp)
 
-    def _constructCalibrationStateRoot(self, stateId) -> Path:
+    def constructCalibrationStateRoot(self, stateId) -> Path:
         return Path(Config["instrument.calibration.powder.home"], str(stateId))
 
     def _constructCalibrationStatePath(self, stateId, useLiteMode) -> Path:
         mode = "lite" if useLiteMode else "native"
-        return self._constructCalibrationStateRoot(stateId) / mode / "diffraction"
+        return self.constructCalibrationStateRoot(stateId) / mode / "diffraction"
 
     def _constructNormalizationStatePath(self, stateId, useLiteMode) -> Path:
         mode = "lite" if useLiteMode else "native"
-        return self._constructCalibrationStateRoot(stateId) / mode / "normalization"
+        return self.constructCalibrationStateRoot(stateId) / mode / "normalization"
 
     # reduction paths #
 
     @validate_call
     def _constructReductionStateRoot(self, runNumber: str) -> Path:
-        stateId, _ = self._generateStateId(runNumber)
+        stateId, _ = self.generateStateId(runNumber)
         IPTS = Path(self.getIPTS(runNumber))
         # Substitute the last component of the IPTS-directory for the '{IPTS}' tag,
         #   but only if the '{IPTS}' tag exists in the format string
@@ -326,12 +363,7 @@ class LocalDataService:
 
     @validate_call
     def _constructReductionDataFilePath(self, runNumber: str, useLiteMode: bool, timestamp: float) -> Path:
-        stateId, _ = self._generateStateId(runNumber)
-
-        # In order to facilitate eventual application to reductions containing multiple runNumber,
-        #   the output file is named as the <reduction output-group> (including only the stateSHA).
-        # If this causes confusion in the interim, this should be changed to `wng.reductionOutput`.
-        fileName = wng.reductionOutputGroup().stateId(stateId).timestamp(timestamp).build()
+        fileName = wng.reductionOutputGroup().runNumber(runNumber).timestamp(timestamp).build()
         fileName += Config["nexus.file.extension"]
         filePath = self._constructReductionDataPath(runNumber, useLiteMode, timestamp) / fileName
         return filePath
@@ -406,7 +438,7 @@ class LocalDataService:
         return Indexer(indexerType=indexerType, directory=path)
 
     def indexer(self, runNumber: str, useLiteMode: bool, indexerType: IndexerType):
-        stateId, _ = self._generateStateId(runNumber)
+        stateId, _ = self.generateStateId(runNumber)
         return self._indexer(stateId, useLiteMode, indexerType)
 
     def calibrationIndexer(self, runId: str, useLiteMode: bool):
@@ -821,7 +853,7 @@ class LocalDataService:
         grocer.deleteWorkspaceUnconditional(outWS)
 
     def generateInstrumentStateFromRoot(self, runId: str):
-        stateId, _ = self._generateStateId(runId)
+        stateId, _ = self.generateStateId(runId)
 
         # Read the detector state from the pv data file
         detectorState = self.readDetectorState(runId)
@@ -862,14 +894,14 @@ class LocalDataService:
     @ExceptionHandler(StateValidationException)
     # NOTE if you are debugging and got here, coment out the ExceptionHandler and try again
     def initializeState(self, runId: str, useLiteMode: bool, name: str = None):
-        stateId, _ = self._generateStateId(runId)
+        stateId, _ = self.generateStateId(runId)
 
         instrumentState = self.generateInstrumentStateFromRoot(runId)
 
         calibrationReturnValue = None
 
         # Make sure that the state root directory has been initialized:
-        stateRootPath: Path = self._constructCalibrationStateRoot(stateId)
+        stateRootPath: Path = self.constructCalibrationStateRoot(stateId)
         if not stateRootPath.exists():
             # WARNING: `_prepareStateRoot` is also called at `readStateConfig`; this allows
             #   some order independence of initialization if the back-end is run separately (e.g. in unit tests).
@@ -918,7 +950,7 @@ class LocalDataService:
         """
         Create the state root directory, and populate it with any necessary metadata files.
         """
-        stateRootPath: Path = self._constructCalibrationStateRoot(stateId)
+        stateRootPath: Path = self.constructCalibrationStateRoot(stateId)
         if not stateRootPath.exists():
             stateRootPath.mkdir(parents=True, exist_ok=True)
 
@@ -945,8 +977,8 @@ class LocalDataService:
             return False
         # if found, try to construct the path and test if the path exists
         else:
-            stateID, _ = self._generateStateId(runId)
-            calibrationStatePath: Path = self._constructCalibrationStateRoot(stateID)
+            stateID, _ = self.generateStateId(runId)
+            calibrationStatePath: Path = self.constructCalibrationStateRoot(stateID)
             return calibrationStatePath.exists()
 
     ##### GROUPING MAP METHODS #####
@@ -960,7 +992,7 @@ class LocalDataService:
     def readGroupingMap(self, runNumber: str):
         # if the state exists then lookup its grouping map
         if self.checkCalibrationFileExists(runNumber):
-            stateId, _ = self._generateStateId(runNumber)
+            stateId, _ = self.generateStateId(runNumber)
             return self._readGroupingMap(stateId)
         # otherwise return the default map
         else:
@@ -991,7 +1023,7 @@ class LocalDataService:
         return GroupingMap.calibrationGroupingHome() / "defaultGroupingMap.json"
 
     def _groupingMapPath(self, stateId) -> Path:
-        return self._constructCalibrationStateRoot(stateId) / "groupingMap.json"
+        return self.constructCalibrationStateRoot(stateId) / "groupingMap.json"
 
     ## PIXEL-MASK SUPPORT METHODS
 
@@ -1009,7 +1041,7 @@ class LocalDataService:
         )
         if mtd[wsName].getNumberHistograms() != targetPixelCount:
             return False
-        expectedStateId, _ = self._generateStateId(runNumber)
+        expectedStateId, _ = self.generateStateId(runNumber)
         actualStateId, _ = self.stateIdFromWorkspace(wsName)
         if actualStateId != expectedStateId:
             return False

--- a/src/snapred/backend/error/ContinueWarning.py
+++ b/src/snapred/backend/error/ContinueWarning.py
@@ -14,6 +14,7 @@ class ContinueWarning(Exception):
         MISSING_DIFFRACTION_CALIBRATION = auto()
         MISSING_NORMALIZATION = auto()
         LOW_PEAK_COUNT = auto()
+        NO_WRITE_PERMISSIONS = auto()
 
     class Model(BaseModel):
         message: str

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -19,6 +19,7 @@ from snapred.backend.dao.request import (
     CalibrationExportRequest,
     CalibrationIndexRequest,
     CalibrationLoadAssessmentRequest,
+    CalibrationWritePermissionsRequest,
     CreateCalibrationRecordRequest,
     DiffractionCalibrationRequest,
     FarmFreshIngredients,
@@ -31,6 +32,7 @@ from snapred.backend.dao.response.CalibrationAssessmentResponse import Calibrati
 from snapred.backend.data.DataExportService import DataExportService
 from snapred.backend.data.DataFactoryService import DataFactoryService
 from snapred.backend.data.GroceryService import GroceryService
+from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.DiffractionCalibrationRecipe import DiffractionCalibrationRecipe
 from snapred.backend.recipe.GenerateCalibrationMetricsWorkspaceRecipe import GenerateCalibrationMetricsWorkspaceRecipe
@@ -89,6 +91,7 @@ class CalibrationService(Service):
         self.registerPath("loadQualityAssessment", self.loadQualityAssessment)
         self.registerPath("index", self.getCalibrationIndex)
         self.registerPath("diffraction", self.diffractionCalibration)
+        self.registerPath("validateWritePermissions", self.validateWritePermissions)
         return
 
     @staticmethod
@@ -143,6 +146,8 @@ class CalibrationService(Service):
 
     @FromString
     def diffractionCalibration(self, request: DiffractionCalibrationRequest):
+        self.validateRequest(request)
+
         # ingredients
         ingredients = self.prepDiffractionCalibrationIngredients(request)
         ingredients.removeBackground = request.removeBackground
@@ -152,6 +157,42 @@ class CalibrationService(Service):
         # now have all ingredients and groceries, run recipe
         return DiffractionCalibrationRecipe().executeRecipe(ingredients, groceries)
 
+    def validateRequest(self, request: DiffractionCalibrationRequest):
+        """
+        Validate the diffraction-calibration request.
+
+        :param request: a diffraction-calibration request
+        :type request: DiffractionCalibrationRequest
+        """
+
+        # This is a redundant call, but it is placed here to facilitate re-sequencing.
+        permissionsRequest = CalibrationWritePermissionsRequest(
+            runNumber=request.runNumber, continueFlags=request.continueFlags
+        )
+        self.validateWritePermissions(permissionsRequest)
+
+    def validateWritePermissions(self, request: CalibrationWritePermissionsRequest):
+        """
+        Validate that the diffraction-calibration workflow will be able to save its output.
+
+        :param request: a write-permissions request containing the run number and existing continue flags
+        :type request: CalibrationWritePermissionsRequest
+        """
+        # Note: this is split-out as a separate method and a registered service call.
+        #   Permissions must be checked as early as possible in the workflow.
+
+        # check that the user has write permissions to the save directory
+        if not self.checkWritePermissions(request.runNumber):
+            raise RuntimeError(
+                "<font size = ""2"" >"
+                + "<p>It looks like you don't have permissions to write to "
+                + f"<br><b>{self.getSavePath(request.runNumber)}</b>,<br>"
+                + "which is a requirement in order to run the diffraction-calibration workflow.</p>"
+                + "<p>If this is something that you need to do, then you may need to change the "
+                + "<br><b>instrument.calibration.powder.home</b> entry in SNAPRed's <b>application.yml</b> file.</p>"
+                + "</font>"            
+            )
+            
     @FromString
     def focusSpectra(self, request: FocusSpectraRequest):
         # prep the ingredients -- a pixel group
@@ -244,7 +285,7 @@ class CalibrationService(Service):
                             wng.diffCalTable().runNumber(record.runNumber).version(version).build()
                         )
                 case _:
-                    raise RuntimeError(f"Unexpected output type {key} for {wsName}")
+                    raise RuntimeError(f"Unexpected output type {key} for {wsNames}")
             for oldName, newName in zip(wsNames, savedWorkspaces[key]):
                 self.groceryService.renameWorkspace(oldName, newName)
 
@@ -293,6 +334,13 @@ class CalibrationService(Service):
             logger.error(f"Invalid run number: {runId}")
             return False
         return self.dataFactoryService.checkCalibrationStateExists(runId)
+
+    def checkWritePermissions(self, runNumber: str) -> bool:
+        path = self.dataExportService.getCalibrationStateRoot(runNumber)
+        return self.dataExportService.checkWritePermissions(path)
+
+    def getSavePath(self, runNumber: str) -> Path:
+        return self.dataExportService.getCalibrationStateRoot(runNumber)
 
     @staticmethod
     def parseCalibrationMetricList(src: str) -> List[CalibrationMetric]:

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -32,7 +32,6 @@ from snapred.backend.dao.response.CalibrationAssessmentResponse import Calibrati
 from snapred.backend.data.DataExportService import DataExportService
 from snapred.backend.data.DataFactoryService import DataFactoryService
 from snapred.backend.data.GroceryService import GroceryService
-from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.DiffractionCalibrationRecipe import DiffractionCalibrationRecipe
 from snapred.backend.recipe.GenerateCalibrationMetricsWorkspaceRecipe import GenerateCalibrationMetricsWorkspaceRecipe
@@ -184,15 +183,17 @@ class CalibrationService(Service):
         # check that the user has write permissions to the save directory
         if not self.checkWritePermissions(request.runNumber):
             raise RuntimeError(
-                "<font size = ""2"" >"
+                "<font size = "
+                "2"
+                " >"
                 + "<p>It looks like you don't have permissions to write to "
                 + f"<br><b>{self.getSavePath(request.runNumber)}</b>,<br>"
                 + "which is a requirement in order to run the diffraction-calibration workflow.</p>"
                 + "<p>If this is something that you need to do, then you may need to change the "
                 + "<br><b>instrument.calibration.powder.home</b> entry in SNAPRed's <b>application.yml</b> file.</p>"
-                + "</font>"            
+                + "</font>"
             )
-            
+
     @FromString
     def focusSpectra(self, request: FocusSpectraRequest):
         # prep the ingredients -- a pixel group

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -22,7 +22,6 @@ from snapred.backend.dao.response.NormalizationResponse import NormalizationResp
 from snapred.backend.data.DataExportService import DataExportService
 from snapred.backend.data.DataFactoryService import DataFactoryService
 from snapred.backend.data.GroceryService import GroceryService
-from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.GenericRecipe import (
     FocusSpectraRecipe,
@@ -177,7 +176,9 @@ class NormalizationService(Service):
         # check that the user has write permissions to the save directory
         if not self.checkWritePermissions(request.runNumber):
             raise RuntimeError(
-                "<font size = ""2"" >"
+                "<font size = "
+                "2"
+                " >"
                 + "<p>It looks like you don't have permissions to write to "
                 + f"<br><b>{self.getSavePath(request.runNumber)}</b>,<br>"
                 + "which is a requirement in order to run the normalization-calibration workflow.</p>"
@@ -185,7 +186,7 @@ class NormalizationService(Service):
                 + "<br><b>instrument.calibration.powder.home</b> entry in SNAPRed's <b>application.yml</b> file.</p>"
                 + "</font>"
             )
-        
+
     def _sameStates(self, runnumber1, runnumber2):
         stateId1 = self.dataFactoryService.constructStateId(runnumber1)
         stateId2 = self.dataFactoryService.constructStateId(runnumber2)

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -9,6 +9,7 @@ from snapred.backend.dao.normalization import (
     Normalization,
 )
 from snapred.backend.dao.request import (
+    CalibrationWritePermissionsRequest,
     CreateNormalizationRecordRequest,
     FarmFreshIngredients,
     FocusSpectraRequest,
@@ -21,6 +22,7 @@ from snapred.backend.dao.response.NormalizationResponse import NormalizationResp
 from snapred.backend.data.DataExportService import DataExportService
 from snapred.backend.data.DataFactoryService import DataFactoryService
 from snapred.backend.data.GroceryService import GroceryService
+from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.GenericRecipe import (
     FocusSpectraRecipe,
@@ -58,6 +60,7 @@ class NormalizationService(Service):
         self.diffractionCalibrationService = CalibrationService()
         self.sousChef = SousChef()
         self.registerPath("", self.normalization)
+        self.registerPath("validateWritePermissions", self.validateWritePermissions)
         self.registerPath("assessment", self.normalizationAssessment)
         self.registerPath("save", self.saveNormalization)
         self.registerPath("smooth", self.smoothDataExcludingPeaks)
@@ -69,8 +72,7 @@ class NormalizationService(Service):
 
     @FromString
     def normalization(self, request: NormalizationRequest):
-        if not self._sameStates(request.runNumber, request.backgroundRunNumber):
-            raise ValueError("Run number and background run number must be of the same Instrument State.")
+        self.validateRequest(request)
 
         groupingScheme = request.focusGroup.name
 
@@ -147,10 +149,54 @@ class NormalizationService(Service):
             detectorPeaks=ingredients.detectorPeaks,
         ).dict()
 
+    def validateRequest(self, request: NormalizationRequest):
+        """
+        Validate the normalization request.
+
+        :param request: a normalization request
+        :type request: NormalizationRequest
+        """
+        if not self._sameStates(request.runNumber, request.backgroundRunNumber):
+            raise ValueError("Run number and background run number must be of the same Instrument State.")
+
+        # This is a redundant call, but it is placed here to facilitate re-sequencing.
+        permissionsRequest = CalibrationWritePermissionsRequest(
+            runNumber=request.runNumber, continueFlags=request.continueFlags
+        )
+        self.validateWritePermissions(permissionsRequest)
+
+    def validateWritePermissions(self, request: CalibrationWritePermissionsRequest):
+        """
+        Validate that the normalization-calibration workflow will be able to save its output.
+
+        :param request: a write-permissions request containing the run number and existing continue flags
+        :type request: CalibrationWritePermissionsRequest
+        """
+        # Note: this is split-out as a separate method so it can be checked as early as possible in the workflow.
+
+        # check that the user has write permissions to the save directory
+        if not self.checkWritePermissions(request.runNumber):
+            raise RuntimeError(
+                "<font size = ""2"" >"
+                + "<p>It looks like you don't have permissions to write to "
+                + f"<br><b>{self.getSavePath(request.runNumber)}</b>,<br>"
+                + "which is a requirement in order to run the normalization-calibration workflow.</p>"
+                + "<p>If this is something that you need to do, then you may need to change the "
+                + "<br><b>instrument.calibration.powder.home</b> entry in SNAPRed's <b>application.yml</b> file.</p>"
+                + "</font>"
+            )
+        
     def _sameStates(self, runnumber1, runnumber2):
         stateId1 = self.dataFactoryService.constructStateId(runnumber1)
         stateId2 = self.dataFactoryService.constructStateId(runnumber2)
         return stateId1 == stateId2
+
+    def checkWritePermissions(self, runNumber: str) -> bool:
+        path = self.dataExportService.getCalibrationStateRoot(runNumber)
+        return self.dataExportService.checkWritePermissions(path)
+
+    def getSavePath(self, runNumber: str) -> Path:
+        return self.dataExportService.getCalibrationStateRoot(runNumber)
 
     @FromString
     def normalizationAssessment(self, request: NormalizationRequest):

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -116,7 +116,7 @@ mantid:
           smoothedFocusedRawVanadium: "{unit},{group},{runNumber},fitted_van_corr,{version}"
         reduction:
           output: "reduced,{unit},{group},{runNumber},{timestamp}"
-          outputGroup: "reduced,{stateId},{timestamp}"
+          outputGroup: "reduced,{runNumber},{timestamp}"
           pixelMask: "pixelmask,{runNumber},{timestamp}"
           # the user pixel mask name token is case sensitive
           userPixelMask: "MaskWorkspace,{numberTag}"

--- a/src/snapred/ui/handler/SNAPResponseHandler.py
+++ b/src/snapred/ui/handler/SNAPResponseHandler.py
@@ -71,7 +71,7 @@ class SNAPResponseHandler(QWidget):
                 SNAPResponseHandler.handleStateMessage(view, recoverableException)
         elif code == ResponseCode.CONTINUE_WARNING:
             continueInfo = ContinueWarning.Model.model_validate_json(message)
-            if SNAPResponseHandler._handleContinueWarning(continueInfo.message, view):
+            if SNAPResponseHandler._handleContinueWarning(continueInfo, view):
                 view.continueAnyway.emit(continueInfo)
         elif message:
             SNAPResponseHandler._handleWarning(message, view)
@@ -89,7 +89,7 @@ class SNAPResponseHandler(QWidget):
         messageBox.exec()
 
     @staticmethod
-    def _handleContinueWarning(message, view):
+    def _handleContinueWarning(continueInfo: ContinueWarning.Model, view):
         # print stacktrace
         logger.info("It happens here and here")
         import traceback
@@ -99,9 +99,9 @@ class SNAPResponseHandler(QWidget):
         continueAnyway = QMessageBox.warning(
             view,
             "Warning",
-            message,
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            continueInfo.message,
+            buttons=QMessageBox.Yes | QMessageBox.No,
+            defaultButton=QMessageBox.No,
         )
         return continueAnyway == QMessageBox.Yes
 

--- a/src/snapred/ui/view/DiffCalAssessmentView.py
+++ b/src/snapred/ui/view/DiffCalAssessmentView.py
@@ -96,5 +96,5 @@ class DiffCalAssessmentView(QWidget):
         self.signalRunNumberUpdate.emit(runNumber, useLiteMode)
 
     def verify(self):
-        # TODO vwhat fields need to be verified?
+        # TODO: what fields need to be verified?
         return True

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -62,7 +62,7 @@ class DiffCalTweakPeakView(BackendRequestView):
         self.signalMaxChiSqUpdate.connect(self._updateMaxChiSq)
 
         self.continueAnyway = False
-        self.signalContinueAnyway.connect(self._updateContineAnyway)
+        self.signalContinueAnyway.connect(self._updateContinueAnyway)
 
         # create the graph elements
         self.figure = plt.figure(constrained_layout=True)
@@ -112,11 +112,11 @@ class DiffCalTweakPeakView(BackendRequestView):
 
         self.signalUpdateRecalculationButton.connect(self.setEnableRecalculateButton)
 
-    def updateContinueAnyway(self, continueAnyway):
+    def updateContinueAnyway(self, continueAnyway: bool):
         self.signalContinueAnyway.emit(continueAnyway)
 
     @Slot(bool)
-    def _updateContineAnyway(self, continueAnyway):
+    def _updateContinueAnyway(self, continueAnyway: bool):
         self.continueAnyway = continueAnyway
 
     @Slot(str)

--- a/src/snapred/ui/view/reduction/ReductionSaveView.py
+++ b/src/snapred/ui/view/reduction/ReductionSaveView.py
@@ -1,17 +1,62 @@
+from pathlib import Path
+
+from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import QLabel
+from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.view.BackendRequestView import BackendRequestView
 
 
 @Resettable
 class ReductionSaveView(BackendRequestView):
+    signalContinueAnyway = Signal(ContinueWarning.Type)
+    signalSavePath = Signal(Path)
+
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.saveMessage = QLabel(
-            "Please use available Workbench tools to save your data before proceeding."
-            + "\nThey are denoted with the prefix `output_"
-        )
+        self.continueAnywayFlags = None
+        self.signalContinueAnyway.connect(self._updateContinueAnyway)
+
+        self.savePath = None
+        self.signalSavePath.connect(self._updateSavePath)
+
+        self.saveMessage = QLabel("Please use available Workbench tools to save your workspaces before proceeding.")
         self.layout.addWidget(self.saveMessage)
+
+    def updateContinueAnyway(self, continueAnywayFlags: ContinueWarning.Type):
+        self.signalContinueAnyway.emit(continueAnywayFlags)
+
+    @Slot(ContinueWarning.Type)
+    def _updateContinueAnyway(self, continueAnywayFlags: ContinueWarning.Type):
+        self.continueAnywayFlags = continueAnywayFlags
+
+    def updateSavePath(self, path: Path):
+        self.signalSavePath.emit(path)
+
+    @Slot(Path)
+    def _updateSavePath(self, path: Path):
+        self.saveMessage.setEnabled(False)
+        self.savePath = path
+        panelText = None
+        if (
+            self.continueAnywayFlags is not None
+            and ContinueWarning.Type.NO_WRITE_PERMISSIONS in self.continueAnywayFlags
+        ):
+            panelText = (
+                "<p>You didn't have permissions to write to "
+                + f"<br><b>{self.savePath}</b>,<br>"
+                + "but you can still save using the workbench tools.</p>"
+                + "<p>Please remember to save your output workspaces!</p>"
+            )
+        else:
+            panelText = (
+                "<p>Reduction workspaces have been saved to "
+                + f"<br><b>{self.savePath}</b>.<br></p>"
+                + "<p>If required later, these can be reloaded into Mantid workbench using 'LoadNexus'.</p>"
+            )
+        self.saveMessage.setText(panelText)
+        self.saveMessage.setEnabled(True)
+        # self.saveMessage.update() # TODO: is this the correct way to do this?
 
     def verify(self):
         return True

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -1,7 +1,13 @@
 from typing import Dict, List
 
-from snapred.backend.dao.request import ReductionRequest
+from qtpy.QtCore import Slot
+
+from snapred.backend.dao.request import (
+    ReductionExportRequest,
+    ReductionRequest,
+)
 from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
+from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.log.logger import snapredLogger
 from snapred.meta.decorators.ExceptionToErrLog import ExceptionToErrLog
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
@@ -17,16 +23,19 @@ class ReductionWorkflow(WorkflowImplementer):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        self._reductionView = ReductionRequestView(
-            parent=parent, populatePixelMaskDropdown=self._populatePixelMaskDropdown
+        self._reductionRequestView = ReductionRequestView(
+            parent=parent,
+            populatePixelMaskDropdown=self._populatePixelMaskDropdown,
+            validateRunNumbers=self._validateRunNumbers,
         )
         self._compatibleMasks: Dict[str, WorkspaceName] = {}
 
-        self._reductionView.enterRunNumberButton.clicked.connect(lambda: self._populatePixelMaskDropdown())
-        self._reductionView.pixelMaskDropdown.dropDown.view().pressed.connect(self._onPixelMaskSelection)
+        self._reductionRequestView.enterRunNumberButton.clicked.connect(lambda: self._populatePixelMaskDropdown())
+        self._reductionRequestView.pixelMaskDropdown.dropDown.view().pressed.connect(self._onPixelMaskSelection)
 
-        # TODO: Save Screen, to give users a chance to save their work before the reduction
-        # completes and erases the data
+        self._reductionSaveView = ReductionSaveView(
+            parent=parent,
+        )
 
         self.workflow = (
             WorkflowBuilder(
@@ -37,34 +46,35 @@ class ReductionWorkflow(WorkflowImplementer):
             )
             .addNode(
                 self._triggerReduction,
-                self._reductionView,
+                self._reductionRequestView,
                 "Reduction",
                 continueAnywayHandler=self._continueAnywayHandler,
             )
-            .addNode(self._nothing, ReductionSaveView(parent=parent), "Save")
+            .addNode(self._nothing, self._reductionSaveView, "Save")
             .build()
         )
 
-        self._reductionView.retainUnfocusedDataCheckbox.checkedChanged.connect(self._enableConvertToUnits)
+        self._reductionRequestView.retainUnfocusedDataCheckbox.checkedChanged.connect(self._enableConvertToUnits)
 
     def _enableConvertToUnits(self):
-        state = self._reductionView.retainUnfocusedDataCheckbox.isChecked()
-        self._reductionView.convertUnitsDropdown.setEnabled(state)
+        state = self._reductionRequestView.retainUnfocusedDataCheckbox.isChecked()
+        self._reductionRequestView.convertUnitsDropdown.setEnabled(state)
 
     def _nothing(self, workflowPresenter):  # noqa: ARG002
         return SNAPResponse(code=200)
 
     @ExceptionToErrLog
     def _populatePixelMaskDropdown(self):
-        if len(self._reductionView.getRunNumbers()) == 0:
+        if len(self._reductionRequestView.getRunNumbers()) == 0:
             return
 
-        runNumbers = self._reductionView.getRunNumbers()
-        useLiteMode = self._reductionView.liteModeToggle.field.getState()  # noqa: F841
+        runNumbers = self._reductionRequestView.getRunNumbers()
+        useLiteMode = self._reductionRequestView.liteModeToggle.field.getState()  # noqa: F841
 
-        self._reductionView.liteModeToggle.setEnabled(False)
-        self._reductionView.pixelMaskDropdown.setEnabled(False)
-        self._reductionView.retainUnfocusedDataCheckbox.setEnabled(False)
+        self._reductionRequestView.liteModeToggle.setEnabled(False)
+        self._reductionRequestView.pixelMaskDropdown.setEnabled(False)
+        self._reductionRequestView.retainUnfocusedDataCheckbox.setEnabled(False)
+
         # Assemble the list of compatible masks for the current reduction state --
         #   note that all run numbers should be from the same state.
         compatibleMasks = []
@@ -84,21 +94,36 @@ class ReductionWorkflow(WorkflowImplementer):
         #  for reconstruction of the complete type after passing through Qt.
         self._compatibleMasks = {name.toString(): name for name in compatibleMasks}
 
-        self._reductionView.pixelMaskDropdown.setItems(list(self._compatibleMasks.keys()))
+        self._reductionRequestView.pixelMaskDropdown.setItems(list(self._compatibleMasks.keys()))
 
-        self._reductionView.liteModeToggle.setEnabled(True)
-        self._reductionView.pixelMaskDropdown.setEnabled(True)
-        self._reductionView.retainUnfocusedDataCheckbox.setEnabled(True)
-        # self._reductionView.convertUnitsDropdown.setEnabled(True)
+        self._reductionRequestView.liteModeToggle.setEnabled(True)
+        self._reductionRequestView.pixelMaskDropdown.setEnabled(True)
+        self._reductionRequestView.retainUnfocusedDataCheckbox.setEnabled(True)
+        # self._reductionRequestView.convertUnitsDropdown.setEnabled(True)
+
+    def _validateRunNumbers(self, runNumbers: List[str]):
+        # For now, all run numbers in a reduction batch must be from the same instrument state.
+        # This is primarily because pixel-mask selection occurs by instrument state.
+        stateIds = []
+        try:
+            stateIds = self.request(path="reduction/getStateIds", payload=runNumbers).data
+        except Exception as e:  # noqa: BLE001
+            raise ValueError(f"Unable to get instrument state for {runNumbers}: {e}")
+        if len(stateIds) > 1:
+            stateId = stateIds[0]
+            for id_ in stateIds[1:]:
+                if id_ != stateId:
+                    raise ValueError("all run numbers must be from the same state")
 
     def _reconstructPixelMaskNames(self, pixelMasks: List[str]) -> List[WorkspaceName]:
         return [self._compatibleMasks[name] for name in pixelMasks]
 
+    @Slot()
     def _onPixelMaskSelection(self):
         pass
         #  The previous version of this method actually does nothing:  :(
         #
-        # selectedKeys = self._reductionView.getPixelMasks()
+        # selectedKeys = self._reductionRequestView.getPixelMasks()
         # selectedWorkspaceNames = self._reconstructPixelMaskNames(selectedKeys)
         # ReductionRequest.pixelMasks = selectedWorkspaceNames
         #
@@ -107,33 +132,52 @@ class ReductionWorkflow(WorkflowImplementer):
     def _triggerReduction(self, workflowPresenter):
         view = workflowPresenter.widget.tabView  # noqa: F841
 
-        runNumbers = self._reductionView.getRunNumbers()
-        pixelMasks = self._reconstructPixelMaskNames(self._reductionView.getPixelMasks())
+        runNumbers = self._reductionRequestView.getRunNumbers()
+        pixelMasks = self._reconstructPixelMaskNames(self._reductionRequestView.getPixelMasks())
 
         # Use one timestamp for the entire set of runNumbers:
         timestamp = self.request(path="reduction/getUniqueTimestamp").data
         for runNumber in runNumbers:
-            payload = ReductionRequest(
+            request_ = ReductionRequest(
                 runNumber=str(runNumber),
-                useLiteMode=self._reductionView.liteModeToggle.field.getState(),
+                useLiteMode=self._reductionRequestView.liteModeToggle.field.getState(),
                 timestamp=timestamp,
                 continueFlags=self.continueAnywayFlags,
                 pixelMasks=pixelMasks,
-                keepUnfocused=self._reductionView.retainUnfocusedDataCheckbox.isChecked(),
-                convertUnitsTo=self._reductionView.convertUnitsDropdown.currentText(),
+                keepUnfocused=self._reductionRequestView.retainUnfocusedDataCheckbox.isChecked(),
+                convertUnitsTo=self._reductionRequestView.convertUnitsDropdown.currentText(),
             )
-            # TODO: Handle Continue Anyway
-            response = self.request(path="reduction/", payload=payload)
+
+            response = self.request(path="reduction/", payload=request_)
             if response.code == ResponseCode.OK:
-                self.outputs.extend(response.data.workspaces)
-                # Retain the unfocused data after the workflow is complete (if the box was checked),
-                # but do not actually save it as part of the reduction-data file.
+                record, unfocusedData = response.data.record, response.data.unfocusedData
+
+                # .. update "save" panel message:
+                savePath = self.request(path="reduction/getSavePath", payload=record.runNumber).data
+                self._reductionSaveView.updateContinueAnyway(self.continueAnywayFlags)
+                #    Warning: 'updateSavePath' uses the current 'continueAnywayFlags'
+                self._reductionSaveView.updateSavePath(savePath)
+
+                # Save the reduced data. (This is automatic: it happens before the "save" panel opens.)
+                if ContinueWarning.Type.NO_WRITE_PERMISSIONS not in self.continueAnywayFlags:
+                    self.request(path="reduction/save", payload=ReductionExportRequest(record=record))
+
+                # Retain the output workspaces after the workflow is complete.
+                self.outputs.extend(record.workspaceNames)
+
+                # Also retain the unfocused data after the workflow is complete (if the box was checked),
+                #   but do not actually save it as part of the reduction-data file.
                 # The unfocused data does not get added to the response.workspaces list.
-                if response.data.unfocusedData is not None:
-                    self.outputs.append(response.data.unfocusedData)
+                if unfocusedData is not None:
+                    self.outputs.append(unfocusedData)
 
             # Note that the run number is deliberately not deleted from the run numbers list.
             # Almost certainly it should be moved to a "completed run numbers" list.
+
+        # SPECIAL FOR THE REDUCTION WORKFLOW: clear everything _except_ the output workspaces
+        #   _before_ transitioning to the "save" panel.
+        # TODO: make '_clearWorkspaces' a public method (i.e make this combination a special `cleanup` method).
+        self._clearWorkspaces(exclude=self.outputs, clearCachedWorkspaces=True)
 
         return self.responses[-1]
 

--- a/src/snapred/ui/workflow/WorkflowImplementer.py
+++ b/src/snapred/ui/workflow/WorkflowImplementer.py
@@ -95,6 +95,7 @@ class WorkflowImplementer(QObject):
         self.responses = []
         self.outputs = []
         self.collectedOutputs = []
+        self.continueAnywayFlags = ContinueWarning.Type.UNSET
 
         for hook in self.resetHooks:
             hook()

--- a/tests/integration/test_versions_in_order.py
+++ b/tests/integration/test_versions_in_order.py
@@ -86,10 +86,10 @@ class ImitationDataService(LocalDataService):
         # if this is not overriden, it creates hundreds of headaches
         return Resource.getPath("inputs/testInstrument/IPTS-456/")
 
-    def _generateStateId(self, runId: str) -> Tuple[str, str]:
+    def generateStateId(self, runId: str) -> Tuple[str, str]:
         return (self.stateId, "gibberish")
 
-    def _constructCalibrationStateRoot(self, stateId) -> Path:
+    def constructCalibrationStateRoot(self, stateId) -> Path:
         return Path(self._stateRoot)
 
     def readCalibrationState(self, runId: str, useLiteMode: bool):
@@ -245,8 +245,8 @@ class TestVersioning(TestCase):
         self.instance.dataFactoryService.lookupService = self.localDataService
         self.instance.sousChef.dataFactoryService = self.instance.dataFactoryService
 
-        self.stateId = self.localDataService._generateStateId(self.runNumber)
-        self.stateRoot = self.localDataService._constructCalibrationStateRoot(self.stateId)
+        self.stateId = self.localDataService.generateStateId(self.runNumber)
+        self.stateRoot = self.localDataService.constructCalibrationStateRoot(self.stateId)
 
         # grab the associated Indexer
         self.indexer = self.localDataService.calibrationIndexer(self.runNumber, self.useLiteMode)

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -123,7 +123,7 @@ mantid:
             smoothedFocusedRawVanadium: "_{unit},{group},fitted_van_corr,{runNumber},{version}"
           reduction:
             output: "_reduced,{unit},{group},{runNumber},{timestamp}"
-            outputGroup: "_reduced,{stateId},{timestamp}"
+            outputGroup: "_reduced,{runNumber},{timestamp}"
             pixelMask: "_pixelmask,{runNumber},{timestamp}"
             # the user pixel mask name token is case sensitive
             userPixelMask: "MaskWorkspace,{numberTag}"

--- a/tests/unit/backend/data/test_DataExportService.py
+++ b/tests/unit/backend/data/test_DataExportService.py
@@ -39,6 +39,11 @@ class TestDataExportService(unittest.TestCase):
         self.instance.checkFileandPermission(filePath)
         assert self.instance.dataService.checkFileandPermission.called
 
+    def test_checkWritePermissions(self):
+        path = Path("some/mock/path")
+        self.instance.checkWritePermissions(path)
+        assert self.instance.dataService.checkWritePermissions.called
+
     def test_getUniqueTimestamp(self):
         self.instance.getUniqueTimestamp()
         assert self.instance.dataService.getUniqueTimestamp.called
@@ -56,6 +61,15 @@ class TestDataExportService(unittest.TestCase):
     def test_exportCalibrationWorkspaces(self):
         self.instance.exportCalibrationWorkspaces(mock.Mock())
         assert self.instance.dataService.writeCalibrationWorkspaces.called
+
+    def test_getCalibrationStateRoot(self):
+        with mock.patch.object(self.instance.dataService, "generateStateId") as mockGenerateStateId:
+            mockGenerateStateId.return_value = ("1a2b3c4d5e6f7a8b", None)
+            self.instance.getCalibrationStateRoot(mock.Mock())
+            assert mockGenerateStateId.called
+            self.instance.dataService.constructCalibrationStateRoot.assert_called_once_with(
+                mockGenerateStateId.return_value[0]
+            )
 
     def test_exportCalibrationState(self):
         self.instance.exportCalibrationState(mock.Mock())
@@ -92,6 +106,10 @@ class TestDataExportService(unittest.TestCase):
     def test_exportReductionData(self):
         self.instance.exportReductionData(mock.Mock())
         assert self.instance.dataService.writeReductionData.called
+
+    def test_getReductionStateRoot(self):
+        self.instance.getReductionStateRoot(mock.Mock())
+        assert self.instance.dataService._constructReductionStateRoot.called
 
     ##### TEST WORKSPACE METHODS #####
 

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -827,11 +827,7 @@ def test_CheckFileAndPermission_fileDoesNotExist(mockExists):  # noqa: ARG001
 @mock.patch("os.stat")
 @mock.patch("pathlib.Path.exists", return_value=True)
 def test_checkFileAndPermission_fileExistsAndWritePermission(mockExists, mockStat, mockS_IMODE):  # noqa: ARG001
-    mockStat.return_value = mock.Mock(
-        st_uid=os.getuid(),
-        st_gid=os.getgroups()[0],
-        st_mode=0o777
-    )
+    mockStat.return_value = mock.Mock(st_uid=os.getuid(), st_gid=os.getgroups()[0], st_mode=0o777)
     filePath = Path("/some/path/to/file")
     localDS = LocalDataService()
     localDS._hasWritePermissionstoPath = mock.Mock()
@@ -844,11 +840,7 @@ def test_checkFileAndPermission_fileExistsAndWritePermission(mockExists, mockSta
 @mock.patch("os.stat")
 @mock.patch("pathlib.Path.exists", return_value=True)
 def test__hasWritePermissionsToPath_fileExistsWithPermission(mockExists, mockStat, mockS_IMODE):  # noqa: ARG001
-    mockStat.return_value = mock.Mock(
-        st_uid=os.getuid(),
-        st_gid=os.getgroups()[0],
-        st_mode=0o777
-    )
+    mockStat.return_value = mock.Mock(st_uid=os.getuid(), st_gid=os.getgroups()[0], st_mode=0o777)
     filePath = Path("/some/path/to/file")
     localDS = LocalDataService()
     result = localDS._hasWritePermissionstoPath(filePath)

--- a/tests/unit/backend/service/test_ReductionService.py
+++ b/tests/unit/backend/service/test_ReductionService.py
@@ -1,5 +1,6 @@
 import unittest
 import unittest.mock as mock
+from pathlib import Path
 from typing import List
 
 import numpy as np
@@ -71,8 +72,6 @@ class TestReductionService(unittest.TestCase):
             versions=(1, 2),
             pixelMasks=[],
             focusGroups=[FocusGroup(name="apple", definition="path/to/grouping")],
-            continueFlags=ContinueWarning.Type.MISSING_DIFFRACTION_CALIBRATION
-            | ContinueWarning.Type.MISSING_NORMALIZATION,
         )
 
     def test_name(self):
@@ -122,7 +121,9 @@ class TestReductionService(unittest.TestCase):
         }
         mockReductionRecipe.return_value.cook = mock.Mock(return_value=mockResult)
         self.instance.dataFactoryService.getThisOrLatestCalibrationVersion = mock.Mock(return_value=1)
+        self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
         self.instance.dataFactoryService.getThisOrLatestNormalizationVersion = mock.Mock(return_value=1)
+        self.instance.dataFactoryService.normalizationExists = mock.Mock(return_value=True)
 
         result = self.instance.reduction(self.request)
         groupings = self.instance.fetchReductionGroupings(self.request)
@@ -131,7 +132,7 @@ class TestReductionService(unittest.TestCase):
         groceries["groupingWorkspaces"] = groupings["groupingWorkspaces"]
         mockReductionRecipe.assert_called()
         mockReductionRecipe.return_value.cook.assert_called_once_with(ingredients, groceries)
-        assert result.workspaces == mockReductionRecipe.return_value.cook.return_value["outputs"]
+        assert result.record.workspaceNames == mockReductionRecipe.return_value.cook.return_value["outputs"]
 
     def test_saveReduction(self):
         with (
@@ -146,7 +147,7 @@ class TestReductionService(unittest.TestCase):
                 useLiteMode=useLiteMode,
                 timestamp=timestamp,
             )
-            request = ReductionExportRequest(reductionRecord=record)
+            request = ReductionExportRequest(record=record)
             with reduction_root_redirect(self.localDataService):
                 self.instance.saveReduction(request)
                 mockExportRecord.assert_called_once_with(record)
@@ -164,6 +165,44 @@ class TestReductionService(unittest.TestCase):
         assert self.instance.hasState("123456")
         assert not self.instance.hasState("not a state")
         assert not self.instance.hasState("1")
+
+    def test_uniqueTimestamp(self):
+        with mock.patch.object(self.instance.dataExportService, "getUniqueTimestamp") as mockTimestamp:
+            mockTimestamp.return_value = 123.456
+            assert self.instance.getUniqueTimestamp() == mockTimestamp.return_value
+
+    def test_checkWritePermissions(self):
+        with (
+            mock.patch.object(self.instance.dataExportService, "checkWritePermissions") as mockCheckWritePermissions,
+            mock.patch.object(self.instance.dataExportService, "getReductionStateRoot") as mockGetReductionStateRoot,
+        ):
+            runNumber = "12345"
+            mockCheckWritePermissions.return_value = True
+            mockGetReductionStateRoot.return_value = Path("/reduction/state/root")
+            assert self.instance.checkWritePermissions(runNumber)
+            mockCheckWritePermissions.assert_called_once_with(mockGetReductionStateRoot.return_value)
+            mockGetReductionStateRoot.assert_called_once_with(runNumber)
+
+    def test_getSavePath(self):
+        with mock.patch.object(self.instance.dataExportService, "getReductionStateRoot") as mockGetReductionStateRoot:
+            runNumber = "12345"
+            expected = Path("/reduction/state/root")
+            mockGetReductionStateRoot.return_value = expected
+            actual = self.instance.getSavePath(runNumber)
+            assert actual == expected
+            mockGetReductionStateRoot.assert_called_once_with(runNumber)
+
+    def test_getStateIds(self):
+        expectedStateIds = ["0" * 16, "1" * 16, "2" * 16, "3" * 16]
+        with mock.patch.object(self.instance.dataFactoryService, "constructStateId") as mockConstructStateId:
+            runNumbers = ["4" * 6, "5" * 6, "6" * 6, "7" * 6]
+            mockConstructStateId.side_effect = lambda runNumber: (
+                dict(zip(runNumbers, expectedStateIds))[runNumber],
+                None,
+            )
+            actualStateIds = self.instance.getStateIds(runNumbers)
+            assert actualStateIds == expectedStateIds
+            mockConstructStateId.call_count == len(runNumbers)
 
     def test_groupRequests(self):
         payload = self.request.json()
@@ -190,11 +229,11 @@ class TestReductionService(unittest.TestCase):
         assert result["root"]["state1"]["normalization_0"][0] == request
 
     def test_validateReduction(self):
-        # assert no exceptions are raised
-        try:
-            self.instance.validateReduction(self.request)
-        except Exception as e:  # noqa: BLE001
-            self.fail(f"Unexpected exception: {e}")
+        fakeDataService = mock.Mock()
+        fakeDataService.calibrationExists.return_value = True
+        fakeDataService.normalizationExists.return_value = True
+        self.instance.dataFactoryService = fakeDataService
+        self.instance.validateReduction(self.request)
 
     def test_validateReduction_noCalibration(self):
         # assert ContinueWarning is raised
@@ -203,17 +242,113 @@ class TestReductionService(unittest.TestCase):
         # its even in the same file
         fakeDataService = mock.Mock()
         fakeDataService.calibrationExists.return_value = False
+        fakeDataService.normalizationExists.return_value = True
         self.instance.dataFactoryService = fakeDataService
-        with pytest.raises(ContinueWarning):
+        with pytest.raises(ContinueWarning) as excInfo:
             self.instance.validateReduction(self.request)
+        assert excInfo.value.model.flags == ContinueWarning.Type.MISSING_DIFFRACTION_CALIBRATION
 
     def test_validateReduction_noNormalization(self):
         # assert ContinueWarning is raised
         fakeDataService = mock.Mock()
+        fakeDataService.calibrationExists.return_value = True
         fakeDataService.normalizationExists.return_value = False
         self.instance.dataFactoryService = fakeDataService
-        with pytest.raises(ContinueWarning):
+        with pytest.raises(ContinueWarning) as excInfo:
             self.instance.validateReduction(self.request)
+        assert excInfo.value.model.flags == ContinueWarning.Type.MISSING_NORMALIZATION
+
+    def test_validateReduction_reentry(self):
+        # assert ContinueWarning is NOT raised multiple times
+        fakeDataService = mock.Mock()
+        fakeDataService.calibrationExists.return_value = False
+        fakeDataService.normalizationExists.return_value = False
+        self.instance.dataFactoryService = fakeDataService
+        self.request.continueFlags = (
+            ContinueWarning.Type.MISSING_DIFFRACTION_CALIBRATION | ContinueWarning.Type.MISSING_NORMALIZATION
+        )
+        self.instance.validateReduction(self.request)
+
+    def test_validateReduction_no_permissions(self):
+        # assert ContinueWarning is raised
+        fakeDataService = mock.Mock()
+        fakeDataService.calibrationExists.return_value = True
+        fakeDataService.normalizationExists.return_value = True
+        self.instance.dataFactoryService = fakeDataService
+        fakeExportService = mock.Mock()
+        fakeExportService.checkWritePermissions.return_value = False
+        self.instance.dataExportService = fakeExportService
+        with pytest.raises(ContinueWarning) as excInfo:
+            self.instance.validateReduction(self.request)
+        assert excInfo.value.model.flags == ContinueWarning.Type.NO_WRITE_PERMISSIONS
+
+    def test_validateReduction_no_permissions_reentry(self):
+        # assert ContinueWarning is NOT raised multiple times
+        fakeDataService = mock.Mock()
+        fakeDataService.calibrationExists.return_value = True
+        fakeDataService.normalizationExists.return_value = True
+        self.instance.dataFactoryService = fakeDataService
+        fakeExportService = mock.Mock()
+        fakeExportService.checkWritePermissions.return_value = False
+        self.instance.dataExportService = fakeExportService
+        self.request.continueFlags = ContinueWarning.Type.NO_WRITE_PERMISSIONS
+        self.instance.validateReduction(self.request)
+
+    def test_validateReduction_no_permissions_and_no_calibrations(self):
+        # assert ContinueWarning is raised
+        fakeDataService = mock.Mock()
+        fakeDataService.calibrationExists.return_value = False
+        fakeDataService.normalizationExists.return_value = False
+        self.instance.dataFactoryService = fakeDataService
+        fakeExportService = mock.Mock()
+        fakeExportService.checkWritePermissions.return_value = False
+        self.instance.dataExportService = fakeExportService
+        with pytest.raises(ContinueWarning) as excInfo:
+            self.instance.validateReduction(self.request)
+
+        # Note: this tests the _first_ continue-anyway check,
+        #   which _only_ deals with the calibrations.
+        assert (
+            excInfo.value.model.flags
+            == ContinueWarning.Type.MISSING_DIFFRACTION_CALIBRATION | ContinueWarning.Type.MISSING_NORMALIZATION
+        )
+
+    def test_validateReduction_no_permissions_and_no_calibrations_first_reentry(self):
+        # assert ContinueWarning is raised
+        fakeDataService = mock.Mock()
+        fakeDataService.calibrationExists.return_value = False
+        fakeDataService.normalizationExists.return_value = False
+        self.instance.dataFactoryService = fakeDataService
+        fakeExportService = mock.Mock()
+        fakeExportService.checkWritePermissions.return_value = False
+        self.instance.dataExportService = fakeExportService
+        self.request.continueFlags = (
+            ContinueWarning.Type.MISSING_DIFFRACTION_CALIBRATION | ContinueWarning.Type.MISSING_NORMALIZATION
+        )
+        with pytest.raises(ContinueWarning) as excInfo:
+            self.instance.validateReduction(self.request)
+
+        # Note: this tests re-entry for the _first_ continue-anyway check,
+        #   but with no re-entry for the second continue-anyway check.
+        assert excInfo.value.model.flags == ContinueWarning.Type.NO_WRITE_PERMISSIONS
+
+    def test_validateReduction_no_permissions_and_no_calibrations_second_reentry(self):
+        # assert ContinueWarning is raised
+        fakeDataService = mock.Mock()
+        fakeDataService.calibrationExists.return_value = False
+        fakeDataService.normalizationExists.return_value = False
+        self.instance.dataFactoryService = fakeDataService
+        fakeExportService = mock.Mock()
+        fakeExportService.checkWritePermissions.return_value = False
+        self.instance.dataExportService = fakeExportService
+        self.request.continueFlags = (
+            ContinueWarning.Type.MISSING_DIFFRACTION_CALIBRATION
+            | ContinueWarning.Type.MISSING_NORMALIZATION
+            | ContinueWarning.Type.NO_WRITE_PERMISSIONS
+        )
+        # Note: this tests re-entry for the _first_ continue-anyway check,
+        #   and in addition, re-entry for the second continue-anyway check.
+        self.instance.validateReduction(self.request)
 
 
 class TestReductionServiceMasks:
@@ -289,7 +424,7 @@ class TestReductionServiceMasks:
     def _setup_test_mocks(self, monkeypatch, cleanup_workspace_at_exit):
         monkeypatch.setattr(
             self.service.dataFactoryService.lookupService,
-            "_generateStateId",
+            "generateStateId",
             lambda runNumber: {
                 self.runNumber1: (self.stateId1, None),
                 self.runNumber2: (self.stateId1, None),

--- a/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
+++ b/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
@@ -131,10 +131,11 @@ def testReductionOutputName():
 
 def testReductionOutputGroupName():
     assert (  # "reduced_data,{stateId},{timestamp}"
-        f"_reduced_{fStateId}" == wng.reductionOutputGroup().stateId(stateId).build()
+        f"_reduced_{fRunNumber}" == wng.reductionOutputGroup().runNumber(runNumber).build()
     )
     assert (
-        f"_reduced_{fStateId}_{fTimestamp}" == wng.reductionOutputGroup().stateId(stateId).timestamp(timestamp).build()
+        f"_reduced_{fRunNumber}_{fTimestamp}"
+        == wng.reductionOutputGroup().runNumber(runNumber).timestamp(timestamp).build()
     )
 
 

--- a/tests/util/WhateversInTheFridge.py
+++ b/tests/util/WhateversInTheFridge.py
@@ -63,7 +63,7 @@ class WhateversInTheFridge(LocalDataService):
         return str(self.iptsCache[key])
 
     @ExceptionHandler(StateValidationException)
-    def _generateStateId(self, runId: str) -> Tuple[str, str]:
+    def generateStateId(self, runId: str) -> Tuple[str, str]:
         stateId = DAOFactory.magical_state_id.copy()
         return stateId.hex, stateId.decodedKey
 

--- a/tests/util/state_helpers.py
+++ b/tests/util/state_helpers.py
@@ -31,8 +31,8 @@ def state_root_override(runNumber: str, name: str, useLiteMode: bool = False, de
 
     # __enter__
     dataService = LocalDataService()
-    stateId, _ = dataService._generateStateId(runNumber)
-    stateRoot = Path(dataService._constructCalibrationStateRoot(stateId))
+    stateId, _ = dataService.generateStateId(runNumber)
+    stateRoot = Path(dataService.constructCalibrationStateRoot(stateId))
     if stateRoot.exists():
         raise RuntimeError(f"state-root directory '{stateRoot}' already exists -- please move it out of the way!")
 
@@ -74,8 +74,8 @@ class state_root_redirect:
     def __init__(self, dataService: LocalDataService, *, stateId: str = None):
         self.dataService = dataService
         self.stateId = stateId
-        self.old_constructCalibrationStateRoot = dataService._constructCalibrationStateRoot
-        self.old_generateStateId = dataService._generateStateId
+        self.old_constructCalibrationStateRoot = dataService.constructCalibrationStateRoot
+        self.old_generateStateId = dataService.generateStateId
 
     def __enter__(self):
         self.tmpdir = TemporaryDirectory(dir=Resource.getPath("outputs"), suffix="/")
@@ -84,13 +84,13 @@ class state_root_redirect:
             self.tmppath = self.tmppath / Path(self.stateId)
         else:
             self.stateId = str(self.tmppath.parts[-1])
-        self.dataService._generateStateId = lambda *x, **y: (self.stateId, None)  # noqa ARG005
-        self.dataService._constructCalibrationStateRoot = lambda *x, **y: self.tmppath  # noqa ARG005
+        self.dataService.generateStateId = lambda *x, **y: (self.stateId, None)  # noqa ARG005
+        self.dataService.constructCalibrationStateRoot = lambda *x, **y: self.tmppath  # noqa ARG005
         return self
 
     def __exit__(self, *arg, **kwargs):
-        self.dataService._constructCalibrationStateRoot = self.old_constructCalibrationStateRoot
-        self.dataService._generateStateId = self.old_generateStateId
+        self.dataService.constructCalibrationStateRoot = self.old_constructCalibrationStateRoot
+        self.dataService.generateStateId = self.old_generateStateId
         self.tmpdir.cleanup()
         assert not self.tmppath.exists()
         del self.tmpdir
@@ -129,7 +129,7 @@ class reduction_root_redirect:
         self.dataService = dataService
         self.stateId = stateId
         self.old_constructReductionStateRoot = dataService._constructReductionStateRoot
-        self.old_generateStateId = dataService._generateStateId
+        self.old_generateStateId = dataService.generateStateId
 
     def __enter__(self):
         self.tmpdir = TemporaryDirectory(dir=Resource.getPath("outputs"), suffix="/")
@@ -138,13 +138,13 @@ class reduction_root_redirect:
             self.tmppath = self.tmppath / Path(self.stateId)
         else:
             self.stateId = str(self.tmppath.parts[-1])
-        self.dataService._generateStateId = lambda *x, **y: (self.stateId, None)  # noqa ARG005
+        self.dataService.generateStateId = lambda *x, **y: (self.stateId, None)  # noqa ARG005
         self.dataService._constructReductionStateRoot = lambda *x, **y: self.tmppath  # noqa ARG005
         return self
 
     def __exit__(self, *arg, **kwargs):
         self.dataService._constructReductionStateRoot = self.old_constructReductionStateRoot
-        self.dataService._generateStateId = self.old_generateStateId
+        self.dataService.generateStateId = self.old_generateStateId
         self.tmpdir.cleanup()
         assert not self.tmppath.exists()
         del self.tmpdir

--- a/tests/util_tests/test_state_helpers.py
+++ b/tests/util_tests/test_state_helpers.py
@@ -36,7 +36,7 @@ def initPVFileMock():
 
 
 @mock.patch.object(LocalDataService, "_writeDefaultDiffCalTable")
-@mock.patch.object(LocalDataService, "_generateStateId")
+@mock.patch.object(LocalDataService, "generateStateId")
 @mock.patch.object(LocalDataService, "_readDefaultGroupingMap")
 @mock.patch.object(LocalDataService, "readInstrumentConfig")
 @mock.patch.object(LocalDataService, "_readPVFile")
@@ -132,13 +132,13 @@ def test_state_root_override_exit_no_delete(
 
 def test_state_root_redirect_no_stateid():
     localDataService = LocalDataService()
-    oldSelf = localDataService._constructCalibrationStateRoot
+    oldSelf = localDataService.constructCalibrationStateRoot
     with state_root_redirect(localDataService) as tmpRoot:
         # make sure the path exists
         assert tmpRoot.path().exists()
         # make sure the data service's path points to the tmp directory
-        assert localDataService._constructCalibrationStateRoot() == tmpRoot.path()
-        assert localDataService._generateStateId()[0] == tmpRoot.path().parts[-1]
+        assert localDataService.constructCalibrationStateRoot() == tmpRoot.path()
+        assert localDataService.generateStateId()[0] == tmpRoot.path().parts[-1]
         # make sure a file can be added inside the directory -- can be any file
         # verify it can be found by data services and equals the value written
         localDataService.calibrationExists = mock.Mock(return_value=True)
@@ -153,7 +153,7 @@ def test_state_root_redirect_no_stateid():
     # make sure the directory is deleted at exit
     assert not tmpRoot.path().exists()
     # make sure the construct state root method is restored on exit
-    assert oldSelf == localDataService._constructCalibrationStateRoot
+    assert oldSelf == localDataService.constructCalibrationStateRoot
 
 
 def test_state_root_redirect_with_stateid():
@@ -161,9 +161,9 @@ def test_state_root_redirect_with_stateid():
     localDataService = LocalDataService()
     with state_root_redirect(localDataService, stateId=stateId) as tmpRoot:
         # make sure the root is pointing to this state ID
-        assert localDataService._generateStateId() == (stateId, None)
-        assert localDataService._constructCalibrationStateRoot() == tmpRoot.path()
-        assert stateId == localDataService._constructCalibrationStateRoot().parts[-1]
+        assert localDataService.generateStateId() == (stateId, None)
+        assert localDataService.constructCalibrationStateRoot() == tmpRoot.path()
+        assert stateId == localDataService.constructCalibrationStateRoot().parts[-1]
 
 
 def test_reduction_root_redirect_no_stateid():
@@ -174,7 +174,7 @@ def test_reduction_root_redirect_no_stateid():
         assert tmpRoot.path().exists()
         # make sure the data service's path points to the tmp directory
         assert localDataService._constructReductionStateRoot() == tmpRoot.path()
-        assert localDataService._generateStateId()[0] == tmpRoot.path().parts[-1]
+        assert localDataService.generateStateId()[0] == tmpRoot.path().parts[-1]
     # make sure the directory is deleted at exit
     assert not tmpRoot.path().exists()
     # make sure the construct state root method is restored on exit
@@ -186,6 +186,6 @@ def test_reduction_root_redirect_with_stateid():
     localDataService = LocalDataService()
     with reduction_root_redirect(localDataService, stateId=stateId) as tmpRoot:
         # make sure the root is pointing to this state ID
-        assert localDataService._generateStateId() == (stateId, None)
+        assert localDataService.generateStateId() == (stateId, None)
         assert localDataService._constructReductionStateRoot() == tmpRoot.path()
         assert stateId == localDataService._constructReductionStateRoot().parts[-1]


### PR DESCRIPTION

## Description of work

At the end of the reduction process for each run number, the complete reduction output data and metadata are saved to a path under the IPTS directory associated with that run number.  This saving step occurs automatically prior to the display of the actual reduction "save" panel. In addition, any cleanup of ADS-resident workspaces occurs at the same time.  The final reduction "save" panel now shows a helpful message indicating that the data has been saved, and to which output path (shown as the reduction-output state root).

In the case that the user does not have write permissions to the expected save directory, a continue-anyway prompt is displayed at the start of the reduction process. In this case, the message in the "save" panel reminds the user that they need to save their output workspaces.

## Explanation of work

This commit includes the following changes:

  * Automatic save of reduction output-workspace data and metadata at the end of the reduction process for each run;

  * Checks of write-permissions and any associated notification prior to the start of the reduction process;

  * Analogous write-permissions checks prior to the start of the diffraction-calibration and normalization-calibration processes;  Note that unlike reduction, users without the required write permissions for diffraction-calibration or normalization-calibration are not allowed to continue with these processes.  Regardless, the continue-anyway mechanisms have been applied to this purpose, as this then allows any modification of all of this behavior to be centralized.

  * Same-state verification of run numbers entered in the reduction-request panel.  At present, in order to facilitate pixel-mask selection, all run numbers must be from the same state.  This requirement can eventually be omitted through the addition of a more-complicated reduction-panel sequence involving pixel-mask selection and assignment on a per-state basis.

  * Reduction output filenames now include the run number, rather than the state-id.  (Note that this is the first time that these output steps have actually been hooked up, so this change shouldn't affect anything.)

  * Adjustments to the text format in some continue-anyway message boxes in order to make better use of screen real estate.  Some text is smaller, and some _bold_ formatting is now used.

  * Fixups to `ValueError` input-validation behavior in the reduction panels so that these exceptions actually result in message boxes, rather than core dumps.  Note that the previous code had been written under the assumption that all of these input-validation steps were occurring in sections wrapped by `SNAPResponseHandler`, and this is most definitely _not_ the case.

  * Fixups to continue-anyway logic.  This allows multiple continue-anyway messages to pop-up in the correct sequence, and prevents these queries from occurring multiple times.

  * Implementation of a more general service-layer `checkWritePermissions` method, which actually checks whether or not the user _could_ correctly _create_ a given path, provided at least one of its parent components exists.

## To test

### Dev testing
Additional unit tests have been added to cover the changes of this commit.  Several _existing_ unit tests were modified so that they made a bit more sense (e.g. continue-anyway logic).

**Automatic save process:** verify that the expected files are written to the correct location on disk.  Ironically, the easiest way to get this location is to look at the message in the final "save" panel.  Note that the _contents_ of these files has been verified elsewhere, and is _not_ part of this pull request.

**In order to test the write permissions tests and notifications:**
    Start with an SNS-mirror section, containing your favorite run numbers (e.g. 46680 and 61991 -- two different states).  Step by step, going through the workflows: (1) demonstrate that the panel succeeds as expected in normal operation; (2) `chmod 555 "instrument.calibration.powder.home" / <state id>` -- demonstrate that the notification pops up, and you aren't actually allowed to continue with diffraction-calibration or normalization-calibration workflows, and (3) for reduction, `chmod 555 <read out the save directory root from the successful process test>` -- a notification should pop up, and after continuing, the "save" panel should show an appropriate reminder.


### CIS testing
Same as for dev testing.


## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#6323](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=6323)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
