### PR TITLE
Ewm6834 fix default record

### DIFF
--- a/src/snapred/backend/dao/calibration/CalibrationDefaultRecord.py
+++ b/src/snapred/backend/dao/calibration/CalibrationDefaultRecord.py
@@ -1,0 +1,26 @@
+from typing import Dict, List
+
+from snapred.backend.dao.calibration.Calibration import Calibration
+from snapred.backend.dao.indexing.Record import Record
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName, WorkspaceType
+
+
+class CalibrationDefaultRecord(Record, extra="ignore"):
+    """
+
+    The refer to the CalibrationRecord class for a more in-depth explanation of Calibration Records.
+    This class contains the default, most basic information contained within the default Calibration.
+
+    """
+
+    # inherits from Record
+    # - runNumber
+    # - useLiteMode
+    # - version
+    # override this to point at the correct daughter class
+    # NOTE the version on the calculationParameters MUST match the version on the record
+    # this should be enforced by a validator
+    calculationParameters: Calibration
+
+    # specific to calibration records
+    workspaces: Dict[WorkspaceType, List[WorkspaceName]]

--- a/src/snapred/backend/dao/calibration/CalibrationRecord.py
+++ b/src/snapred/backend/dao/calibration/CalibrationRecord.py
@@ -1,14 +1,12 @@
-from typing import Dict, List, Optional
+from typing import List, Optional
 
-from snapred.backend.dao.calibration.Calibration import Calibration
+from snapred.backend.dao.calibration.CalibrationDefaultRecord import CalibrationDefaultRecord
 from snapred.backend.dao.calibration.FocusGroupMetric import FocusGroupMetric
 from snapred.backend.dao.CrystallographicInfo import CrystallographicInfo
-from snapred.backend.dao.indexing.Record import Record
 from snapred.backend.dao.state.PixelGroup import PixelGroup
-from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName, WorkspaceType
 
 
-class CalibrationRecord(Record, extra="ignore"):
+class CalibrationRecord(CalibrationDefaultRecord, extra="ignore"):
     """
 
     The CalibrationRecord class, serves as a comprehensive log of the inputs and parameters employed
@@ -22,17 +20,7 @@ class CalibrationRecord(Record, extra="ignore"):
 
     """
 
-    # inherits from Record
-    # - runNumber
-    # - useLiteMode
-    # - version
-    # override this to point at the correct daughter class
-    # NOTE the version on the calculationParameters MUST match the version on the record
-    # this should be enforced by a validator
-    calculationParameters: Calibration
-
-    # specific to calibration records
+    # specific to full calibration records
     crystalInfo: CrystallographicInfo
     pixelGroups: Optional[List[PixelGroup]] = None  # TODO: really shouldn't be optional, will be when sns data fixed
     focusGroupCalibrationMetrics: FocusGroupMetric
-    workspaces: Dict[WorkspaceType, List[WorkspaceName]]

--- a/src/snapred/backend/dao/ingredients/ReductionIngredients.py
+++ b/src/snapred/backend/dao/ingredients/ReductionIngredients.py
@@ -24,6 +24,8 @@ class ReductionIngredients(BaseModel):
 
     # these should come from calibration / normalization records
     # But will not exist if we proceed without calibration / normalization
+    # NOTE: These are peaks for normalization, and thus should use the
+    # Calibrant Sample for the Normalization
     detectorPeaksMany: Optional[List[List[GroupPeakList]]] = None
     smoothingParameter: Optional[float]
     calibrantSamplePath: Optional[str]

--- a/src/snapred/backend/dao/normalization/NormalizationRecord.py
+++ b/src/snapred/backend/dao/normalization/NormalizationRecord.py
@@ -33,6 +33,7 @@ class NormalizationRecord(Record, extra="ignore"):
     workspaceNames: List[WorkspaceName] = []
     calibrationVersionUsed: int = VERSION_DEFAULT
     crystalDBounds: Limit[float]
+    normalizationCalibrantSamplePath: str
 
     # must also parse integers as background run numbers
     @field_validator("backgroundRunNumber", mode="before")

--- a/src/snapred/backend/dao/reduction/ReductionRecord.py
+++ b/src/snapred/backend/dao/reduction/ReductionRecord.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from snapred.backend.dao.calibration import CalibrationDefaultRecord
 from snapred.backend.dao.calibration.CalibrationRecord import CalibrationRecord
 from snapred.backend.dao.normalization.NormalizationRecord import NormalizationRecord
 from snapred.backend.dao.state.PixelGroupingParameters import PixelGroupingParameters
@@ -24,7 +25,7 @@ class ReductionRecord(BaseModel):
     timestamp: float = Field(frozen=True, default=None)
 
     # specific to reduction records
-    calibration: Optional[CalibrationRecord] = None
+    calibration: Optional[CalibrationRecord | CalibrationDefaultRecord] = None
     normalization: Optional[NormalizationRecord] = None
     pixelGroupingParameters: Dict[str, List[PixelGroupingParameters]]
 

--- a/src/snapred/backend/dao/request/CreateNormalizationRecordRequest.py
+++ b/src/snapred/backend/dao/request/CreateNormalizationRecordRequest.py
@@ -1,29 +1,18 @@
-from typing import List, Optional
+from pydantic import ConfigDict
 
-from pydantic import BaseModel, ConfigDict
-
-from snapred.backend.dao.indexing.Versioning import VERSION_DEFAULT
-from snapred.backend.dao.Limit import Limit
-from snapred.backend.dao.normalization.Normalization import Normalization
-from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
+from snapred.backend.dao.normalization import NormalizationRecord
 
 
-class CreateNormalizationRecordRequest(BaseModel, extra="forbid"):
+class CreateNormalizationRecordRequest(NormalizationRecord, extra="forbid"):
     """
     The needed data to create a NormalizationRecord.
     """
-
-    runNumber: str
-    useLiteMode: bool
-    version: Optional[int] = None
-    calculationParameters: Normalization
-    backgroundRunNumber: str
-    smoothingParameter: float
-    workspaceNames: List[WorkspaceName] = []
-    calibrationVersionUsed: Optional[int] = VERSION_DEFAULT
-    crystalDBounds: Limit[float]
 
     model_config = ConfigDict(
         # required in order to use 'WorkspaceName'
         arbitrary_types_allowed=True,
     )
+
+    @classmethod
+    def parseVersion(cls, version, *, exclude_none: bool = False, exclude_default: bool = False) -> int | None:  # noqa: ARG003
+        return version

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -26,6 +26,7 @@ from snapred.meta.decorators.Singleton import Singleton
 from snapred.meta.mantid.WorkspaceNameGenerator import (
     NameBuilder,
     WorkspaceName,
+    WorkspaceType,
 )
 from snapred.meta.mantid.WorkspaceNameGenerator import (
     WorkspaceNameGenerator as wng,
@@ -43,6 +44,8 @@ class GroceryService:
 
     Just send me a list.
     """
+
+    diffcalTableFileExtension: str = ".h5"
 
     def __init__(self, dataService: LocalDataService = None):
         # 'LocalDataService' is a singleton:
@@ -224,11 +227,19 @@ class GroceryService:
             / (self._createDiffcalOutputWorkspaceName(item) + ext)
         )
 
-    @validate_call
-    def _createDiffcalTableFilename(self, runNumber: str, useLiteMode: bool, version: Optional[int]) -> str:
+    def _createDiffcalTableFilepathFromWsName(
+        self, runNumber: str, useLiteMode: bool, version: Optional[int], wsName: WorkspaceName
+    ) -> str:
         return str(
             Path(self._getCalibrationDataPath(runNumber, useLiteMode, version))
-            / (self._createDiffcalTableWorkspaceName(runNumber, useLiteMode, version) + ".h5")
+            / (wsName + self.diffcalTableFileExtension)
+        )
+
+    @validate_call
+    def _createDiffcalTableFilepath(self, runNumber: str, useLiteMode: bool, version: Optional[int]) -> str:
+        return str(
+            Path(self._getCalibrationDataPath(runNumber, useLiteMode, version))
+            / (self.createDiffcalTableWorkspaceName(runNumber, useLiteMode, version) + self.diffcalTableFileExtension)
         )
 
     @validate_call
@@ -245,7 +256,10 @@ class GroceryService:
     def _createReductionPixelMaskWorkspaceFilename(self, runNumber: str, useLiteMode: bool, timestamp: float) -> str:
         return str(
             Path(self._getReductionDataPath(runNumber, useLiteMode, timestamp))
-            / (self._createReductionPixelMaskWorkspaceName(runNumber, useLiteMode, timestamp) + ".h5")
+            / (
+                self._createReductionPixelMaskWorkspaceName(runNumber, useLiteMode, timestamp)
+                + self.diffcalTableFileExtension
+            )
         )
 
     ## WORKSPACE NAME METHODS
@@ -285,8 +299,29 @@ class GroceryService:
             .build()
         )
 
+    def lookupDiffcalTableWorkspaceName(
+        self, runNumber: str, useLiteMode: bool, version: Optional[int]
+    ) -> WorkspaceName:
+        indexer = self.dataService.calibrationIndexer(runNumber, useLiteMode)
+        if not isinstance(version, int):
+            version = indexer.latestApplicableVersion(runNumber)
+
+        record = indexer.readRecord(version)
+        if record is None:
+            raise RuntimeError(f"Could not find calibration record for run {runNumber} and version {version}")
+
+        # find first difcal table in record
+        wsTableNameTuple = next(filter(lambda t: t[0] == WorkspaceType.DIFFCAL_TABLE, record.workspaces.items()), None)
+        if wsTableNameTuple is None:
+            raise RuntimeError(
+                f"Could not find diffcal table in record for run {runNumber} in workspaces: {record.workspaces}"
+            )
+        # grab first value in list value of tuple
+        tableWorkspaceName = wsTableNameTuple[1][0]
+        return tableWorkspaceName
+
     @validate_call
-    def _createDiffcalTableWorkspaceName(
+    def createDiffcalTableWorkspaceName(
         self,
         runNumber: str,
         useLiteMode: bool,  # noqa: ARG002
@@ -854,7 +889,7 @@ class GroceryService:
         :rtype: Dict[str, Any]
         """
         runNumber, version, useLiteMode = item.runNumber, item.version, item.useLiteMode
-        tableWorkspaceName = self._createDiffcalTableWorkspaceName(runNumber, useLiteMode, version)
+        tableWorkspaceName = self.lookupDiffcalTableWorkspaceName(runNumber, useLiteMode, version)
         maskWorkspaceName = self._createDiffcalMaskWorkspaceName(runNumber, useLiteMode, version)
 
         if self.workspaceDoesExist(tableWorkspaceName):
@@ -865,7 +900,7 @@ class GroceryService:
             }
         else:
             # table + mask are in the same hdf5 file:
-            filename = self._createDiffcalTableFilename(runNumber, useLiteMode, version)
+            filename = self._createDiffcalTableFilepathFromWsName(runNumber, useLiteMode, version, tableWorkspaceName)
 
             # Unless overridden: use a cached workspace as the instrument donor.
             instrumentPropertySource, instrumentSource = (
@@ -888,9 +923,10 @@ class GroceryService:
 
         return data
 
+    # this isnt really a fetch method, this generates data
     @validate_call
     def fetchDefaultDiffCalTable(self, runNumber: str, useLiteMode: bool, version: int) -> WorkspaceName:
-        tableWorkspaceName = self._createDiffcalTableWorkspaceName("default", useLiteMode, version)
+        tableWorkspaceName = self.createDiffcalTableWorkspaceName("default", useLiteMode, version)
         self.mantidSnapper.CalculateDiffCalTable(
             "Generate the default diffcal table",
             InputWorkspace=self._fetchInstrumentDonor(runNumber, useLiteMode),
@@ -1074,7 +1110,8 @@ class GroceryService:
                     # NOTE: fetchCalibrationWorkspaces will set the workspace name
                     # to that of the table workspace.  Because of possible confusion with
                     # the behavior of the mask workspace, the workspace name is overridden here.
-                    tableWorkspaceName = self._createDiffcalTableWorkspaceName(
+
+                    tableWorkspaceName = self.lookupDiffcalTableWorkspaceName(
                         item.runNumber, item.useLiteMode, item.version
                     )
                     res = self.fetchCalibrationWorkspaces(item)

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -236,7 +236,7 @@ class GroceryService:
         if wsName != expectedWsName:
             raise ValueError(
                 f"Workspace name {wsName} does not match the expected diffcal table workspace name for run {runNumber}",
-                "(i.e. {expectedWsName})",
+                f"(i.e. {expectedWsName})",
             )
 
         return str(calibrationDataPath / (wsName + self.diffcalTableFileExtension))

--- a/src/snapred/backend/data/Indexer.py
+++ b/src/snapred/backend/data/Indexer.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional
 from pydantic import validate_call
 
 from snapred.backend.dao.calibration.Calibration import Calibration
-from snapred.backend.dao.calibration.CalibrationRecord import CalibrationRecord
+from snapred.backend.dao.calibration.CalibrationRecord import CalibrationDefaultRecord, CalibrationRecord
 from snapred.backend.dao.indexing.CalculationParameters import CalculationParameters
 from snapred.backend.dao.indexing.IndexEntry import IndexEntry
 from snapred.backend.dao.indexing.Record import Record
@@ -57,6 +57,10 @@ RECORD_TYPE = {
     IndexerType.NORMALIZATION: NormalizationRecord,
     IndexerType.REDUCTION: ReductionRecord,
     IndexerType.DEFAULT: Record,
+}
+
+DEFAULT_RECORD_TYPE = {
+    IndexerType.CALIBRATION: CalibrationDefaultRecord,
 }
 
 # the params type for each indexer type
@@ -354,6 +358,15 @@ class Indexer:
         record.calculationParameters.version = record.version
         return record
 
+    def _determineRecordType(self, version: Optional[int] = None):
+        version = self.thisOrCurrentVersion(version)
+        recordType = None
+        if version == VERSION_DEFAULT:
+            recordType = DEFAULT_RECORD_TYPE.get(self.indexerType, None)
+        if recordType is None:
+            recordType = RECORD_TYPE[self.indexerType]
+        return recordType
+
     def readRecord(self, version: Optional[int] = None) -> Record:
         """
         If no version given, defaults to current version
@@ -362,7 +375,7 @@ class Indexer:
         filePath = self.recordPath(version)
         record = None
         if filePath.exists():
-            record = parse_file_as(RECORD_TYPE[self.indexerType], filePath)
+            record = parse_file_as(self._determineRecordType(version), filePath)
         return record
 
     def writeRecord(self, record: Record):

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -216,6 +216,7 @@ class NormalizationService(Service):
             useLiteMode=request.useLiteMode,
             backgroundRunNumber=request.backgroundRunNumber,
             smoothingParameter=request.smoothingParameter,
+            normalizationCalibrantSamplePath=request.calibrantSamplePath,
             calculationParameters=normalization,
             crystalDBounds=request.crystalDBounds,
         )

--- a/src/snapred/backend/service/ReductionService.py
+++ b/src/snapred/backend/service/ReductionService.py
@@ -343,13 +343,10 @@ class ReductionService(Service):
         #   TODO: set these when the request is initially generated.
         calVersion = None
         normVersion = None
-        if ContinueWarning.Type.MISSING_DIFFRACTION_CALIBRATION not in request.continueFlags:
-            calVersion = self.dataFactoryService.getThisOrLatestCalibrationVersion(
-                request.runNumber, request.useLiteMode
-            )
-            self.groceryClerk.name("diffcalWorkspace").diffcal_table(request.runNumber, calVersion).useLiteMode(
-                request.useLiteMode
-            ).add()
+        calVersion = self.dataFactoryService.getThisOrLatestCalibrationVersion(request.runNumber, request.useLiteMode)
+        self.groceryClerk.name("diffcalWorkspace").diffcal_table(request.runNumber, calVersion).useLiteMode(
+            request.useLiteMode
+        ).add()
 
         if ContinueWarning.Type.MISSING_NORMALIZATION not in request.continueFlags:
             normVersion = self.dataFactoryService.getThisOrLatestNormalizationVersion(

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -209,7 +209,8 @@ class SousChef(Service):
         )
         if calibrationRecord is not None:
             ingredients.calibrantSamplePath = calibrationRecord.calculationParameters.calibrantSamplePath
-            ingredients.cifPath = self.dataFactoryService.getCifFilePath(Path(ingredients.calibrantSamplePath).stem)
+            if ingredients.calibrantSamplePath:
+                ingredients.cifPath = self.dataFactoryService.getCifFilePath(Path(ingredients.calibrantSamplePath).stem)
         return ingredients
 
     def _pullManyCalibrationDetectorPeaks(

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -237,6 +237,7 @@ class NormalizationWorkflow(WorkflowImplementer):
             workspaceNames=normalizationRecord.workspaceNames,
             calibrationVersionUsed=normalizationRecord.calibrationVersionUsed,
             crystalDBounds=normalizationRecord.crystalDBounds,
+            normalizationCalibrantSamplePath=normalizationRecord.normalizationCalibrantSamplePath
         )
 
         payload = NormalizationExportRequest(

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -237,7 +237,7 @@ class NormalizationWorkflow(WorkflowImplementer):
             workspaceNames=normalizationRecord.workspaceNames,
             calibrationVersionUsed=normalizationRecord.calibrationVersionUsed,
             crystalDBounds=normalizationRecord.crystalDBounds,
-            normalizationCalibrantSamplePath=normalizationRecord.normalizationCalibrantSamplePath
+            normalizationCalibrantSamplePath=normalizationRecord.normalizationCalibrantSamplePath,
         )
 
         payload = NormalizationExportRequest(

--- a/tests/integration/test_versions_in_order.py
+++ b/tests/integration/test_versions_in_order.py
@@ -187,7 +187,7 @@ class ImitationGroceryService(GroceryService):
 
     def fetchCalibrationWorkspaces(self, item: Any) -> Dict[str, Any]:
         runNumber, version, useLiteMode = item.runNumber, item.version, item.useLiteMode
-        tableWorkspaceName = self._createDiffcalTableWorkspaceName(runNumber, useLiteMode, version)
+        tableWorkspaceName = self.createDiffcalTableWorkspaceName(runNumber, useLiteMode, version)
         maskWorkspaceName = self._createDiffcalMaskWorkspaceName(runNumber, useLiteMode, version)
 
         CloneWorkspace(InputWorkspace=self.diffcalTableWS, OutputWorkspace=tableWorkspaceName)
@@ -199,7 +199,7 @@ class ImitationGroceryService(GroceryService):
         }
 
     def fetchDefaultDiffCalTable(self, runNumber: str, useLiteMode: bool, version: int | Any) -> str:
-        tableWorkspaceName = self._createDiffcalTableWorkspaceName("default", useLiteMode, version)
+        tableWorkspaceName = self.createDiffcalTableWorkspaceName("default", useLiteMode, version)
         CloneWorkspace(InputWorkspace=self.diffcalTableWS, OutputWorkspace=tableWorkspaceName)
         return tableWorkspaceName
 

--- a/tests/resources/inputs/reduction/ReductionRecord_20240614T130420.json
+++ b/tests/resources/inputs/reduction/ReductionRecord_20240614T130420.json
@@ -761,7 +761,8 @@
             "fitted_strippedFocussedData_stripped_2"
         ],
         "version": 7,
-        "crystalDBounds": {"minimum": 0.4, "maximum": 100.0}
+        "crystalDBounds": {"minimum": 0.4, "maximum": 100.0},
+        "normalizationCalibrantSamplePath": "/SNS/SNAP/shared/Calibration/Calibrants/Al2O3/Al2O3_20240614T130420.nxs"
     },
     "calculationParameters": {
         "instrumentState": {

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -299,6 +299,23 @@ class TestGroceryService(unittest.TestCase):
         assert "some" in res
         assert ".nxs.h5" in res
 
+    def test_diffcal_table_filename_from_workspaceName(self):
+        workspaceName = wng.diffCalTable().runNumber(self.runNumber).version(self.version).build()
+        res = self.instance._createDiffcalTableFilepathFromWsName(
+            self.runNumber, self.useLiteMode, self.version, workspaceName
+        )
+        assert workspaceName in res
+        assert self.runNumber in res
+        assert wnvf.formatVersion(self.version) in res
+        assert ".h5" in res
+
+    def test_diffcal_table_filename_from_workspaceName_failure_name_mismatch(self):
+        workspaceName = "bogus_name_"
+        with pytest.raises(ValueError, match=r".*Workspace name .* does not match the expected *"):
+            self.instance._createDiffcalTableFilepathFromWsName(
+                self.runNumber, self.useLiteMode, self.version, workspaceName
+            )
+
     def test_diffcal_table_filename(self):
         # Test name generation for diffraction-calibration table filename
         res = self.instance._createDiffcalTableFilepath(self.runNumber, self.useLiteMode, self.version)

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -300,7 +300,7 @@ class TestGroceryService(unittest.TestCase):
 
     def test_diffcal_table_filename(self):
         # Test name generation for diffraction-calibration table filename
-        res = self.instance._createDiffcalTableFilename(self.runNumber, self.useLiteMode, self.version)
+        res = self.instance._createDiffcalTableFilepath(self.runNumber, self.useLiteMode, self.version)
         assert self.difc_name in res
         assert self.runNumber in res
         assert wnvf.formatVersion(self.version) in res
@@ -392,7 +392,7 @@ class TestGroceryService(unittest.TestCase):
 
     def test_diffcal_table_workspacename(self):
         # Test name generation for diffraction-calibration output table
-        res = self.instance._createDiffcalTableWorkspaceName(self.runNumber, self.useLiteMode, self.version)
+        res = self.instance.createDiffcalTableWorkspaceName(self.runNumber, self.useLiteMode, self.version)
         assert self.difc_name in res
         assert self.runNumber in res
         assert wnvf.formatVersion(self.version) in res
@@ -1128,7 +1128,8 @@ class TestGroceryService(unittest.TestCase):
             groceryList = GroceryListItem.builder().native().diffcal_table(self.runNumber1, self.version).buildList()
             # independently construct the pathname, move file to there, assert exists
             diffCalTableName = wng.diffCalTable().runNumber(self.runNumber1).version(self.version).build()
-            diffCalTableFilename = self.instance._createDiffcalTableFilename(
+            self.instance.lookupDiffcalTableWorkspaceName = mock.Mock(return_value=diffCalTableName)
+            diffCalTableFilename = self.instance._createDiffcalTableFilepath(
                 runNumber=groceryList[0].runNumber,
                 useLiteMode=groceryList[0].useLiteMode,
                 version=self.version,
@@ -1149,6 +1150,7 @@ class TestGroceryService(unittest.TestCase):
         groceryList = GroceryListItem.builder().native().diffcal_table(self.runNumber1, self.version).buildList()
         diffCalTableName = wng.diffCalTable().runNumber(self.runNumber1).build()
         diffCalTableName = f"{diffCalTableName}_{wnvf.formatVersion(self.version)}"
+        self.instance.lookupDiffcalTableWorkspaceName = mock.Mock(return_value=diffCalTableName)
 
         CloneWorkspace(
             InputWorkspace=self.sampleTableWS,
@@ -1169,8 +1171,9 @@ class TestGroceryService(unittest.TestCase):
         with state_root_redirect(self.instance.dataService) as tmpRoot:
             groceryList = GroceryListItem.builder().native().diffcal_table(self.runNumber1, self.version).buildList()
             diffCalTableName = wng.diffCalTable().runNumber(self.runNumber1).version(self.version).build()
+            self.instance.lookupDiffcalTableWorkspaceName = mock.Mock(return_value=diffCalTableName)
             diffCalMaskName = wng.diffCalMask().runNumber(self.runNumber1).version(self.version).build()
-            diffCalTableFilename = self.instance._createDiffcalTableFilename(
+            diffCalTableFilename = self.instance._createDiffcalTableFilepath(
                 runNumber=groceryList[0].runNumber,
                 useLiteMode=groceryList[0].useLiteMode,
                 version=self.version,
@@ -1193,7 +1196,7 @@ class TestGroceryService(unittest.TestCase):
             diffCalMaskName = wng.diffCalMask().runNumber(self.runNumber1).version(self.version).build()
 
             # DiffCal filename is constructed from the table name
-            diffCalTableFilename = self.instance._createDiffcalTableFilename(
+            diffCalTableFilename = self.instance._createDiffcalTableFilepath(
                 runNumber=groceryList[0].runNumber,
                 useLiteMode=groceryList[0].useLiteMode,
                 version=groceryList[0].version,
@@ -1202,6 +1205,9 @@ class TestGroceryService(unittest.TestCase):
             assert Path(diffCalTableFilename).exists()
 
             assert not mtd.doesExist(diffCalMaskName)
+            self.instance.lookupDiffcalTableWorkspaceName = mock.Mock(
+                return_value=wng.diffCalTable().runNumber(self.runNumber1).version(self.version).build()
+            )
             items = self.instance.fetchGroceryList(groceryList)
             assert items[0] == diffCalMaskName
             assert mtd.doesExist(diffCalMaskName)
@@ -1211,6 +1217,9 @@ class TestGroceryService(unittest.TestCase):
         #   workspace already in ADS
         groceryList = GroceryListItem.builder().native().diffcal_mask(self.runNumber1, self.version).buildList()
         diffCalMaskName = wng.diffCalMask().runNumber(self.runNumber1).version(self.version).build()
+        self.instance.lookupDiffcalTableWorkspaceName = mock.Mock(
+            return_value=wng.diffCalTable().runNumber(self.runNumber1).version(self.version).build()
+        )
         CloneWorkspace(
             InputWorkspace=self.sampleMaskWS,
             OutputWorkspace=diffCalMaskName,
@@ -1242,7 +1251,8 @@ class TestGroceryService(unittest.TestCase):
 
             # DiffCal filename is constructed from the table name
             diffCalTableName = wng.diffCalTable().runNumber(self.runNumber1).version(self.version).build()
-            diffCalTableFilename = self.instance._createDiffcalTableFilename(
+            self.instance.lookupDiffcalTableWorkspaceName = mock.Mock(return_value=diffCalTableName)
+            diffCalTableFilename = self.instance._createDiffcalTableFilepath(
                 runNumber=groceryList[0].runNumber,
                 useLiteMode=groceryList[0].useLiteMode,
                 version=groceryList[0].version,
@@ -1639,7 +1649,7 @@ class TestGroceryService(unittest.TestCase):
         ws = self.instance.fetchDefaultDiffCalTable(runNumber, useLiteMode, self.version)
 
         # make sure the correct workspace name is generated
-        assert ws == self.instance._createDiffcalTableWorkspaceName("default", useLiteMode, self.version)
+        assert ws == self.instance.createDiffcalTableWorkspaceName("default", useLiteMode, self.version)
         ## Compare the two diffcal tables to ensure equality
         table1 = mtd[ws]
         table2 = mtd[refTable]

--- a/tests/unit/backend/data/test_Indexer.py
+++ b/tests/unit/backend/data/test_Indexer.py
@@ -19,7 +19,7 @@ from snapred.backend.dao.indexing.Record import Record
 from snapred.backend.dao.indexing.Versioning import VERSION_DEFAULT, VERSION_START
 from snapred.backend.dao.normalization.Normalization import Normalization
 from snapred.backend.dao.normalization.NormalizationRecord import NormalizationRecord
-from snapred.backend.data.Indexer import Indexer, IndexerType
+from snapred.backend.data.Indexer import DEFAULT_RECORD_TYPE, Indexer, IndexerType
 from snapred.meta.Config import Resource
 from snapred.meta.mantid.WorkspaceNameGenerator import ValueFormatter as wnvf
 from snapred.meta.redantic import parse_file_as, write_model_list_pretty, write_model_pretty
@@ -1008,3 +1008,7 @@ class TestIndexer(unittest.TestCase):
         res = indexer.readParameters()
         assert type(res) is CalculationParameters
         assert res == params
+
+    def test__determineRecordType(self):
+        indexer = self.initIndexer(IndexerType.CALIBRATION)
+        assert indexer._determineRecordType(VERSION_DEFAULT) == DEFAULT_RECORD_TYPE.get(IndexerType.CALIBRATION)

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -1859,7 +1859,7 @@ def test_readWriteCalibrationState():
         assert ans == calibration
 
 
-@mock.patch("snapred.backend.data.GroceryService.GroceryService._createDiffcalTableWorkspaceName")
+@mock.patch("snapred.backend.data.GroceryService.GroceryService.createDiffcalTableWorkspaceName")
 @mock.patch("snapred.backend.data.GroceryService.GroceryService._fetchInstrumentDonor")
 def test_writeDefaultDiffCalTable(fetchInstrumentDonor, createDiffCalTableWorkspaceName):
     # verify that the default diffcal table is being written to the default state directory

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -484,7 +484,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             self.instance.dataFactoryService.getCalibrationDataPath = mock.Mock(return_value=tmpDir)
             self.instance.groceryService.dataService.readCalibrationRecord = mock.Mock()
             self.instance.groceryService.fetchCalibrationWorkspaces = mock.Mock()
-            self.instance.groceryService._createDiffcalTableWorkspaceName = mock.Mock()
+            self.instance.groceryService.createDiffcalTableWorkspaceName = mock.Mock()
             self.instance.groceryService.fetchGroceryDict = mock.Mock()
             self.create_fake_diffcal_files(Path(tmpDir), calibRecord.workspaces, calibRecord.version)
 

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -35,19 +35,20 @@ class TestSousChef(unittest.TestCase):
     def test_prepManyDetectorPeaks(self):
         self.instance.prepDetectorPeaks = mock.Mock()
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
+        self.instance._getThresholdFromCalibrantSample = mock.Mock(return_value=0.5)
         res = self.instance.prepManyDetectorPeaks(self.ingredients)
         assert res[0] == self.instance.prepDetectorPeaks.return_value
         self.instance.prepDetectorPeaks.assert_called_once_with(self.ingredients, purgePeaks=False)
 
     def test_prepManyDetectorPeaks_no_calibration(self):
         self.instance.prepDetectorPeaks = mock.Mock()
-        self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=False)
+        self.ingredients.calibrantSamplePath = None
         self.instance.logger = mock.Mock()
         self.instance.logger.warning = mock.Mock()
 
         res = self.instance.prepManyDetectorPeaks(self.ingredients)
         assert res is None
-        self.instance.logger().warning.assert_called_once_with("No calibration record found for run 123 in lite mode.")
+        self.instance.logger().warning.assert_called_once_with("No calibrant sample found for run 123 in lite mode.")
 
     def test_prepManyPixelGroups(self):
         self.instance.prepPixelGroup = mock.Mock()
@@ -84,6 +85,7 @@ class TestSousChef(unittest.TestCase):
         mockCalibration = mock.Mock()
         self.instance.dataFactoryService.getCalibrationState = mock.Mock(return_value=mockCalibration)
         self.instance.prepCalibrantSample = mock.Mock()
+        self.instance._getThresholdFromCalibrantSample = mock.Mock(return_value=0.5)
 
         res = self.instance.prepCalibration(self.ingredients)
 
@@ -97,6 +99,7 @@ class TestSousChef(unittest.TestCase):
     def test_prepCalibration_userFWHM(self):
         mockCalibration = mock.Mock()
         self.instance.dataFactoryService.getCalibrationState = mock.Mock(return_value=mockCalibration)
+        self.instance._getThresholdFromCalibrantSample = mock.Mock(return_value=0.5)
         fakeLeft = 116
         fakeRight = 17
         self.ingredients.fwhmMultipliers = mock.Mock(left=fakeLeft, right=fakeRight)
@@ -302,6 +305,7 @@ class TestSousChef(unittest.TestCase):
         self.instance.prepCalibrantSample = mock.Mock()
         self.instance.prepPeakIngredients = mock.Mock()
         self.instance.parseGroupPeakList = mock.Mock(side_effect=lambda y: [y])
+        self.instance._getThresholdFromCalibrantSample = mock.Mock(return_value=0.5)
 
         res = self.instance.prepDetectorPeaks(self.ingredients, False)
 
@@ -336,6 +340,7 @@ class TestSousChef(unittest.TestCase):
 
         self.instance.prepCalibrantSample = mock.Mock()
         self.instance.prepPeakIngredients = mock.Mock()
+        self.instance._getThresholdFromCalibrantSample = mock.Mock(return_value=0.5)
         self.instance.parseGroupPeakList = mock.Mock(side_effect=lambda y: [y])
 
         res = self.instance.prepDetectorPeaks(self.ingredients)
@@ -362,20 +367,23 @@ class TestSousChef(unittest.TestCase):
         # ensure the cache is prepared
         self.instance._peaksCache[key] = [mock.Mock()]
         self.instance.prepCalibrantSample = mock.Mock()
+        self.instance._getThresholdFromCalibrantSample = mock.Mock(return_value=0.5)
 
         res = self.instance.prepDetectorPeaks(self.ingredients)
 
         assert not DetectorPeakPredictorRecipe.called
         assert res == self.instance._peaksCache[key]
 
+    @mock.patch("os.path.exists", return_value=True)
     @mock.patch(thisService + "ReductionIngredients")
-    def test_prepReductionIngredients(self, ReductionIngredients):
+    def test_prepReductionIngredients(self, ReductionIngredients, mockOS):  # noqa: ARG002
         calibrationCalibrantSamplePath = "a/sample.x"
         record = mock.Mock(
             smoothingParamter=1.0,
             calculationParameters=mock.Mock(
                 calibrantSamplePath=calibrationCalibrantSamplePath,
             ),
+            calibrantSamplePath=calibrationCalibrantSamplePath,
         )
         self.instance.prepCalibrantSample = mock.Mock()
         self.instance.prepRunConfig = mock.Mock()

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -32,6 +32,9 @@ class TestSousChef(unittest.TestCase):
         for ws in mtd.getObjectNames():
             DeleteWorkspace(ws)
 
+    def test_name(self):
+        assert SousChef.name() == "souschef"
+
     def test_prepManyDetectorPeaks(self):
         self.instance.prepDetectorPeaks = mock.Mock()
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)

--- a/tests/util/InstaEats.py
+++ b/tests/util/InstaEats.py
@@ -54,6 +54,9 @@ class InstaEats(GroceryService):
             path = self.groupingMap.getMap(useLiteMode)[groupingScheme].definition
         return str(path)
 
+    def lookupDiffcalTableWorkspaceName(self, runNumber: str, useLiteMode: bool, version: int = 0) -> WorkspaceName:
+        return self.createDiffcalTableWorkspaceName(runNumber, useLiteMode, version)
+
     ## FETCH METHODS
 
     def _fetchInstrumentDonor(self, runNumber: str, useLiteMode: bool) -> WorkspaceName:

--- a/tests/util/WhateversInTheFridge.py
+++ b/tests/util/WhateversInTheFridge.py
@@ -100,7 +100,7 @@ class WhateversInTheFridge(LocalDataService):
             useLiteMode=useLiteMode,
             version=version,
             calculationParameters=self.calculationParameters_with_stateId("0xdeadbeef"),
-            normalizatinoCalibrantSamplePath="path/to/calibrant",
+            normalizationCalibrationSamplePath="path/to/calibrant",
         )
         return record
 

--- a/tests/util/WhateversInTheFridge.py
+++ b/tests/util/WhateversInTheFridge.py
@@ -100,6 +100,7 @@ class WhateversInTheFridge(LocalDataService):
             useLiteMode=useLiteMode,
             version=version,
             calculationParameters=self.calculationParameters_with_stateId("0xdeadbeef"),
+            normalizatinoCalibrantSamplePath="path/to/calibrant",
         )
         return record
 

--- a/tests/util/dao.py
+++ b/tests/util/dao.py
@@ -582,6 +582,7 @@ class DAOFactory:
         other_properties.setdefault(
             "calculationParameters", cls.normalizationParameters(runNumber, useLiteMode, version)
         )
+        other_properties.setdefault("normalizationCalibrantSamplePath", "fakePath")
 
         return NormalizationRecord(
             runNumber=runNumber,


### PR DESCRIPTION
## Description of work

This pr allows:
- snapred to utilize the default calib record written out as part of state init
- reduction to refer to the correct calibrant sample when creating peaks to purge from normalization

This needs a follow up to address when a state is totally uninitialized.

## Explanation of work


I brought over some changes from `staging` for the calibrant sample stuff.  These were actually somewhat essential when interacting with the default record, as it doesnt have a calibrant sample set (nor is it relevant to reduction).

I updated `GroceryService` and `Indexer` to account for the default record, adding a case to attempt to read on if no other record is available.  Doing this, I also changed the way we pull diffcaltable names, and refer to the calibration record filtering on ws type--this simplified referring to the special name default tables recieve and allow me to avoid special logic in this case.

## To test

Initialize a new state.
run reduction
it should prompt you to continue anyway
see that it completes
```
For reduction/calib
Runnumber: 59039 

for calib:
sample: LA11b6
Grouping: Column
Peak Intensity Thresh: 0.01
Chi: 200
dmin: 1

for norm:
rnunumber: 58810
bgrunnumber: 58813
```

this should apply the default calibration during reduction.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#6834](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6834)

