### PR TITLE
Ewm4848 migrate to run number dao for backend validation

### DIFF
--- a/src/snapred/backend/dao/state/RunNumber.py
+++ b/src/snapred/backend/dao/state/RunNumber.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel, Field, validator
+
+from snapred.backend.log.logger import snapredLogger
+from snapred.meta.validator.RunNumberValidator import RunNumberValidator
+
+logger = snapredLogger.getLogger(__name__)
+
+
+class RunNumber(BaseModel):
+    runNumber: int = Field(..., description="The run number provided by the user for reduction.")
+
+    @validator("runNumber", pre=True, always=True)
+    def validateRunNumber(cls, value):
+        # Check if run number is an integer
+        if not isinstance(value, int):
+            logger.error("Run number must be an integer.")
+            raise ValueError("Run number must be an integer. Please enter a valid run number.")
+
+        # Use RunNumberValidator to check the minimum run number and cached data existence
+        if not RunNumberValidator.validateRunNumber(str(value)):
+            logger.error("Run number does not meet the minimum required value or does not have cached data available.")
+            raise ValueError(
+                "Run number is below the minimum value or data does not exist. Please enter a valid run number."
+            )
+
+        return value


### PR DESCRIPTION
## Description of work
This story includes the implementation of a RunNumber DAO that can be used for validation within the backend of SNAPRed. This story went through some scope changes based on a discussion between Michael and I.
<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work
This ended up being a simple implementation of `RunNumberValidation.py` within this new DAO object. Since the outlying cases of checking for state, diffcal and nrmcal were delegated to be checked per request basis, this ended up being much simpler than expected.
<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test
Insure all pytests pass. Check the code, this hasn't been implemented within the code base yet, this is a creation story.

<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM # 4848](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4848)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
