### PR TITLE
Ewm7122 implement artificial normalization algo

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,6 +18,7 @@ jobs:
     - name: Set up MicroMamaba
       uses: mamba-org/setup-micromamba@v1
       with:
+        micromamba-version: '1.5.10-0'
         environment-file: environment.yml
         condarc: |
           channels:
@@ -67,6 +68,7 @@ jobs:
     - name: Set up MicroMamaba
       uses: mamba-org/setup-micromamba@v1
       with:
+        micromamba-version: '1.5.10-0'
         environment-file: environment.yml
         condarc: |
           channels:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -42,7 +42,7 @@ requirements:
 
   run:
     - {{ pin_compatible("pydantic", min_pin="2.7.3", max_pin="3") }}
-    - mantidworkbench>=6.10.20240909
+    - mantidworkbench
 
 about:
   home: {{ url }}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -42,7 +42,7 @@ requirements:
 
   run:
     - {{ pin_compatible("pydantic", min_pin="2.7.3", max_pin="3") }}
-    - mantidworkbench
+    - mantidworkbench>=6.10.20240909
 
 about:
   home: {{ url }}

--- a/src/snapred/backend/dao/ingredients/ArtificialNormalizationIngredients.py
+++ b/src/snapred/backend/dao/ingredients/ArtificialNormalizationIngredients.py
@@ -1,12 +1,14 @@
 from pydantic import BaseModel
 
+from snapred.meta.Config import Config
+
 
 class ArtificialNormalizationIngredients(BaseModel):
     """
-    Class to hold ingredients for the creationon of artificial normalization data.
+    Class to hold ingredients for the creation of artificial normalization data.
     """
 
-    peakWindowClippingSize: int = 10
+    peakWindowClippingSize: int = Config["constants.ArtiificialNormalization.peakWindowClippingSize"]
     smoothingParameter: float
     decreaseParameter: bool = True
     lss: bool = True

--- a/src/snapred/backend/dao/ingredients/ArtificialNormalizationIngredients.py
+++ b/src/snapred/backend/dao/ingredients/ArtificialNormalizationIngredients.py
@@ -8,7 +8,7 @@ class ArtificialNormalizationIngredients(BaseModel):
     Class to hold ingredients for the creation of artificial normalization data.
     """
 
-    peakWindowClippingSize: int = Config["constants.ArtiificialNormalization.peakWindowClippingSize"]
+    peakWindowClippingSize: int = Config["constants.ArtificialNormalization.peakWindowClippingSize"]
     smoothingParameter: float
     decreaseParameter: bool = True
     lss: bool = True

--- a/src/snapred/backend/dao/ingredients/ArtificialNormalizationIngredients.py
+++ b/src/snapred/backend/dao/ingredients/ArtificialNormalizationIngredients.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+
+
+class ArtificialNormalizationIngredients(BaseModel):
+    """
+    Class to hold ingredients for the creationon of artificial normalization data.
+    """
+
+    peakWindowClippingSize: int = 10
+    smoothingParameter: float
+    decreaseParameter: bool = True
+    lss: bool = True

--- a/src/snapred/backend/recipe/algorithm/CreateArtificialNormalizationAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/CreateArtificialNormalizationAlgo.py
@@ -1,0 +1,144 @@
+import json
+
+import numpy as np
+from mantid.api import (
+    AlgorithmFactory,
+    MatrixWorkspaceProperty,
+    PropertyMode,
+    PythonAlgorithm,
+    WorkspaceUnitValidator,
+)
+from mantid.kernel import Direction
+
+from snapred.backend.log.logger import snapredLogger
+from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
+
+logger = snapredLogger.getLogger(__name__)
+
+
+class CreateArtificialNormalizationAlgo(PythonAlgorithm):
+    def category(self):
+        return "SNAPRed Data Processing"
+
+    def PyInit(self):
+        self.declareProperty(
+            MatrixWorkspaceProperty(
+                "InputWorkspace",
+                "",
+                Direction.Input,
+                PropertyMode.Mandatory,
+                validator=WorkspaceUnitValidator("dSpacing"),
+            ),
+            doc="Workspace that contains calibrated and focused diffraction data.",
+        )
+        self.declareProperty(
+            MatrixWorkspaceProperty(
+                "OutputWorkspace",
+                "",
+                Direction.Output,
+                PropertyMode.Mandatory,
+                validator=WorkspaceUnitValidator("dSpacing"),
+            ),
+            doc="Workspace that contains artificial normalization.",
+        )
+        self.declareProperty(
+            "Ingredients",
+            defaultValue="",
+            direction=Direction.Input,
+        )
+        self.setRethrows(True)
+        self.mantidSnapper = MantidSnapper(self, __name__)
+
+    def chopInredients(self, ingredientsStr: str):
+        ingredientsDict = json.loads(ingredientsStr)
+        self.peakWindowClippingSize = ingredientsDict["peakWindowClippingSize"]
+        self.smoothingParameter = ingredientsDict["smoothingParameter"]
+        self.decreaseParameter = ingredientsDict["decreaseParameter"]
+        self.LSS = ingredientsDict["lss"]
+
+    def unbagGroceries(self):
+        self.inputWorkspaceName = self.getPropertyValue("InputWorkspace")
+        self.outputWorkspaceName = self.getPropertyValue("OutputWorkspace")
+
+    def peakClip(self, data, winSize: int, decrese: bool, LLS: bool, smoothing: float):
+        # Clipping peaks from the data with optional smoothing and transformations
+        startData = np.copy(data)
+        window = winSize
+        if smoothing > 0:
+            data = self.smooth(data, smoothing)
+
+        if LLS:
+            data = self.LLSTransformation(data)
+
+        temp = data.copy()
+        scan = list(range(window + 1, 0, -1)) if decrese else list(range(1, window + 1))
+
+        for w in scan:
+            for i in range(len(temp)):
+                if i < w or i > (len(temp) - w - 1):
+                    continue
+                winArray = temp[i - w : i + w + 1].copy()
+                winArrayReversed = winArray[::-1]
+                average = (winArray + winArrayReversed) / 2
+                temp[i] = np.min(average[: int(len(average) / 2)])
+
+        if LLS:
+            temp = self.InvLLSTransformation(temp)
+
+        index = np.where((startData - temp) == min(startData - temp))[0][0]
+        output = temp * (startData[index] / temp[index])
+        return output
+
+    def smooth(self, data, order):
+        # Applies smoothing to the data
+        sm = np.zeros(len(data))
+        factor = order / 2 + 1
+        for i in range(len(data)):
+            temp = 0
+            ave = 0
+            for r in range(max(0, i - int(order / 2)), min(i + int(order / 2), len(data) - 1) + 1):
+                temp += (factor - abs(r - i)) * data[r]
+                ave += factor - abs(r - i)
+            sm[i] = temp / ave
+        return sm
+
+    def LLSTransformation(self, input):  # noqa: A002
+        # Applies LLS transformation to emphasize weaker peaks
+        return np.log(np.log((input + 1) ** 0.5 + 1) + 1)
+
+    def InvLLSTransformation(self, input):  # noqa: A002
+        # Reverts LLS transformation
+        return (np.exp(np.exp(input) - 1) - 1) ** 2 - 1
+
+    def PyExec(self):
+        # Main execution method for the algorithm
+        self.unbagGroceries()
+        ingredients = self.getProperty("Ingredients").value
+        self.chopInredients(ingredients)
+        self.mantidSnapper.CloneWorkspace(
+            "Cloning input workspace...",
+            InputWorkspace=self.inputWorkspaceName,
+            OutputWorkspace=self.outputWorkspaceName,
+        )
+        self.mantidSnapper.executeQueue()
+        self.inputWorkspace = self.mantidSnapper.mtd[self.inputWorkspaceName]
+        self.outputWorkspace = self.mantidSnapper.mtd[self.outputWorkspaceName]
+
+        # Apply peak clipping to each histogram in the workspace
+        for i in range(self.outputWorkspace.getNumberHistograms()):
+            dataY = self.outputWorkspace.readY(i)
+            clippedData = self.peakClip(
+                data=dataY,
+                winSize=self.peakWindowClippingSize,
+                decrese=self.decreaseParameter,
+                LLS=self.LSS,
+                smoothing=self.smoothingParameter,
+            )
+            self.outputWorkspace.setY(i, clippedData)
+
+        # Set the output workspace property
+        self.setProperty("OutputWorkspace", self.outputWorkspaceName)
+
+
+# Register algorithm with Mantid
+AlgorithmFactory.subscribe(CreateArtificialNormalizationAlgo)

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -195,6 +195,9 @@ constants:
     crystalDMin: 0.4
     crystalDMax: 100.0
 
+  ArtificialNormalization:
+    peakWindowClippingSize: 10
+
   CalibrationReduction:
     tofMin: 2000
     tofMax: 14500

--- a/tests/cis_tests/artificial_norm_script.py
+++ b/tests/cis_tests/artificial_norm_script.py
@@ -125,3 +125,133 @@ fakeNormAlgo.setPropertyValue("OutputWorkspace", outputWS)
 fakeNormAlgo.execute()
 
 assert False
+
+### This following script reflects the use of this new algo "CreateArtificialNormalizationAlgo" within Reduction
+import json
+
+## for creating ingredients
+from snapred.backend.dao.request.FarmFreshIngredients import FarmFreshIngredients
+from snapred.backend.service.SousChef import SousChef
+from snapred.backend.data.LocalDataService import LocalDataService
+from snapred.backend.dao.ingredients.ArtificialNormalizationIngredients import ArtificialNormalizationIngredients as FakeNormIngredients
+## for loading data
+from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
+from snapred.backend.data.GroceryService import GroceryService
+
+## the code to test
+from snapred.backend.recipe.ReductionRecipe import ReductionRecipe as Recipe
+
+# for running through service layer
+from snapred.backend.dao.request.ReductionRequest import ReductionRequest
+from snapred.backend.service.ReductionService import ReductionService
+from snapred.backend.recipe.algorithm.FocusSpectraAlgorithm import FocusSpectraAlgorithm as FocusSpec
+from snapred.backend.recipe.algorithm.CreateArtificialNormalizationAlgo import CreateArtificialNormalizationAlgo as FakeNormAlgo
+
+from snapred.meta.Config import Config
+from pathlib import Path
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng, ValueFormatter as wnvf
+
+from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
+from mantid.simpleapi import ConvertToMatrixWorkspace
+
+groceryService = GroceryService()
+
+#User input ###########################
+runNumber = "46680" #"57482"
+isLite = True
+Config._config["cis_mode"] = True
+version=(1, None)
+grouping = "Column"
+
+### PREP INGREDIENTS ################
+
+groups = LocalDataService().readGroupingMap(runNumber).getMap(isLite)
+
+farmFresh = FarmFreshIngredients(
+    runNumber=runNumber,
+    versions=version,
+    useLiteMode=isLite,
+    focusGroups=list(groups.values()),
+    timestamp=1726848143.8856316,
+    keepUnfocused=True,
+    convertUnitsTo="TOF",
+)
+
+ingredients = SousChef().prepReductionIngredients(farmFresh)
+
+selectedFocusGroup = next(
+    (fg for fg in farmFresh.focusGroups if fg.name == grouping), None
+)
+
+if selectedFocusGroup:
+    print(f"Selected FocusGroup: {selectedFocusGroup}")
+    
+    updatedFarmFresh = FarmFreshIngredients(
+        runNumber=farmFresh.runNumber,
+        useLiteMode=farmFresh.useLiteMode,
+        focusGroups=[selectedFocusGroup], 
+    )
+    
+    pixelGroup = SousChef().prepPixelGroup(updatedFarmFresh)
+
+# TODO: This probably needs to be a thing:
+# ingredients.detectorPeaks = normalizationRecord.detectorPeaks
+
+
+### FETCH GROCERIES ##################
+
+clerk = GroceryListItem.builder()
+
+for key, group in groups.items():
+  clerk.fromRun(runNumber).grouping(group.name).useLiteMode(isLite).add()
+groupingWorkspaces = GroceryService().fetchGroceryList(clerk.buildList())
+# ...
+clerk.name("inputWorkspace").neutron(runNumber).useLiteMode(isLite).add()
+clerk.name("diffcalWorkspace").diffcal_table(runNumber, 1).useLiteMode(isLite).add()
+
+
+groceries = GroceryService().fetchGroceryDict(
+    groceryDict=clerk.buildDict()
+)
+groceries["groupingWorkspaces"] = groupingWorkspaces
+
+rawWs = "tof_all_lite_copy1_046680"
+groupingWs = f"SNAPLite_grouping__{grouping}_{runNumber}"
+
+focusSpec =  FocusSpec()
+focusSpec.initialize()
+focusSpec.setPropertyValue("InputWorkspace", rawWs)
+focusSpec.setPropertyValue("OutputWorkspace", rawWs)
+focusSpec.setPropertyValue("GroupingWorkspace", groupingWs)
+focusSpec.setPropertyValue("Ingredients", pixelGroup.json())
+focusSpec.setProperty("RebinOutput", False)
+focusSpec.execute()
+
+rawWs = ConvertToMatrixWorkspace(rawWs)
+
+def convertIngredients(ingredients):
+    if hasattr(ingredients, "json"):  # If it's a Pydantic object, use the json() method
+        return ingredients.json()
+    elif isinstance(ingredients, dict):  # If it's already a dictionary, convert to JSON
+        return json.dumps(ingredients)
+    else:
+        raise TypeError("The provided ingredients object is not compatible with JSON serialization")
+
+
+fakeNormIngredients = FakeNormIngredients(
+    peakWindowClippingSize=10,
+    smoothingParameter=0.1,
+    decreaseParameter=True,
+    lss=True,
+)
+
+fakeNormIngredients_json = convertIngredients(fakeNormIngredients)
+
+fakeNormAlgo = FakeNormAlgo()
+fakeNormAlgo.initialize()
+fakeNormAlgo.setProperty("InputWorkspace", rawWs)
+fakeNormAlgo.setPropertyValue("Ingredients", fakeNormIngredients_json)
+fakeNormAlgo.setProperty("OutputWorkspace", "artificial_Norm_Ws")
+fakeNormAlgo.execute()
+
+assert False

--- a/tests/cis_tests/artificial_norm_script.py
+++ b/tests/cis_tests/artificial_norm_script.py
@@ -1,0 +1,127 @@
+# Use this script to test Diffraction Calibration
+from mantid.simpleapi import *
+import matplotlib.pyplot as plt
+import numpy as np
+import json
+from typing import List
+
+
+## for creating ingredients
+from snapred.backend.dao.request.FarmFreshIngredients import FarmFreshIngredients
+from snapred.backend.dao.ingredients.ArtificialNormalizationIngredients import ArtificialNormalizationIngredients as FakeNormIngredients
+from snapred.backend.service.SousChef import SousChef
+
+## for loading data
+from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
+from snapred.backend.data.GroceryService import GroceryService
+
+## the code to test
+from snapred.backend.recipe.algorithm.PixelDiffractionCalibration import PixelDiffractionCalibration as PixelAlgo
+from snapred.backend.recipe.algorithm.GroupDiffractionCalibration import GroupDiffractionCalibration as GroupAlgo
+from snapred.backend.recipe.algorithm.CreateArtificialNormalizationAlgo import CreateArtificialNormalizationAlgo as FakeNormAlgo
+from snapred.backend.recipe.DiffractionCalibrationRecipe import DiffractionCalibrationRecipe as Recipe
+
+# for running through service layer
+from snapred.backend.service.CalibrationService import CalibrationService
+from snapred.backend.dao.request.DiffractionCalibrationRequest import DiffractionCalibrationRequest
+
+from snapred.meta.Config import Config
+
+#User input ###########################
+runNumber = "58882"
+groupingScheme = "Column"
+cifPath = "/SNS/users/dzj/Calibration_next/CalibrantSamples/cif/Silicon_NIST_640d.cif"
+calibrantSamplePath = "/SNS/users/dzj/Calibration_next/CalibrantSamples/Silicon_NIST_640D_001.json"
+peakThreshold = 0.05
+offsetConvergenceLimit = 0.1
+isLite = True
+Config._config["cis_mode"] = False
+#######################################
+
+### PREP INGREDIENTS ################
+farmFresh = FarmFreshIngredients(
+    runNumber=runNumber,
+    useLiteMode=isLite,
+    focusGroups=[{"name": groupingScheme, "definition": ""}],
+    cifPath=cifPath,
+    calibrantSamplePath=calibrantSamplePath,
+    convergenceThreshold=offsetConvergenceLimit,
+    maxOffset=100.0,
+)
+ingredients = SousChef().prepDiffractionCalibrationIngredients(farmFresh)
+
+### FETCH GROCERIES ##################
+
+clerk = GroceryListItem.builder()
+clerk.neutron(runNumber).useLiteMode(isLite).add()
+clerk.fromRun(runNumber).grouping(groupingScheme).useLiteMode(isLite).add()
+groceries = GroceryService().fetchGroceryList(clerk.buildList())
+
+### RUN PIXEL CALIBRATION ##########
+pixelAlgo = PixelAlgo()
+pixelAlgo.initialize()
+pixelAlgo.setPropertyValue("Ingredients", ingredients.json())
+pixelAlgo.setPropertyValue("InputWorkspace",groceries[0])
+pixelAlgo.setPropertyValue("GroupingWorkspace", groceries[1])
+pixelAlgo.execute()
+
+assert False
+
+median = json.loads(pixelAlgo.getPropertyValue("data"))["medianOffset"]
+print(median)
+
+count = 0
+while median > offsetConvergenceLimit or count < 5:
+    pixelAlgo.execute()
+    median = json.loads(pixelAlgo.getPropertyValue("data"))["medianOffset"]
+    count += 1
+    
+### RUN GROUP CALIBRATION
+
+DIFCprev = pixelAlgo.getPropertyValue("CalibrationTable")
+
+outputWS = mtd.unique_name(prefix="output_")
+groupAlgo = GroupAlgo()
+groupAlgo.initialize()
+groupAlgo.setPropertyValue("Ingredients", ingredients.json())
+groupAlgo.setPropertyValue("InputWorkspace", groceries[0])
+groupAlgo.setPropertyValue("GroupingWorkspace", groceries[1])
+groupAlgo.setPropertyValue("PreviousCalibrationTable", DIFCprev)
+groupAlgo.setPropertyValue("OutputWorkspace", outputWS)
+groupAlgo.execute()
+
+### PAUSE
+"""
+Stop here and examine the fits.
+Make sure the diffraction focused TOF workspace looks as expected.
+Make sure the offsets workspace has converged, the DIFCpd only fit pixels inside the group,
+and that the fits match with the TOF diffraction focused workspace.
+"""
+assert False
+
+def convertIngredients(ingredients):
+    if hasattr(ingredients, "json"):  # If it's a Pydantic object, use the json() method
+        return ingredients.json()
+    elif isinstance(ingredients, dict):  # If it's already a dictionary, convert to JSON
+        return json.dumps(ingredients)
+    else:
+        raise TypeError("The provided ingredients object is not compatible with JSON serialization")
+
+
+fakeNormIngredients = FakeNormIngredients(
+    peakWindowClippingSize=10,
+    smoothingParameter=0.1,
+    decreaseParameter=True,
+    lss=True,
+)
+
+fakeNormIngredients_json = convertIngredients(fakeNormIngredients)
+
+fakeNormAlgo = FakeNormAlgo()
+fakeNormAlgo.initialize()
+fakeNormAlgo.setPropertyValue("InputWorkspace", outputWS)
+fakeNormAlgo.setPropertyValue("Ingredients", fakeNormIngredients_json)
+fakeNormAlgo.setPropertyValue("OutputWorkspace", outputWS)
+fakeNormAlgo.execute()
+
+assert False

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -213,6 +213,9 @@ constants:
     crystalDMin: 0.4
     crystalDMax: 100.0
 
+  ArtificialNormalization:
+    peakWindowClippingSize: 10
+
   CalibrationReduction:
     tofMin: 2000
     tofMax: 14500

--- a/tests/unit/backend/recipe/algorithm/test_CreateArtifificialNormaliztionAlgo.py
+++ b/tests/unit/backend/recipe/algorithm/test_CreateArtifificialNormaliztionAlgo.py
@@ -1,92 +1,93 @@
-import json
 import unittest
 
 import numpy as np
-from mantid.api import WorkspaceFactory
-from mantid.simpleapi import *
-from snapred.backend.recipe.algorithm.CreateArtificialNormalizationAlgo import (
-    CreateArtificialNormalizationAlgo as ThisAlgo,
+from mantid.simpleapi import (
+    ConvertUnits,
+    mtd,
 )
+from snapred.backend.dao.ingredients.ArtificialNormalizationIngredients import ArtificialNormalizationIngredients
+from snapred.backend.recipe.algorithm.CreateArtificialNormalizationAlgo import CreateArtificialNormalizationAlgo as Algo
+from util.diffraction_calibration_synthetic_data import SyntheticData
 
 
 class TestCreateArtificialNormalizationAlgo(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        """Set up the workspaces and ingredients used in all tests."""
-        # Create a simple input workspace for testing (mock diffraction data)
-        cls.inputWS = WorkspaceFactory.create("Workspace2D", NVectors=1, XLength=10, YLength=10)
-        cls.inputWS.setY(0, np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
-        cls.inputWSName = "TestInputWorkspace"
-        cls.outputWSName = "TestOutputWorkspace"
-        AddWorkspace(cls.inputWS, cls.inputWSName)
+    def setUp(self):
+        self.inputs = SyntheticData()
+        self.fakeIngredients = self.inputs.ingredients
 
-        # Define a fake ingredients JSON for the test
-        cls.fakeIngredients = {
-            "peakWindowClippingSize": 2,
-            "smoothingParameter": 0.5,
-            "decreaseParameter": True,
-            "lss": True,
-        }
-        cls.fakeIngredientsStr = json.dumps(cls.fakeIngredients)
+        self.fakeRawData = "test_data_ws"
+        self.fakeGroupingWorkspace = "test_grouping_ws"
+        self.fakeMaskWorkspace = "test_mask_ws"
+        self.inputs.generateWorkspaces(self.fakeRawData, self.fakeGroupingWorkspace, self.fakeMaskWorkspace)
 
-    @classmethod
-    def tearDownClass(cls):
-        """Clean up workspaces created during the tests."""
-        DeleteWorkspace(cls.inputWSName)
-        DeleteWorkspace(cls.outputWSName)
+        ConvertUnits(
+            InputWorkspace=self.fakeRawData,
+            OutputWorkspace=self.fakeRawData,
+            Target="dSpacing",
+        )
 
-    def test_init_properties(self):
-        """Test that the properties of the algorithm can be initialized correctly."""
-        algo = ThisAlgo()
-        algo.initialize()
-        algo.setProperty("Ingredients", self.fakeIngredientsStr)
-        algo.setProperty("InputWorkspace", self.inputWSName)
-        algo.setProperty("OutputWorkspace", self.outputWSName)
-
-        self.assertEqual(algo.getProperty("Ingredients").value, self.fakeIngredientsStr)  # noqa: PT009
-        self.assertEqual(algo.getPropertyValue("InputWorkspace"), self.inputWSName)  # noqa: PT009
-        self.assertEqual(algo.getPropertyValue("OutputWorkspace"), self.outputWSName)  # noqa: PT009
+    def tearDown(self) -> None:
+        mtd.clear()
+        assert len(mtd.getObjectNames()) == 0
+        return super().tearDown()
 
     def test_chop_ingredients(self):
-        """Test that ingredients are correctly processed."""
-        algo = ThisAlgo()
+        self.fakeIngredients = ArtificialNormalizationIngredients(
+            peakWindowClippingSize=10,
+            smoothingParameter=0.5,
+            decreaseParameter=True,
+            lss=True,
+        )
+        algo = Algo()
         algo.initialize()
-        algo.chopInredients(self.fakeIngredientsStr)
+        algo.setProperty("InputWorkspace", self.fakeRawData)
+        algo.setProperty("Ingredients", self.fakeIngredients.json())
+        algo.setProperty("OutputWorkspace", "test_output_ws")
+        originalData = []
+        inputWs = mtd[self.fakeRawData]
+        for i in range(inputWs.getNumberHistograms()):
+            originalData.append(inputWs.readY(i).copy())
+        algo.execute()
+        self.assertTrue(mtd.doesExist("test_output_ws"))  # noqa: PT009
+        output_ws = mtd["test_output_ws"]
+        for i in range(output_ws.getNumberHistograms()):
+            dataY = output_ws.readY(i)
+            self.assertNotEqual(list(dataY), list(originalData[i]), f"Data for histogram {i} was not modified")  # noqa: PT009
+            self.assertTrue(np.any(dataY))  # noqa: PT009
+        self.assertEqual(algo.peakWindowClippingSize, 10)  # noqa: PT009
+        self.assertEqual(algo.smoothingParameter, 0.5)  # noqa: PT009
+        self.assertTrue(algo.decreaseParameter)  # noqa: PT009
+        self.assertTrue(algo.LSS)  # noqa: PT009
 
-        # Verify the extracted values
-        self.assertEqual(algo.peakWindowClippingSize, self.fakeIngredients["peakWindowClippingSize"])  # noqa: PT009
-        self.assertEqual(algo.smoothingParameter, self.fakeIngredients["smoothingParameter"])  # noqa: PT009
-        self.assertEqual(algo.decreaseParameter, self.fakeIngredients["decreaseParameter"])  # noqa: PT009
-        self.assertEqual(algo.LSS, self.fakeIngredients["lss"])  # noqa: PT009
-
-    def test_peak_clipping(self):
-        """Test the peak clipping logic on sample data."""
-        algo = ThisAlgo()
+    def test_execute(self):
+        self.fakeIngredients = ArtificialNormalizationIngredients(
+            peakWindowClippingSize=10,
+            smoothingParameter=0.5,
+            decreaseParameter=True,
+            lss=True,
+        )
+        algo = Algo()
         algo.initialize()
+        algo.setProperty("InputWorkspace", self.fakeRawData)
+        algo.setProperty("Ingredients", self.fakeIngredients.json())
+        algo.setProperty("OutputWorkspace", "test_output_ws")
+        assert algo.execute()
 
-        # Test data
-        data = np.array([1, 3, 2, 5, 4])
-        clipped_data = algo.peakClip(data, winSize=2, decrese=True, LLS=False, smoothing=0)
-
-        # Expected output after clipping
-        expected_output = np.array([1, 1, 1, 1, 1])
-        np.testing.assert_array_almost_equal(clipped_data, expected_output)
-
-    def test_execution(self):
-        """Test that the algorithm executes and modifies the output workspace."""
-        algo = ThisAlgo()
+    def test_output_data_characteristics(self):
+        self.fakeIngredients = ArtificialNormalizationIngredients(
+            peakWindowClippingSize=10,
+            smoothingParameter=0.5,
+            decreaseParameter=True,
+            lss=True,
+        )
+        algo = Algo()
         algo.initialize()
-        algo.setProperty("Ingredients", self.fakeIngredientsStr)
-        algo.setProperty("InputWorkspace", self.inputWSName)
-        algo.setProperty("OutputWorkspace", self.outputWSName)
-
-        # Execute the algorithm
-        self.assertTrue(algo.execute())  # noqa: PT009
-
-        # Check that the output workspace has been modified
-        outputWS = mtd[self.outputWSName]
-        outputY = outputWS.readY(0)
-
-        # Verify that the output Y data has been clipped
-        expected_output = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
-        np.testing.assert_array_almost_equal(outputY, expected_output)
+        algo.setProperty("InputWorkspace", self.fakeRawData)
+        algo.setProperty("Ingredients", self.fakeIngredients.json())
+        algo.setProperty("OutputWorkspace", "test_output_ws")
+        algo.execute()
+        output_ws = mtd["test_output_ws"]
+        for i in range(output_ws.getNumberHistograms()):
+            dataY = output_ws.readY(i)
+            self.assertFalse(np.isnan(dataY).any(), f"Histogram {i} contains NaN values")  # noqa: PT009
+            self.assertFalse(np.isinf(dataY).any(), f"Histogram {i} contains infinite values")  # noqa: PT009

--- a/tests/unit/backend/recipe/algorithm/test_CreateArtifificialNormaliztionAlgo.py
+++ b/tests/unit/backend/recipe/algorithm/test_CreateArtifificialNormaliztionAlgo.py
@@ -1,0 +1,92 @@
+import json
+import unittest
+
+import numpy as np
+from mantid.api import WorkspaceFactory
+from mantid.simpleapi import *
+from snapred.backend.recipe.algorithm.CreateArtificialNormalizationAlgo import (
+    CreateArtificialNormalizationAlgo as ThisAlgo,
+)
+
+
+class TestCreateArtificialNormalizationAlgo(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Set up the workspaces and ingredients used in all tests."""
+        # Create a simple input workspace for testing (mock diffraction data)
+        cls.inputWS = WorkspaceFactory.create("Workspace2D", NVectors=1, XLength=10, YLength=10)
+        cls.inputWS.setY(0, np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
+        cls.inputWSName = "TestInputWorkspace"
+        cls.outputWSName = "TestOutputWorkspace"
+        AddWorkspace(cls.inputWS, cls.inputWSName)
+
+        # Define a fake ingredients JSON for the test
+        cls.fakeIngredients = {
+            "peakWindowClippingSize": 2,
+            "smoothingParameter": 0.5,
+            "decreaseParameter": True,
+            "lss": True,
+        }
+        cls.fakeIngredientsStr = json.dumps(cls.fakeIngredients)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up workspaces created during the tests."""
+        DeleteWorkspace(cls.inputWSName)
+        DeleteWorkspace(cls.outputWSName)
+
+    def test_init_properties(self):
+        """Test that the properties of the algorithm can be initialized correctly."""
+        algo = ThisAlgo()
+        algo.initialize()
+        algo.setProperty("Ingredients", self.fakeIngredientsStr)
+        algo.setProperty("InputWorkspace", self.inputWSName)
+        algo.setProperty("OutputWorkspace", self.outputWSName)
+
+        self.assertEqual(algo.getProperty("Ingredients").value, self.fakeIngredientsStr)  # noqa: PT009
+        self.assertEqual(algo.getPropertyValue("InputWorkspace"), self.inputWSName)  # noqa: PT009
+        self.assertEqual(algo.getPropertyValue("OutputWorkspace"), self.outputWSName)  # noqa: PT009
+
+    def test_chop_ingredients(self):
+        """Test that ingredients are correctly processed."""
+        algo = ThisAlgo()
+        algo.initialize()
+        algo.chopInredients(self.fakeIngredientsStr)
+
+        # Verify the extracted values
+        self.assertEqual(algo.peakWindowClippingSize, self.fakeIngredients["peakWindowClippingSize"])  # noqa: PT009
+        self.assertEqual(algo.smoothingParameter, self.fakeIngredients["smoothingParameter"])  # noqa: PT009
+        self.assertEqual(algo.decreaseParameter, self.fakeIngredients["decreaseParameter"])  # noqa: PT009
+        self.assertEqual(algo.LSS, self.fakeIngredients["lss"])  # noqa: PT009
+
+    def test_peak_clipping(self):
+        """Test the peak clipping logic on sample data."""
+        algo = ThisAlgo()
+        algo.initialize()
+
+        # Test data
+        data = np.array([1, 3, 2, 5, 4])
+        clipped_data = algo.peakClip(data, winSize=2, decrese=True, LLS=False, smoothing=0)
+
+        # Expected output after clipping
+        expected_output = np.array([1, 1, 1, 1, 1])
+        np.testing.assert_array_almost_equal(clipped_data, expected_output)
+
+    def test_execution(self):
+        """Test that the algorithm executes and modifies the output workspace."""
+        algo = ThisAlgo()
+        algo.initialize()
+        algo.setProperty("Ingredients", self.fakeIngredientsStr)
+        algo.setProperty("InputWorkspace", self.inputWSName)
+        algo.setProperty("OutputWorkspace", self.outputWSName)
+
+        # Execute the algorithm
+        self.assertTrue(algo.execute())  # noqa: PT009
+
+        # Check that the output workspace has been modified
+        outputWS = mtd[self.outputWSName]
+        outputY = outputWS.readY(0)
+
+        # Verify that the output Y data has been clipped
+        expected_output = np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+        np.testing.assert_array_almost_equal(outputY, expected_output)

--- a/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
+++ b/tests/unit/backend/recipe/algorithm/test_DiffractionSpectrumWeightCalculator.py
@@ -97,6 +97,7 @@ with mock.patch.dict(
         assert_almost_equal(
             Workspace1=input_ws_name,
             Workspace2=weight_ws_name,
+            rtol=1.0e-10,
         )
 
     def test_unbag_ingredients_converts_events():
@@ -133,6 +134,7 @@ with mock.patch.dict(
         assert_almost_equal(
             Workspace1=input_ws_name,
             Workspace2=weight_ws_name,
+            rtol=1.0e-10,
         )
 
     def test_validate_fail_wrong_sizes():
@@ -257,6 +259,7 @@ with mock.patch.dict(
         assert_almost_equal(
             Workspace1=output_ws_name,
             Workspace2=weight_ws_name,
+            rtol=1.0e-10,
         )
 
     def test_with_predicted_peaks():
@@ -299,4 +302,5 @@ with mock.patch.dict(
             Workspace1=weight_ws_name,
             Workspace2=ref_weight_ws_name,
             CheckInstrument=False,
+            rtol=1.0e-10,
         )

--- a/tests/unit/backend/recipe/algorithm/test_FocusSpectraAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FocusSpectraAlgorithm.py
@@ -141,6 +141,7 @@ class TestFocusSpectra(unittest.TestCase):
             Workspace1=outputWs,
             Workspace2=outputWs + "_loaded",
             CheckAllData=True,
+            rtol=1.0e-10,
         )
 
     def test_chopIngredients(self):


### PR DESCRIPTION
## Description of work
This work is to facilitate the addition of artificial normalization within the reduction workflow in cases where a calibration is non-existent or a normalization is missing. For now, this story deals with the creation of the algorithm that executes the backend logic to produce an artificial normalization.
<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work
Within this work, a new algorithm named CreateArtificialNormalizationAlgo is introduced. Its purpose is to create an artificial normalization workspace, ensuring that reduction workflows remain uninterrupted even when calibration data is missing. The algorithm takes in diffraction data, applies various transformations such as peak clipping and optional smoothing, and outputs a new workspace that simulates normalized data.

**Inputs:**
* InputWorkspace - (units DSpacing, EMode="Elastic")
* Ingredients = (
                            PeakWindowClippingSize = Int (default 10),
                            SmoothingParameter = Double,
                            decreaseParameter = boolean (default True),
                            LSS = boolean (default True) 
* OutputWorkspaceName

**Output:**
* Workspace containing Artificial Normalization

The algorithm processes each histogram in the input workspace, clipping peaks, smoothing the data, and applying transformations as specified by the ingredients. It clones the input workspace and modifies the data to produce the desired output, allowing the reduction process to continue even in the absence of proper calibration or normalization files.
<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing
Please insure all `pytests` pass. There is a `cis_test` script created that can be used to test called `artificial_norm_script`.
<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing
Please take a look at the cis_test mentioned above for testing. There are two cases presented here which will be reflected within the final implementation in SNAPRed:

1. Calibration exists without Normalization (in this case, we load calibrated diffraction focused workspace as input)
2. Calibration does not exist (in this case, we take the raw input data and apply `FocusSpectraAlgorithm` to it to create artificial norm)
<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

``` python
# Use this script to test Diffraction Calibration
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
import json
from typing import List


## for creating ingredients
from snapred.backend.dao.request.FarmFreshIngredients import FarmFreshIngredients
from snapred.backend.dao.ingredients.ArtificialNormalizationIngredients import ArtificialNormalizationIngredients as FakeNormIngredients
from snapred.backend.service.SousChef import SousChef

## for loading data
from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
from snapred.backend.data.GroceryService import GroceryService

## the code to test
from snapred.backend.recipe.algorithm.PixelDiffractionCalibration import PixelDiffractionCalibration as PixelAlgo
from snapred.backend.recipe.algorithm.GroupDiffractionCalibration import GroupDiffractionCalibration as GroupAlgo
from snapred.backend.recipe.algorithm.CreateArtificialNormalizationAlgo import CreateArtificialNormalizationAlgo as FakeNormAlgo
from snapred.backend.recipe.DiffractionCalibrationRecipe import DiffractionCalibrationRecipe as Recipe

# for running through service layer
from snapred.backend.service.CalibrationService import CalibrationService
from snapred.backend.dao.request.DiffractionCalibrationRequest import DiffractionCalibrationRequest

from snapred.meta.Config import Config

#User input ###########################
runNumber = "58882"
groupingScheme = "Column"
cifPath = "/SNS/users/dzj/Calibration_next/CalibrantSamples/cif/Silicon_NIST_640d.cif"
calibrantSamplePath = "/SNS/users/dzj/Calibration_next/CalibrantSamples/Silicon_NIST_640D_001.json"
peakThreshold = 0.05
offsetConvergenceLimit = 0.1
isLite = True
Config._config["cis_mode"] = False
#######################################

### PREP INGREDIENTS ################
farmFresh = FarmFreshIngredients(
    runNumber=runNumber,
    useLiteMode=isLite,
    focusGroups=[{"name": groupingScheme, "definition": ""}],
    cifPath=cifPath,
    calibrantSamplePath=calibrantSamplePath,
    convergenceThreshold=offsetConvergenceLimit,
    maxOffset=100.0,
)
ingredients = SousChef().prepDiffractionCalibrationIngredients(farmFresh)

### FETCH GROCERIES ##################

clerk = GroceryListItem.builder()
clerk.neutron(runNumber).useLiteMode(isLite).add()
clerk.fromRun(runNumber).grouping(groupingScheme).useLiteMode(isLite).add()
groceries = GroceryService().fetchGroceryList(clerk.buildList())

### RUN PIXEL CALIBRATION ##########
pixelAlgo = PixelAlgo()
pixelAlgo.initialize()
pixelAlgo.setPropertyValue("Ingredients", ingredients.json())
pixelAlgo.setPropertyValue("InputWorkspace",groceries[0])
pixelAlgo.setPropertyValue("GroupingWorkspace", groceries[1])
pixelAlgo.execute()

assert False

median = json.loads(pixelAlgo.getPropertyValue("data"))["medianOffset"]
print(median)

count = 0
while median > offsetConvergenceLimit or count < 5:
    pixelAlgo.execute()
    median = json.loads(pixelAlgo.getPropertyValue("data"))["medianOffset"]
    count += 1
    
### RUN GROUP CALIBRATION

DIFCprev = pixelAlgo.getPropertyValue("CalibrationTable")

outputWS = mtd.unique_name(prefix="output_")
groupAlgo = GroupAlgo()
groupAlgo.initialize()
groupAlgo.setPropertyValue("Ingredients", ingredients.json())
groupAlgo.setPropertyValue("InputWorkspace", groceries[0])
groupAlgo.setPropertyValue("GroupingWorkspace", groceries[1])
groupAlgo.setPropertyValue("PreviousCalibrationTable", DIFCprev)
groupAlgo.setPropertyValue("OutputWorkspace", outputWS)
groupAlgo.execute()

### PAUSE
"""
Stop here and examine the fits.
Make sure the diffraction focused TOF workspace looks as expected.
Make sure the offsets workspace has converged, the DIFCpd only fit pixels inside the group,
and that the fits match with the TOF diffraction focused workspace.
"""
assert False

def convertIngredients(ingredients):
    if hasattr(ingredients, "json"):  # If it's a Pydantic object, use the json() method
        return ingredients.json()
    elif isinstance(ingredients, dict):  # If it's already a dictionary, convert to JSON
        return json.dumps(ingredients)
    else:
        raise TypeError("The provided ingredients object is not compatible with JSON serialization")


fakeNormIngredients = FakeNormIngredients(
    peakWindowClippingSize=10,
    smoothingParameter=0.1,
    decreaseParameter=True,
    lss=True,
)

fakeNormIngredients_json = convertIngredients(fakeNormIngredients)

fakeNormAlgo = FakeNormAlgo()
fakeNormAlgo.initialize()
fakeNormAlgo.setPropertyValue("InputWorkspace", outputWS)
fakeNormAlgo.setPropertyValue("Ingredients", fakeNormIngredients_json)
fakeNormAlgo.setPropertyValue("OutputWorkspace", outputWS)
fakeNormAlgo.execute()

assert False

### This following script reflects the use of this new algo "CreateArtificialNormalizationAlgo" within Reduction
import json

## for creating ingredients
from snapred.backend.dao.request.FarmFreshIngredients import FarmFreshIngredients
from snapred.backend.service.SousChef import SousChef
from snapred.backend.data.LocalDataService import LocalDataService
from snapred.backend.dao.ingredients.ArtificialNormalizationIngredients import ArtificialNormalizationIngredients as FakeNormIngredients
## for loading data
from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
from snapred.backend.data.GroceryService import GroceryService

## the code to test
from snapred.backend.recipe.ReductionRecipe import ReductionRecipe as Recipe

# for running through service layer
from snapred.backend.dao.request.ReductionRequest import ReductionRequest
from snapred.backend.service.ReductionService import ReductionService
from snapred.backend.recipe.algorithm.FocusSpectraAlgorithm import FocusSpectraAlgorithm as FocusSpec
from snapred.backend.recipe.algorithm.CreateArtificialNormalizationAlgo import CreateArtificialNormalizationAlgo as FakeNormAlgo

from snapred.meta.Config import Config
from pathlib import Path
from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng, ValueFormatter as wnvf

from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
from mantid.simpleapi import ConvertToMatrixWorkspace

groceryService = GroceryService()

#User input ###########################
runNumber = "46680" #"57482"
isLite = True
Config._config["cis_mode"] = True
version=(1, None)
grouping = "Column"

### PREP INGREDIENTS ################

groups = LocalDataService().readGroupingMap(runNumber).getMap(isLite)

farmFresh = FarmFreshIngredients(
    runNumber=runNumber,
    versions=version,
    useLiteMode=isLite,
    focusGroups=list(groups.values()),
    timestamp=1726848143.8856316,
    keepUnfocused=True,
    convertUnitsTo="TOF",
)

ingredients = SousChef().prepReductionIngredients(farmFresh)

selectedFocusGroup = next(
    (fg for fg in farmFresh.focusGroups if fg.name == grouping), None
)

if selectedFocusGroup:
    print(f"Selected FocusGroup: {selectedFocusGroup}")
    
    updatedFarmFresh = FarmFreshIngredients(
        runNumber=farmFresh.runNumber,
        useLiteMode=farmFresh.useLiteMode,
        focusGroups=[selectedFocusGroup], 
    )
    
    pixelGroup = SousChef().prepPixelGroup(updatedFarmFresh)

# TODO: This probably needs to be a thing:
# ingredients.detectorPeaks = normalizationRecord.detectorPeaks


### FETCH GROCERIES ##################

clerk = GroceryListItem.builder()

for key, group in groups.items():
  clerk.fromRun(runNumber).grouping(group.name).useLiteMode(isLite).add()
groupingWorkspaces = GroceryService().fetchGroceryList(clerk.buildList())
# ...
clerk.name("inputWorkspace").neutron(runNumber).useLiteMode(isLite).add()
clerk.name("diffcalWorkspace").diffcal_table(runNumber, 1).useLiteMode(isLite).add()


groceries = GroceryService().fetchGroceryDict(
    groceryDict=clerk.buildDict()
)
groceries["groupingWorkspaces"] = groupingWorkspaces

rawWs = "tof_all_lite_copy1_046680"
groupingWs = f"SNAPLite_grouping__{grouping}_{runNumber}"

focusSpec =  FocusSpec()
focusSpec.initialize()
focusSpec.setPropertyValue("InputWorkspace", rawWs)
focusSpec.setPropertyValue("OutputWorkspace", rawWs)
focusSpec.setPropertyValue("GroupingWorkspace", groupingWs)
focusSpec.setPropertyValue("Ingredients", pixelGroup.json())
focusSpec.setProperty("RebinOutput", False)
focusSpec.execute()

rawWs = ConvertToMatrixWorkspace(rawWs)

def convertIngredients(ingredients):
    if hasattr(ingredients, "json"):  # If it's a Pydantic object, use the json() method
        return ingredients.json()
    elif isinstance(ingredients, dict):  # If it's already a dictionary, convert to JSON
        return json.dumps(ingredients)
    else:
        raise TypeError("The provided ingredients object is not compatible with JSON serialization")


fakeNormIngredients = FakeNormIngredients(
    peakWindowClippingSize=10,
    smoothingParameter=0.1,
    decreaseParameter=True,
    lss=True,
)

fakeNormIngredients_json = convertIngredients(fakeNormIngredients)

fakeNormAlgo = FakeNormAlgo()
fakeNormAlgo.initialize()
fakeNormAlgo.setProperty("InputWorkspace", rawWs)
fakeNormAlgo.setPropertyValue("Ingredients", fakeNormIngredients_json)
fakeNormAlgo.setProperty("OutputWorkspace", "artificial_Norm_Ws")
fakeNormAlgo.execute()

assert False
```

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM # 7122](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7122)

### Verification

- [ ] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] acceptance criterion 1
- [ ] acceptance criterion 2
