### PR TITLE
Ewm 6274 skip pixel calibration

### DIFF
--- a/src/snapred/backend/dao/ingredients/DiffractionCalibrationIngredients.py
+++ b/src/snapred/backend/dao/ingredients/DiffractionCalibrationIngredients.py
@@ -28,5 +28,6 @@ class DiffractionCalibrationIngredients(BaseModel):
     peakFunction: SymmetricPeakEnum = SymmetricPeakEnum[Config["calibration.diffraction.peakFunction"]]
     maxOffset: float = Config["calibration.diffraction.maximumOffset"]
     maxChiSq: float = Config["constants.GroupDiffractionCalibration.MaxChiSq"]
+    skipPixelCalibration: bool = False
 
     model_config = ConfigDict(extra="forbid")

--- a/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
+++ b/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
@@ -34,6 +34,7 @@ class DiffractionCalibrationRequest(BaseModel, extra="forbid"):
     maximumOffset: float = Config["calibration.diffraction.maximumOffset"]
     fwhmMultipliers: Pair[float] = Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
     maxChiSq: float = Config["constants.GroupDiffractionCalibration.MaxChiSq"]
+    skipPixelCalibration: bool = False
 
     @field_validator("fwhmMultipliers", mode="before")
     @classmethod

--- a/src/snapred/backend/dao/request/FarmFreshIngredients.py
+++ b/src/snapred/backend/dao/request/FarmFreshIngredients.py
@@ -65,6 +65,8 @@ class FarmFreshIngredients(BaseModel):
 
     focusGroups: Optional[List[FocusGroup]] = None
 
+    skipPixelCalibration: bool = False
+
     # Allow 'focusGroups' to be accessed as a single 'focusGroup'
     @property
     def focusGroup(self) -> FocusGroup:

--- a/src/snapred/backend/dao/request/FarmFreshIngredients.py
+++ b/src/snapred/backend/dao/request/FarmFreshIngredients.py
@@ -65,8 +65,6 @@ class FarmFreshIngredients(BaseModel):
 
     focusGroups: Optional[List[FocusGroup]] = None
 
-    skipPixelCalibration: bool = False
-
     # Allow 'focusGroups' to be accessed as a single 'focusGroup'
     @property
     def focusGroup(self) -> FocusGroup:

--- a/src/snapred/backend/recipe/DiffractionCalibrationRecipe.py
+++ b/src/snapred/backend/recipe/DiffractionCalibrationRecipe.py
@@ -35,6 +35,7 @@ class DiffractionCalibrationRecipe:
         self.runNumber = ingredients.runConfig.runNumber
         self.threshold = ingredients.convergenceThreshold
         self.maxIterations = Config["calibration.diffraction.maximumIterations"]
+        self.skipPixelCalibration = ingredients.skipPixelCalibration
 
     def unbagGroceries(self, groceries: Dict[str, Any]):
         """
@@ -63,42 +64,43 @@ class DiffractionCalibrationRecipe:
         dataSteps: List[Dict[str, Any]] = []
         medianOffsets: List[float] = []
 
-        logger.info("Calibrating by cross-correlation and adjusting offsets...")
-        pixelAlgo = PixelDiffractionCalibration()
-        pixelAlgo.initialize()
-        pixelAlgo.setProperty("InputWorkspace", self.rawInput)
-        pixelAlgo.setProperty("GroupingWorkspace", self.groupingWS)
-        pixelAlgo.setProperty("Ingredients", ingredients.json())
-        pixelAlgo.setProperty("CalibrationTable", self.calTable)
-        pixelAlgo.setProperty("MaskWorkspace", self.maskWS)
-        try:
-            pixelAlgo.execute()
-            dataSteps.append(json.loads(pixelAlgo.getPropertyValue("data")))
-            medianOffsets.append(dataSteps[-1]["medianOffset"])
-        except RuntimeError as e:
-            errorString = str(e)
-            raise RuntimeError(errorString) from e
-        counter = 1
-        while abs(medianOffsets[-1]) > self.threshold and counter < self.maxIterations:
-            counter = counter + 1
-            logger.info(f"... converging to answer; step {counter}, {medianOffsets[-1]} > {self.threshold}")
+        if self.skipPixelCalibration is not True:
+            logger.info("Calibrating by cross-correlation and adjusting offsets...")
+            pixelAlgo = PixelDiffractionCalibration()
+            pixelAlgo.initialize()
+            pixelAlgo.setProperty("InputWorkspace", self.rawInput)
+            pixelAlgo.setProperty("GroupingWorkspace", self.groupingWS)
+            pixelAlgo.setProperty("Ingredients", ingredients.json())
+            pixelAlgo.setProperty("CalibrationTable", self.calTable)
+            pixelAlgo.setProperty("MaskWorkspace", self.maskWS)
             try:
                 pixelAlgo.execute()
-                newDataStep = json.loads(pixelAlgo.getPropertyValue("data"))
+                dataSteps.append(json.loads(pixelAlgo.getPropertyValue("data")))
+                medianOffsets.append(dataSteps[-1]["medianOffset"])
             except RuntimeError as e:
                 errorString = str(e)
                 raise RuntimeError(errorString) from e
-            # ensure monotonic decrease in the median offset
-            if newDataStep["medianOffset"] < dataSteps[-1]["medianOffset"]:
-                dataSteps.append(newDataStep)
-                medianOffsets.append(newDataStep["medianOffset"])
-            else:
-                logger.warning("Offsets failed to converge monotonically")
-                break
-        if counter >= self.maxIterations:
-            logger.warning("Offset convergence reached max iterations without convergning")
-        data["steps"] = dataSteps
-        logger.info(f"Initial calibration converged.  Offsets: {medianOffsets}")
+            counter = 1
+            while abs(medianOffsets[-1]) > self.threshold and counter < self.maxIterations:
+                counter = counter + 1
+                logger.info(f"... converging to answer; step {counter}, {medianOffsets[-1]} > {self.threshold}")
+                try:
+                    pixelAlgo.execute()
+                    newDataStep = json.loads(pixelAlgo.getPropertyValue("data"))
+                except RuntimeError as e:
+                    errorString = str(e)
+                    raise RuntimeError(errorString) from e
+                # ensure monotonic decrease in the median offset
+                if newDataStep["medianOffset"] < dataSteps[-1]["medianOffset"]:
+                    dataSteps.append(newDataStep)
+                    medianOffsets.append(newDataStep["medianOffset"])
+                else:
+                    logger.warning("Offsets failed to converge monotonically")
+                    break
+            if counter >= self.maxIterations:
+                logger.warning("Offset convergence reached max iterations without convergning")
+            data["steps"] = dataSteps
+            logger.info(f"Initial calibration converged.  Offsets: {medianOffsets}")
 
         logger.info("Beginning group-by-group fitting calibration")
         groupedAlgo = GroupDiffractionCalibration()

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -117,7 +117,6 @@ class CalibrationService(Service):
             nBinsAcrossPeakWidth=request.nBinsAcrossPeakWidth,
             fwhmMultipliers=request.fwhmMultipliers,
             maxChiSq=request.maxChiSq,
-            skipPixelCalibration=request.skipPixelCalibration,
         )
         return self.sousChef.prepDiffractionCalibrationIngredients(farmFresh)
 
@@ -161,7 +160,7 @@ class CalibrationService(Service):
         if request.skipPixelCalibration is False:
             maskWS = groceries.get("maskWorkspace", "")
             percentMasked = mtd[maskWS].getNumberMasked() / mtd[maskWS].getNumberHistograms()
-            threshold = 0.15
+            threshold = Config["constants.maskedPixelThreshold"]
             if percentMasked > threshold:
                 raise Exception(
                     (

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -153,21 +153,19 @@ class CalibrationService(Service):
         # now have all ingredients and groceries, run recipe
         res = DiffractionCalibrationRecipe().executeRecipe(ingredients, groceries)
 
-        if request.useLiteMode is False:
-            if request.skipPixelCalibration is False:
-                maskWS = groceries.get("maskWorkspace", "")
-                print(maskWS)
-                percentMasked = mtd[maskWS].getNumberMasked() / mtd[maskWS].getNumberHistograms()
-                threshold = 0.15
-                if percentMasked > threshold:
-                    raise Exception(
-                        (
-                            "WARNING: More than 15% of pixels failed calibration. Please check your input data. If "
-                            "input data has poor statistics, you may get better results by disabling Cross "
-                            "Correlation. You can also improve statistics by activating Lite mode if this is not "
-                            "already activated."
-                        ),
-                    )
+        if request.skipPixelCalibration is False:
+            maskWS = groceries.get("maskWorkspace", "")
+            percentMasked = mtd[maskWS].getNumberMasked() / mtd[maskWS].getNumberHistograms()
+            threshold = 0.15
+            if percentMasked > threshold:
+                raise Exception(
+                    (
+                        f"WARNING: More than {threshold*100}% of pixels failed calibration. Please check your input "
+                        "data. If input data has poor statistics, you may get better results by disabling Cross "
+                        "Correlation. You can also improve statistics by activating Lite mode if this is not "
+                        "already activated."
+                    ),
+                )
 
         return res
 

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -189,6 +189,7 @@ constants:
   millisecondsPerSecond: 1000
   PeakIntensityFractionThreshold: 0.05
   m2cm: 10000.0 # conversion factor for m^2 to cm^2
+  maskedPixelThreshold: 0.15
 
   CrystallographicInfo:
     crystalDMin: 0.4

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -94,6 +94,10 @@ class DiffCalTweakPeakView(BackendRequestView):
         self.recalculationButton = QPushButton("Recalculate")
         self.recalculationButton.clicked.connect(self.emitValueChange)
 
+        # skip pixel calibration button
+        self.skipPixelCalToggle = self._labeledField("Skip Pixel Calibration", Toggle(parent=self, state=False))
+        self.skipPixelCalToggle.setEnabled(False)
+
         # add all elements to the grid layout
         self.layout.addWidget(self.runNumberField, 0, 0)
         self.layout.addWidget(self.litemodeToggle, 0, 1)
@@ -104,6 +108,7 @@ class DiffCalTweakPeakView(BackendRequestView):
         self.layout.addWidget(self.groupingFileDropdown, 4, 1)
         self.layout.addWidget(self.peakFunctionDropdown, 4, 2)
         self.layout.addWidget(self.recalculationButton, 5, 0, 1, 2)
+        self.layout.addWidget(self.skipPixelCalToggle, 0, 2)
 
         self.layout.setRowStretch(2, 10)
 

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -96,7 +96,6 @@ class DiffCalTweakPeakView(BackendRequestView):
 
         # skip pixel calibration button
         self.skipPixelCalToggle = self._labeledField("Skip Pixel Calibration", Toggle(parent=self, state=False))
-        self.skipPixelCalToggle.setEnabled(False)
 
         # add all elements to the grid layout
         self.layout.addWidget(self.runNumberField, 0, 0)
@@ -108,7 +107,7 @@ class DiffCalTweakPeakView(BackendRequestView):
         self.layout.addWidget(self.groupingFileDropdown, 4, 1)
         self.layout.addWidget(self.peakFunctionDropdown, 4, 2)
         self.layout.addWidget(self.recalculationButton, 5, 0, 1, 2)
-        self.layout.addWidget(self.skipPixelCalToggle, 0, 2)
+        self.layout.addWidget(self.skipPixelCalToggle, 3, 2, 1, 2)
 
         self.layout.setRowStretch(2, 10)
 

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -164,8 +164,9 @@ class DiffCalWorkflow(WorkflowImplementer):
 
         # Enable pixel calibration skip only if not using lite mode
         if useLiteMode is False:
-            self._tweakPeakView.skipPixelCalToggle.setEnabled(True)
             self._tweakPeakView.skipPixelCalToggle.field.setState(True)
+        else:
+            self._tweakPeakView.skipPixelCalToggle.field.setState(False)
 
         self._requestView.groupingFileDropdown.setEnabled(False)
         # TODO: Use threads, account for fail cases

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -150,6 +150,10 @@ class DiffCalWorkflow(WorkflowImplementer):
         # when the run number is updated, freeze the drop down to populate it
         useLiteMode = self._requestView.litemodeToggle.field.getState()
 
+        # Enable pixel calibration skip only if not using lite mode
+        if useLiteMode is False:
+            self._tweakPeakView.skipPixelCalToggle.setEnabled(True)
+
         self._requestView.groupingFileDropdown.setEnabled(False)
         # TODO: Use threads, account for fail cases
         try:
@@ -198,6 +202,7 @@ class DiffCalWorkflow(WorkflowImplementer):
             nBinsAcrossPeakWidth=self.nBinsAcrossPeakWidth,
             fwhmMultipliers=self.prevFWHM,
             maxChiSq=self.maxChiSq,
+            skipPixelCalibration=self._tweakPeakView.skipPixelCalToggle.field.getState(),
         )
 
         self.ingredients = self.request(path="calibration/ingredients", payload=payload.json()).data
@@ -280,6 +285,7 @@ class DiffCalWorkflow(WorkflowImplementer):
             crystalDMax=xtalDMax,
             fwhmMultipliers=fwhm,
             maxChiSq=maxChiSq,
+            skipPixelCalibration=self._tweakPeakView.skipPixelCalToggle.field.getState(),
         )
         response = self.request(path="calibration/ingredients", payload=payload.json())
         self.ingredients = response.data
@@ -330,6 +336,7 @@ class DiffCalWorkflow(WorkflowImplementer):
             nBinsAcrossPeakWidth=self.nBinsAcrossPeakWidth,
             fwhmMultipliers=self.prevFWHM,
             maxChiSq=self.maxChiSq,
+            skipPixelCalibration=self._tweakPeakView.skipPixelCalToggle.field.getState(),
         )
 
         response = self.request(path="calibration/diffraction", payload=payload.json())

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -160,6 +160,7 @@ class DiffCalWorkflow(WorkflowImplementer):
     def _switchLiteNativeGroups(self):
         # when the run number is updated, freeze the drop down to populate it
         useLiteMode = self._requestView.litemodeToggle.field.getState()
+        self._tweakPeakView.litemodeToggle.field.setState(useLiteMode)
 
         # Enable pixel calibration skip only if not using lite mode
         if useLiteMode is False:

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -153,6 +153,7 @@ class DiffCalWorkflow(WorkflowImplementer):
         # Enable pixel calibration skip only if not using lite mode
         if useLiteMode is False:
             self._tweakPeakView.skipPixelCalToggle.setEnabled(True)
+            self._tweakPeakView.skipPixelCalToggle.field.setState(True)
 
         self._requestView.groupingFileDropdown.setEnabled(False)
         # TODO: Use threads, account for fail cases

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -207,6 +207,7 @@ constants:
   millisecondsPerSecond: 1000
   PeakIntensityFractionThreshold: 0.05
   m2cm: 10000.0 # conversion factor for m^2 to cm^2
+  maskedPixelThreshold: 0.15
 
   CrystallographicInfo:
     crystalDMin: 0.4

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -665,7 +665,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         DiffractionCalibrationRecipe().executeRecipe.return_value = {"calibrationTable": "fake"}
 
         self.instance.groceryClerk = mock.Mock()
-        self.instance.groceryService.fetchGroceryDict = mock.Mock(return_value={"grocery1": "orange"})
+        self.instance.groceryService.fetchGroceryDict = mock.Mock(return_value={"maskWorkspace": self.sampleMaskWS})
 
         # Call the method with the provided parameters
         request = mock.Mock(

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -811,6 +811,8 @@ class TestCalibrationServiceMethods(unittest.TestCase):
     ):
         FarmFreshIngredients.return_value = mock.Mock(runNumber="123")
         self.instance.dataFactoryService.getCifFilePath = mock.Mock(return_value="bundt/cake.egg")
+        self.instance.dataExportService.getCalibrationStateRoot = mock.Mock(return_value="lah/dee/dah")
+        self.instance.dataExportService.checkWritePermissions = mock.Mock(return_value=True)
         self.instance.sousChef = SculleryBoy()
 
         DiffractionCalibrationRecipe().executeRecipe.return_value = {"calibrationTable": "fake"}
@@ -822,10 +824,14 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         self.instance.groceryService.fetchGroceryDict = mock.Mock(return_value={"maskWorkspace": self.sampleMaskWS})
 
         # Call the method with the provided parameters
-        request = mock.Mock(
+        # Call the method with the provided parameters
+        request = DiffractionCalibrationRequest(
             runNumber="123",
             useLiteMode=True,
             calibrantSamplePath="bundt/cake_egg.py",
+            removeBackground=True,
+            focusGroup=FocusGroup(name="all", definition="path/to/all"),
+            continueFlags=ContinueWarning.Type.UNSET,
             skipPixelCalibration=False,
         )
         with pytest.raises(Exception, match=r".*pixels failed calibration*"):

--- a/tests/util/diffraction_calibration_synthetic_data.py
+++ b/tests/util/diffraction_calibration_synthetic_data.py
@@ -111,6 +111,7 @@ class SyntheticData(object):
             maxOffset=100.0,  # bins: '100.0' seems to work
             pixelGroup=self.fakePixelGroup,
             maxChiSq=100.0,
+            skipPixelCalibration=False,
         )
 
     @staticmethod


### PR DESCRIPTION
## Description of work

This allows user to skip pixel calibration during diffraction calibration. This is needed when pixel calibration fails due to having too many masked pixels.

## Explanation of work

A button was added to the Tweak Peaks tab to skip pixel calibration. The DiffractionCalibrationRequest was modified so there is now a skipPixelCalibration flag. In the calibration service, The diffraction calibration step now checks for percentage of masked pixels, and throws an exception if there's too many masked pixels. The diffcal recipe now checks for the skipPixelCalibration flag to see if PixelCalibration needs to be executed.

## To test

### Dev testing

Locally, run diffraction calibration for run 46680 in native mode. On the tweak peaks tab, you should see a Skip Pixel Calibration button in the top right corner. By default, this should be toggled on when in native mode. Toggle the skip pixel calibration to be off. When you try to advance past the Tweak Peaks tab, you  should get a warning message pop up saying there is too many masked pixels. Redo the tweak peaks step and toggle the skip pixel calibration to be on. You should now be able to complete diffraction calibration. Note: running in native mode takes longer than lite mode.

Repeat diffcal in lite mode, but notice now that skipping pixel calibration defaults to off.

### CIS testing

See dev testing

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#6274](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6274)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
