### PR TITLE
All workflow panels: happy-path integration tests

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -35,7 +35,7 @@ jobs:
         /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
     - name: Test with pytest
       run: |
-        xvfb-run --server-args="-screen 0 1280x1024x16" -a python -m pytest --cov=src --cov-report=xml --cov-report=term
+        xvfb-run --server-args="-screen 0 1280x1024x16" -a python -m pytest --cov=src --cov-report=xml --cov-report=term -m "not integration"
     - name: Upload coverage reports
       uses: codecov/codecov-action@v4
       if:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ markers = [
   "mount_snap: mark a test as using /SNS/SNAP/ data mount",
   "golden_data(*, path=None, short_name=None, date=None): mark golden data to use with a test"
 ]
+# The following will be overridden by the commandline option "-m integration"
 addopts = "-m 'not integration'"
 
 

--- a/src/snapred/backend/data/DataExportService.py
+++ b/src/snapred/backend/data/DataExportService.py
@@ -21,9 +21,9 @@ from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
 @Singleton
 class DataExportService:
-    dataService: "LocalDataService"
-
     def __init__(self, dataService: LocalDataService = None) -> None:
+        # 'LocalDataService' is a singleton: declare it as an instance attribute, rather than a class attribute,
+        #   to allow singleton reset during testing.
         self.dataService = self._defaultClass(dataService, LocalDataService)
 
     def _defaultClass(self, val, clazz):

--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -22,12 +22,13 @@ from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
 @Singleton
 class DataFactoryService:
-    lookupService: "LocalDataService"  # Optional[LocalDataService]
-    groceryService: "GroceryService"
     # TODO: rules for busting cache
     cache: Dict[str, ReductionState] = {}
 
     def __init__(self, lookupService: LocalDataService = None, groceryService: GroceryService = None) -> None:
+        # 'LocalDataService' and 'GroceryService' are singletons:
+        #   declare them here as instance attributes, rather than class attributes,
+        #   to allow singleton reset during testing.
         self.lookupService = self._defaultClass(lookupService, LocalDataService)
         self.groceryService = self._defaultClass(groceryService, GroceryService)
 

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -44,10 +44,12 @@ class GroceryService:
     Just send me a list.
     """
 
-    dataService: "LocalDataService"
-
     def __init__(self, dataService: LocalDataService = None):
+        # 'LocalDataService' is a singleton:
+        #   declare it here as an instance attribute, rather than a class attribute,
+        #   to allow singleton reset during testing.
         self.dataService = self._defaultClass(dataService, LocalDataService)
+
         self.workspaceMetadataService = WorkspaceMetadataService()
 
         # _loadedRuns caches a count of the number of copies made from the neutron-data workspace

--- a/src/snapred/backend/data/Indexer.py
+++ b/src/snapred/backend/data/Indexer.py
@@ -96,10 +96,12 @@ class Indexer:
         for fname in self.rootDirectory.glob("v_*"):
             if os.path.isdir(fname):
                 version = str(fname).split("_")[-1]
-                if version.isdigit():
-                    version = int(version)
-                if version == VERSION_DEFAULT_NAME:
+                # Warning: order matters here:
+                #   check VERSION_DEFAULT_NAME _before_ the `isdigit` check.
+                if str(version) == str(VERSION_DEFAULT_NAME):
                     version = VERSION_DEFAULT
+                elif version.isdigit():
+                    version = int(version)
                 versions.add(version)
         return versions
 
@@ -145,16 +147,16 @@ class Indexer:
         """
         The largest version found by the Indexer.
         """
-        currentVersion = None
+        version = None
         overlap = set.union(set(self.index.keys()), self.dirVersions)
         if len(overlap) == 0:
-            currentVersion = None
+            version = None
         elif len(overlap) == 1:
-            currentVersion = list(overlap)[0]
+            version = list(overlap)[0]
         else:
-            versions = [version for version in overlap if isinstance(version, int)]
-            currentVersion = max(versions)
-        return currentVersion
+            versions = [v for v in overlap if isinstance(v, int)]
+            version = max(versions)
+        return version
 
     def latestApplicableVersion(self, runNumber: str) -> int:
         """

--- a/src/snapred/backend/service/ApiService.py
+++ b/src/snapred/backend/service/ApiService.py
@@ -32,11 +32,14 @@ def _convertToJsonSchema(parameterDic):
 
 @Singleton
 class ApiService(Service):
-    serviceDirectory: "ServiceDirectory"
-
     def __init__(self):
         super().__init__()
+
+        # 'ServiceDirectory' is a singletion:
+        #   declaring it as an instance attribute, rather than a class attribute,
+        #   allows singleton reset during testing.
         self.serviceDirectory = ServiceDirectory()
+
         self.registerPath("", self.getValidPaths)
         self.registerPath("parameters", self.getPathParameters)
         self.apiCache = None

--- a/src/snapred/backend/service/CalibrantSampleService.py
+++ b/src/snapred/backend/service/CalibrantSampleService.py
@@ -7,11 +7,14 @@ from snapred.meta.decorators.Singleton import Singleton
 
 @Singleton
 class CalibrantSampleService(Service):
-    dataExportService: "DataExportService"
-
     def __init__(self):
         super().__init__()
+
+        # 'DataExportService' is a singleton:
+        #   declaring it as an instance attribute, instead of a class attribute,
+        #   allows singleton reset during testing.
         self.dataExportService = DataExportService()
+
         self.registerPath("save_sample", self.save_sample)
         return
 

--- a/src/snapred/backend/service/ConfigLookupService.py
+++ b/src/snapred/backend/service/ConfigLookupService.py
@@ -11,12 +11,15 @@ from snapred.meta.decorators.Singleton import Singleton
 
 @Singleton
 class ConfigLookupService(Service):
-    dataFactoryService: "DataFactoryService"
-
     # register the service in ServiceFactory
     def __init__(self):
         super().__init__()
+
+        # 'DataFactoryService' is a singleton:
+        #   declaring it as an instance attribute, instead of a class attribute,
+        #   allows singleton reset during testing.
         self.dataFactoryService = DataFactoryService()
+
         self.registerPath("", self.getConfigs)
         self.registerPath("samplePaths", self.getSampleFilePaths)
         self.registerPath("groupingMap", self.getGroupingMap)

--- a/src/snapred/backend/service/MetadataLookupService.py
+++ b/src/snapred/backend/service/MetadataLookupService.py
@@ -13,12 +13,15 @@ logger = snapredLogger.getLogger(__name__)
 
 @Singleton
 class MetadataLookupService(Service):
-    dataFactoryService = "DataFactoryService"
-
     # register the service in ServiceFactory please!
     def __init__(self):
         super().__init__()
+
+        # 'DataFactoryService' is a singleton:
+        #   declaring it as an instance attribute, instead of a class attribute,
+        #   allows singleton reset during testing.
         self.dataFactoryService = DataFactoryService()
+
         self.registerPath("", self.verifyMultipleRuns)
         return
 

--- a/src/snapred/backend/service/StateIdLookupService.py
+++ b/src/snapred/backend/service/StateIdLookupService.py
@@ -9,11 +9,12 @@ from snapred.meta.decorators.Singleton import Singleton
 
 @Singleton
 class StateIdLookupService(Service):
-    dataFactoryService = "DataFactoryService"
-
     # register the service in ServiceFactory please!
     def __init__(self):
         super().__init__()
+        # 'DataFactoryService' is a singleton:
+        #  declaring it as an instance attribute, instead of a class attribute,
+        #  allows singleton reset during testing.
         self.dataFactoryService = DataFactoryService()
         self.registerPath("", self.getStateIds)
         return

--- a/src/snapred/meta/decorators/Singleton.py
+++ b/src/snapred/meta/decorators/Singleton.py
@@ -1,4 +1,7 @@
 from functools import wraps
+from typing import List
+
+_Singleton_instances: List[type] = []
 
 
 def Singleton(orig_cls):
@@ -10,18 +13,61 @@ def Singleton(orig_cls):
     @wraps(orig_cls.__init__)
     def __init__(self, *args, **kwargs):
         nonlocal initialized
-        if initialized is True:
+        if initialized:
             return
         initialized = True
         orig_init(self, *args, **kwargs)
 
     @wraps(orig_cls.__new__)
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args, **kwargs):  # noqa: ARG001
         nonlocal instance
         if instance is None:
-            instance = orig_new(cls, *args, **kwargs)
+            # this needs to work with object.__new__, which only has only the `cls` arg
+            instance = orig_new(cls)  # , *args, **kwargs)
         return instance
+
+    def _reset_Singleton(*, fully_unwrap: bool = False):
+        # Reset the Singleton:
+        #
+        #   * The `@Singleton` decorator is applied at time of import.
+        #   * This method does not _reinitialize_ any existing class instances;
+        #       it just ensures that the next time the `__init__` is called it will
+        #       initialize a new instance.
+        #   * If `fully_unwrap` is set, it is equivalent to removing the `@Singleton` decorator from the class.
+        #
+        #   This method is provided for use by `pytest` fixtures,
+        #     as an alternative to mocking out the `Singleton` entirely.
+        #
+        nonlocal instance
+        nonlocal initialized
+        instance = None
+        initialized = False
+
+        if fully_unwrap:
+            # this should be equivalent to mocking out the decorator
+            orig_cls.__new__ = orig_cls.__new__.__wrapped__
+            orig_cls.__init__ = orig_cls.__init__.__wrapped__
 
     orig_cls.__new__ = __new__
     orig_cls.__init__ = __init__
+
+    orig_cls._reset_Singleton = _reset_Singleton
+    global _Singleton_instances
+    _Singleton_instances.append(orig_cls)
+
     return orig_cls
+
+
+def reset_Singletons(*, fully_unwrap: bool = False):
+    # Implementation notes:
+    #
+    #   * The `@Singleton` decorator is applied at time of import.
+    #   * This module-scope method does not _reinitialize_ any existing class instances;
+    #       it just ensures that the next time the `__init__`[s] are called they will
+    #       initialize new instances.
+    #   * If `fully_unwrap` is set, it is equivalent to removing the `@Singleton` decorator from all of the classes;
+    #       and, if that approach is taken, it's only necessary to apply this method at `scope="session"`.
+    #
+    global _Singleton_instances
+    for cls in _Singleton_instances:
+        cls._reset_Singleton(fully_unwrap=fully_unwrap)

--- a/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
+++ b/src/snapred/ui/presenter/CalibrationAssessmentPresenter.py
@@ -24,11 +24,15 @@ class CalibrationAssessmentPresenter(QObject):
 
     """
 
-    worker_pool = WorkerPool()
-    interfaceController = InterfaceController()
-
     def __init__(self, view):
         super().__init__()
+
+        # `InterfaceController` and `WorkerPool` are singletons:
+        #   declaring them as instance attributes, rather than class attributes,
+        #   allows singleton reset during testing.
+        self.interfaceController = InterfaceController()
+        self.worker_pool = WorkerPool()
+
         self.view = view
 
     @Slot()

--- a/src/snapred/ui/presenter/InitializeStatePresenter.py
+++ b/src/snapred/ui/presenter/InitializeStatePresenter.py
@@ -22,8 +22,12 @@ class InitializeStatePresenter(QObject):
 
     def __init__(self, view):
         super().__init__()
-        self.view = view
+
+        # 'InterfaceController' is a singleton: declaring it as an instance attribute,
+        #   rather than a class attribute, allows singleton reset during testing.
         self.interfaceController = InterfaceController()
+
+        self.view = view
 
     def handleButtonClicked(self):
         runNumber = self.view.getRunNumber()

--- a/src/snapred/ui/presenter/LogTablePresenter.py
+++ b/src/snapred/ui/presenter/LogTablePresenter.py
@@ -6,10 +6,13 @@ from snapred.ui.threading.worker_pool import WorkerPool
 
 
 class LogTablePresenter(object):
-    interfaceController = InterfaceController()
-    worker_pool = WorkerPool()
-
     def __init__(self, view, model):
+        # `InterfaceController` and `WorkerPool` are singletons:
+        #   declaring them as instance attributes, rather than class attributes,
+        #   allows singleton reset during testing.
+        self.interfaceController = InterfaceController()
+        self.worker_pool = WorkerPool()
+
         self.view = view
         self.model = model
 

--- a/src/snapred/ui/presenter/TestPanelPresenter.py
+++ b/src/snapred/ui/presenter/TestPanelPresenter.py
@@ -1,3 +1,4 @@
+from qtpy.QtCore import QObject
 from qtpy.QtWidgets import QGridLayout, QWidget
 
 from snapred.backend.api.InterfaceController import InterfaceController
@@ -10,11 +11,14 @@ from snapred.ui.workflow.ReductionWorkflow import ReductionWorkflow
 logger = snapredLogger.getLogger(__name__)
 
 
-class TestPanelPresenter(object):
-    interfaceController = InterfaceController()
-    worker_pool = WorkerPool()
-
+class TestPanelPresenter(QObject):
     def __init__(self, view):
+        # `InterfaceController` and `WorkerPool` are singletons:
+        #   declaring them as instance attributes, rather than class attributes,
+        #   allows singleton reset during testing.
+        self.interfaceController = InterfaceController()
+        self.worker_pool = WorkerPool()
+
         self.view = view
 
         # For testing purposes:

--- a/src/snapred/ui/presenter/WorkflowNodePresenter_.py
+++ b/src/snapred/ui/presenter/WorkflowNodePresenter_.py
@@ -18,13 +18,19 @@ class _Spinner:
 
 
 class WorkflowNodePresenter(QObject):
-    worker_pool = WorkerPool()
+    # Allow an observer (e.g. `qtbot`) to monitor action completion.
+    actionCompleted = Signal()
 
     # Allow an observer (e.g. `qtbot`) to monitor action completion.
     actionCompleted = Signal()
 
     def __init__(self, view, model):
         super().__init__()
+
+        # WorkerPool is a singleton: declaring it as an instance attribute, instead of a class attribute,
+        #   allows singleton reset during testing.
+        self.worker_pool = WorkerPool()
+
         self.view = view
         self.model = model
 

--- a/src/snapred/ui/presenter/WorkflowPresenter.py
+++ b/src/snapred/ui/presenter/WorkflowPresenter.py
@@ -18,9 +18,9 @@ logger = snapredLogger.getLogger(__name__)
 class WorkflowPresenter(QObject):
     enableAllWorkflows = Signal()
     disableOtherWorkflows = Signal()
-    worker_pool = WorkerPool()
 
-    actionCompleted = Signal()  # Allow an observer (e.g. ``qtbot``) to monitor action completion.
+    # Allow an observer (e.g. `qtbot`) to monitor action completion.
+    actionCompleted = Signal()
 
     def __init__(
         self,
@@ -32,6 +32,12 @@ class WorkflowPresenter(QObject):
         parent=None,
     ):
         super().__init__()
+
+        # 'WorkerPool' is a singleton:
+        #    declaring it as an instance attribute, rather than a class attribute,
+        #    allows singleton reset during testing.
+        self.worker_pool = WorkerPool()
+
         self.view = WorkflowView(model, parent)
         self._iteration = 1
         self.model = model

--- a/src/snapred/ui/view/BackendRequestView.py
+++ b/src/snapred/ui/view/BackendRequestView.py
@@ -9,11 +9,15 @@ from snapred.ui.widget.SampleDropDown import SampleDropDown
 
 
 class BackendRequestView(QWidget):
-    interfaceController = InterfaceController()
-    worker_pool = WorkerPool()
-
     def __init__(self, parent=None):
         super(BackendRequestView, self).__init__(parent)
+
+        # `InterfaceController` and `WorkerPool` are singletons:
+        #   declaring them as instance attributes, rather than class attributes,
+        #   allows singleton reset during testing.
+        self.interfaceController = InterfaceController()
+        self.worker_pool = WorkerPool()
+
         self.layout = QGridLayout()
         self.setLayout(self.layout)
 

--- a/src/snapred/ui/view/reduction/ReductionRequestView.py
+++ b/src/snapred/ui/view/reduction/ReductionRequestView.py
@@ -34,7 +34,7 @@ class ReductionRequestView(BackendRequestView):
         self.populatePixelMaskDropdown = populatePixelMaskDropdown
         self.validateRunNumbers = validateRunNumbers
 
-        # Horizontal layout for run number input and butto  n
+        # Horizontal layout for run number input and button
         self.runNumberLayout = QHBoxLayout()
         self.runNumberInput = QLineEdit()
         self.enterRunNumberButton = QPushButton("Enter Run Number")

--- a/src/snapred/ui/workflow/WorkflowImplementer.py
+++ b/src/snapred/ui/workflow/WorkflowImplementer.py
@@ -23,7 +23,12 @@ class WorkflowImplementer(QObject):
     def __init__(self, parent=None):
         super().__init__()
         self.parent = parent
+
+        # 'InterfaceController' is a singleton:
+        #   declaring it as an instance attribute, instead of a class attribute,
+        #   allows singleton reset during testing.
         self.interfaceController = InterfaceController()
+
         self.responseHandler = SNAPResponseHandler(parent)
         self.workflow: Workflow = None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 import unittest.mock as mock
 
 from snapred.meta.decorators import Resettable
+from snapred.meta.decorators.Singleton import reset_Singletons
 
 # import sys
 # sys.path.append('.')
@@ -44,11 +45,7 @@ mock.Mock.not_called = banned_function("not_called")
 def mock_decorator(orig_cls):
     return orig_cls
 
-
-# PATCH THE DECORATOR HERE
-mockSingleton = mock.Mock()
-mockSingleton.Singleton = mock_decorator
-mock.patch.dict("sys.modules", {"snapred.meta.decorators.Singleton": mockSingleton}).start()
+###### PATCH THE DECORATORS HERE ######
 
 mockResettable = mock.Mock()
 mockResettable.Resettable = mock_decorator
@@ -60,9 +57,10 @@ mantidConfig["CheckMantidVersion.OnStartup"] = "0"
 mantidConfig["UpdateInstrumentDefinitions.OnStartup"] = "0"
 mantidConfig["usagereports.enabled"] = "0"
 
+#######################################
 
-# this at teardown removes the loggers, eliminating logger error printouts
-# see https://github.com/pytest-dev/pytest/issues/5502#issuecomment-647157873
+# this at teardown removes the loggers, eliminating logger-related error printouts
+#   see https://github.com/pytest-dev/pytest/issues/5502#issuecomment-647157873
 @pytest.fixture(autouse=True, scope="session")
 def clear_loggers():  # noqa: PT004
     """Remove handlers from all loggers"""
@@ -74,6 +72,57 @@ def clear_loggers():  # noqa: PT004
         handlers = getattr(logger, "handlers", [])
         for handler in handlers:
             logger.removeHandler(handler)
+
+########################################################################################################################
+# In combination, the following autouse fixtures allow unit tests and integration tests
+#   to be run successfully without mocking out the `@Singleton` decorator.
+#
+#   * The main objective is to allow the `@Singleton` classes to function as singletons, for the
+#     duration of the single-test scope.  This functionality is necessary, for example, in order for
+#     the `Indexer` class to function correctly during the state-initialization sequence.
+#
+#   * There are some fine points involved with using `@Singleton` classes during testing at class and module scope.
+#     Such usage should probably be avoided whenever possible.  It's a bit tricky to get this to work correctly
+#     within the test framework.
+#
+#   * TODO: Regardless of these fixtures, at the moment the `@Singleton` decorator must be completely turned ON during
+#     integration tests, without any modification (e.g. or "reset").  There is something going on at "session" scope
+#     with specific singletons not being deleted between tests, which results in multiple singleton instances when the
+#     fixtures are used.  This behavior does not seem to be an issue for the unit tests.
+#     We can track this down by turning on the garbage collector `gc`, but this work has not yet been completed.
+#
+# Implementation notes:
+#
+#   * Right now, there are > 36 `@Singleton` decorated classes.  Probably, there should be far fewer.
+#     Almost none of these classes are compute-intensive to initialize, or retain any cached data.
+#     These would be the normal justifications for the use of this pattern.
+#
+#   * Applying the `@Singleton` decorator changes the behavior of the classes,
+#     so we don't want to mock the decorator out during testing. At present, the key class where this is important
+#     is the `Indexer` class, which is not itself a singleton, but which is owned and cached
+#     by the `LocalDataService` singleton.  `Indexer` instances retain local data about indexing events
+#     that have occurred since their initialization.
+#
+
+@pytest.fixture(autouse=True)
+def _reset_Singletons(request):
+    if not "integration" in request.keywords:
+        reset_Singletons()
+    yield
+
+@pytest.fixture(scope="class", autouse=True)
+def _reset_class_scope_Singletons(request):
+    if not "integration" in request.keywords:
+        reset_Singletons()
+    yield
+
+@pytest.fixture(scope="module", autouse=True)
+def _reset_module_scope_Singletons(request):
+    if not "integration" in request.keywords:
+        reset_Singletons()
+    yield
+
+########################################################################################################################
 
 
 ## Import various `pytest.fixture` defined in separate `tests/util` modules:

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -7,17 +7,18 @@ def test_executeRequest_noop():
     # import must be here or it will put things in a funny state and break other tests
     from snapred.backend.api.InterfaceController import InterfaceController
 
-    expected_keys = [  # TODO: reduction was removed, re-add this later
-        "config",
-        "stateId",
-        "calibration",
-        "ingestion",
-        "calibrant_sample",
+    expected_keys = [
         "api",
+        "calibrant_sample",
+        "calibration",
+        "config",
+        "ingestion",
+        "metadata",
         "normalization",
         "reduceLiteData",
+        "reduction",
+        "stateId",
         "workspace",
-        "metadata",
     ]
     expected_keys.sort()
 

--- a/tests/integration/test_diffcal.py
+++ b/tests/integration/test_diffcal.py
@@ -20,6 +20,10 @@ def _cleanup_directories():
         shutil.rmtree(stateRootPath)
 
 
+@pytest.mark.skip(
+    reason="TODO: integrate treatment of state-root directory with "
+    + "that used by 'tests/integration/test_workflow_panels_happy_path.py'"
+)
 @pytest.mark.golden_data(
     path=Resource.getPath("outputs/integration/diffcal/golden_data"), short_name="diffcal", date="2024-04-24"
 )

--- a/tests/integration/test_versions_in_order.py
+++ b/tests/integration/test_versions_in_order.py
@@ -220,6 +220,7 @@ class ImitationSousChef(SousChef):
 ###############################################################################
 
 
+# @pytest.mark.integration()  # TODO: why is this mark not used?!
 class TestVersioning(TestCase):
     def setUp(self):
         # NOTE the act of importing InterfaceController will cause test_APIService
@@ -259,6 +260,7 @@ class TestVersioning(TestCase):
     def tearDown(self):
         self.api.serviceFactory.getService = self.old_self
 
+    # @pytest.mark.integration()  # TODO: why is this mark not used?!
     def test_calibration_versioning(self):
         """
         After setting up the data services with the appropriate imitations,

--- a/tests/integration/test_workflow_panels_happy_path.py
+++ b/tests/integration/test_workflow_panels_happy_path.py
@@ -1,0 +1,1347 @@
+import os
+import re
+import tempfile
+from contextlib import ExitStack, suppress
+from pathlib import Path
+from typing import Optional
+from unittest import mock
+
+import pytest
+from mantid.kernel import amend_config
+from qtpy import QtCore
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (
+    QMessageBox,
+    QTabWidget,
+)
+from snapred.__main__ import _prepend_datasearch_directories
+
+# I would prefer not to access `LocalDataService` within an integration test,
+#   however, for the moment, the reduction-data output relocation fixture is defined in the current file.
+from snapred.backend.data.LocalDataService import LocalDataService
+from snapred.meta.Config import Config, Resource
+from snapred.ui.main import SNAPRedGUI
+from snapred.ui.view import InitializeStateCheckView
+from snapred.ui.view.DiffCalAssessmentView import DiffCalAssessmentView
+from snapred.ui.view.DiffCalRequestView import DiffCalRequestView
+from snapred.ui.view.DiffCalSaveView import DiffCalSaveView
+from snapred.ui.view.DiffCalTweakPeakView import DiffCalTweakPeakView
+from snapred.ui.view.NormalizationRequestView import NormalizationRequestView
+from snapred.ui.view.NormalizationSaveView import NormalizationSaveView
+from snapred.ui.view.NormalizationTweakPeakView import NormalizationTweakPeakView
+from snapred.ui.view.reduction.ReductionRequestView import ReductionRequestView
+from snapred.ui.view.reduction.ReductionSaveView import ReductionSaveView
+from util.Config_helpers import Config_override
+
+# TODO: WorkflowNodeComplete signal, at end of each node!
+
+
+class InterruptWithBlock(BaseException):
+    pass
+
+
+@pytest.fixture()
+def calibration_home_from_mirror():
+    # Test fixture to create a copy of the calibration home directory from an existing mirror:
+    # * creates a temporary calibration home directory under the optional `prefix` path;
+    #   when not specified, the temporary directory is created under the existing
+    #   `Config["instrument.calibration.powder.home"]`;
+    # * creates symlinks within the directory to required metadata files and directories
+    #   from the already existing `Config["instrument.calibration.powder.home"]`;
+    # * ignores any existing diffraction-calibration and normalization-calibration subdirectories;
+    # * and finally, overrides the `Config` entry for "instrument.calibration.powder.home".
+
+    # IMPLEMENTATION notes:
+    # * The functionality of this fixture is deliberately NOT implemented as a context manager,
+    #   although certain context-manager features are used.
+    # * If this were a context manager, it would  be terminated at any exception throw.  For example,
+    #   it would be terminated by the "initialize state" `RecoverableException`.  Such termination would interfere with
+    #   the requirements of the integration tests.
+    _stack = ExitStack()
+
+    def _calibration_home_from_mirror(prefix: Optional[Path] = None):
+        originalCalibrationHome: Path = Path(Config["instrument.calibration.powder.home"])
+        if prefix is None:
+            prefix = originalCalibrationHome
+
+        # Override calibration home directory:
+        tmpCalibrationHome = Path(_stack.enter_context(tempfile.TemporaryDirectory(dir=prefix, suffix=os.sep)))
+        assert tmpCalibrationHome.exists()
+        _stack.enter_context(Config_override("instrument.calibration.powder.home", str(tmpCalibrationHome)))
+
+        # WARNING: for these integration tests `LocalDataService` is a singleton.
+        #   The Indexer's `lru_cache` MUST be reset after the Config override, otherwise
+        #     it will return indexers synched to the previous `Config["instrument.calibration.powder.home"]`.
+        LocalDataService()._indexer.cache_clear()
+
+        # Create symlinks to metadata files and directories.
+        metadatas = [Path("LiteGroupMap.hdf"), Path("PixelGroupingDefinitions"), Path("SNAPLite.xml")]
+        for path_ in metadatas:
+            os.symlink(originalCalibrationHome / path_, tmpCalibrationHome / path_)
+        return tmpCalibrationHome
+
+    yield _calibration_home_from_mirror
+
+    # teardown => __exit__
+    _stack.close()
+    LocalDataService()._indexer.cache_clear()
+
+
+@pytest.fixture()
+def reduction_home_from_mirror():
+    # Test fixture to write reduction data to a temporary directory under `Config["instrument.reduction.home"]`.
+    # * creates a temporary reduction state root directory under the optional `prefix` path;
+    #   when not specified, the temporary directory is created under the existing
+    #   `Config["instrument.reduction.home"]` (with the substituted 'IPTS' tag).
+    # * overrides the `Config` entry for "instrument.reduction.home".
+
+    # IMPLEMENTATION notes: (see previous).
+    _stack = ExitStack()
+
+    def _reduction_home_from_mirror(runNumber: str, prefix: Optional[Path] = None):
+        if prefix is None:
+            dataService = LocalDataService()
+            originalReductionHome = dataService._constructReductionStateRoot(runNumber)
+
+            # WARNING: this 'mkdir' step will not be reversed at exit,
+            #   but that shouldn't matter very much.
+            originalReductionHome.mkdir(parents=True, exist_ok=True)
+            prefix = originalReductionHome
+
+            tmpReductionHome = Path(_stack.enter_context(tempfile.TemporaryDirectory(dir=prefix, suffix=os.sep)))
+
+            # Ensure that `_createReductionStateRoot` will return the temporary directory,
+            #   while still exercising it's IPTS-substitution functionality.
+            _stack.enter_context(
+                Config_override(
+                    "instrument.reduction.home", Config["instrument.reduction.home"] + os.sep + tmpReductionHome.name
+                )
+            )
+
+            # No `LocalDataService._indexer.cache_clear()` should be required here, but keep it in mind, just in case!
+
+        else:
+            # Specified prefix => just use that, without any substitution.
+            # In this case `_constructReductionStateRoot` will return a path
+            #   which does not depend on the IPTS-directory for the run number.
+            tmpReductionHome = Path(_stack.enter_context(tempfile.TemporaryDirectory(dir=prefix, suffix=os.sep)))
+            _stack.enter_context(Config_override("instrument.reduction.home", str(tmpReductionHome)))
+
+        assert tmpReductionHome.exists()
+        return tmpReductionHome
+
+    yield _reduction_home_from_mirror
+
+    # teardown => __exit__
+    _stack.close()
+
+
+@pytest.mark.integration()
+class TestGUIPanels:
+    @pytest.fixture(scope="function", autouse=True)  # noqa: PT003
+    def _setup_gui(self, qapp):
+        # ---------------------------------------------------------------------------
+        # DEFAULT PATCHES:
+        #   FAIL TEST if any 'warning' OR 'critical' message boxes occur.
+        #   In the test body, these patches are overridden for special cases.
+
+        self._warningMessageBox = mock.patch(
+            "qtpy.QtWidgets.QMessageBox.warning",
+            lambda *args, **kwargs: pytest.fail(
+                "WARNING messagebox:\n" + f"    args: {args}\n" + f"    kwargs: {kwargs}", pytrace=False
+            ),
+        )
+        self._warningMessageBox.start()
+
+        self._criticalMessageBox = mock.patch(
+            "qtpy.QtWidgets.QMessageBox.critical",
+            lambda *args, **kwargs: pytest.fail(
+                "CRITICAL messagebox:\n" + f"    args: {args}\n" + f"    kwargs: {kwargs}", pytrace=False
+            ),
+        )
+        self._criticalMessageBox.start()
+
+        # patch log-warnings QMessage box: runs using `QMessageBox.exec`.
+        self._logWarningsMessageBox = mock.patch(
+            "qtpy.QtWidgets.QMessageBox.exec",
+            lambda self, *args, **kwargs: QMessageBox.Ok
+            if (
+                "The backend has encountered warning(s)" in self.text()
+                and "InstrumentDonor will only be used if GroupingFilename is in XML format." in self.detailedText()
+            )
+            else pytest.fail(
+                "unexpected QMessageBox.exec:\n"
+                + f"    args: {args}\n"
+                + f"    kwargs: {kwargs}\n"
+                + f"    text: '{self.text()}'\n"
+                + f"    detailed text: '{self.detailedText()}'",
+                pytrace=False,
+            ),
+        )
+        self._logWarningsMessageBox.start()
+
+        # Automatically continue at the end of each workflow.
+        self._actionPrompt = mock.patch(
+            "snapred.ui.presenter.WorkflowPresenter.ActionPrompt.prompt",
+            lambda *args: TestGUIPanels._actionPromptContinue(
+                *args, match=r".*The workflow has been completed successfully.*"
+            ),
+        )
+        self._actionPrompt.start()
+        # ---------------------------------------------------------------------------
+
+        with Resource.open("../../src/snapred/resources/style.qss", "r") as styleSheet:
+            qapp.setStyleSheet(styleSheet.read())
+
+        # Establish context for each test: these normally run as part of `src/snapred/__main__.py`.
+        self.exitStack = ExitStack()
+        self.exitStack.enter_context(amend_config(data_dir=_prepend_datasearch_directories(), prepend_datadir=True))
+        yield
+
+        # teardown...
+        self._warningMessageBox.stop()
+        self._criticalMessageBox.stop()
+        self._logWarningsMessageBox.stop()
+        self._actionPrompt.stop()
+        self.exitStack.close()
+
+    @staticmethod
+    def _actionPromptContinue(title, message, action, parent=None, match=r".*"):  # noqa: ARG004
+        _pattern = re.compile(match)
+        if not _pattern.match(message):
+            pytest.fail(
+                f"unexpected: ActionPrompt.prompt('{title}', '{message}'...)\n"
+                + f"    expecting:  ActionPrompt.prompt(...'{message}'...)"
+            )
+
+    @pytest.mark.skip(reason="each workflow panel now has a separate test")
+    def test_calibration_and_reduction_panels_happy_path(
+        self, qtbot, qapp, calibration_home_from_mirror, reduction_home_from_mirror
+    ):
+        # TODO: these could be initialized in the 'setup', but the current plan is to use a YML test template.
+        reductionRunNumber = "46680"
+        reductionStateId = "04bd2c53f6bf6754"
+
+        # Override the mirror with a new calibration-home directory, omitting any existing
+        #   calibration or normalization data.
+        tmpCalibrationHomeDirectory = calibration_home_from_mirror()  # noqa: F841
+
+        # Override the standard reduction-output location, using a temporary directory
+        #   under the existing location within the mirror.
+        tmpReductionHomeDirectory = reduction_home_from_mirror(reductionRunNumber)  # noqa: F841
+
+        with (
+            qtbot.captureExceptions() as exceptions,
+            suppress(InterruptWithBlock),
+        ):
+            gui = SNAPRedGUI(translucentBackground=True)
+            gui.show()
+            qtbot.addWidget(gui)
+
+            """
+            SNAPRedGUI owns the following widgets:
+
+              * self.calibrationPanelButton [new] = QPushButton("Open Calibration Panel")
+
+                <button click> => self.newWindow = TestPanel(self).setWindowTitle("Calibration Panel")
+
+              * LogTable("load dummy", self).widget
+
+              * WorkspaceWidget(self)
+
+              * AlgorithmProgressWidget()
+
+              * <central widget>: QWidget().setObjectName("centralWidget")
+
+              * self.userDocButton = UserDocsButton(self)
+            """
+
+            # Open the calibration panel:
+            # QPushButton* button = pWin->findChild<QPushButton*>("Button name");
+            qtbot.mouseClick(gui.calibrationPanelButton, QtCore.Qt.LeftButton)
+            if len(exceptions):
+                raise InterruptWithBlock
+            calibrationPanel = gui.calibrationPanel
+
+            # tab indices: (0) diffraction calibration, (1) normalization calibration, and (2) reduction
+            calibrationPanelTabs = calibrationPanel.presenter.view.tabWidget
+
+            ##########################################################################################################
+            ##################### DIFFRACTION CALIBRATION PANEL: #####################################################
+            ##########################################################################################################
+
+            # Diffraction calibration:
+            calibrationPanelTabs.setCurrentIndex(0)
+            diffractionCalibrationWidget = calibrationPanelTabs.currentWidget()
+
+            ### The use of this next signal is somewhat cryptic, but it makes testing the GUI much more stable:
+            ##    The `actionCompleted` signal is emitted whenever a workflow node completes its action.
+            ##    Otherwise, we would need to infer that the action is completed by other means.
+            actionCompleted = (
+                calibrationPanel.presenter.diffractionCalibrationWorkflow.workflow.presenter.actionCompleted
+            )
+            ###
+
+            # node-tab indices: (0) request view, (1) tweak-peak view, (2) assessment view, and (4) save view
+            workflowNodeTabs = diffractionCalibrationWidget.findChild(QTabWidget, "nodeTabs")
+
+            requestView = workflowNodeTabs.currentWidget().view
+            assert isinstance(requestView, DiffCalRequestView)
+
+            #    set "Run Number", "Convergence Threshold", ,:
+            requestView.runNumberField.setText(reductionRunNumber)
+            requestView.fieldConvergenceThreshold.setText("0.1")
+            requestView.fieldNBinsAcrossPeakWidth.setText("10")
+
+            #    set all dropdown selections, but make sure that the dropdown contents are as expected
+            requestView.sampleDropdown.setCurrentIndex(0)
+            assert requestView.sampleDropdown.currentIndex() == 0
+            assert requestView.sampleDropdown.currentText().endswith("Diamond_001.json")
+
+            #    Without this next 'qtbot.wait(1000)',
+            #      the 'groupingFileDropdown' gets reset after this successful initialization.
+            #    I assume this is because somehow the 'populateGroupingDropdown',
+            #      triggered by the 'runNumberField' 'editComplete', hasn't actually occurred yet?
+            qtbot.wait(1000)
+            requestView.groupingFileDropdown.setCurrentIndex(1)
+            assert requestView.groupingFileDropdown.currentIndex() == 1
+            assert requestView.groupingFileDropdown.currentText() == "Bank"
+
+            requestView.peakFunctionDropdown.setCurrentIndex(0)
+            assert requestView.peakFunctionDropdown.currentIndex() == 0
+            assert requestView.peakFunctionDropdown.currentText() == "Gaussian"
+
+            #    execute the request
+
+            # TODO: make sure that there's no initialized state => abort the test if there is!
+            waitForStateInit = True
+            if (Path(Config["instrument.calibration.powder.home"]) / reductionStateId).exists():
+                # raise RuntimeError(
+                #           f"The state root directory for '{reductionStateId}' already exists! "\
+                #           + " Please move it out of the way."
+                #       )
+                waitForStateInit = False
+
+            if waitForStateInit:
+                # ---------------------------------------------------------------------------
+                # IMPORTANT: "initialize state" dialog is triggered by an exception throw:
+                #   therefore, we cannot patch using a `with` clause!
+                questionMessageBox = mock.patch(  # noqa: PT008
+                    "qtpy.QtWidgets.QMessageBox.question",
+                    lambda *args, **kwargs: QMessageBox.Yes,  # noqa: ARG005
+                )
+                questionMessageBox.start()
+                successPrompt = mock.patch(
+                    "snapred.ui.widget.SuccessPrompt.SuccessPrompt.prompt",
+                    lambda parent: parent.close() if parent is not None else None,
+                )
+                successPrompt.start()
+                # ---------------------------------------------------------------------------
+
+                #    (1) respond to the "initialize state" request
+                with qtbot.waitSignal(actionCompleted, timeout=60000):
+                    qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+                qtbot.waitUntil(
+                    lambda: len(
+                        [
+                            o
+                            for o in qapp.topLevelWidgets()
+                            if isinstance(o, InitializeStateCheckView.InitializationMenu)
+                        ]
+                    )
+                    > 0,
+                    timeout=1000,
+                )
+                stateInitDialog = [
+                    o for o in qapp.topLevelWidgets() if isinstance(o, InitializeStateCheckView.InitializationMenu)
+                ][0]
+
+                stateInitDialog.stateNameField.setText("my happy state")
+                qtbot.mouseClick(stateInitDialog.beginFlowButton, Qt.MouseButton.LeftButton)
+
+                # State initialization dialog is "application modal" => no need to explicitly wait
+                questionMessageBox.stop()
+                successPrompt.stop()
+
+            #    (2) execute the calibration workflow
+            with qtbot.waitSignal(actionCompleted, timeout=60000):
+                qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+            qtbot.waitUntil(
+                lambda: isinstance(workflowNodeTabs.currentWidget().view, DiffCalTweakPeakView), timeout=60000
+            )
+
+            tweakPeakView = workflowNodeTabs.currentWidget().view
+
+            # ---------------------------------------------------------------------------
+            # Required patch for "TweakPeakView": ensure continuation if only two peaks are found.
+            # IMPORTANT: "greater than two peaks" warning is triggered by an exception throw:
+            #   => do _not_ patch using a with clause!
+            warningMessageBox = mock.patch(  # noqa: PT008
+                "qtpy.QtWidgets.QMessageBox.warning",
+                lambda *args, **kwargs: QMessageBox.Yes,  # noqa: ARG005
+            )
+            warningMessageBox.start()
+            # ---------------------------------------------------------------------------
+
+            #    set "xtal dMin", "FWHM left", and "FWHM right": these are sufficient to get "46680" to pass.
+            #    TODO: set ALL of the relevant fields, and use a test initialization template for this.
+            tweakPeakView.fieldXtalDMin.setText("0.72")
+            tweakPeakView.fieldFWHMleft.setText("2.0")
+            tweakPeakView.fieldFWHMright.setText("2.0")
+            tweakPeakView.peakFunctionDropdown.setCurrentIndex(0)
+            assert tweakPeakView.peakFunctionDropdown.currentIndex() == 0
+            assert tweakPeakView.peakFunctionDropdown.currentText() == "Gaussian"
+
+            #    recalculate using the new values
+            #    * recalculate => peak display is recalculated,
+            #      not the entire calibration.
+            qtbot.mouseClick(tweakPeakView.recalculationButton, Qt.MouseButton.LeftButton)
+            qtbot.wait(10000)
+
+            #    continue to the next panel
+            with qtbot.waitSignal(actionCompleted, timeout=60000):
+                qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+
+            qtbot.waitUntil(
+                lambda: isinstance(workflowNodeTabs.currentWidget().view, DiffCalAssessmentView), timeout=60000
+            )
+
+            # Placing this next `stop` correctly, causes some difficulty:
+            #   if it's placed too early, the `warning` box patch doesn't correctly trap the "tweak peaks" warning.
+            # So, for this reason this stop is placed _after_ the `waitUntil`.
+            #   ("Tweak peaks" view should have definitely completed by this point.)
+            warningMessageBox.stop()
+
+            assessmentView = workflowNodeTabs.currentWidget().view  # noqa: F841
+            #    nothing to do here, for this test
+
+            #    continue to the next panel
+            with qtbot.waitSignal(actionCompleted, timeout=60000):
+                qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+
+            qtbot.waitUntil(lambda: isinstance(workflowNodeTabs.currentWidget().view, DiffCalSaveView), timeout=5000)
+            saveView = workflowNodeTabs.currentWidget().view
+
+            #    set "author" and "comment"
+            saveView.fieldAuthor.setText("kat")
+            saveView.fieldComments.setText("calibration-panel integration test")
+
+            #    continue in order to save workspaces and to finish the workflow
+            with qtbot.waitSignal(actionCompleted, timeout=60000):
+                qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+
+            #   `ActionPrompt.prompt("..The workflow has completed successfully..)` gives immediate mocked response:
+            #      However, here we still need to wait until the ADS cleanup has occurred,
+            #      or else it will finish up in the middle of the next workflow. :(
+            qtbot.waitUntil(
+                lambda: isinstance(workflowNodeTabs.currentWidget().view, DiffCalRequestView), timeout=10000
+            )
+
+            #####################################################################################################
+            ##################### NORMALIZATION PANEL: ##########################################################
+            #####################################################################################################
+
+            # Normalization calibration:
+            calibrationPanelTabs.setCurrentIndex(1)
+            normalizationCalibrationWidget = calibrationPanelTabs.currentWidget()
+
+            #################################################################
+            #### We need to access the signal specific to each workflow. ####
+            #################################################################
+            actionCompleted = (
+                calibrationPanel.presenter.normalizationCalibrationWorkflow.workflow.presenter.actionCompleted
+            )
+            ###
+
+            # node-tab indices: (0) request view, (1) tweak-peak view, and (3) save view
+            workflowNodeTabs = normalizationCalibrationWidget.findChild(QTabWidget, "nodeTabs")
+
+            requestView = workflowNodeTabs.currentWidget().view
+            assert isinstance(requestView, NormalizationRequestView)
+
+            #    set "Run Number", "Background run number":
+            requestView.runNumberField.setText(reductionRunNumber)
+            requestView.backgroundRunNumberField.setText(reductionRunNumber)
+
+            #    set all dropdown selections, but make sure that the dropdown contents are as expected
+            requestView.sampleDropdown.setCurrentIndex(0)
+            assert requestView.sampleDropdown.currentIndex() == 0
+            assert requestView.sampleDropdown.currentText().endswith("Diamond_001.json")
+
+            #    Without this next 'qtbot.wait(1000)',
+            #      the 'groupingFileDropdown' gets reset after this successful initialization.
+            #    I assume this is because somehow the 'populateGroupingDropdown',
+            #      triggered by the 'runNumberField' 'editComplete' hasn't actually occurred yet?
+            qtbot.wait(1000)
+            requestView.groupingFileDropdown.setCurrentIndex(1)
+            assert requestView.groupingFileDropdown.currentIndex() == 1
+            assert requestView.groupingFileDropdown.currentText() == "Bank"
+
+            """ # Why no "peak function" for normalization calibration?!
+            requestView.peakFunctionDropdown.setCurrentIndex(0)
+            assert requestView.peakFunctionDropdown.currentIndex() == 0
+            assert requestView.peakFunctionDropdown.currentText() == "Gaussian"
+            """
+
+            #    execute the request
+
+            # TODO: make sure that there's no initialized state => abort the test if there is!
+            waitForStateInit = True
+            if (Path(Config["instrument.calibration.powder.home"]) / reductionStateId).exists():
+                # raise RuntimeError(
+                #           f"The state root directory for '{reductionStateId}' already exists! "\
+                #           + "Please move it out of the way."
+                #       )
+                waitForStateInit = False
+
+            if waitForStateInit:
+                # ---------------------------------------------------------------------------
+                # IMPORTANT: "initialize state" dialog is triggered by an exception throw:
+                #   => do _not_ patch using a with clause!
+                questionMessageBox = mock.patch(  # noqa: PT008
+                    "qtpy.QtWidgets.QMessageBox.question",
+                    lambda *args, **kwargs: QMessageBox.Yes,  # noqa: ARG005
+                )
+                questionMessageBox.start()
+                successPrompt = mock.patch(
+                    "snapred.ui.widget.SuccessPrompt.SuccessPrompt.prompt",
+                    lambda parent: parent.close() if parent is not None else None,
+                )
+                successPrompt.start()
+                # ---------------------------------------------------------------------------
+
+                #    (1) respond to the "initialize state" request
+                with qtbot.waitSignal(actionCompleted, timeout=60000):
+                    qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+                qtbot.waitUntil(
+                    lambda: len(
+                        [
+                            o
+                            for o in qapp.topLevelWidgets()
+                            if isinstance(o, InitializeStateCheckView.InitializationMenu)
+                        ]
+                    )
+                    > 0,
+                    timeout=1000,
+                )
+                stateInitDialog = [
+                    o for o in qapp.topLevelWidgets() if isinstance(o, InitializeStateCheckView.InitializationMenu)
+                ][0]
+
+                stateInitDialog.stateNameField.setText("my happy state")
+                qtbot.mouseClick(stateInitDialog.beginFlowButton, Qt.MouseButton.LeftButton)
+
+                # State initialization dialog is "application modal" => no need to explicitly wait
+                questionMessageBox.stop()
+                successPrompt.stop()
+
+            #    (2) execute the normalization workflow
+            with qtbot.waitSignal(actionCompleted, timeout=60000):
+                qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+            qtbot.waitUntil(
+                lambda: isinstance(workflowNodeTabs.currentWidget().view, NormalizationTweakPeakView), timeout=60000
+            )
+
+            tweakPeakView = workflowNodeTabs.currentWidget().view
+
+            #    set "Smoothing", "xtal dMin", "xtal dMax", "intensity threshold", and "groupingDropDown"
+            tweakPeakView.smoothingSlider.field.setValue("0.4")
+            tweakPeakView.fieldXtalDMin.setText("0.4")
+            tweakPeakView.fieldXtalDMax.setText("90.0")
+
+            #    See comment at prevous "groupingFileDropdown".
+            qtbot.wait(1000)
+            tweakPeakView.groupingFileDropdown.setCurrentIndex(0)
+            assert tweakPeakView.groupingFileDropdown.currentIndex() == 0
+            assert tweakPeakView.groupingFileDropdown.currentText() == "All"
+
+            #    recalculate using the new values
+            #    * recalculate => peak display is recalculated,
+            #      not the entire calibration.
+            qtbot.mouseClick(tweakPeakView.recalculationButton, Qt.MouseButton.LeftButton)
+            qtbot.wait(5000)
+
+            #    continue to the next panel
+            with qtbot.waitSignal(actionCompleted, timeout=60000):
+                qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+            qtbot.waitUntil(
+                lambda: isinstance(workflowNodeTabs.currentWidget().view, NormalizationSaveView), timeout=60000
+            )
+            saveView = workflowNodeTabs.currentWidget().view
+
+            #    set "author" and "comment"
+            saveView.fieldAuthor.setText("kat")
+            saveView.fieldComments.setText("calibration-panel integration test")
+
+            #    continue in order to save workspaces and to finish the workflow
+            with qtbot.waitSignal(actionCompleted, timeout=60000):
+                qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+
+            #   `ActionPrompt.prompt("..The workflow has completed successfully..)` gives immediate mocked response:
+            #     Here we still need to wait until the ADS cleanup has occurred,
+            #     or else it will happen in the middle of the next workflow. :(
+            qtbot.waitUntil(
+                lambda: isinstance(workflowNodeTabs.currentWidget().view, NormalizationRequestView), timeout=10000
+            )
+
+            #################################################################################################
+            ##################### REDUCTION PANEL: ##########################################################
+            #################################################################################################
+
+            # Reduction:
+            calibrationPanelTabs.setCurrentIndex(2)
+            reductionWidget = calibrationPanelTabs.currentWidget()
+
+            #################################################################
+            #### We need to access the signal specific to each workflow. ####
+            #################################################################
+            actionCompleted = calibrationPanel.presenter.reductionWorkflow.workflow.presenter.actionCompleted
+            ###
+
+            # node-tab indices: (0) request view, and (2) save view
+            workflowNodeTabs = reductionWidget.findChild(QTabWidget, "nodeTabs")
+
+            requestView = workflowNodeTabs.currentWidget().view
+            assert isinstance(requestView, ReductionRequestView)
+
+            #    enter a "Run Number":
+            requestView.runNumberInput.setText(reductionRunNumber)
+            qtbot.mouseClick(requestView.enterRunNumberButton, Qt.MouseButton.LeftButton)
+            _currentText = requestView.runNumberDisplay.toPlainText()
+            _runNumbers = [num.strip() for num in _currentText.split("\n") if num.strip()]
+            assert reductionRunNumber in _runNumbers
+
+            """
+            request.liteModeToggle.setState(True);
+            request.retainUnfocusedDataCheckbox.setValue(False);
+            """
+
+            """
+            # Set some pixel masks in the ADS, and on the filesystem, prior to this test section.  Then we can test
+            #   the pixel-mask dropdown.
+            request.pixelMaskDropdown.setCurrentIndex() # or set-selected range? or by index?
+            """
+
+            #    execute the request
+
+            # TODO: make sure that there's no initialized state => abort the test if there is!
+            waitForStateInit = True
+            if (Path(Config["instrument.calibration.powder.home"]) / reductionStateId).exists():
+                # raise RuntimeError(
+                #           f"The state root directory for '{reductionStateId}' already exists! "\
+                #           + "Please move it out of the way."
+                #       )
+                waitForStateInit = False
+
+            if waitForStateInit:
+                # ---------------------------------------------------------------------------
+                # IMPORTANT: "initialize state" dialog is triggered by an exception throw:
+                #   => do _not_ patch using a with clause!
+                questionMessageBox = mock.patch(  # noqa: PT008
+                    "qtpy.QtWidgets.QMessageBox.question",
+                    lambda *args, **kwargs: QMessageBox.Yes,  # noqa: ARG005
+                )
+                questionMessageBox.start()
+                successPrompt = mock.patch(
+                    "snapred.ui.widget.SuccessPrompt.SuccessPrompt.prompt",
+                    lambda parent: parent.close() if parent is not None else None,
+                )
+                successPrompt.start()
+                # ---------------------------------------------------------------------------
+
+                #    (1) respond to the "initialize state" request
+                with qtbot.waitSignal(actionCompleted, timeout=60000):
+                    qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+                qtbot.waitUntil(
+                    lambda: len(
+                        [
+                            o
+                            for o in qapp.topLevelWidgets()
+                            if isinstance(o, InitializeStateCheckView.InitializationMenu)
+                        ]
+                    )
+                    > 0,
+                    timeout=1000,
+                )
+                stateInitDialog = [
+                    o for o in qapp.topLevelWidgets() if isinstance(o, InitializeStateCheckView.InitializationMenu)
+                ][0]
+
+                stateInitDialog.stateNameField.setText("my happy state")
+                qtbot.mouseClick(stateInitDialog.beginFlowButton, Qt.MouseButton.LeftButton)
+
+                # State initialization dialog is "application modal" => no need to explicitly wait
+                questionMessageBox.stop()
+                successPrompt.stop()
+
+            #    (2) execute the reduction workflow
+            with qtbot.waitSignal(actionCompleted, timeout=120000):
+                qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+            qtbot.waitUntil(lambda: isinstance(workflowNodeTabs.currentWidget().view, ReductionSaveView), timeout=60000)
+            saveView = workflowNodeTabs.currentWidget().view
+
+            """
+            #    set "author" and "comment"
+            saveView.fieldAuthor.setText("kat")
+            saveView.fieldComments.setText("calibration-panel integration test")
+            """
+
+            #    continue in order to save workspaces and to finish the workflow
+            with qtbot.waitSignal(actionCompleted, timeout=60000):
+                qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+
+            #   `ActionPrompt.prompt("..The workflow has completed successfully..)` gives immediate mocked response:
+            #      Here we still need to wait until the ADS cleanup has occurred,
+            #      or else it will happen in the middle of the next workflow. :(
+            qtbot.waitUntil(
+                lambda: isinstance(workflowNodeTabs.currentWidget().view, ReductionRequestView), timeout=5000
+            )
+
+            ###############################
+            ########### END OF TEST #######
+            ###############################
+
+            calibrationPanel.widget.close()
+            gui.close()
+
+        #####################################################################
+        # Force a printout of information about any exceptions that happened#
+        #   within the Qt event loop.                                       #
+        #####################################################################
+        if len(exceptions):
+            # sys.exc_info ::= type(e), e, <traceback>
+            _, e, _ = exceptions[0]
+            raise e
+
+        # Force a clean exit
+        qtbot.wait(5000)
+
+    def test_diffraction_calibration_panel_happy_path(self, qtbot, qapp, calibration_home_from_mirror):
+        # Override the mirror with a new home directory, omitting any existing
+        #   calibration or normalization data.
+        tmpCalibrationHomeDirectory = calibration_home_from_mirror()  # noqa: F841
+
+        with (
+            qtbot.captureExceptions() as exceptions,
+            suppress(InterruptWithBlock),
+        ):
+            gui = SNAPRedGUI(translucentBackground=True)
+            gui.show()
+            qtbot.addWidget(gui)
+
+            """
+            SNAPRedGUI owns the following widgets:
+
+              * self.calibrationPanelButton [new] = QPushButton("Open Calibration Panel")
+
+                <button click> => self.newWindow = TestPanel(self).setWindowTitle("Calibration Panel")
+
+              * LogTable("load dummy", self).widget
+
+              * WorkspaceWidget(self)
+
+              * AlgorithmProgressWidget()
+
+              * <central widget>: QWidget().setObjectName("centralWidget")
+
+              * self.userDocButton = UserDocsButton(self)
+            """
+
+            # Open the calibration panel:
+            # QPushButton* button = pWin->findChild<QPushButton*>("Button name");
+            qtbot.mouseClick(gui.calibrationPanelButton, QtCore.Qt.LeftButton)
+            if len(exceptions):
+                raise InterruptWithBlock
+            calibrationPanel = gui.calibrationPanel
+
+            # tab indices: (0) diffraction calibration, (1) normalization calibration, and (2) reduction
+            calibrationPanelTabs = calibrationPanel.presenter.view.tabWidget
+
+            ##########################################################################################################
+            ##################### DIFFRACTION CALIBRATION PANEL: #####################################################
+            ##########################################################################################################
+
+            # Diffraction calibration:
+            calibrationPanelTabs.setCurrentIndex(0)
+            diffractionCalibrationWidget = calibrationPanelTabs.currentWidget()
+
+            ### The use of this next signal is somewhat cryptic, but it makes testing the GUI much more stable:
+            ##    The `actionCompleted` signal is emitted whenever a workflow node completes its action.
+            ##    Otherwise, we would need to infer that the action is completed by other means.
+            actionCompleted = (
+                calibrationPanel.presenter.diffractionCalibrationWorkflow.workflow.presenter.actionCompleted
+            )
+            ###
+
+            # node-tab indices: (0) request view, (1) tweak-peak view, (2) assessment view, and (4) save view
+            workflowNodeTabs = diffractionCalibrationWidget.findChild(QTabWidget, "nodeTabs")
+
+            requestView = workflowNodeTabs.currentWidget().view
+            assert isinstance(requestView, DiffCalRequestView)
+
+            #    set "Run Number", "Convergence Threshold", ,:
+            requestView.runNumberField.setText("46680")
+            requestView.fieldConvergenceThreshold.setText("0.1")
+            requestView.fieldNBinsAcrossPeakWidth.setText("10")
+
+            #    set all dropdown selections, but make sure that the dropdown contents are as expected
+            requestView.sampleDropdown.setCurrentIndex(0)
+            assert requestView.sampleDropdown.currentIndex() == 0
+            assert requestView.sampleDropdown.currentText().endswith("Diamond_001.json")
+
+            #    Without this next 'qtbot.wait(1000)',
+            #      the 'groupingFileDropdown' gets reset after this successful initialization.
+            #    I assume this is because somehow the 'populateGroupingDropdown',
+            #    triggered by the 'runNumberField' 'editComplete' hasn't actually occurred yet?
+            qtbot.wait(1000)
+            requestView.groupingFileDropdown.setCurrentIndex(1)
+            assert requestView.groupingFileDropdown.currentIndex() == 1
+            assert requestView.groupingFileDropdown.currentText() == "Bank"
+
+            requestView.peakFunctionDropdown.setCurrentIndex(0)
+            assert requestView.peakFunctionDropdown.currentIndex() == 0
+            assert requestView.peakFunctionDropdown.currentText() == "Gaussian"
+
+            #    execute the request
+
+            # TODO: make sure that there's no initialized state => abort the test if there is!
+            #   At the moment, we preserve some options here to speed up development.
+            stateId = "04bd2c53f6bf6754"
+            waitForStateInit = True
+            if (Path(Config["instrument.calibration.powder.home"]) / stateId).exists():
+                # raise RuntimeError(
+                #           f"The state root directory for '{stateId}' already exists! "\
+                #           + "Please move it out of the way."
+                #       )
+                waitForStateInit = False
+
+            if waitForStateInit:
+                # ---------------------------------------------------------------------------
+                # IMPORTANT: "initialize state" dialog is triggered by an exception throw:
+                #   therefore, we cannot patch using a `with` clause!
+                questionMessageBox = mock.patch(  # noqa: PT008
+                    "qtpy.QtWidgets.QMessageBox.question",
+                    lambda *args, **kwargs: QMessageBox.Yes,  # noqa: ARG005
+                )
+                questionMessageBox.start()
+                successPrompt = mock.patch(
+                    "snapred.ui.widget.SuccessPrompt.SuccessPrompt.prompt",
+                    lambda parent: parent.close() if parent is not None else None,
+                )
+                successPrompt.start()
+                # ---------------------------------------------------------------------------
+
+                #    (1) respond to the "initialize state" request
+                with qtbot.waitSignal(actionCompleted, timeout=60000):
+                    qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+                qtbot.waitUntil(
+                    lambda: len(
+                        [
+                            o
+                            for o in qapp.topLevelWidgets()
+                            if isinstance(o, InitializeStateCheckView.InitializationMenu)
+                        ]
+                    )
+                    > 0,
+                    timeout=1000,
+                )
+                stateInitDialog = [
+                    o for o in qapp.topLevelWidgets() if isinstance(o, InitializeStateCheckView.InitializationMenu)
+                ][0]
+
+                stateInitDialog.stateNameField.setText("my happy state")
+                qtbot.mouseClick(stateInitDialog.beginFlowButton, Qt.MouseButton.LeftButton)
+
+                # State initialization dialog is "application modal" => no need to explicitly wait
+                questionMessageBox.stop()
+                successPrompt.stop()
+
+            #    (2) execute the calibration workflow
+            with qtbot.waitSignal(actionCompleted, timeout=60000):
+                qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+            qtbot.waitUntil(
+                lambda: isinstance(workflowNodeTabs.currentWidget().view, DiffCalTweakPeakView), timeout=60000
+            )
+
+            tweakPeakView = workflowNodeTabs.currentWidget().view
+
+            # ---------------------------------------------------------------------------
+            # Required patch for "TweakPeakView": ensure continuation if only two peaks are found.
+            # IMPORTANT: "greater than two peaks" warning is triggered by an exception throw:
+            #   => do _not_ patch using a with clause!
+            warningMessageBox = mock.patch(  # noqa: PT008
+                "qtpy.QtWidgets.QMessageBox.warning",
+                lambda *args, **kwargs: QMessageBox.Yes,  # noqa: ARG005
+            )
+            warningMessageBox.start()
+            # ---------------------------------------------------------------------------
+
+            #    set "xtal dMin", "FWHM left", and "FWHM right": these are sufficient to get "46680" to pass.
+            #    TODO: set ALL of the relevant fields, and use a test initialization template for this.
+            tweakPeakView.fieldXtalDMin.setText("0.72")
+            tweakPeakView.fieldFWHMleft.setText("2.0")
+            tweakPeakView.fieldFWHMright.setText("2.0")
+            tweakPeakView.peakFunctionDropdown.setCurrentIndex(0)
+            assert tweakPeakView.peakFunctionDropdown.currentIndex() == 0
+            assert tweakPeakView.peakFunctionDropdown.currentText() == "Gaussian"
+
+            #    recalculate using the new values
+            #    * recalculate => peak display is recalculated,
+            #      not the entire calibration.
+            qtbot.mouseClick(tweakPeakView.recalculationButton, Qt.MouseButton.LeftButton)
+            qtbot.wait(10000)
+
+            #    continue to the next panel
+            with qtbot.waitSignal(actionCompleted, timeout=60000):
+                qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+
+            qtbot.waitUntil(
+                lambda: isinstance(workflowNodeTabs.currentWidget().view, DiffCalAssessmentView), timeout=60000
+            )
+
+            # Placing this next `stop` correctly, causes some difficulty:
+            #   if it's placed too early, the `warning` box patch doesn't correctly trap the "tweak peaks" warning.
+            # So, for this reason this stop is placed _after_ the `waitUntil`.
+            # ("Tweak peaks" view should have definitely completed by this point.)
+            warningMessageBox.stop()
+
+            assessmentView = workflowNodeTabs.currentWidget().view  # noqa: F841
+            #    nothing to do here, for this test
+
+            #    continue to the next panel
+            with qtbot.waitSignal(actionCompleted, timeout=60000):
+                qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+
+            qtbot.waitUntil(lambda: isinstance(workflowNodeTabs.currentWidget().view, DiffCalSaveView), timeout=5000)
+            saveView = workflowNodeTabs.currentWidget().view
+
+            #    set "author" and "comment"
+            saveView.fieldAuthor.setText("kat")
+            saveView.fieldComments.setText("calibration-panel integration test")
+
+            #    continue in order to save workspaces and to finish the workflow
+            with qtbot.waitSignal(actionCompleted, timeout=60000):
+                qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+
+            #   `ActionPrompt.prompt("..The workflow has completed successfully..)` gives immediate mocked response:
+            #      Here we still need to wait until the ADS cleanup has occurred,
+            #      or else it will happen in the middle of the next workflow. :(
+            qtbot.waitUntil(
+                lambda: isinstance(workflowNodeTabs.currentWidget().view, DiffCalRequestView), timeout=10000
+            )
+
+            ###############################
+            ########### END OF TEST #######
+            ###############################
+
+            calibrationPanel.widget.close()
+            gui.close()
+
+        #####################################################################
+        # Force a printout of information about any exceptions that happened#
+        #   within the Qt event loop.                                       #
+        #####################################################################
+        if len(exceptions):
+            # sys.exc_info ::= type(e), e, <traceback>
+            _, e, _ = exceptions[0]
+            raise e
+
+        # Force a clean exit
+        qtbot.wait(5000)
+
+    def test_normalization_panel_happy_path(self, qtbot, qapp, calibration_home_from_mirror):
+        # Override the mirror with a new home directory, omitting any existing
+        #   calibration or normalization data.
+        tmpCalibrationHomeDirectory = calibration_home_from_mirror()  # noqa: F841
+
+        with (
+            qtbot.captureExceptions() as exceptions,
+            suppress(InterruptWithBlock),
+        ):
+            gui = SNAPRedGUI(translucentBackground=True)
+            gui.show()
+            qtbot.addWidget(gui)
+
+            """
+            SNAPRedGUI owns the following widgets:
+
+              * self.calibrationPanelButton [new] = QPushButton("Open Calibration Panel")
+
+                <button click> => self.newWindow = TestPanel(self).setWindowTitle("Calibration Panel")
+
+              * LogTable("load dummy", self).widget
+
+              * WorkspaceWidget(self)
+
+              * AlgorithmProgressWidget()
+
+              * <central widget>: QWidget().setObjectName("centralWidget")
+
+              * self.userDocButton = UserDocsButton(self)
+            """
+
+            # Open the calibration panel:
+            # QPushButton* button = pWin->findChild<QPushButton*>("Button name");
+            qtbot.mouseClick(gui.calibrationPanelButton, QtCore.Qt.LeftButton)
+            if len(exceptions):
+                raise InterruptWithBlock
+            calibrationPanel = gui.calibrationPanel
+
+            # tab indices: (0) diffraction calibration, (1) normalization calibration, and (2) reduction
+            calibrationPanelTabs = calibrationPanel.presenter.view.tabWidget
+
+            #####################################################################################################
+            ##################### NORMALIZATION PANEL: ##########################################################
+            #####################################################################################################
+
+            # Normalization calibration:
+            calibrationPanelTabs.setCurrentIndex(1)
+            normalizationCalibrationWidget = calibrationPanelTabs.currentWidget()
+
+            #################################################################
+            #### We need to access the signal specific to each workflow. ####
+            #################################################################
+            actionCompleted = (
+                calibrationPanel.presenter.normalizationCalibrationWorkflow.workflow.presenter.actionCompleted
+            )
+            ###
+
+            # node-tab indices: (0) request view, (1) tweak-peak view, and (3) save view
+            workflowNodeTabs = normalizationCalibrationWidget.findChild(QTabWidget, "nodeTabs")
+
+            requestView = workflowNodeTabs.currentWidget().view
+            assert isinstance(requestView, NormalizationRequestView)
+
+            #    set "Run Number", "Background run number":
+            requestView.runNumberField.setText("46680")
+            requestView.backgroundRunNumberField.setText("46680")
+
+            #    set all dropdown selections, but make sure that the dropdown contents are as expected
+            requestView.sampleDropdown.setCurrentIndex(0)
+            assert requestView.sampleDropdown.currentIndex() == 0
+            assert requestView.sampleDropdown.currentText().endswith("Diamond_001.json")
+
+            #    Without this next 'qtbot.wait(1000)',
+            #      the 'groupingFileDropdown' gets reset after this successful initialization.
+            #    I assume this is because somehow the 'populateGroupingDropdown',
+            #    triggered by the 'runNumberField' 'editComplete' hasn't actually occurred yet?
+            qtbot.wait(1000)
+            requestView.groupingFileDropdown.setCurrentIndex(1)
+            assert requestView.groupingFileDropdown.currentIndex() == 1
+            assert requestView.groupingFileDropdown.currentText() == "Bank"
+
+            """ # Why no "peak function" for normalization calibration?!
+            requestView.peakFunctionDropdown.setCurrentIndex(0)
+            assert requestView.peakFunctionDropdown.currentIndex() == 0
+            assert requestView.peakFunctionDropdown.currentText() == "Gaussian"
+            """
+
+            #    execute the request
+
+            # TODO: make sure that there's no initialized state => abort the test if there is!
+            #   At the moment, we preserve some options here to speed up development.
+            stateId = "04bd2c53f6bf6754"
+            waitForStateInit = True
+            if (Path(Config["instrument.calibration.powder.home"]) / stateId).exists():
+                # raise RuntimeError(
+                #           f"The state root directory for '{stateId}' already exists! "\
+                #           + "Please move it out of the way."
+                #       )
+                waitForStateInit = False
+
+            if waitForStateInit:
+                # ---------------------------------------------------------------------------
+                # IMPORTANT: "initialize state" dialog is triggered by an exception throw:
+                #   => do _not_ patch using a with clause!
+                questionMessageBox = mock.patch(  # noqa: PT008
+                    "qtpy.QtWidgets.QMessageBox.question",
+                    lambda *args, **kwargs: QMessageBox.Yes,  # noqa: ARG005
+                )
+                questionMessageBox.start()
+                successPrompt = mock.patch(
+                    "snapred.ui.widget.SuccessPrompt.SuccessPrompt.prompt",
+                    lambda parent: parent.close() if parent is not None else None,
+                )
+                successPrompt.start()
+                # ---------------------------------------------------------------------------
+
+                #    (1) respond to the "initialize state" request
+                with qtbot.waitSignal(actionCompleted, timeout=60000):
+                    qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+                qtbot.waitUntil(
+                    lambda: len(
+                        [
+                            o
+                            for o in qapp.topLevelWidgets()
+                            if isinstance(o, InitializeStateCheckView.InitializationMenu)
+                        ]
+                    )
+                    > 0,
+                    timeout=1000,
+                )
+                stateInitDialog = [
+                    o for o in qapp.topLevelWidgets() if isinstance(o, InitializeStateCheckView.InitializationMenu)
+                ][0]
+
+                stateInitDialog.stateNameField.setText("my happy state")
+                qtbot.mouseClick(stateInitDialog.beginFlowButton, Qt.MouseButton.LeftButton)
+
+                # State initialization dialog is "application modal" => no need to explicitly wait
+                questionMessageBox.stop()
+                successPrompt.stop()
+
+            #    (2) execute the normalization workflow
+            with qtbot.waitSignal(actionCompleted, timeout=60000):
+                qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+            qtbot.waitUntil(
+                lambda: isinstance(workflowNodeTabs.currentWidget().view, NormalizationTweakPeakView), timeout=60000
+            )
+
+            tweakPeakView = workflowNodeTabs.currentWidget().view
+
+            #    set "Smoothing", "xtal dMin", "xtal dMax", "intensity threshold", and "groupingDropDown"
+            tweakPeakView.smoothingSlider.field.setValue("0.4")
+            tweakPeakView.fieldXtalDMin.setText("0.4")
+            tweakPeakView.fieldXtalDMax.setText("90.0")
+
+            #    See comment at prevous "groupingFileDropdown".
+            qtbot.wait(1000)
+            tweakPeakView.groupingFileDropdown.setCurrentIndex(0)
+            assert tweakPeakView.groupingFileDropdown.currentIndex() == 0
+            assert tweakPeakView.groupingFileDropdown.currentText() == "All"
+
+            #    recalculate using the new values
+            #    * recalculate => peak display is recalculated,
+            #      not the entire calibration.
+            qtbot.mouseClick(tweakPeakView.recalculationButton, Qt.MouseButton.LeftButton)
+            qtbot.wait(5000)
+
+            #    continue to the next panel
+            with qtbot.waitSignal(actionCompleted, timeout=60000):
+                qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+            qtbot.waitUntil(
+                lambda: isinstance(workflowNodeTabs.currentWidget().view, NormalizationSaveView), timeout=60000
+            )
+            saveView = workflowNodeTabs.currentWidget().view
+
+            #    set "author" and "comment"
+            saveView.fieldAuthor.setText("kat")
+            saveView.fieldComments.setText("calibration-panel integration test")
+
+            #    continue in order to save workspaces and to finish the workflow
+            with qtbot.waitSignal(actionCompleted, timeout=60000):
+                qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+
+            #   `ActionPrompt.prompt("..The workflow has completed successfully..)` gives immediate mocked response:
+            #      Here we still need to wait until the ADS cleanup has occurred,
+            #      or else it will happen in the middle of the next workflow. :(
+            qtbot.waitUntil(
+                lambda: isinstance(workflowNodeTabs.currentWidget().view, NormalizationRequestView), timeout=10000
+            )
+
+            ###############################
+            ########### END OF TEST #######
+            ###############################
+
+            calibrationPanel.widget.close()
+            gui.close()
+
+        #####################################################################
+        # Force a printout of information about any exceptions that happened#
+        #   within the Qt event loop.                                       #
+        #####################################################################
+        if len(exceptions):
+            # sys.exc_info ::= type(e), e, <traceback>
+            _, e, _ = exceptions[0]
+            raise e
+
+        # Force a clean exit
+        qtbot.wait(5000)
+
+    def test_reduction_panel_happy_path(self, qtbot, qapp, reduction_home_from_mirror):
+        ##
+        ## WARNING: this test requires EXISTING diffraction-calibration and normalization-calibration data!
+        ##   As an alternative `test_calibration_and_reduction_panels_happy_path`, now skipped, could be run instead.
+        ##
+
+        # TODO: these could be initialized in the 'setup', but the current plan is to use a YML test template.
+        reductionRunNumber = "46680"
+        reductionStateId = "04bd2c53f6bf6754"
+
+        # Override the standard reduction-output location, using a temporary directory
+        #   under the existing location within the mirror.
+        tmpReductionHomeDirectory = reduction_home_from_mirror(reductionRunNumber)  # noqa: F841
+
+        with (
+            qtbot.captureExceptions() as exceptions,
+            suppress(InterruptWithBlock),
+        ):
+            gui = SNAPRedGUI(translucentBackground=True)
+            gui.show()
+            qtbot.addWidget(gui)
+
+            """
+            SNAPRedGUI owns the following widgets:
+
+              * self.calibrationPanelButton [new] = QPushButton("Open Calibration Panel")
+
+                <button click> => self.newWindow = TestPanel(self).setWindowTitle("Calibration Panel")
+
+              * LogTable("load dummy", self).widget
+
+              * WorkspaceWidget(self)
+
+              * AlgorithmProgressWidget()
+
+              * <central widget>: QWidget().setObjectName("centralWidget")
+
+              * self.userDocButton = UserDocsButton(self)
+            """
+
+            # Open the calibration panel:
+            # QPushButton* button = pWin->findChild<QPushButton*>("Button name");
+            qtbot.mouseClick(gui.calibrationPanelButton, QtCore.Qt.LeftButton)
+            if len(exceptions):
+                raise InterruptWithBlock
+            calibrationPanel = gui.calibrationPanel
+
+            # tab indices: (0) diffraction calibration, (1) normalization calibration, and (2) reduction
+            calibrationPanelTabs = calibrationPanel.presenter.view.tabWidget
+
+            #################################################################################################
+            ##################### REDUCTION PANEL: ##########################################################
+            #################################################################################################
+
+            # Reduction:
+            calibrationPanelTabs.setCurrentIndex(2)
+            reductionWidget = calibrationPanelTabs.currentWidget()
+
+            #################################################################
+            #### We need to access the signal specific to each workflow. ####
+            #################################################################
+            actionCompleted = calibrationPanel.presenter.reductionWorkflow.workflow.presenter.actionCompleted
+            ###
+
+            # node-tab indices: (0) request view, and (2) save view
+            workflowNodeTabs = reductionWidget.findChild(QTabWidget, "nodeTabs")
+
+            requestView = workflowNodeTabs.currentWidget().view
+            assert isinstance(requestView, ReductionRequestView)
+
+            # Without this next wait, the "run number entry" section happens too fast.
+            # (And I'd love to understand _why_!  :(  )
+            qtbot.wait(1000)
+
+            #    enter a "Run Number":
+            requestView.runNumberInput.setText(reductionRunNumber)
+            qtbot.mouseClick(requestView.enterRunNumberButton, Qt.MouseButton.LeftButton)
+
+            _currentText = requestView.runNumberDisplay.toPlainText()
+            _runNumbers = [num.strip() for num in _currentText.split("\n") if num.strip()]
+
+            assert reductionRunNumber in _runNumbers
+
+            """
+            request.liteModeToggle.setState(True);
+            request.retainUnfocusedDataCheckbox.setValue(False);
+            """
+
+            """
+            # Set some pixel masks in the ADS, and on the filesystem, prior to this test section.  Then we can test
+            #   the pixel-mask dropdown.
+            request.pixelMaskDropdown.setCurrentIndex() # or set-selected range? or by index?
+            """
+
+            #    execute the request
+
+            # TODO: make sure that there's no initialized state => abort the test if there is!
+            waitForStateInit = True
+            if (Path(Config["instrument.calibration.powder.home"]) / reductionStateId).exists():
+                # raise RuntimeError(
+                #           f"The state root directory for '{reductionStateId}' already exists! "\
+                #           + "Please move it out of the way."
+                # )
+                waitForStateInit = False
+
+            if waitForStateInit:
+                # ---------------------------------------------------------------------------
+                # IMPORTANT: "initialize state" dialog is triggered by an exception throw:
+                #   => do _not_ patch using a with clause!
+                questionMessageBox = mock.patch(  # noqa: PT008
+                    "qtpy.QtWidgets.QMessageBox.question",
+                    lambda *args, **kwargs: QMessageBox.Yes,  # noqa: ARG005
+                )
+                questionMessageBox.start()
+                successPrompt = mock.patch(
+                    "snapred.ui.widget.SuccessPrompt.SuccessPrompt.prompt",
+                    lambda parent: parent.close() if parent is not None else None,
+                )
+                successPrompt.start()
+                # ---------------------------------------------------------------------------
+
+                #    (1) respond to the "initialize state" request
+                with qtbot.waitSignal(actionCompleted, timeout=60000):
+                    qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+                qtbot.waitUntil(
+                    lambda: len(
+                        [
+                            o
+                            for o in qapp.topLevelWidgets()
+                            if isinstance(o, InitializeStateCheckView.InitializationMenu)
+                        ]
+                    )
+                    > 0,
+                    timeout=1000,
+                )
+                stateInitDialog = [
+                    o for o in qapp.topLevelWidgets() if isinstance(o, InitializeStateCheckView.InitializationMenu)
+                ][0]
+
+                stateInitDialog.stateNameField.setText("my happy state")
+                qtbot.mouseClick(stateInitDialog.beginFlowButton, Qt.MouseButton.LeftButton)
+
+                # State initialization dialog is "application modal" => no need to explicitly wait
+                questionMessageBox.stop()
+                successPrompt.stop()
+
+            #    (2) execute the reduction workflow
+            with qtbot.waitSignal(actionCompleted, timeout=120000):
+                qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+            qtbot.waitUntil(lambda: isinstance(workflowNodeTabs.currentWidget().view, ReductionSaveView), timeout=60000)
+            saveView = workflowNodeTabs.currentWidget().view  # noqa: F841
+
+            """
+            #    set "author" and "comment"
+            saveView.fieldAuthor.setText("kat")
+            saveView.fieldComments.setText("calibration-panel integration test")
+            """
+
+            #    continue in order to save workspaces and to finish the workflow
+            with qtbot.waitSignal(actionCompleted, timeout=60000):
+                qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+
+            #   `ActionPrompt.prompt("..The workflow has completed successfully..)` gives immediate mocked response:
+            #      Here we still need to wait until the ADS cleanup has occurred,
+            #      or else it will happen in the middle of the next workflow. :(
+            qtbot.waitUntil(
+                lambda: isinstance(workflowNodeTabs.currentWidget().view, ReductionRequestView), timeout=5000
+            )
+
+            ###############################
+            ########### END OF TEST #######
+            ###############################
+
+            calibrationPanel.widget.close()
+            gui.close()
+
+        #####################################################################
+        # Force a printout of information about any exceptions that happened#
+        #   within the Qt event loop.                                       #
+        #####################################################################
+        if len(exceptions):
+            # sys.exc_info ::= type(e), e, <traceback>
+            _, e, _ = exceptions[0]
+            raise e
+
+        # Force a clean exit
+        qtbot.wait(5000)

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -17,7 +17,7 @@ instrument:
     home: ${instrument.home}/shared/Calibration
     sample:
       # "instrument.calibration.sample.home" is overridden in "test.yml":
-      home: ${instrument.calibration.home}/CalibrantSample
+      home: ${instrument.calibration.home}/CalibrantSamples
       extensions:
         - json
 
@@ -38,12 +38,12 @@ instrument:
     pixelResolution: 1179648
     # "instrument.native.definition" is overridden in "test.yml":
     definition:
-      file: ${module.root}/resources/SNAP_Definition.xml
+      file: ${module.root}/resources/inputs/pixel_grouping/SNAP_Definition.xml
   lite:
     pixelResolution: 18432
     # "instrument.lite.definition" is overridden in "test.yml":
     definition:
-      file: ${module.root}/resources/SNAPLite_Definition.xml
+      file: ${module.root}/resources/inputs/pixel_grouping/SNAPLite_Definition.xml
     map:
       file: ${instrument.calibration.home}/Powder/LiteGroupMap.hdf
   startingRunNumber: 10000

--- a/tests/resources/integration_test.yml
+++ b/tests/resources/integration_test.yml
@@ -1,10 +1,14 @@
 # environment: integration_test
 # At present:
-#   * "integration_test" doesn't override anything except the "IPTS.root";
-#   * note that "module.root" will still be defined as for "test.yml".
+#   * this "integration_test.yml" overrides "IPTS.root", and "constants.maskedPixelThreshold";
+#   * "module.root" will still be defined as in "test.yml".
 
 IPTS:
   # Eventually, for SNAPRed's test framework:
   #   this should be a shared location on "analysis.sns.gov".
   # For the moment, each developer needs to set this individually to their local path.
-  root: /mnt/data0/workspaces/ORNL-work/SNAPRed/SNS_root
+  root: /SNS/users/ux0/workspaces/SNAPRed/SNS_root
+
+constants:
+  # For tests with '46680' this seems to be necessary.
+  maskedPixelThreshold: 1.0

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -1,8 +1,7 @@
 import hashlib
-import os.path
-import tempfile
 import unittest
 import unittest.mock as mock
+from pathlib import Path
 from random import randint
 
 from mantid.simpleapi import CreateSingleValuedWorkspace, DeleteWorkspace, mtd
@@ -60,6 +59,8 @@ class TestDataFactoryService(unittest.TestCase):
         )
         cls.mockLookupService.readRunConfig.return_value = RunConfig.construct({})
 
+        cls.mockLookupService.fileExists.return_value = lambda filePath: Path(filePath).exists()
+
         # these are treated specially to give the return of a mocked indexer
         cls.mockLookupService.calibrationIndexer.return_value = mock.Mock(
             versionPath=mock.Mock(side_effect=lambda *x: cls.expected(cls, "Calibration", *x)),
@@ -88,17 +89,10 @@ class TestDataFactoryService(unittest.TestCase):
         del self.instance
         return super().tearDown()
 
-    def test_fileExists_yes(self):
-        # create a temp file that exists, and verify it exists
-        with tempfile.NamedTemporaryFile(suffix=".biscuit") as existent:
-            assert DataFactoryService().fileExists(existent.name)
-
-    def test_fileExists_no(self):
-        # assert that a file that does not exist, does not exist
-        with tempfile.TemporaryDirectory() as tmpdir:
-            nonexistent = tmpdir + "/0x0f.biscuit"
-            assert not os.path.isfile(nonexistent)
-            assert not DataFactoryService().fileExists(nonexistent)
+    def test_fileExists(self):
+        arg = mock.Mock()
+        actual = self.instance.fileExists(arg)
+        assert actual == self.expected(arg)
 
     def test_getRunConfig(self):
         actual = self.instance.getRunConfig(mock.Mock())

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -141,7 +141,8 @@ class TestGroceryService(unittest.TestCase):
             .source(InstrumentDonor=self.sampleWS)
             .build()
         )
-        # each test, ensure a random version is drawn
+
+        # For each test, ensure a random version is used.
         self.version = randint(1, 120)
         self.instance.dataService.latestVersion = self.version
         self.diffCalOutputName = (

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -1,5 +1,4 @@
 # ruff: noqa: ARG001, E501, PT012
-
 import os
 import unittest
 from unittest import mock

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -220,17 +220,15 @@ class TestNormalizationService(unittest.TestCase):
     @patch(thisService + "RawVanadiumCorrectionRecipe")
     @patch(thisService + "FocusSpectraRecipe")
     @patch(thisService + "SmoothDataExcludingPeaksRecipe")
-    @patch(thisService + "GroceryService")
     def test_normalization(
         self,
-        mockGroceryService,
         mockSmoothDataExcludingPeaks,
         mockFocusSpectra,
         mockVanadiumCorrection,
         FarmFreshIngredients,
     ):
         FarmFreshIngredients.return_value = {"purge": True}
-        mockGroceryService = mockGroceryService.return_value
+        mockGroceryService = mock.Mock()
         mockGroceryService.fetchGroceryDict.return_value = {
             "backgroundWorkspace": "bg_ws",
             "inputWorkspace": "input_ws",
@@ -243,8 +241,9 @@ class TestNormalizationService(unittest.TestCase):
         mockSmoothDataExcludingPeaks.executeRecipe.return_value = "smoothed_output_ws"
 
         self.instance = NormalizationService()
-        self.instance._sameStates = MagicMock(return_value=True)
+        self.instance._sameStates = mock.Mock(return_value=True)
         self.instance.sousChef = SculleryBoy()
+        self.instance.groceryService = mockGroceryService
         self.instance.dataFactoryService.getCifFilePath = MagicMock(return_value="path/to/cif")
         self.instance.dataExportService.getCalibrationStateRoot = mock.Mock(return_value="lah/dee/dah")
         self.instance.dataExportService.checkWritePermissions = mock.Mock(return_value=True)
@@ -304,14 +303,14 @@ class TestNormalizationService(unittest.TestCase):
             self.instance.validateWritePermissions(permissionsRequest)
 
     @patch(thisService + "FarmFreshIngredients")
-    @patch(thisService + "GroceryService")
-    def test_cachedNormalization(self, mockGroceryService, mockFarmFreshIngredients):
+    def test_cachedNormalization(self, mockFarmFreshIngredients):
         mockFarmFreshIngredients.return_value = {"purge": True}
-        mockGroceryService.workSpaceDoesExist = mock.Mock(return_value=True)
         self.instance = NormalizationService()
-        self.instance._sameStates = MagicMock(return_value=True)
+        self.instance._sameStates = mock.Mock(return_value=True)
         self.instance.sousChef = SculleryBoy()
-        self.instance.dataFactoryService.getCifFilePath = MagicMock(return_value="path/to/cif")
+        self.instance.groceryService = mock.Mock()
+        self.instance.groceryService.workSpaceDoesExist = mock.Mock(return_value=True)
+        self.instance.dataFactoryService.getCifFilePath = mock.Mock(return_value="path/to/cif")
         self.instance.dataExportService.getCalibrationStateRoot = mock.Mock(return_value="lah/dee/dah")
         self.instance.dataExportService.checkWritePermissions = mock.Mock(return_value=True)
         result = self.instance.normalization(self.request)

--- a/tests/unit/meta/test_Config.py
+++ b/tests/unit/meta/test_Config.py
@@ -77,6 +77,12 @@ def test_resource_packageMode(caplog):
         del sys.modules["snapred.meta.Config"]
         from snapred.meta.Config import _Resource
 
+        # `@Singleton` is now active for tests:
+        #    we need to reset it, so that we can recreate the class.
+        # In this case, we need to fully remove the decorator, so that the original `__init__` will be called.
+        # Otherwise, the applied mocks will have no effect during the initialization.
+        _Resource._reset_Singleton(fully_unwrap=True)
+
         with (
             mock.patch.object(_Resource, "_existsInPackage") as mockExistsInPackage,
             caplog.at_level(logging.DEBUG, logger="snapred.meta.Config.Resource"),
@@ -124,6 +130,12 @@ def test_resource_packageMode_exists():
         # Trigger a fresh import for the "Config" module.
         del sys.modules["snapred.meta.Config"]
         from snapred.meta.Config import _Resource
+
+        # `@Singleton` is now active for tests:
+        #    we need to reset it, so that we can recreate the class.
+        # In this case, we need to fully remove the decorator, so that the original `__init__` will be called.
+        # Otherwise, the applied mocks will have no effect during the initialization.
+        _Resource._reset_Singleton(fully_unwrap=True)
 
         with (
             mock.patch.object(_Resource, "_existsInPackage") as mockExistsInPackage,


### PR DESCRIPTION
## Description of work

To run these tests, a suitable mirror of the "/SNS" directory structure is required.  The minimum setup required is the tree as shown inline below. As currently setup, each of the tests creates any new files under a temporary directory location. By default these locations are just _under_ the `Config["instrument.calibration.powder.home"]` or the (IPTS-substituted) `Config["instrument.reduction.home"]` that would be used with the `Config["IPTS.root"]` as specified in order to setup the "/SNS" mirror.  This behavior means that the contents of the SNS mirror should not have changed after any test run.

Neither of the diffraction-calibration or the normalization-calibration workflow tests require existing calibration data.  However, the reduction-workflow tests, `test_reduction_panel_happy_path`, does require this data to exist.  If these data need to be updated, they can be generated using the `test_calibration_and_reduction_panels_happy_path` test (but comment out the `@pytest.skip`, and the following lines for `calibration_home_from_mirror` and `reduction_home_from_mirror` so that the generated files will be retained at the correct locations after the test exits).

It is hoped that these tests will prove useful to build out our integration-test framework.

There are a few fine points:

  * Simple dialogs, such as `QMessageBox`, `ActionPrompt`, and `SuccessPrompt` are mocked, using the appropriate _static_ methods (e.g `question`, `warning`, or `critical`).  For all of these cases, the expected message text is known, and any other message text will be treated as a fatal error.

  * Usage such as `
        self._criticalMessageBox = mock.patch(
            "qtpy.QtWidgets.QMessageBox.critical",
            lambda *args, *kwargs: pytest.fail(f"CRITICAL messagebox: {args}", pytrace=False)
        )
        self._criticalMessageBox.start()
        ...
        self._criticalMessageBox.stop() # IMPORTANT: don't forget this!
`
is REQUIRED over using the `mock.patch` as a context manager (e.g. in a `with` clause`).  The problem is that any exception throw, such as a `RecoverableException` or a `ContinueWarning` will break out of any enclosing `with` clause, and at that point, the `mock.patch` won't be working anymore.

  * As recommended by the online `qtbot` documentation, most data input is implemented by directly calling the associated methods (e.g. `setText`), rather than locating the dialog, entering text, and then clicking on the control to (e.g.) enter it.  There is one example of something like the latter, which actually was required for the "Initialize State" dialog, but that example will illustrate why such an approach isn't really recommended.  That example also illustrates why it's really useful to associate widgets (even temporary ones) with instance attributes, so that they can be accessed by name.

  * At several positions in the flow, it's necessary to _wait_ for the GUI state to catch up.  Some of these `waitUntil` have been located using _empirical_ techniques, and they don't always make sense. For successfully running on a laptop, a few of these `waitUntil` are also of longer duration -- in general this only has an effect on total test duration if the test FAILs.

  * A few convenience `pyqt.Signal` have been added, to assist in the detection of the completion of various workflow steps.  Most of these additions have already been merged to "next", as part of other PRs.

  * IMPORTANT: note that the `@Singleton` operator is _not_ mocked out for these tests, nor for any test using the `integration` marker (see the outermost `conftest.py`).  This was necessary in order to get the new `Indexer` class to work with respect to the newly-initialized state.  (Otherwise, each of the services has its own `LocalDataService` instance with its own `_indexer` `lru_cache`, and only _one_ of them ends up knowing about the state initialization until the indexers are reloaded at the next startup.)  FOR THE MOMENT: THIS MEANS THAT `integration` MARKED TESTS MUST BE RUN IN THEIR OWN `pytest` SESSION.

  * A related issue to the previous is that `LocalDataService()._indexer.cache_clear()` must be called after the `Config["instrument.calibration.powder.home"]` is overridden.  Otherwise, any cached indexers will still be operating with respect to the previous calibration-directory locations.

## Explanation of work

This commit includes the following changes:

  * A `qtbot`-based integration test for the diffraction-calibration workflow.  This integration test executes the "happy path", that is, it assumes input is correctly entered, and that all of the information required to execute the workflow is available.  The one exception to this being that the "initialize state" dialog is exercised.

  * An integration test for the normalization-calibration workflow.  As mentioned, this integration test executes the "happy path".  The "initialize state" dialog is also exercised for this test.

  * An integration test including all three of the diffraction-calibration, normalization-calibration, and the reduction workflows.  By default, this test is marked as `@pytest.skip`, because each of these workflows has its own separate test.  This test is still useful in case a new set of diffraction-calibration and normalization-calibration data need to be generated for the reduction workflow test.

  * A test fixture to override the `Config["instrument.calibration.powder.home"]`, including rebuilding the directory skeleton under a temporary location, without including any existing calibration data. This fixture generates the setup required to run the diffraction-calibration and normalization-calibration tests.

  * A test fixture to override the (IPTS-substituted) `Config["instrument.reduction.home"]`.  It wasn't necessary to include any skeleton data for this fixture, and it primarily allows the generated reduced data to be cleaned up at test exit.
 
  * In the outermost `conftest.py`: `auto-use` test fixtures (at various scopes) to _reset_, or to _completely unwrap_ the `@Singleton` decorator, depending on whether or not integration tests are being run.

For testing:

Repeatedly, I have successfully run this test module on an _old_ laptop with 16GB RAM.  It isn't necessary to run them on `analysis.sns.gov`.  Issues (on a laptop) can sometimes occur if running multiple integration-test modules at once; however, these issues don't seem to occur on analysis.  This has something to do with memory allocation not succesfully being cleaned up between module-scope tests.  I am still working on this issue.

## To test

### Dev testing

To run the tests:

  * set `IPTS.root` in `integration_test.yml` to the prepared SNS-mirror path;

  * the commandline should be: `env=integration_test pytest -m integration -k happy_path`

  * on analysis (or any system with enough memory), you can run: `env=integration_test pytest -m integration`

  * `-m integration` is _critical_, as the `@Singleton`-related fixtures in `conftest.py` will act differently depending on it.

**Required minimal SNS-mirror directory tree:**

(WARNING: remember that any test-environment _data_ and _metadata_ files usually begin with the _underscore_, so you need to make sure that the calibration _versioned_ data has this format.)

(**I'm placing a copy of this on `analysis.sns.gov` under Michael's shared area: `/SNS/users/wqp/shared/EWM5537.SNS_root.tar`**  .)

------------------------------

<pre>
SNS_root
&#x2514&#x2500&#x2500 SNAP
&#x251c&#x2500&#x2500 IPTS-24641 &#x2502   &#x251c&#x2500&#x2500 nexus &#x2502   &#x2502   &#x2514&#x2500&#x2500 SNAP_46680.nxs.h5 &#x2502   &#x2514&#x2500&#x2500 shared
&#x2502   &#x251c&#x2500&#x2500 lite
&#x2502   &#x2502   &#x2514&#x2500&#x2500 SNAP_46680.lite.nxs.h5
&#x2514&#x2500&#x2500 shared
&#x251c&#x2500&#x2500 Calibration
&#x2502   &#x251c&#x2500&#x2500 CalibrantSamples
&#x2502   &#x2502   &#x251c&#x2500&#x2500 Diamond_001.json
&#x2502   &#x2502   &#x251c&#x2500&#x2500 EntryWithCollCode120585.cif
&#x2502   &#x2502   &#x251c&#x2500&#x2500 EntryWithCollCode37502_Nickel.cif
&#x2502   &#x2502   &#x251c&#x2500&#x2500 EntryWithCollCode40947_LaB6.cif
&#x2502   &#x2502   &#x251c&#x2500&#x2500 EntryWithCollCode51688.cif
&#x2502   &#x2502   &#x251c&#x2500&#x2500 EntryWithCollCode52054_diamond.cif
&#x2502   &#x2502   &#x251c&#x2500&#x2500 EntryWithCollCode94254_LaB6_neutron_2001.cif
&#x2502   &#x2502   &#x251c&#x2500&#x2500 fakeVanadium.cif
&#x2502   &#x2502   &#x251c&#x2500&#x2500 fakeVanadium.json
&#x2502   &#x2502   &#x251c&#x2500&#x2500 La11B6_NIST_660c_001.json
&#x2502   &#x2502   &#x251c&#x2500&#x2500 Na2Ca3Al2F14.cif
&#x2502   &#x2502   &#x251c&#x2500&#x2500 NAC.json
&#x2502   &#x2502   &#x251c&#x2500&#x2500 nickel_001.json
&#x2502   &#x2502   &#x251c&#x2500&#x2500 Silicon_NIST_640D_001.json
&#x2502   &#x2502   &#x251c&#x2500&#x2500 Silicon_NIST_640d.cif
&#x2502   &#x2502   &#x251c&#x2500&#x2500 vanadium_CollCode171003.cif
&#x2502   &#x2502   &#x251c&#x2500&#x2500 vanadium_cylinder_001.json
&#x2502   &#x2502   &#x251c&#x2500&#x2500 vanadium_niobium.cif
&#x2502   &#x2502   &#x2514&#x2500&#x2500 V-Nb_cylinder_001.json
&#x2502   &#x251c&#x2500&#x2500 Powder
&#x2502   &#x2502   &#x251c&#x2500&#x2500 04bd2c53f6bf6754
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 groupingMap.json
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 lite
&#x2502   &#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 diffraction
&#x2502   &#x2502   &#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 CalibrationIndex.json
&#x2502   &#x2502   &#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 v_0001
&#x2502   &#x2502   &#x2502   &#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 CalibrationParameters.json
&#x2502   &#x2502   &#x2502   &#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 CalibrationRecord.json
&#x2502   &#x2502   &#x2502   &#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 _diagnostic_bank_046680_v0001.nxs.h5
&#x2502   &#x2502   &#x2502   &#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 _diffract_consts_046680_v0001.h5
&#x2502   &#x2502   &#x2502   &#x2502   &#x2502   &#x2502   &#x2514&#x2500&#x2500 _dsp_bank_046680_v0001.nxs.h5
&#x2502   &#x2502   &#x2502   &#x2502   &#x2514&#x2500&#x2500 normalization
&#x2502   &#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 NormalizationIndex.json
&#x2502   &#x2502   &#x2502   &#x2502   &#x2514&#x2500&#x2500 v_0001
&#x2502   &#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 _dsp_all_fitted_van_corr_046680_v0001.nxs
&#x2502   &#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 NormalizationParameters.json
&#x2502   &#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 NormalizationRecord.json
&#x2502   &#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 _tof_all_s+f-vanadium_046680_v0001.nxs
&#x2502   &#x2502   &#x2502   &#x2502   &#x2514&#x2500&#x2500 _tof_unfoc_raw_van_corr_046680_v0001.nxs
&#x2502   &#x2502   &#x251c&#x2500&#x2500 LiteGroupMap.hdf
&#x2502   &#x2502   &#x251c&#x2500&#x2500 PixelGroupingDefinitions
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 defaultGroupingMap.json
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 SingleColumn5.hdf
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 SNAPFocGroup_2_4.hdf
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 SNAPFocGroup_2_4.lite.hdf
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 SNAPFocGroup_5degSlice.lite.nxs
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 SNAPFocGroup_All.hdf
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 SNAPFocGroup_All.lite.hdf
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 SNAPFocGroup_All.lite.nxs
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 SNAPFocGroup_All.xml
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 SNAPFocGroup_Bank.hdf
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 SNAPFocGroup_Bank.lite.hdf
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 SNAPFocGroup_Bank.lite.nxs
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 SNAPFocGroup_Bank.xml
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 SNAPFocGroup_Column.hdf
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 SNAPFocGroup_Column.lite.hdf
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 SNAPFocGroup_Column.lite.nxs
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 SNAPFocGroup_Column.xml
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 SNAPFocGrp_All.lite.xml
&#x2502   &#x2502   &#x2502   &#x251c&#x2500&#x2500 SNAPFocGrp_Bank.lite.xml
&#x2502   &#x2502   &#x2502   &#x2514&#x2500&#x2500 SNAPFocGrp_Column.lite.xml
&#x2502   &#x2502   &#x2514&#x2500&#x2500 SNAPLite.xml
&#x2502   &#x251c&#x2500&#x2500 SNAPInstPrm.json
</pre>

------------------------------

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#5537](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=5537)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
