### PR TITLE
Ewm7115 fix remove event background undersampling

### DIFF
--- a/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
@@ -88,7 +88,7 @@ class PixelDiffCalRecipe(Recipe[Ingredients]):
         self.maskWS = groceries["maskWorkspace"]
         # the name of the output calibration table
         self.DIFCpixel = groceries["calibrationTable"]
-        self.isEvent = self.mantidSnapper.mtd[self.wsTOF].isEventWorkspace()
+        self.isHisto = self.mantidSnapper.mtd[self.wsTOF].isHistogramData()
         # the input data converted to d-spacing
         self.wsDSP = wng.diffCalInputDSP().runNumber(self.runNumber).build()
         self.mantidSnapper.ConvertUnits(
@@ -147,7 +147,7 @@ class PixelDiffCalRecipe(Recipe[Ingredients]):
             GroupingWorkspace=groupingWS,
             DetectorPeaks=peaks,
         )
-        if self.isEvent:
+        if not self.isHisto:
             self.mantidSnapper.ConvertToEventWorkspace(
                 "Converting TOF data to EventWorkspace...",
                 InputWorkspace=wsBG,

--- a/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
@@ -88,7 +88,7 @@ class PixelDiffCalRecipe(Recipe[Ingredients]):
         self.maskWS = groceries["maskWorkspace"]
         # the name of the output calibration table
         self.DIFCpixel = groceries["calibrationTable"]
-
+        self.isEvent = self.mantidSnapper.mtd[self.wsTOF].isEventWorkspace()
         # the input data converted to d-spacing
         self.wsDSP = wng.diffCalInputDSP().runNumber(self.runNumber).build()
         self.mantidSnapper.ConvertUnits(
@@ -147,11 +147,12 @@ class PixelDiffCalRecipe(Recipe[Ingredients]):
             GroupingWorkspace=groupingWS,
             DetectorPeaks=peaks,
         )
-        self.mantidSnapper.ConvertToMatrixWorkspace(
-            "Converting TOF data to MatrixWorkspace...",
-            InputWorkspace=inputWS,
-            OutputWorkspace=inputWS,
-        )
+        if self.isEvent:
+            self.mantidSnapper.ConvertToEventWorkspace(
+                "Converting TOF data to EventWorkspace...",
+                InputWorkspace=wsBG,
+                OutputWorkspace=wsBG,
+            )
         self.mantidSnapper.Minus(
             "Subtracting background from input data",
             LHSWorkspace=inputWS,

--- a/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
+++ b/src/snapred/backend/recipe/algorithm/PixelDiffractionCalibration.py
@@ -88,7 +88,7 @@ class PixelDiffCalRecipe(Recipe[Ingredients]):
         self.maskWS = groceries["maskWorkspace"]
         # the name of the output calibration table
         self.DIFCpixel = groceries["calibrationTable"]
-        self.isHisto = self.mantidSnapper.mtd[self.wsTOF].isHistogramData()
+        self.isEventWs = self.mantidSnapper.mtd[self.wsTOF].id() == "EventWorkspace"
         # the input data converted to d-spacing
         self.wsDSP = wng.diffCalInputDSP().runNumber(self.runNumber).build()
         self.mantidSnapper.ConvertUnits(
@@ -147,7 +147,7 @@ class PixelDiffCalRecipe(Recipe[Ingredients]):
             GroupingWorkspace=groupingWS,
             DetectorPeaks=peaks,
         )
-        if not self.isHisto:
+        if self.isEventWs:
             self.mantidSnapper.ConvertToEventWorkspace(
                 "Converting TOF data to EventWorkspace...",
                 InputWorkspace=wsBG,

--- a/tests/unit/backend/recipe/algorithm/test_PixelDiffractionCalibration.py
+++ b/tests/unit/backend/recipe/algorithm/test_PixelDiffractionCalibration.py
@@ -88,9 +88,9 @@ class TestPixelDiffractionCalibration(unittest.TestCase):
         assert allOffsets[-1] <= self.ingredients.convergenceThreshold
 
     def test_execute_ordered(self):
-        # Mock workspace and isHistogramData method
+        # Mock workspace and check for event workspace using id()
         mockWorkspace = mock.MagicMock()
-        mockWorkspace.isHistogramData.return_value = True
+        mockWorkspace.id.return_value = "EventWorkspace"
 
         # Use MagicMock to allow item assignment
         rx = Recipe()
@@ -126,9 +126,9 @@ class TestPixelDiffractionCalibration(unittest.TestCase):
         assert result.medianOffsets == [2, 1]
 
     def test_hard_cap_at_five(self):
-        # Mock workspace and isHistogramData method
+        # Mock workspace and check for event workspace using id()
         mockWorkspace = mock.MagicMock()
-        mockWorkspace.isHistogramData.return_value = True
+        mockWorkspace.id.return_value = "EventWorkspace"
 
         # Mock mtd and ensure it returns the mockWorkspace when accessed
         rx = Recipe()

--- a/tests/unit/backend/recipe/algorithm/test_PixelDiffractionCalibration.py
+++ b/tests/unit/backend/recipe/algorithm/test_PixelDiffractionCalibration.py
@@ -88,12 +88,27 @@ class TestPixelDiffractionCalibration(unittest.TestCase):
         assert allOffsets[-1] <= self.ingredients.convergenceThreshold
 
     def test_execute_ordered(self):
-        # produce 4, 2, 1, 0.5
+        # Mock workspace and isHistogramData method
+        mockWorkspace = mock.MagicMock()
+        mockWorkspace.isHistogramData.return_value = True
+
+        # Use MagicMock to allow item assignment
         rx = Recipe()
-        rx.mantidSnapper = mock.Mock()
-        rx.mantidSnapper.GroupedDetectorIDs.return_value = {}
-        rx.mantidSnapper.OffsetStatistics.side_effect = [{"medianOffset": 4 * 2 ** (-i)} for i in range(10)]
+        rx.mantidSnapper = mock.MagicMock()
+        rx.mantidSnapper.mtd[self.groceries["inputWorkspace"]] = mockWorkspace
+
+        # Mock OffsetStatistics to return different values for "medianOffset" in each iteration
+        rx.mantidSnapper.OffsetStatistics.side_effect = [
+            {"medianOffset": 4.0},
+            {"medianOffset": 2.0},
+            {"medianOffset": 1.0},
+            {"medianOffset": 0.5},
+        ]
+
+        # Run the cook method
         result = rx.cook(self.ingredients, self.groceries)
+
+        # Assert the result
         assert result.result
         assert result.medianOffsets == [4, 2, 1, 0.5]
 
@@ -102,28 +117,33 @@ class TestPixelDiffractionCalibration(unittest.TestCase):
         If the median offsets do not converge monotonically, the recipe stops
         """
         rx = Recipe()
-        rx.mantidSnapper = mock.Mock()
+        rx.mantidSnapper = mock.MagicMock()
         rx.mantidSnapper.GroupedDetectorIDs.return_value = {}
         rx.mantidSnapper.OffsetStatistics.side_effect = [{"medianOffset": x} for x in [2, 1, 2, 0]]
+
         result = rx.cook(self.ingredients, self.groceries)
         assert result.result
         assert result.medianOffsets == [2, 1]
 
     def test_hard_cap_at_five(self):
-        maxIterations = Config["calibration.diffraction.maximumIterations"]
+        # Mock workspace and isHistogramData method
+        mockWorkspace = mock.MagicMock()
+        mockWorkspace.isHistogramData.return_value = True
+
+        # Mock mtd and ensure it returns the mockWorkspace when accessed
         rx = Recipe()
-        rx.mantidSnapper = mock.Mock()
+        rx.mantidSnapper = mock.MagicMock()  # Use MagicMock here
+        rx.mantidSnapper.mtd = mock.MagicMock()  # Use MagicMock for mtd to support item assignment
+        rx.mantidSnapper.mtd[self.groceries["inputWorkspace"]] = mockWorkspace
+
+        # Simulate maximum iterations and offsets
+        maxIterations = Config["calibration.diffraction.maximumIterations"]
         rx.mantidSnapper.GroupedDetectorIDs.return_value = {}
         rx.mantidSnapper.OffsetStatistics.side_effect = [{"medianOffset": x} for x in range(10 * maxIterations, 5, -1)]
+
+        # Run the test
         result = rx.cook(self.ingredients, self.groceries)
-        assert result.result
-        assert result.medianOffsets == list(range(10 * maxIterations, 9 * maxIterations, -1))
-        # change the config then run again
-        maxIterations = 7
-        Config._config["calibration"]["diffraction"]["maximumIterations"] = maxIterations
-        rx._counts = 0
-        rx.mantidSnapper.OffsetStatistics.side_effect = [{"medianOffset": x} for x in range(10 * maxIterations, 5, -1)]
-        result = rx.cook(self.ingredients, self.groceries)
+
         assert result.result
         assert result.medianOffsets == list(range(10 * maxIterations, 9 * maxIterations, -1))
 


### PR DESCRIPTION
## Description of work
This work is to facilitate the resolution of a defect in this implementation. The issue resulted in "under-binning" of the data.
<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work
The logic implemented:
1. Keep the original ws with events. Create a copy
2. Convert the copy to histogram and fit the background
3. Use the mantid algorithm ConvertToEventWorkspace on the background and convert this to an eventworksapce
4. Subtract the Event Background from the original ws.
<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### CIS testing
Please follow the same steps listed within [PR 449](https://github.com/neutrons/SNAPRed/pull/449).
<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM # 7115](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7115)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
