### PR TITLE
Reduction save panel [staging]

### DIFF
--- a/docs/source/api/snapred.ui.view.rst
+++ b/docs/source/api/snapred.ui.view.rst
@@ -30,7 +30,7 @@ snapred.ui.view.DiffCalAssessmentView module
    :show-inheritance:
 
 snapred.ui.view.DiffCalRequestView module
-------------------------------------------------------
+-----------------------------------------
 
 .. automodule:: snapred.ui.view.DiffCalRequestView
    :members:
@@ -105,7 +105,7 @@ snapred.ui.view.NormalizationRequestView module
    :show-inheritance:
 
 snapred.ui.view.NormalizationSaveView module
------------------------------------------------
+--------------------------------------------
 
 .. automodule:: snapred.ui.view.NormalizationSaveView
    :members:
@@ -132,10 +132,10 @@ snapred.ui.view.PromptUserforCalibrationInputView module
    :show-inheritance:
    :exclude-members: dataEntered
 
-snapred.ui.view.reduction.ReductionView module
-----------------------------------------------
+snapred.ui.view.reduction.ReductionRequestView module
+-----------------------------------------------------
 
-.. automodule:: snapred.ui.view.reduction.ReductionView
+.. automodule:: snapred.ui.view.reduction.ReductionRequestView
    :members:
    :undoc-members:
    :exclude-members: signalRemoveRunNumber

--- a/src/snapred/backend/dao/calibration/CalibrationIndexEntry.py
+++ b/src/snapred/backend/dao/calibration/CalibrationIndexEntry.py
@@ -22,7 +22,7 @@ class CalibrationIndexEntry(BaseModel):
     appliesTo: Optional[str] = None
     comments: str
     author: str
-    timestamp: Optional[int] = None
+    timestamp: Optional[float] = None
 
     def parseAppliesTo(appliesTo: str):
         symbols = [">=", "<=", "<", ">"]

--- a/src/snapred/backend/dao/reduction/ReductionRecord.py
+++ b/src/snapred/backend/dao/reduction/ReductionRecord.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -19,13 +19,13 @@ class ReductionRecord(BaseModel):
     # Reduction has distinct registration attributes from Calibration and Normalization.
     #   for this reason, this class is not derived from 'Record',
     #   and does not include a 'CalculationParameters' instance.
+    runNumber: str
     useLiteMode: bool
     timestamp: float = Field(frozen=True, default=None)
 
     # specific to reduction records
-    runNumber: str
-    calibration: CalibrationRecord
-    normalization: NormalizationRecord
+    calibration: Optional[CalibrationRecord] = None
+    normalization: Optional[NormalizationRecord] = None
     pixelGroupingParameters: Dict[str, List[PixelGroupingParameters]]
 
     workspaceNames: List[WorkspaceName]

--- a/src/snapred/backend/dao/request/CalibrationWritePermissionsRequest.py
+++ b/src/snapred/backend/dao/request/CalibrationWritePermissionsRequest.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+from snapred.backend.error.ContinueWarning import ContinueWarning
+
+
+class CalibrationWritePermissionsRequest(BaseModel):
+    runNumber: str
+    continueFlags: ContinueWarning.Type

--- a/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
+++ b/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
@@ -1,10 +1,11 @@
 # TODO this can probably be relaced in the code with FarmFreshIngredients
-from typing import Any
+from typing import Any, Optional
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
 from snapred.backend.dao.Limit import Pair
 from snapred.backend.dao.state.FocusGroup import FocusGroup
+from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.meta.Config import Config
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
 
@@ -35,6 +36,8 @@ class DiffractionCalibrationRequest(BaseModel, extra="forbid"):
     maximumOffset: float = Config["calibration.diffraction.maximumOffset"]
     fwhmMultipliers: Pair[float] = Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
     maxChiSq: float = Config["constants.GroupDiffractionCalibration.MaxChiSq"]
+
+    continueFlags: Optional[ContinueWarning.Type] = ContinueWarning.Type.UNSET
 
     @field_validator("fwhmMultipliers", mode="before")
     @classmethod

--- a/src/snapred/backend/dao/request/NormalizationRequest.py
+++ b/src/snapred/backend/dao/request/NormalizationRequest.py
@@ -1,7 +1,10 @@
+from typing import Optional
+
 from pydantic import BaseModel
 
 from snapred.backend.dao.Limit import Limit, Pair
 from snapred.backend.dao.state.FocusGroup import FocusGroup
+from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.meta.Config import Config
 
 
@@ -28,3 +31,5 @@ class NormalizationRequest(BaseModel, extra="forbid"):
     peakIntensityThreshold: float = Config["constants.PeakIntensityFractionThreshold"]
     nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]
     fwhmMultipliers: Pair[float] = Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
+
+    continueFlags: Optional[ContinueWarning.Type] = ContinueWarning.Type.UNSET

--- a/src/snapred/backend/dao/request/ReductionExportRequest.py
+++ b/src/snapred/backend/dao/request/ReductionExportRequest.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from snapred.backend.dao.reduction.ReductionRecord import ReductionRecord
 
@@ -7,8 +7,13 @@ class ReductionExportRequest(BaseModel):
     """
 
     Sent from reduction workflow to reduction service, requesting
-    the reduction service save the data for the reduction.
+    the reduction service to save the data for the reduction.
 
     """
 
-    reductionRecord: ReductionRecord
+    record: ReductionRecord
+
+    model_config = ConfigDict(
+        # required in order to use 'WorkspaceName'
+        arbitrary_types_allowed=True,
+    )

--- a/src/snapred/backend/dao/request/ReductionRequest.py
+++ b/src/snapred/backend/dao/request/ReductionRequest.py
@@ -19,6 +19,6 @@ class ReductionRequest(BaseModel):
     versions: Versions = Versions(None, None)
 
     # TODO: Move to SNAPRequest
-    continueFlags: Optional[ContinueWarning.Type] = None
+    continueFlags: Optional[ContinueWarning.Type] = ContinueWarning.Type.UNSET
 
     model_config = ConfigDict(extra="forbid")

--- a/src/snapred/backend/dao/response/ReductionResponse.py
+++ b/src/snapred/backend/dao/response/ReductionResponse.py
@@ -1,15 +1,11 @@
-from typing import List
-
 from pydantic import BaseModel, ConfigDict
 
-from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
+from snapred.backend.dao.reduction.ReductionRecord import ReductionRecord
 
 
 class ReductionResponse(BaseModel):
-    workspaces: List[WorkspaceName]
+    record: ReductionRecord
 
     model_config = ConfigDict(
         extra="forbid",
-        # required in order to use 'WorkspaceName'
-        arbitrary_types_allowed=True,
     )

--- a/src/snapred/backend/data/DataExportService.py
+++ b/src/snapred/backend/data/DataExportService.py
@@ -48,6 +48,9 @@ class DataExportService:
 
     # NOTE will be added shortly
 
+    def checkWritePermissions(self, path: Path) -> bool:
+        return self.dataService.checkWritePermissions(path)
+
     ##### CALIBRATION METHODS #####
 
     @validate_call
@@ -65,6 +68,10 @@ class DataExportService:
 
     def exportCalibrationState(self, calibration: Calibration):
         return self.dataService.writeCalibrationState(calibration)
+
+    def getCalibrationStateRoot(self, runNumber: str) -> Path:
+        stateId, _ = self.dataService.generateStateId(runNumber)
+        return self.dataService.constructCalibrationStateRoot(stateId)
 
     ##### NORMALIZATION METHODS #####
 
@@ -87,6 +94,9 @@ class DataExportService:
 
     def exportReductionData(self, record: ReductionRecord):
         self.dataService.writeReductionData(record)
+
+    def getReductionStateRoot(self, runNumber: str) -> Path:
+        return self.dataService._constructReductionStateRoot(runNumber)
 
     ##### WORKSPACE METHODS #####
 

--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -46,7 +46,7 @@ class DataFactoryService:
         return self.lookupService.readStateConfig(runId, useLiteMode)
 
     def constructStateId(self, runId: str):
-        return self.lookupService._generateStateId(runId)
+        return self.lookupService.generateStateId(runId)
 
     def getCalibrantSample(self, filePath):
         return self.lookupService.readCalibrantSample(filePath)

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -3,7 +3,6 @@ import glob
 import json
 import os
 import stat
-import re
 import time
 from copy import deepcopy
 from errno import ENOENT as NOT_FOUND
@@ -161,10 +160,10 @@ class LocalDataService:
     @staticmethod
     def _hasWritePermissionstoPath(filePath: Path) -> bool:
         # WARNING: `os.access` does not work correctly on the `/SNS` shared filesystem.
-        
+
         # formerly:
         #   `return os.access(filePath, os.W_OK) if filePath.exists() else False`
-        
+
         # alternative implementation (LINUX specific):
         hasPermissions = False
         if filePath.exists():
@@ -185,9 +184,9 @@ class LocalDataService:
             #   checking the user-bits, if the current user is the owner;
             #   then checking the group-bits, if the user belongs to the file-owner's group;
             #   and finally checking the other-bits.
-            hasPermissions = (uid == fuid) and bool(mode & 0o200)\
-                or (fgid in gids) and bool(mode & 0o020)\
-                or bool(mode & 0o002)
+            hasPermissions = (
+                (uid == fuid) and bool(mode & 0o200) or (fgid in gids) and bool(mode & 0o020) or bool(mode & 0o002)
+            )
         return hasPermissions
 
     @staticmethod

--- a/src/snapred/backend/error/ContinueWarning.py
+++ b/src/snapred/backend/error/ContinueWarning.py
@@ -14,6 +14,7 @@ class ContinueWarning(Exception):
         MISSING_DIFFRACTION_CALIBRATION = auto()
         MISSING_NORMALIZATION = auto()
         LOW_PEAK_COUNT = auto()
+        NO_WRITE_PERMISSIONS = auto()
 
     class Model(BaseModel):
         message: str

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -1,4 +1,3 @@
-import time
 from pathlib import Path
 from typing import Dict, List
 
@@ -21,6 +20,7 @@ from snapred.backend.dao.request import (
     CalibrationExportRequest,
     CalibrationIndexRequest,
     CalibrationLoadAssessmentRequest,
+    CalibrationWritePermissionsRequest,
     DiffractionCalibrationRequest,
     FarmFreshIngredients,
     FitMultiplePeaksRequest,
@@ -68,8 +68,6 @@ class CalibrationService(Service):
 
     """
 
-    dataFactoryService: "DataFactoryService"
-    dataExportService: "DataExportService"
     MILLISECONDS_PER_SECOND = Config["constants.millisecondsPerSecond"]
     MINIMUM_PEAKS_PER_GROUP = Config["calibration.diffraction.minimumPeaksPerGroup"]
 
@@ -93,6 +91,7 @@ class CalibrationService(Service):
         self.registerPath("loadQualityAssessment", self.loadQualityAssessment)
         self.registerPath("index", self.getCalibrationIndex)
         self.registerPath("diffraction", self.diffractionCalibration)
+        self.registerPath("validateWritePermissions", self.validateWritePermissions)
         return
 
     @staticmethod
@@ -148,6 +147,8 @@ class CalibrationService(Service):
 
     @FromString
     def diffractionCalibration(self, request: DiffractionCalibrationRequest):
+        self.validateRequest(request)
+
         # ingredients
         ingredients = self.prepDiffractionCalibrationIngredients(request)
         # groceries
@@ -155,6 +156,44 @@ class CalibrationService(Service):
 
         # now have all ingredients and groceries, run recipe
         return DiffractionCalibrationRecipe().executeRecipe(ingredients, groceries)
+
+    def validateRequest(self, request: DiffractionCalibrationRequest):
+        """
+        Validate the diffraction-calibration request.
+
+        :param request: a diffraction-calibration request
+        :type request: DiffractionCalibrationRequest
+        """
+
+        # This is a redundant call, but it is placed here to facilitate re-sequencing.
+        permissionsRequest = CalibrationWritePermissionsRequest(
+            runNumber=request.runNumber, continueFlags=request.continueFlags
+        )
+        self.validateWritePermissions(permissionsRequest)
+
+    def validateWritePermissions(self, request: CalibrationWritePermissionsRequest):
+        """
+        Validate that the diffraction-calibration workflow will be able to save its output.
+
+        :param request: a write-permissions request containing the run number and existing continue flags
+        :type request: CalibrationWritePermissionsRequest
+        """
+        # Note: this is split-out as a separate method and a registered service call.
+        #   Permissions must be checked as early as possible in the workflow.
+
+        # check that the user has write permissions to the save directory
+        if not self.checkWritePermissions(request.runNumber):
+            raise RuntimeError(
+                "<font size = "
+                "2"
+                " >"
+                + "<p>It looks like you don't have permissions to write to "
+                + f"<br><b>{self.getSavePath(request.runNumber)}</b>,<br>"
+                + "which is a requirement in order to run the diffraction-calibration workflow.</p>"
+                + "<p>If this is something that you need to do, then you may need to change the "
+                + "<br><b>instrument.calibration.powder.home</b> entry in SNAPRed's <b>application.yml</b> file.</p>"
+                + "</font>"
+            )
 
     @FromString
     def focusSpectra(self, request: FocusSpectraRequest):
@@ -217,7 +256,7 @@ class CalibrationService(Service):
         if entry.appliesTo is None:
             entry.appliesTo = ">=" + entry.runNumber
         if entry.timestamp is None:
-            entry.timestamp = int(round(time.time() * self.MILLISECONDS_PER_SECOND))
+            entry.timestamp = self.dataExportService.getUniqueTimestamp()
         logger.info("Saving calibration index entry for Run Number {}".format(entry.runNumber))
         self.dataExportService.exportCalibrationIndexEntry(entry)
 
@@ -240,6 +279,13 @@ class CalibrationService(Service):
             logger.error(f"Invalid run number: {runId}")
             return False
         return self.dataFactoryService.checkCalibrationStateExists(runId)
+
+    def checkWritePermissions(self, runNumber: str) -> bool:
+        path = self.dataExportService.getCalibrationStateRoot(runNumber)
+        return self.dataExportService.checkWritePermissions(path)
+
+    def getSavePath(self, runNumber: str) -> Path:
+        return self.dataExportService.getCalibrationStateRoot(runNumber)
 
     @staticmethod
     def parseCalibrationMetricList(src: str) -> List[CalibrationMetric]:
@@ -338,10 +384,6 @@ class CalibrationService(Service):
 
     @FromString
     def assessQuality(self, request: CalibrationAssessmentRequest):
-        # NOTE the previous structure of this method implied it was meant to loop over a list.
-        # However, its actual implementation did not actually loop over a list.
-        # I removed most of the parts that implied a loop or list.
-        # This can be easily refactored to a loop structure when needed
         cifPath = self.dataFactoryService.getCifFilePath(Path(request.calibrantSamplePath).stem)
         farmFresh = FarmFreshIngredients(
             runNumber=request.run.runNumber,

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -117,7 +117,7 @@ mantid:
           smoothedFocusedRawVanadium: "{unit},{group},{runNumber},fitted_van_corr,{version}"
         reduction:
           output: "reduced,{unit},{group},{runNumber},{timestamp}"
-          outputGroup: "reduced,{stateId},{timestamp}"
+          outputGroup: "reduced,{runNumber},{timestamp}"
           pixelMask: "pixelmask,{runNumber},{timestamp}"
           # the user pixel mask name token is case sensitive
           userPixelMask: "MaskWorkspace,{numberTag}"

--- a/src/snapred/ui/handler/SNAPResponseHandler.py
+++ b/src/snapred/ui/handler/SNAPResponseHandler.py
@@ -71,7 +71,7 @@ class SNAPResponseHandler(QWidget):
                 SNAPResponseHandler.handleStateMessage(view, recoverableException)
         elif code == ResponseCode.CONTINUE_WARNING:
             continueInfo = ContinueWarning.Model.model_validate_json(message)
-            if SNAPResponseHandler._handleContinueWarning(continueInfo.message, view):
+            if SNAPResponseHandler._handleContinueWarning(continueInfo, view):
                 view.continueAnyway.emit(continueInfo)
         elif message:
             SNAPResponseHandler._handleWarning(message, view)
@@ -89,7 +89,7 @@ class SNAPResponseHandler(QWidget):
         messageBox.exec()
 
     @staticmethod
-    def _handleContinueWarning(message, view):
+    def _handleContinueWarning(continueInfo: ContinueWarning.Model, view):
         # print stacktrace
         logger.info("It happens here and here")
         import traceback
@@ -99,9 +99,9 @@ class SNAPResponseHandler(QWidget):
         continueAnyway = QMessageBox.warning(
             view,
             "Warning",
-            message,
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            continueInfo.message,
+            buttons=QMessageBox.Yes | QMessageBox.No,
+            defaultButton=QMessageBox.No,
         )
         return continueAnyway == QMessageBox.Yes
 

--- a/src/snapred/ui/view/DiffCalAssessmentView.py
+++ b/src/snapred/ui/view/DiffCalAssessmentView.py
@@ -96,5 +96,5 @@ class DiffCalAssessmentView(QWidget):
         self.signalRunNumberUpdate.emit(runNumber, useLiteMode)
 
     def verify(self):
-        # TODO vwhat fields need to be verified?
+        # TODO: what fields need to be verified?
         return True

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -64,7 +64,7 @@ class DiffCalTweakPeakView(BackendRequestView):
         self.signalPeakThresholdUpdate.connect(self._updatePeakThreshold)
         self.signalMaxChiSqUpdate.connect(self._updateMaxChiSq)
         self.continueAnyway = False
-        self.signalContinueAnyway.connect(self._updateContineAnyway)
+        self.signalContinueAnyway.connect(self._updateContinueAnyway)
 
         # create the graph elements
         self.figure = plt.figure(constrained_layout=True)
@@ -116,11 +116,11 @@ class DiffCalTweakPeakView(BackendRequestView):
 
         self.signalUpdateRecalculationButton.connect(self.setEnableRecalculateButton)
 
-    def updateContinueAnyway(self, continueAnyway):
+    def updateContinueAnyway(self, continueAnyway: bool):
         self.signalContinueAnyway.emit(continueAnyway)
 
     @Slot(bool)
-    def _updateContineAnyway(self, continueAnyway):
+    def _updateContinueAnyway(self, continueAnyway: bool):
         self.continueAnyway = continueAnyway
 
     @Slot(str)

--- a/src/snapred/ui/view/reduction/ReductionSaveView.py
+++ b/src/snapred/ui/view/reduction/ReductionSaveView.py
@@ -1,17 +1,62 @@
+from pathlib import Path
+
+from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import QLabel
+from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.view.BackendRequestView import BackendRequestView
 
 
 @Resettable
 class ReductionSaveView(BackendRequestView):
+    signalContinueAnyway = Signal(ContinueWarning.Type)
+    signalSavePath = Signal(Path)
+
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.saveMessage = QLabel(
-            "Please use available Workbench tools to save your data before proceeding."
-            + "\nThey are denoted with the prefix `output_"
-        )
+        self.continueAnywayFlags = None
+        self.signalContinueAnyway.connect(self._updateContinueAnyway)
+
+        self.savePath = None
+        self.signalSavePath.connect(self._updateSavePath)
+
+        self.saveMessage = QLabel("Please use available Workbench tools to save your workspaces before proceeding.")
         self.layout.addWidget(self.saveMessage)
+
+    def updateContinueAnyway(self, continueAnywayFlags: ContinueWarning.Type):
+        self.signalContinueAnyway.emit(continueAnywayFlags)
+
+    @Slot(ContinueWarning.Type)
+    def _updateContinueAnyway(self, continueAnywayFlags: ContinueWarning.Type):
+        self.continueAnywayFlags = continueAnywayFlags
+
+    def updateSavePath(self, path: Path):
+        self.signalSavePath.emit(path)
+
+    @Slot(Path)
+    def _updateSavePath(self, path: Path):
+        self.saveMessage.setEnabled(False)
+        self.savePath = path
+        panelText = None
+        if (
+            self.continueAnywayFlags is not None
+            and ContinueWarning.Type.NO_WRITE_PERMISSIONS in self.continueAnywayFlags
+        ):
+            panelText = (
+                "<p>You didn't have permissions to write to "
+                + f"<br><b>{self.savePath}</b>,<br>"
+                + "but you can still save using the workbench tools.</p>"
+                + "<p>Please remember to save your output workspaces!</p>"
+            )
+        else:
+            panelText = (
+                "<p>Reduction workspaces have been saved to "
+                + f"<br><b>{self.savePath}</b>.<br></p>"
+                + "<p>If required later, these can be reloaded into Mantid workbench using 'LoadNexus'.</p>"
+            )
+        self.saveMessage.setText(panelText)
+        self.saveMessage.setEnabled(True)
+        # self.saveMessage.update() # TODO: is this the correct way to do this?
 
     def verify(self):
         return True

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -6,12 +6,14 @@ from snapred.backend.dao.Limit import Pair
 from snapred.backend.dao.request import (
     CalibrationAssessmentRequest,
     CalibrationExportRequest,
+    CalibrationWritePermissionsRequest,
     DiffractionCalibrationRequest,
     FitMultiplePeaksRequest,
     FocusSpectraRequest,
     HasStateRequest,
 )
 from snapred.backend.dao.SNAPResponse import SNAPResponse
+from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.log.logger import snapredLogger
 from snapred.meta.Config import Config
 from snapred.meta.decorators.ExceptionToErrLog import ExceptionToErrLog
@@ -94,7 +96,12 @@ class DiffCalWorkflow(WorkflowImplementer):
                 resetLambda=self.reset,
                 parent=parent,
             )
-            .addNode(self._specifyRun, self._requestView, "Diffraction Calibration")
+            .addNode(
+                self._specifyRun,
+                self._requestView,
+                "Diffraction Calibration",
+                continueAnywayHandler=self._continueAnywayHandler,
+            )
             .addNode(
                 self._triggerDiffractionCalibration,
                 self._tweakPeakView,
@@ -106,7 +113,8 @@ class DiffCalWorkflow(WorkflowImplementer):
             .build()
         )
 
-    def _continueAnywayHandlerTweak(self, continueInfo):  # noqa: ARG002
+    def _continueAnywayHandlerTweak(self, continueInfo: ContinueWarning.Model):  # noqa: ARG002
+        self._continueAnywayHandler(continueInfo)
         self._tweakPeakView.updateContinueAnyway(True)
 
     @ExceptionToErrLog
@@ -167,6 +175,12 @@ class DiffCalWorkflow(WorkflowImplementer):
         self.calibrantSamplePath = view.sampleDropdown.currentText()
         self.peakFunction = view.peakFunctionDropdown.currentText()
         self.maxChiSq = self.DEFAULT_MAX_CHI_SQ
+
+        # Validate that the user has write permissions as early as possible in the workflow.
+        permissionsRequest = CalibrationWritePermissionsRequest(
+            runNumber=self.runNumber, continueFlags=self.continueAnywayFlags
+        )
+        self.request(path="calibration/validateWritePermissions", payload=permissionsRequest)
 
         self._tweakPeakView.updateRunNumber(self.runNumber)
         self._saveView.updateRunNumber(self.runNumber)

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -1,10 +1,14 @@
-from snapred.backend.dao.request import ReductionRequest
+from typing import List
+
+from snapred.backend.dao.request import (
+    ReductionExportRequest,
+    ReductionRequest,
+)
 from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.log.logger import snapredLogger
-from snapred.meta.decorators.ExceptionToErrLog import ExceptionToErrLog
+from snapred.ui.view.reduction.ReductionRequestView import ReductionRequestView
 from snapred.ui.view.reduction.ReductionSaveView import ReductionSaveView
-from snapred.ui.view.reduction.ReductionView import ReductionView
 from snapred.ui.workflow.WorkflowBuilder import WorkflowBuilder
 from snapred.ui.workflow.WorkflowImplementer import WorkflowImplementer
 
@@ -15,13 +19,11 @@ class ReductionWorkflow(WorkflowImplementer):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        self._reductionView = ReductionView(parent=parent)
-        self.continueAnywayFlags = None
+        self._reductionRequestView = ReductionRequestView(parent=parent, validateRunNumbers=self._validateRunNumbers)
 
-        self._reductionView.enterRunNumberButton.clicked.connect(lambda: self._populatePixelMaskDropdown())
-
-        # TODO; Save Screen, to give users a chance to save their work before the reduction
-        # completes and erases the data
+        self._reductionSaveView = ReductionSaveView(
+            parent=parent,
+        )
 
         self.workflow = (
             WorkflowBuilder(
@@ -32,65 +34,70 @@ class ReductionWorkflow(WorkflowImplementer):
             )
             .addNode(
                 self._triggerReduction,
-                self._reductionView,
+                self._reductionRequestView,
                 "Reduction",
-                continueAnywayHandler=self._continueReductionHandler,
+                continueAnywayHandler=self._continueAnywayHandler,
             )
-            .addNode(self._nothing, ReductionSaveView(parent=parent), "Save")
+            .addNode(self._nothing, self._reductionSaveView, "Save")
             .build()
         )
 
     def _nothing(self, workflowPresenter):  # noqa: ARG002
         return SNAPResponse(code=200)
 
-    def _continueReductionHandler(self, continueInfo):
-        if isinstance(continueInfo, ContinueWarning.Model):
-            self.continueAnywayFlags = self.continueAnywayFlags | continueInfo.flag
-        else:
-            raise ValueError(f"Invalid continueInfo type: {type(continueInfo)}, expecting ContinueWarning.Model.")
-
-    @ExceptionToErrLog
-    def _populatePixelMaskDropdown(self):
-        if len(self._reductionView.getRunNumbers()) == 0:
-            return
-
-        runNumbers = self._reductionView.getRunNumbers()
-        useLiteMode = self._reductionView.liteModeToggle.field.getState()  # noqa: F841
-
-        self._reductionView.liteModeToggle.setEnabled(False)
-        self._reductionView.pixelMaskDropdown.setEnabled(False)
-        self._reductionView.retainUnfocusedDataCheckbox.setEnabled(False)
-
-        for runNumber in runNumbers:
-            try:
-                self.request(path="reduction/hasState", payload=runNumber).data
-            except Exception as e:  # noqa: BLE001
-                print(e)
-
-        self._reductionView.liteModeToggle.setEnabled(True)
-        self._reductionView.pixelMaskDropdown.setEnabled(True)
+    def _validateRunNumbers(self, runNumbers: List[str]):
+        # For now, all run numbers in a reduction batch must be from the same instrument state.
+        # This is primarily because pixel-mask selection occurs by instrument state.
+        stateIds = []
+        try:
+            stateIds = self.request(path="reduction/getStateIds", payload=runNumbers).data
+        except Exception as e:  # noqa: BLE001
+            raise ValueError(f"Unable to get instrument state for {runNumbers}: {e}")
+        if len(stateIds) > 1:
+            stateId = stateIds[0]
+            for id_ in stateIds[1:]:
+                if id_ != stateId:
+                    raise ValueError("all run numbers must be from the same state")
 
     def _triggerReduction(self, workflowPresenter):
         view = workflowPresenter.widget.tabView  # noqa: F841
 
-        runNumbers = self._reductionView.getRunNumbers()
+        runNumbers = self._reductionRequestView.getRunNumbers()
 
         # Use one timestamp for the entire set of runNumbers:
         timestamp = self.request(path="reduction/getUniqueTimestamp").data
         for runNumber in runNumbers:
-            payload = ReductionRequest(
-                runNumber=runNumber,
-                useLiteMode=self._reductionView.liteModeToggle.field.getState(),
+            request_ = ReductionRequest(
+                runNumber=str(runNumber),
+                useLiteMode=self._reductionRequestView.liteModeToggle.field.getState(),
                 timestamp=timestamp,
                 continueFlags=self.continueAnywayFlags,
             )
-            # TODO: Handle Continue Anyway
-            response = self.request(path="reduction/", payload=payload.json())
+
+            response = self.request(path="reduction/", payload=request_)
             if response.code == ResponseCode.OK:
-                self.outputs.extend(response.data.workspaces)
+                record = response.data.record
+
+                # .. update "save" panel message:
+                savePath = self.request(path="reduction/getSavePath", payload=record.runNumber).data
+                self._reductionSaveView.updateContinueAnyway(self.continueAnywayFlags)
+                #    Warning: 'updateSavePath' uses the current 'continueAnywayFlags'
+                self._reductionSaveView.updateSavePath(savePath)
+
+                # Save the reduced data. (This is automatic: it happens before the "save" panel opens.)
+                if ContinueWarning.Type.NO_WRITE_PERMISSIONS not in self.continueAnywayFlags:
+                    self.request(path="reduction/save", payload=ReductionExportRequest(record=record))
+
+                # Retain the output workspaces after the workflow is complete.
+                self.outputs.extend(record.workspaceNames)
 
             # Note that the run number is deliberately not deleted from the run numbers list.
             # Almost certainly it should be moved to a "completed run numbers" list.
+
+        # SPECIAL FOR THE REDUCTION WORKFLOW: clear everything _except_ the output workspaces
+        #   _before_ transitioning to the "save" panel.
+        # TODO: make '_clearWorkspaces' a public method (i.e make this combination a special `cleanup` method).
+        self._clearWorkspaces(exclude=self.outputs, clearCachedWorkspaces=True)
 
         return self.responses[-1]
 

--- a/src/snapred/ui/workflow/WorkflowImplementer.py
+++ b/src/snapred/ui/workflow/WorkflowImplementer.py
@@ -87,6 +87,7 @@ class WorkflowImplementer(QObject):
         self.responses = []
         self.outputs = []
         self.collectedOutputs = []
+        self.continueAnywayFlags = ContinueWarning.Type.UNSET
 
     def _clearWorkspaces(self, *, exclude: List[str], clearCachedWorkspaces: bool):
         # Always exclude any external workspaces.

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -124,7 +124,7 @@ mantid:
             smoothedFocusedRawVanadium: "_{unit},{group},fitted_van_corr,{runNumber},{version}"
           reduction:
             output: "_reduced,{unit},{group},{runNumber},{timestamp}"
-            outputGroup: "_reduced,{stateId},{timestamp}"
+            outputGroup: "_reduced,{runNumber},{timestamp}"
             pixelMask: "_pixelmask,{runNumber},{timestamp}"
             # the user pixel mask name token is case sensitive
             userPixelMask: "MaskWorkspace,{numberTag}"

--- a/tests/unit/backend/api/test_APIService.py
+++ b/tests/unit/backend/api/test_APIService.py
@@ -49,8 +49,6 @@ class TestAPIService:
         mockService = MockService()
         serviceDirectory.registerService(mockService)
         validPaths = apiService.getValidPaths()
-        with Resource.open("/outputs/APIServicePaths.json.new", "w") as f:
-            f.write(json.dumps(validPaths, indent=2))
         with Resource.open("/outputs/APIServicePaths.json", "r") as f:
             actualValidPaths = json.load(f)
             assert validPaths == actualValidPaths

--- a/tests/unit/backend/data/test_DataExportService.py
+++ b/tests/unit/backend/data/test_DataExportService.py
@@ -18,7 +18,6 @@ class TestDataExportService(unittest.TestCase):
 
     def setUp(self):
         self.instance = DataExportService(dataService=self.mockLookupService)
-        # self.instance.lookupService = self.mockLookupService
         assert isinstance(self.instance, DataExportService)
         return super().setUp()
 
@@ -37,13 +36,14 @@ class TestDataExportService(unittest.TestCase):
         self.instance.getFullLiteDataFilePath(mock.Mock())
         assert self.instance.dataService.getIPTS.called
 
+    def test_checkWritePermissions(self):
+        path = Path("some/mock/path")
+        self.instance.checkWritePermissions(path)
+        assert self.instance.dataService.checkWritePermissions.called
+
     def test_getUniqueTimestamp(self):
         self.instance.getUniqueTimestamp()
         assert self.instance.dataService.getUniqueTimestamp.called
-
-    ##### TEST REDUCTION METHODS #####
-
-    # NOTE will exist in future
 
     ##### TEST CALIBRATION METHODS #####
 
@@ -60,6 +60,15 @@ class TestDataExportService(unittest.TestCase):
     def test_exportCalibrationWorkspaces(self):
         self.instance.exportCalibrationWorkspaces(mock.Mock())
         assert self.instance.dataService.writeCalibrationWorkspaces.called
+
+    def test_getCalibrationStateRoot(self):
+        with mock.patch.object(self.instance.dataService, "generateStateId") as mockGenerateStateId:
+            mockGenerateStateId.return_value = ("1a2b3c4d5e6f7a8b", None)
+            self.instance.getCalibrationStateRoot(mock.Mock())
+            assert mockGenerateStateId.called
+            self.instance.dataService.constructCalibrationStateRoot.assert_called_once_with(
+                mockGenerateStateId.return_value[0]
+            )
 
     def test_exportCalibrationState(self):
         self.instance.exportCalibrationState(mock.Mock())
@@ -98,6 +107,10 @@ class TestDataExportService(unittest.TestCase):
     def test_exportReductionData(self):
         self.instance.exportReductionData(mock.Mock())
         assert self.instance.dataService.writeReductionData.called
+
+    def test_getReductionStateRoot(self):
+        self.instance.getReductionStateRoot(mock.Mock())
+        assert self.instance.dataService._constructReductionStateRoot.called
 
     ##### TEST WORKSPACE METHODS #####
 

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -150,8 +150,8 @@ def test_readStateConfig():
     localDataService._readPVFile = mock.Mock()
     fileMock = mock.Mock()
     localDataService._readPVFile.return_value = fileMock
-    localDataService._generateStateId = mock.Mock()
-    localDataService._generateStateId.return_value = (ENDURING_STATE_ID, None)
+    localDataService.generateStateId = mock.Mock()
+    localDataService.generateStateId.return_value = (ENDURING_STATE_ID, None)
     localDataService.readCalibrationState = mock.Mock()
     localDataService.readCalibrationState.return_value = Calibration.model_validate_json(
         Resource.read("inputs/calibration/CalibrationParameters.json")
@@ -177,8 +177,8 @@ def test_readStateConfig_attaches_grouping_map():
     localDataService._readPVFile = mock.Mock()
     fileMock = mock.Mock()
     localDataService._readPVFile.return_value = fileMock
-    localDataService._generateStateId = mock.Mock()
-    localDataService._generateStateId.return_value = (ENDURING_STATE_ID, None)
+    localDataService.generateStateId = mock.Mock()
+    localDataService.generateStateId.return_value = (ENDURING_STATE_ID, None)
     localDataService.readCalibrationState = mock.Mock()
     localDataService.readCalibrationState.return_value = Calibration.model_validate_json(
         Resource.read("inputs/calibration/CalibrationParameters.json")
@@ -208,8 +208,8 @@ def test_readStateConfig_invalid_grouping_map():
         localDataService._readPVFile = mock.Mock()
         fileMock = mock.Mock()
         localDataService._readPVFile.return_value = fileMock
-        localDataService._generateStateId = mock.Mock()
-        localDataService._generateStateId.return_value = (ENDURING_STATE_ID, None)
+        localDataService.generateStateId = mock.Mock()
+        localDataService.generateStateId.return_value = (ENDURING_STATE_ID, None)
         localDataService.readCalibrationState = mock.Mock()
         localDataService.readCalibrationState.return_value = Calibration.model_validate_json(
             Resource.read("inputs/calibration/CalibrationParameters.json")
@@ -238,8 +238,8 @@ def test_readStateConfig_calls_prepareStateRoot(mockPrepareStateRoot):
     localDataService._readPVFile = mock.Mock()
     fileMock = mock.Mock()
     localDataService._readPVFile.return_value = fileMock
-    localDataService._generateStateId = mock.Mock()
-    localDataService._generateStateId.return_value = (ENDURING_STATE_ID, None)
+    localDataService.generateStateId = mock.Mock()
+    localDataService.generateStateId.return_value = (ENDURING_STATE_ID, None)
     localDataService.readCalibrationState = mock.Mock()
     localDataService.readCalibrationState.return_value = Calibration.model_validate_json(
         Resource.read("inputs/calibration/CalibrationParameters.json")
@@ -287,10 +287,9 @@ def test_prepareStateRoot_creates_state_root_directory():
             Resource.read("inputs/pixel_grouping/defaultGroupingMap.json")
         )
         localDataService._readDefaultGroupingMap = mock.Mock(return_value=defaultGroupingMap)
-
-        assert not localDataService._constructCalibrationStateRoot().exists()
+        assert not localDataService.constructCalibrationStateRoot().exists()
         localDataService._prepareStateRoot(stateId)
-        assert localDataService._constructCalibrationStateRoot().exists()
+        assert localDataService.constructCalibrationStateRoot().exists()
 
 
 def test_prepareStateRoot_existing_state_root():
@@ -299,12 +298,12 @@ def test_prepareStateRoot_existing_state_root():
     stateId = ENDURING_STATE_ID
 
     with state_root_redirect(localDataService, stateId=stateId):
-        localDataService._constructCalibrationStateRoot().mkdir()
+        localDataService.constructCalibrationStateRoot().mkdir()
         defaultGroupingMap = GroupingMap.model_validate_json(
             Resource.read("inputs/pixel_grouping/defaultGroupingMap.json")
         )
         localDataService._readDefaultGroupingMap = mock.Mock(return_value=defaultGroupingMap)
-        assert localDataService._constructCalibrationStateRoot().exists()
+        assert localDataService.constructCalibrationStateRoot().exists()
         localDataService._prepareStateRoot(stateId)
 
 
@@ -364,7 +363,7 @@ def test_prepareStateRoot_does_not_overwrite_grouping_map():
     localDataService = LocalDataService()
     stateId = ENDURING_STATE_ID
     with state_root_redirect(localDataService, stateId=stateId):
-        localDataService._constructCalibrationStateRoot().mkdir()
+        localDataService.constructCalibrationStateRoot().mkdir()
         defaultGroupingMapFilePath = Resource.getPath("inputs/pixel_grouping/defaultGroupingMap.json")
 
         # Write a 'groupingMap.json' file to the <state root>, but with a different stateId;
@@ -484,15 +483,15 @@ def test_getIPTS(mockGetIPTS):
     runNumber = "123456"
     res = localDataService.getIPTS(runNumber)
     assert res == mockGetIPTS.return_value
-    assert mockGetIPTS.called_with(
-        runNumber=runNumber,
-        instrumentName=Config["instrument.name"],
+    mockGetIPTS.assert_called_with(
+        RunNumber=runNumber,
+        Instrument=Config["instrument.name"],
     )
     res = localDataService.getIPTS(runNumber, "CRACKLE")
     assert res == mockGetIPTS.return_value
-    assert mockGetIPTS.called_with(
-        runNumber=runNumber,
-        instrumentName="CRACKLE",
+    mockGetIPTS.assert_called_with(
+        RunNumber=runNumber,
+        Instrument="CRACKLE",
     )
 
 
@@ -587,8 +586,8 @@ def test_write_model_pretty_StateConfig_excludes_grouping_map():
     localDataService._readPVFile = mock.Mock()
     fileMock = mock.Mock()
     localDataService._readPVFile.return_value = fileMock
-    localDataService._generateStateId = mock.Mock()
-    localDataService._generateStateId.return_value = (UNCHANGING_STATE_ID, None)
+    localDataService.generateStateId = mock.Mock()
+    localDataService.generateStateId.return_value = (UNCHANGING_STATE_ID, None)
     localDataService.readCalibrationState = mock.Mock()
     localDataService.readCalibrationState.return_value = Calibration.model_validate_json(
         Resource.read("inputs/calibration/CalibrationParameters.json")
@@ -655,7 +654,7 @@ def test_readPVFile(h5pyMock):  # noqa: ARG001
     assert actual is not None
 
 
-def test__generateStateId():
+def test_generateStateId():
     localDataService = LocalDataService()
 
     # Mock the _readPVFile method
@@ -676,13 +675,13 @@ def test__generateStateId():
     localDataService._readPVFile.return_value = pvFile
 
     # Call the method being tested
-    actual, _ = localDataService._generateStateId("12345")
+    actual, _ = localDataService.generateStateId("12345")
 
     # Check that the returned value matches the expected result
     assert actual == UNCHANGING_STATE_ID
 
 
-def test__generateStateId_old_wav_key():
+def test_generateStateId_old_wav_key():
     # Ensures the old value of the wav key is still accepted
     localDataService = LocalDataService()
 
@@ -704,16 +703,16 @@ def test__generateStateId_old_wav_key():
     localDataService._readPVFile.return_value = pvFile
 
     # Call the method being tested
-    actual, _ = localDataService._generateStateId("12345")
+    actual, _ = localDataService.generateStateId("12345")
 
     # Check that the returned value matches the expected result
     assert actual == UNCHANGING_STATE_ID
 
 
-def test__generateStateId_cache():
+def test_generateStateId_cache():
     localDataService = LocalDataService()
-    localDataService._generateStateId.cache_clear()
-    assert localDataService._generateStateId.cache_info() == functools._CacheInfo(
+    localDataService.generateStateId.cache_clear()
+    assert localDataService.generateStateId.cache_info() == functools._CacheInfo(
         hits=0, misses=0, maxsize=128, currsize=0
     )
 
@@ -733,30 +732,30 @@ def test__generateStateId_cache():
     stateSHA2 = "fa0bb25b44874edb"
 
     # Call the method being tested and check the cache behavior
-    actual, _ = localDataService._generateStateId("12345")
+    actual, _ = localDataService.generateStateId("12345")
     assert actual == stateSHA1
-    assert localDataService._generateStateId.cache_info() == functools._CacheInfo(
+    assert localDataService.generateStateId.cache_info() == functools._CacheInfo(
         hits=0, misses=1, maxsize=128, currsize=1
     )
 
     # Check cached value
-    actual, _ = localDataService._generateStateId("12345")
+    actual, _ = localDataService.generateStateId("12345")
     assert actual == stateSHA1
-    assert localDataService._generateStateId.cache_info() == functools._CacheInfo(
+    assert localDataService.generateStateId.cache_info() == functools._CacheInfo(
         hits=1, misses=1, maxsize=128, currsize=1
     )
 
-    # Check a different value
-    actual, _ = localDataService._generateStateId("67890")
+    # check a different value
+    actual, _ = localDataService.generateStateId("67890")
     assert actual == stateSHA2
-    assert localDataService._generateStateId.cache_info() == functools._CacheInfo(
+    assert localDataService.generateStateId.cache_info() == functools._CacheInfo(
         hits=1, misses=2, maxsize=128, currsize=2
     )
 
     # ... and its cached value
-    actual, _ = localDataService._generateStateId("67890")
+    actual, _ = localDataService.generateStateId("67890")
     assert actual == stateSHA2
-    assert localDataService._generateStateId.cache_info() == functools._CacheInfo(
+    assert localDataService.generateStateId.cache_info() == functools._CacheInfo(
         hits=2, misses=2, maxsize=128, currsize=2
     )
 
@@ -769,28 +768,162 @@ def test__findMatchingFileList():
     assert len(actual) == 1
 
 
+### TESTS OF PATH METHODS ###
+
+
+@mock.patch("stat.S_IMODE", return_value=0o777)
+@mock.patch("os.stat")
+@mock.patch("pathlib.Path.exists", return_value=True)
+def test__hasWritePermissionsToPath_fileExistsWithPermission(mockExists, mockStat, mockS_IMODE):  # noqa: ARG001
+    mockStat.return_value = mock.Mock(
+        st_uid=os.getuid(),
+        st_gid=os.getgroups()[0],
+        st_mode=0o777
+    )
+    filePath = Path("/some/path/to/file")
+    localDS = LocalDataService()
+    result = localDS._hasWritePermissionstoPath(filePath)
+    assert result is True
+
+
+@mock.patch("pathlib.Path.exists", return_value=False)
+def test__hasWritePermissionsToPath_fileDoesNotExist(mockExists):  # noqa: ARG001
+    filePath = Path("/some/path/to/nonexistent/file")
+    localDS = LocalDataService()
+    result = localDS._hasWritePermissionstoPath(filePath)
+    assert result is False
+
+
+def test_checkWritePermissions_path_exists():
+    with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tmpDir:
+        path = Path(tmpDir) / "one" / "two" / "three"
+        path.mkdir(parents=True)
+        assert path.exists()
+        status = LocalDataService().checkWritePermissions(path)
+        assert status
+
+
+@mock.patch("stat.S_IMODE", return_value=0o000)
+def test_checkWritePermissions_path_exists_no_permissions(mockOsAccess):
+    with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tmpDir:
+        path = Path(tmpDir) / "one" / "two" / "three"
+        path.mkdir(parents=True)
+        assert path.exists()
+        status = LocalDataService().checkWritePermissions(path)
+        assert not status
+        mockOsAccess.assert_called_once()
+
+
+def test_checkWritePermissions_parent_exists():
+    with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tmpDir:
+        path = Path(tmpDir) / "one" / "two" / "three"
+        path.mkdir(parents=True)
+        assert path.exists()
+        path = path / "four"
+        assert not path.exists()
+        status = LocalDataService().checkWritePermissions(path)
+        assert status
+
+@mock.patch("stat.S_IMODE", return_value=0o000)
+def test_checkWritePermissions_parent_exists_no_permissions(mockOsAccess):
+    with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tmpDir:
+        path = Path(tmpDir) / "one" / "two" / "three"
+        path.mkdir(parents=True)
+        assert path.exists()
+        path = path / "four"
+        assert not path.exists()
+        status = LocalDataService().checkWritePermissions(path)
+        assert not status
+        mockOsAccess.assert_called_once()
+
+
+def test_checkWritePermissions_path_does_not_exist():
+    path = Path("/does_not_exist") / "one" / "two" / "three"
+    assert not path.exists()
+    status = LocalDataService().checkWritePermissions(path)
+    assert not status
+
+
+def test_constructCalibrationStateRoot():
+    fakeState = "joobiewoobie"
+    localDataService = LocalDataService()
+    ans = localDataService.constructCalibrationStateRoot(fakeState)
+    assert isinstance(ans, Path)
+    assert ans.parts[-1] == fakeState
+
+
+def test_constructCalibrationStatePath():
+    fakeState = "joobiewoobie"
+    localDataService = LocalDataService()
+    for useLiteMode in [True, False]:
+        ans = localDataService._constructCalibrationStatePath(fakeState, useLiteMode)
+        assert isinstance(ans, Path)
+        assert ans.parts[-1] == "diffraction"
+        assert ans.parts[-2] == "lite" if useLiteMode else "native"
+        assert ans.parts[:-2] == localDataService.constructCalibrationStateRoot(fakeState).parts
+
+
+def test_constructNormalizationStatePath():
+    fakeState = "joobiewoobie"
+    localDataService = LocalDataService()
+    for useLiteMode in [True, False]:
+        ans = localDataService._constructNormalizationStatePath(fakeState, useLiteMode)
+        assert isinstance(ans, Path)
+        assert ans.parts[-1] == "normalization"
+        assert ans.parts[-2] == "lite" if useLiteMode else "native"
+        assert ans.parts[:-2] == localDataService.constructCalibrationStateRoot(fakeState).parts
+
+
+def test_constructReductionStateRoot():
+    fakeIPTS = "gumdrop"
+    fakeState = "joobiewoobie"
+    localDataService = LocalDataService()
+    localDataService.getIPTS = mock.Mock(return_value=fakeIPTS)
+    localDataService.generateStateId = mock.Mock(return_value=(fakeState, "gibberish"))
+    runNumber = "xyz"
+    ans = localDataService._constructReductionStateRoot(runNumber)
+    assert isinstance(ans, Path)
+    assert ans.parts[-1] == fakeState
+    assert fakeIPTS in ans.parts
+
+
+def test_constructReductionDataRoot():
+    fakeIPTS = "gumdrop"
+    fakeState = "joobiewoobie"
+    localDataService = LocalDataService()
+    localDataService.getIPTS = mock.Mock(return_value=fakeIPTS)
+    localDataService.generateStateId = mock.Mock(return_value=(fakeState, "gibberish"))
+    runNumber = "xyz"
+    for useLiteMode in [True, False]:
+        ans = localDataService._constructReductionDataRoot(runNumber, useLiteMode)
+        assert isinstance(ans, Path)
+        assert ans.parts[-1] == runNumber
+        assert ans.parts[-2] == "lite" if useLiteMode else "native"
+        assert ans.parts[:-2] == localDataService._constructReductionStateRoot(runNumber).parts
+
+
 def test_readCalibrationIndexMissing():
     localDataService = LocalDataService()
     localDataService.instrumentConfig = mock.Mock()
-    localDataService._generateStateId = mock.Mock(return_value=("123", "456"))
+    localDataService.generateStateId = mock.Mock(return_value=("123", "456"))
     localDataService._readReductionParameters = mock.Mock()
-    localDataService._constructCalibrationStateRoot = mock.Mock(return_value=Path(Resource.getPath("outputs")))
+    localDataService.constructCalibrationStateRoot = mock.Mock(return_value=Path(Resource.getPath("outputs")))
     assert len(localDataService.readCalibrationIndex("123", True)) == 0
 
 
 def test_readNormalizationIndexMissing():
     localDataService = LocalDataService()
     localDataService.instrumentConfig = mock.Mock()
-    localDataService._generateStateId = mock.Mock(return_value=("123", "456"))
+    localDataService.generateStateId = mock.Mock(return_value=("123", "456"))
     localDataService._readReductionParameters = mock.Mock()
-    localDataService._constructCalibrationStateRoot = mock.Mock(return_value=Path(Resource.getPath("outputs")))
+    localDataService.constructCalibrationStateRoot = mock.Mock(return_value=Path(Resource.getPath("outputs")))
     assert len(localDataService.readNormalizationIndex("123", True)) == 0
 
 
 def test_writeCalibrationIndexEntry():
     localDataService = LocalDataService()
     localDataService.instrumentConfig = mock.Mock()
-    localDataService._generateStateId = mock.Mock(return_value=("123", "456"))
+    localDataService.generateStateId = mock.Mock(return_value=("123", "456"))
     localDataService._readReductionParameters = mock.Mock()
     localDataService._constructCalibrationStatePath = mock.Mock(return_value=Path(Resource.getPath("outputs")))
     expectedFilePath = Path(Resource.getPath("outputs")) / "CalibrationIndex.json"
@@ -812,8 +945,8 @@ def test_writeCalibrationIndexEntry():
     # def test_writeNormalizationIndexEntry():
     localDataService = LocalDataService()
     localDataService.instrumentConfig = mock.Mock()
-    localDataService._generateStateId = mock.Mock()
-    localDataService._generateStateId.return_value = ("123", "456")
+    localDataService.generateStateId = mock.Mock()
+    localDataService.generateStateId.return_value = ("123", "456")
     localDataService._readReductionParameters = mock.Mock()
     localDataService._constructNormalizationStatePath = mock.Mock()
     localDataService._constructNormalizationStatePath.return_value = Path(Resource.getPath("outputs"))
@@ -843,8 +976,8 @@ def test_writeCalibrationIndexEntry():
 def test_readCalibrationIndexExisting():
     localDataService = LocalDataService()
     localDataService.instrumentConfig = mock.Mock()
-    localDataService._generateStateId = mock.Mock()
-    localDataService._generateStateId.return_value = ("123", "456")
+    localDataService.generateStateId = mock.Mock()
+    localDataService.generateStateId.return_value = ("123", "456")
     localDataService._readReductionParameters = mock.Mock()
     localDataService._constructCalibrationStatePath = mock.Mock()
     localDataService._constructCalibrationStatePath.return_value = Path(Resource.getPath("outputs"))
@@ -862,8 +995,8 @@ def test_readCalibrationIndexExisting():
 def test_readNormalizationIndexExisting():
     localDataService = LocalDataService()
     localDataService.instrumentConfig = mock.Mock()
-    localDataService._generateStateId = mock.Mock()
-    localDataService._generateStateId.return_value = ("123", "456")
+    localDataService.generateStateId = mock.Mock()
+    localDataService.generateStateId.return_value = ("123", "456")
     localDataService._readReductionParameters = mock.Mock()
     localDataService._constructNormalizationStatePath = mock.Mock()
     localDataService._constructNormalizationStatePath.return_value = Path(Resource.getPath("outputs"))
@@ -990,7 +1123,7 @@ def test_writeCalibrationWorkspaces():
         runNumber = testCalibrationRecord.runNumber
         version = testCalibrationRecord.version
         outputDSPWSName = workspaces.pop(wngt.DIFFCAL_OUTPUT)[0]
-        diagnosticWSname = workspaces.pop(wngt.DIFFCAL_DIAG)[0]
+        diagnosticWSName = workspaces.pop(wngt.DIFFCAL_DIAG)[0]
         tableWSName = workspaces.pop(wngt.DIFFCAL_TABLE)[0]
         maskWSName = workspaces.pop(wngt.DIFFCAL_MASK)[0]
         if workspaces:
@@ -1006,7 +1139,7 @@ def test_writeCalibrationWorkspaces():
             NumEvents=500,
             Random=True,
             XUnit="DSP",
-            XMin=0,
+            XMin=0.5,
             XMax=8000,
             BinWidth=100,
         )
@@ -1021,9 +1154,9 @@ def test_writeCalibrationWorkspaces():
         ws1 = CreateSingleValuedWorkspace()
         GroupWorkspaces(
             InputWorkspaces=[ws1],
-            OutputWorkspace=diagnosticWSname,
+            OutputWorkspace=diagnosticWSName,
         )
-        assert mtd.doesExist(diagnosticWSname)
+        assert mtd.doesExist(diagnosticWSName)
 
         # Create diffraction-calibration table and mask workspaces.
         createCompatibleDiffCalTable(tableWSName, outputDSPWSName)
@@ -1034,7 +1167,7 @@ def test_writeCalibrationWorkspaces():
         localDataService.writeCalibrationWorkspaces(testCalibrationRecord)
 
         dspFilename = Path(outputDSPWSName + Config["calibration.diffraction.output.extension"])
-        diagFilename = Path(diagnosticWSname + Config["calibration.diffraction.diagnostic.extension"])
+        diagFilename = Path(diagnosticWSName + Config["calibration.diffraction.diagnostic.extension"])
         diffCalFilename = Path(wng.diffCalTable().runNumber(runNumber).version(version).build() + ".h5")
         assert (basePath / dspFilename).exists()
         assert (basePath / diagFilename).exists()
@@ -1190,7 +1323,10 @@ def test_writeNormalizationWorkspaces():
     mtd.clear()
 
 
-def _writeSyntheticReductionRecord(filePath: Path, version: str):
+### TESTS OF REDUCTION METHODS ###
+
+
+def _writeSyntheticReductionRecord(filePath: Path, timestamp: float):
     # Create a `ReductionRecord` JSON file to be used by the unit tests.
 
     # TODO: Implement methods to create the synthetic `CalibrationRecord` and `NormalizationRecord`.
@@ -1201,20 +1337,19 @@ def _writeSyntheticReductionRecord(filePath: Path, version: str):
         Resource.read("inputs/normalization/NormalizationRecord.json")
     )
     testRecord = ReductionRecord(
-        runNumbers=[testCalibration.runNumber],
+        runNumber=testCalibration.runNumber,
         useLiteMode=testCalibration.useLiteMode,
+        timestamp=timestamp,
         calibration=testCalibration,
         normalization=testNormalization,
         pixelGroupingParameters={
             pg.focusGroup.name: list(pg.pixelGroupingParameters.values()) for pg in testCalibration.pixelGroups
         },
-        version=int(version),
-        stateId=testCalibration.calibrationFittingIngredients.instrumentState.id,
         workspaceNames=[
             wng.reductionOutput()
             .runNumber(testCalibration.runNumber)
             .group(pg.focusGroup.name)
-            .version(testCalibration.version)
+            .timestamp(timestamp)
             .build()
             for pg in testCalibration.pixelGroups
         ],
@@ -1265,7 +1400,6 @@ def test_readWriteReductionRecord(readSyntheticReductionRecord):
     localDataService = LocalDataService()
     with reduction_root_redirect(localDataService, stateId=stateId):
         localDataService.instrumentConfig = mock.Mock()
-        localDataService._getLatestReductionVersionNumber = mock.Mock(return_value=0)
         localDataService.groceryService = mock.Mock()
         localDataService.writeReductionRecord(testRecord)
         actualRecord = localDataService.readReductionRecord(runNumber, testRecord.useLiteMode, testRecord.timestamp)
@@ -1321,6 +1455,7 @@ def readSyntheticReductionRecord():
         #    WARNING: we cannot just use `model_validate` here,
         #      it will recreate the `WorkspaceName(<original name>)` and
         #        the `_builder` args will be stripped.
+        #   (TODO: is this still correct?  I think it works now.)
         record = ReductionRecord.model_validate(dict_)
         record.workspaceNames = wss
 
@@ -1414,7 +1549,7 @@ def test_writeReductionData(readSyntheticReductionRecord, createReductionWorkspa
     # Temporarily use a single run number
     runNumber, useLiteMode, timestamp = testRecord.runNumber, testRecord.useLiteMode, testRecord.timestamp
     stateId = "ab8704b0bc2a2342"
-    fileName = wng.reductionOutputGroup().stateId(stateId).timestamp(timestamp).build()
+    fileName = wng.reductionOutputGroup().runNumber(runNumber).timestamp(timestamp).build()
     fileName += Config["nexus.file.extension"]
 
     wss = createReductionWorkspaces(testRecord.workspaceNames)  # noqa: F841
@@ -1442,7 +1577,7 @@ def test_writeReductionData_no_directories(readSyntheticReductionRecord, createR
 
     runNumber, useLiteMode, timestamp = testRecord.runNumber, testRecord.useLiteMode, testRecord.timestamp
     stateId = "ab8704b0bc2a2342"
-    fileName = wng.reductionOutputGroup().stateId(stateId).timestamp(timestamp).build()
+    fileName = wng.reductionOutputGroup().runNumber(runNumber).timestamp(timestamp).build()
     fileName += Config["nexus.file.extension"]
 
     localDataService = LocalDataService()
@@ -1471,7 +1606,7 @@ def test_writeReductionData_metadata(readSyntheticReductionRecord, createReducti
 
     runNumber, useLiteMode, timestamp = testRecord.runNumber, testRecord.useLiteMode, testRecord.timestamp
     stateId = "ab8704b0bc2a2342"
-    fileName = wng.reductionOutputGroup().stateId(stateId).timestamp(timestamp).build()
+    fileName = wng.reductionOutputGroup().runNumber(runNumber).timestamp(timestamp).build()
     fileName += Config["nexus.file.extension"]
 
     wss = createReductionWorkspaces(testRecord.workspaceNames)  # noqa: F841
@@ -1505,7 +1640,7 @@ def test_readWriteReductionData(readSyntheticReductionRecord, createReductionWor
 
     runNumber, useLiteMode, timestamp = testRecord.runNumber, testRecord.useLiteMode, testRecord.timestamp
     stateId = "ab8704b0bc2a2342"
-    fileName = wng.reductionOutputGroup().stateId(stateId).timestamp(timestamp).build()
+    fileName = wng.reductionOutputGroup().runNumber(runNumber).timestamp(timestamp).build()
     fileName += Config["nexus.file.extension"]
 
     wss = createReductionWorkspaces(testRecord.workspaceNames)  # noqa: F841
@@ -1559,7 +1694,7 @@ def test_readWriteReductionData_pixel_mask(
 
     runNumber, useLiteMode, timestamp = testRecord.runNumber, testRecord.useLiteMode, testRecord.timestamp
     stateId = "ab8704b0bc2a2342"
-    fileName = wng.reductionOutputGroup().stateId(stateId).timestamp(timestamp).build()
+    fileName = wng.reductionOutputGroup().runNumber(runNumber).timestamp(timestamp).build()
     fileName += Config["nexus.file.extension"]
     wss = createReductionWorkspaces(testRecord.workspaceNames)  # noqa: F841
     localDataService = LocalDataService()
@@ -1614,7 +1749,7 @@ def test__constructReductionDataFilePath(readSyntheticReductionRecord):
     runNumber, useLiteMode, timestamp = testRecord.runNumber, testRecord.useLiteMode, testRecord.timestamp
     stateId = "ab8704b0bc2a2342"
     testIPTS = "IPTS-12345"
-    fileName = wng.reductionOutputGroup().stateId(stateId).timestamp(timestamp).build()
+    fileName = wng.reductionOutputGroup().runNumber(runNumber).timestamp(timestamp).build()
     fileName += Config["nexus.file.extension"]
 
     expectedFilePath = (
@@ -1627,7 +1762,7 @@ def test__constructReductionDataFilePath(readSyntheticReductionRecord):
     )
 
     localDataService = LocalDataService()
-    localDataService._generateStateId = mock.Mock(return_value=(stateId, None))
+    localDataService.generateStateId = mock.Mock(return_value=(stateId, None))
     localDataService.getIPTS = mock.Mock(return_value=testIPTS)
     actualFilePath = localDataService._constructReductionDataFilePath(runNumber, useLiteMode, timestamp)
     assert actualFilePath == expectedFilePath
@@ -1636,8 +1771,8 @@ def test__constructReductionDataFilePath(readSyntheticReductionRecord):
 def test_getReductionRecordFilePath():
     timestamp = time.time()
     localDataService = LocalDataService()
-    localDataService._generateStateId = mock.Mock()
-    localDataService._generateStateId.return_value = ("123", "456")
+    localDataService.generateStateId = mock.Mock()
+    localDataService.generateStateId.return_value = ("123", "456")
     localDataService._constructReductionDataRoot = mock.Mock()
     localDataService._constructReductionDataRoot.return_value = Path(Resource.getPath("outputs"))
     actualPath = localDataService._constructReductionRecordFilePath("57514", True, timestamp)
@@ -1648,8 +1783,8 @@ def test_getReductionRecordFilePath():
 def test_getCalibrationRecordFilePath():
     testVersion = randint(1, 20)
     localDataService = LocalDataService()
-    localDataService._generateStateId = mock.Mock()
-    localDataService._generateStateId.return_value = ("123", "456")
+    localDataService.generateStateId = mock.Mock()
+    localDataService.generateStateId.return_value = ("123", "456")
     localDataService._constructCalibrationStatePath = mock.Mock()
     localDataService._constructCalibrationStatePath.return_value = Path(Resource.getPath("outputs"))
     actualPath = localDataService.getCalibrationRecordFilePath("57514", True, testVersion)
@@ -1659,8 +1794,8 @@ def test_getCalibrationRecordFilePath():
 def test_getNormalizationRecordFilePath():
     testVersion = randint(1, 20)
     localDataService = LocalDataService()
-    localDataService._generateStateId = mock.Mock()
-    localDataService._generateStateId.return_value = ("123", "456")
+    localDataService.generateStateId = mock.Mock()
+    localDataService.generateStateId.return_value = ("123", "456")
     localDataService._constructNormalizationStatePath = mock.Mock()
     localDataService._constructNormalizationStatePath.return_value = Path(Resource.getPath("outputs"))
     actualPath = localDataService.getNormalizationRecordFilePath("57514", True, testVersion)
@@ -1864,8 +1999,8 @@ def test__getCurrentNormalizationRecord():
 def test__constructCalibrationParametersFilePath():
     testVersion = randint(10, 20)
     localDataService = LocalDataService()
-    localDataService._generateStateId = mock.Mock()
-    localDataService._generateStateId.return_value = (UNCHANGING_STATE_ID, None)
+    localDataService.generateStateId = mock.Mock()
+    localDataService.generateStateId.return_value = (UNCHANGING_STATE_ID, None)
     localDataService._constructCalibrationStatePath = mock.Mock()
     localDataService._constructCalibrationStatePath.return_value = Path(Resource.getPath("outputs/"))
     actualPath = localDataService._constructCalibrationParametersFilePath("57514", True, testVersion)
@@ -1876,7 +2011,7 @@ def test__constructCalibrationParametersFilePath():
 
 def test_readCalibrationState():
     localDataService = LocalDataService()
-    localDataService._generateStateId = mock.Mock(return_value=(ENDURING_STATE_ID, None))
+    localDataService.generateStateId = mock.Mock(return_value=(ENDURING_STATE_ID, None))
     localDataService.calibrationExists = mock.Mock(return_value=True)
     localDataService._constructCalibrationParametersFilePath = mock.Mock()
     localDataService._constructCalibrationParametersFilePath.return_value = Resource.getPath(
@@ -1894,8 +2029,8 @@ def test_readCalibrationState():
 
 def test_readCalibrationState_no_file():
     localDataService = LocalDataService()
-    localDataService._generateStateId = mock.Mock()
-    localDataService._generateStateId.return_value = (ENDURING_STATE_ID, None)
+    localDataService.generateStateId = mock.Mock()
+    localDataService.generateStateId.return_value = (ENDURING_STATE_ID, None)
     localDataService._constructCalibrationParametersFilePath = mock.Mock()
     localDataService._constructCalibrationParametersFilePath.return_value = Resource.getPath(
         f"{ENDURING_STATE_ID}/v_0001/CalibrationParameters.json"
@@ -1908,8 +2043,8 @@ def test_readCalibrationState_no_file():
 
 def test_readNormalizationState():
     localDataService = LocalDataService()
-    localDataService._generateStateId = mock.Mock()
-    localDataService._generateStateId.return_value = (ENDURING_STATE_ID, None)
+    localDataService.generateStateId = mock.Mock()
+    localDataService.generateStateId.return_value = (ENDURING_STATE_ID, None)
     localDataService.getNormalizationStatePath = mock.Mock()
     localDataService.getNormalizationStatePath.return_value = Path(
         Resource.getPath(f"{ENDURING_STATE_ID}/v_0001/NormalizationParameters.json")
@@ -2108,7 +2243,7 @@ def test_readDetectorState_bad_logs():
 
 def test_initializeState():
     # Test 'initializeState'; test basic functionality.
-    runNumber = "12345"
+    runNumber = "123"
     useLiteMode = True
 
     localDataService = LocalDataService()
@@ -2138,15 +2273,19 @@ def test_initializeState():
     localDataService.writeCalibrationState = mock.Mock()
     localDataService._prepareStateRoot = mock.Mock()
 
-    actual = localDataService.initializeState(runNumber, useLiteMode, "test")
-    actual.creationDate = testCalibrationData.creationDate
-    testCalibrationData.seedRun = runNumber
+    with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tmpDir:
+        stateId = testCalibrationData.instrumentState.id.hex  # "ab8704b0bc2a2342"
+        stateRootPath = Path(tmpDir) / stateId
+        localDataService.constructCalibrationStateRoot = mock.Mock(return_value=stateRootPath)
 
+        actual = localDataService.initializeState(runNumber, useLiteMode, "test")
+        actual.creationDate = testCalibrationData.creationDate
     assert actual == testCalibrationData
-    assert localDataService._writeDefaultDiffCalTable.called_once_with(runNumber, useLiteMode)
+    assert localDataService._writeDefaultDiffCalTable.call_count == 2
+    localDataService._writeDefaultDiffCalTable.assert_any_call(runNumber, True)
+    localDataService._writeDefaultDiffCalTable.assert_any_call(runNumber, False)
 
 
-# @mock.patch.object(LocalDataService, "_prepareStateRoot")
 def test_initializeState_calls_prepareStateRoot():
     # Test that 'initializeState' initializes the <state root> directory.
 
@@ -2180,7 +2319,7 @@ def test_initializeState_calls_prepareStateRoot():
     with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tmpDir:
         stateId = ENDURING_STATE_ID
         stateRootPath = Path(tmpDir) / stateId
-        localDataService._constructCalibrationStateRoot = mock.Mock(return_value=stateRootPath)
+        localDataService.constructCalibrationStateRoot = mock.Mock(return_value=stateRootPath)
 
         assert not stateRootPath.exists()
         localDataService.initializeState(runNumber, useLiteMode, "test")
@@ -2233,7 +2372,7 @@ def test_readSampleFilePaths():
 def test_readGroupingMap_no():
     localDataService = LocalDataService()
     localDataService.checkCalibrationFileExists = mock.Mock(return_value=False)
-    localDataService._generateStateId = mock.Mock(side_effect=RuntimeError("YOU IDIOT!"))
+    localDataService.generateStateId = mock.Mock(side_effect=RuntimeError("YOU IDIOT!"))
     localDataService._readDefaultGroupingMap = mock.Mock()
 
     runNumber = "flan"
@@ -2244,7 +2383,7 @@ def test_readGroupingMap_no():
 def test_readGroupingMap_yes():
     localDataService = LocalDataService()
     localDataService.checkCalibrationFileExists = mock.Mock(return_value=True)
-    localDataService._generateStateId = mock.Mock(return_value=(mock.Mock(), mock.Mock()))
+    localDataService.generateStateId = mock.Mock(return_value=(mock.Mock(), mock.Mock()))
     localDataService._readGroupingMap = mock.Mock()
     localDataService._readDefaultGroupingMap = mock.Mock(side_effect=RuntimeError("YOU IDIOT!"))
 
@@ -2263,7 +2402,8 @@ def test_readNoSampleFilePaths():
     assert "No samples found" in str(e.value)
 
 
-def test_readDefaultGroupingMap():
+def test__readDefaultGroupingMap():
+    # test of private `readDefaultGroupingMap` method
     service = LocalDataService()
     savePath = Config._config["instrument"]["calibration"]["powder"]["grouping"]["home"]
     Config._config["instrument"]["calibration"]["powder"]["grouping"]["home"] = Resource.getPath(
@@ -2292,7 +2432,7 @@ def test_readGroupingMap_initialized_state():
     service = LocalDataService()
     stateId = ENDURING_STATE_ID
     with state_root_redirect(service, stateId=stateId) as tmpRoot:
-        service._constructCalibrationStateRoot(stateId).mkdir()
+        service.constructCalibrationStateRoot(stateId).mkdir()
         tmpRoot.addFileAs(
             Resource.getPath("inputs/pixel_grouping/groupingMap.json"),
             service._groupingMapPath(stateId),
@@ -2387,7 +2527,7 @@ def test_writeRaggedWorkspace():
             NumEvents=500,
             Random=True,
             XUnit="DSP",
-            XMin=0,
+            XMin=0.5,
             XMax=8000,
             BinWidth=100,
         )

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -775,11 +775,7 @@ def test__findMatchingFileList():
 @mock.patch("os.stat")
 @mock.patch("pathlib.Path.exists", return_value=True)
 def test__hasWritePermissionsToPath_fileExistsWithPermission(mockExists, mockStat, mockS_IMODE):  # noqa: ARG001
-    mockStat.return_value = mock.Mock(
-        st_uid=os.getuid(),
-        st_gid=os.getgroups()[0],
-        st_mode=0o777
-    )
+    mockStat.return_value = mock.Mock(st_uid=os.getuid(), st_gid=os.getgroups()[0], st_mode=0o777)
     filePath = Path("/some/path/to/file")
     localDS = LocalDataService()
     result = localDS._hasWritePermissionstoPath(filePath)
@@ -823,6 +819,7 @@ def test_checkWritePermissions_parent_exists():
         assert not path.exists()
         status = LocalDataService().checkWritePermissions(path)
         assert status
+
 
 @mock.patch("stat.S_IMODE", return_value=0o000)
 def test_checkWritePermissions_parent_exists_no_permissions(mockOsAccess):

--- a/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
+++ b/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
@@ -131,10 +131,11 @@ def testReductionOutputName():
 
 def testReductionOutputGroupName():
     assert (  # "reduced_data,{stateId},{timestamp}"
-        f"_reduced_{fStateId}" == wng.reductionOutputGroup().stateId(stateId).build()
+        f"_reduced_{fRunNumber}" == wng.reductionOutputGroup().runNumber(runNumber).build()
     )
     assert (
-        f"_reduced_{fStateId}_{fTimestamp}" == wng.reductionOutputGroup().stateId(stateId).timestamp(timestamp).build()
+        f"_reduced_{fRunNumber}_{fTimestamp}"
+        == wng.reductionOutputGroup().runNumber(runNumber).timestamp(timestamp).build()
     )
 
 

--- a/tests/util/WhateversInTheFridge.py
+++ b/tests/util/WhateversInTheFridge.py
@@ -26,11 +26,12 @@ logger = snapredLogger.getLogger(__name__)
 @Singleton
 class WhateversInTheFridge(LocalDataService):
     """
-    Yeah, it'd be nice to use the LocalDataService and get all this...
+    Yeah, it'd be nice to go to the LocalDataService to get all this...
     But that's really complicated, and we don't have time.
     Just grab whatever's in the fridge.
 
-    Can mock out the LocalDataService for testing
+    Can mock out the LocalDataService for testing.
+    Only mocks out the factory methods; for export methods, use state_root_redirect
     """
 
     iptsCache: Dict[Tuple[str, str], Any] = {}
@@ -73,7 +74,7 @@ class WhateversInTheFridge(LocalDataService):
         return str(self.iptsCache[key])
 
     @ExceptionHandler(StateValidationException)
-    def _generateStateId(self, runId: str) -> Tuple[str, str]:
+    def generateStateId(self, runId: str) -> Tuple[str, str]:
         return "outpus/2kfxjiqm", "some gibberish"
 
     def checkCalibrationFileExists(self, runId: str):

--- a/tests/util/state_helpers.py
+++ b/tests/util/state_helpers.py
@@ -29,8 +29,8 @@ def state_root_override(runNumber: str, name: str, useLiteMode: bool = False, de
 
     # __enter__
     dataService = LocalDataService()
-    stateId, _ = dataService._generateStateId(runNumber)
-    stateRoot = Path(dataService._constructCalibrationStateRoot(stateId))
+    stateId, _ = dataService.generateStateId(runNumber)
+    stateRoot = Path(dataService.constructCalibrationStateRoot(stateId))
     if stateRoot.exists():
         raise RuntimeError(f"state-root directory '{stateRoot}' already exists -- please move it out of the way!")
 
@@ -72,8 +72,8 @@ class state_root_redirect:
     def __init__(self, dataService: LocalDataService, *, stateId: str = None):
         self.dataService = dataService
         self.stateId = stateId
-        self.old_constructCalibrationStateRoot = dataService._constructCalibrationStateRoot
-        self.old_generateStateId = dataService._generateStateId
+        self.old_constructCalibrationStateRoot = dataService.constructCalibrationStateRoot
+        self.old_generateStateId = dataService.generateStateId
 
     def __enter__(self):
         self.tmpdir = TemporaryDirectory(dir=Resource.getPath("outputs"), suffix="/")
@@ -82,13 +82,13 @@ class state_root_redirect:
             self.tmppath = self.tmppath / Path(self.stateId)
         else:
             self.stateId = str(self.tmppath.parts[-1])
-        self.dataService._generateStateId = lambda *x, **y: (self.stateId, "gibberish")  # noqa ARG005
-        self.dataService._constructCalibrationStateRoot = lambda *x, **y: self.tmppath  # noqa ARG005
+        self.dataService.generateStateId = lambda *x, **y: (self.stateId, None)  # noqa ARG005
+        self.dataService.constructCalibrationStateRoot = lambda *x, **y: self.tmppath  # noqa ARG005
         return self
 
     def __exit__(self, *arg, **kwargs):
-        self.dataService._constructCalibrationStateRoot = self.old_constructCalibrationStateRoot
-        self.dataService._generateStateId = self.old_generateStateId
+        self.dataService.constructCalibrationStateRoot = self.old_constructCalibrationStateRoot
+        self.dataService.generateStateId = self.old_generateStateId
         self.tmpdir.cleanup()
         assert not self.tmppath.exists()
         del self.tmpdir
@@ -121,7 +121,7 @@ class reduction_root_redirect:
         self.dataService = dataService
         self.stateId = stateId
         self.old_constructReductionStateRoot = dataService._constructReductionStateRoot
-        self.old_generateStateId = dataService._generateStateId
+        self.old_generateStateId = dataService.generateStateId
 
     def __enter__(self):
         self.tmpdir = TemporaryDirectory(dir=Resource.getPath("outputs"), suffix="/")
@@ -130,13 +130,13 @@ class reduction_root_redirect:
             self.tmppath = self.tmppath / Path(self.stateId)
         else:
             self.stateId = str(self.tmppath.parts[-1])
-        self.dataService._generateStateId = lambda *x, **y: (self.stateId, "gibberish")  # noqa ARG005
+        self.dataService.generateStateId = lambda *x, **y: (self.stateId, None)  # noqa ARG005
         self.dataService._constructReductionStateRoot = lambda *x, **y: self.tmppath  # noqa ARG005
         return self
 
     def __exit__(self, *arg, **kwargs):
         self.dataService._constructReductionStateRoot = self.old_constructReductionStateRoot
-        self.dataService._generateStateId = self.old_generateStateId
+        self.dataService.generateStateId = self.old_generateStateId
         self.tmpdir.cleanup()
         assert not self.tmppath.exists()
         del self.tmpdir


### PR DESCRIPTION
## Description of work
**Modified from the original [PR#450](https://github.com/neutrons/SNAPRed/pull/450) for "next".**

At the end of the reduction process for each run number, the complete reduction output data and metadata are saved to a path under the IPTS directory associated with that run number.  This saving step occurs automatically prior to the display of the actual reduction "save" panel. In addition, any cleanup of ADS-resident workspaces occurs at the same time.  The final reduction "save" panel now shows a helpful message indicating that the data has been saved, and to which output path (shown as the reduction-output state root).

In the case that the user does not have write permissions to the expected save directory, a continue-anyway prompt is displayed at the start of the reduction process. In this case, the message in the "save" panel reminds the user that they need to save their output workspaces.

## Explanation of work

This commit includes the following changes:

  * Automatic save of reduction output-workspace data and metadata at the end of the reduction process for each run;

  * Checks of write-permissions and any associated notification prior to the start of the reduction process;

  * Analogous write-permissions checks prior to the start of the diffraction-calibration and normalization-calibration processes;  Note that unlike reduction, users without the required write permissions for diffraction-calibration or normalization-calibration are not allowed to continue with these processes.  Regardless, the continue-anyway mechanisms have been applied to this purpose, as this then allows any modification of all of this behavior to be centralized.
    
  * **[specific to staging]:** the continue-anyway part of `ReductionService.validateRequest` when diffraction-calibration or normalization-calibration aren't present has been retained from `next`, although modified to not allow the user to continue.  This provides an earlier warning than the previous one.
   
  * Same-state verification of run numbers entered in the reduction-request panel.  At present, in order to facilitate pixel-mask selection, all run numbers must be from the same state.  This requirement can eventually be omitted through the addition of a more-complicated reduction-panel sequence involving pixel-mask selection and assignment on a per-state basis.

  * Reduction output filenames now include the run number, rather than the state-id.  (Note that this is the first time that these output steps have actually been hooked up, so this change shouldn't affect anything.)

  * Adjustments to the text format in some continue-anyway message boxes in order to make better use of screen real estate.  Some text is smaller, and some _bold_ formatting is now used.

  * Fixups to `ValueError` input-validation behavior in the reduction panels so that these exceptions actually result in message boxes, rather than core dumps.  Note that the previous code had been written under the assumption that all of these input-validation steps were occurring in sections wrapped by `SNAPResponseHandler`, and this is most definitely _not_ the case.

  * Fixups to continue-anyway logic.  This allows multiple continue-anyway messages to pop-up in the correct sequence, and prevents these queries from occurring multiple times.

  * Implementation of a more general service-layer `checkWritePermissions` method, which actually checks whether or not the user _could_ correctly _create_ a given path, provided at least one of its parent components exists.

## To test

### Dev testing
Additional unit tests have been added to cover the changes of this commit.  Several _existing_ unit tests were modified so that they made a bit more sense (e.g. continue-anyway logic).

**Automatic save process:** verify that the expected files are written to the correct location on disk.  Ironically, the easiest way to get this location is to look at the message in the final "save" panel.  Note that the _contents_ of these files has been verified elsewhere, and is _not_ part of this pull request.

**In order to test the write permissions tests and notifications:**
    Start with an SNS-mirror section, containing your favorite run numbers (e.g. 46680 and 61991 -- two different states).  Step by step, going through the workflows: (1) demonstrate that the panel succeeds as expected in normal operation; (2) `chmod 555 "instrument.calibration.powder.home" / <state id>` -- demonstrate that the notification pops up, and you aren't actually allowed to continue with diffraction-calibration or normalization-calibration workflows, and (3) for reduction, `chmod 555 <read out the save directory root from the successful process test>` -- a notification should pop up, and after continuing, the "save" panel should show an appropriate reminder.


### CIS testing
Same as for dev testing.


## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#6323](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=6323)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
