### PR TITLE
Updated mantid version to fix conversion defect

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - python=3.10
 - pip
 - pydantic>=2.7.3,<3
-- mantidworkbench>=6.10.20240705
+- mantidworkbench>=6.10.20240909
 - qtpy
 - pre-commit
 - pytest


### PR DESCRIPTION
## Description of work

The mantid version was updated to fix an issue with converting units during reduction returning bad data. The bad data had negative values.

## To test

### Dev testing

On analysis, run reduction with run 61991, keep unfocused data, and convert units to Momentum Transfer. When reduction is complete, open the converted workspace, and you should see that all the data has positive values along the x-axis. 

### CIS testing

See Dev testing.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#6788](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6788)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
