### PR TITLE
Reduction process: effective-instrument geometry.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,12 +2,12 @@ name: SNAPRed
 channels:
 - conda-forge
 - default
-- mantid-ornl/label/rc
+- mantid/label/nightly
 dependencies:
 - python=3.10
 - pip
 - pydantic>=2.7.3,<3
-- mantidworkbench=6.10.0.2rc1
+- mantidworkbench>=6.11.20241111
 - qtpy
 - pre-commit
 - pytest

--- a/src/snapred/backend/dao/ingredients/EffectiveInstrumentIngredients.py
+++ b/src/snapred/backend/dao/ingredients/EffectiveInstrumentIngredients.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel, ConfigDict
+
+from snapred.backend.dao.state.PixelGroup import PixelGroup
+
+
+class EffectiveInstrumentIngredients(BaseModel):
+    unmaskedPixelGroup: PixelGroup
+
+    model_config = ConfigDict(
+        extra="forbid",
+    )

--- a/src/snapred/backend/dao/ingredients/ReductionIngredients.py
+++ b/src/snapred/backend/dao/ingredients/ReductionIngredients.py
@@ -8,6 +8,7 @@ from snapred.backend.dao.ingredients.ApplyNormalizationIngredients import ApplyN
 # These are from the same `__init__` module, so for the moment, we require the full import specifications.
 # (That is, not just "from snapred.backend.dao.ingredients import ...".)
 from snapred.backend.dao.ingredients.ArtificialNormalizationIngredients import ArtificialNormalizationIngredients
+from snapred.backend.dao.ingredients.EffectiveInstrumentIngredients import EffectiveInstrumentIngredients
 from snapred.backend.dao.ingredients.GenerateFocussedVanadiumIngredients import GenerateFocussedVanadiumIngredients
 from snapred.backend.dao.ingredients.PreprocessReductionIngredients import PreprocessReductionIngredients
 from snapred.backend.dao.ingredients.ReductionGroupProcessingIngredients import ReductionGroupProcessingIngredients
@@ -22,6 +23,7 @@ class ReductionIngredients(BaseModel):
     timestamp: float
 
     pixelGroups: List[PixelGroup]
+    unmaskedPixelGroups: List[PixelGroup]
 
     # these should come from calibration / normalization records
     # But will not exist if we proceed without calibration / normalization
@@ -62,6 +64,9 @@ class ReductionIngredients(BaseModel):
         return ApplyNormalizationIngredients(
             pixelGroup=self.pixelGroups[groupingIndex],
         )
+
+    def effectiveInstrument(self, groupingIndex: int) -> EffectiveInstrumentIngredients:
+        return EffectiveInstrumentIngredients(unmaskedPixelGroup=self.unmaskedPixelGroups[groupingIndex])
 
     model_config = ConfigDict(
         extra="forbid",

--- a/src/snapred/backend/dao/state/PixelGroup.py
+++ b/src/snapred/backend/dao/state/PixelGroup.py
@@ -10,7 +10,7 @@ from snapred.meta.Config import Config
 
 
 class PixelGroup(BaseModel):
-    # allow initializtion from either dictionary or list
+    # allow initialization from either dictionary or list
     pixelGroupingParameters: Union[List[PixelGroupingParameters], Dict[int, PixelGroupingParameters]] = {}
     nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]
     focusGroup: FocusGroup

--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -191,24 +191,21 @@ class DataFactoryService:
         return reductionState
 
     @validate_call
-    def getReductionDataPath(self, runId: str, useLiteMode: bool, version: int) -> Path:
-        return self.lookupService._constructReductionDataPath(runId, useLiteMode, version)
+    def getReductionDataPath(self, runId: str, useLiteMode: bool, timestamp: float) -> Path:
+        return self.lookupService._constructReductionDataPath(runId, useLiteMode, timestamp)
 
     @validate_call
-    def getReductionRecord(self, runId: str, useLiteMode: bool, version: Optional[int] = None) -> ReductionRecord:
-        """
-        If no version is passed, will use the latest version applicable to runId
-        """
-        return self.lookupService.readReductionRecord(runId, useLiteMode, version)
+    def getReductionRecord(self, runId: str, useLiteMode: bool, timestamp: float) -> ReductionRecord:
+        return self.lookupService.readReductionRecord(runId, useLiteMode, timestamp)
 
     @validate_call
-    def getReductionData(self, runId: str, useLiteMode: bool, version: int) -> ReductionRecord:
-        return self.lookupService.readReductionData(runId, useLiteMode, version)
+    def getReductionData(self, runId: str, useLiteMode: bool, timestamp: float) -> ReductionRecord:
+        return self.lookupService.readReductionData(runId, useLiteMode, timestamp)
 
     @validate_call
-    def getCompatibleReductionMasks(self, runNumber: str, useLiteMode: bool) -> List[WorkspaceName]:
+    def getCompatibleReductionMasks(self, runId: str, useLiteMode: bool) -> List[WorkspaceName]:
         # Assemble a list of masks, both resident and otherwise, that are compatible with the current reduction
-        return self.lookupService.getCompatibleReductionMasks(runNumber, useLiteMode)
+        return self.lookupService.getCompatibleReductionMasks(runId, useLiteMode)
 
     ##### WORKSPACE METHODS #####
 

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -668,7 +668,7 @@ class LocalDataService:
         # 2) For SNAPRed internal use:
         #        if `reduction.output.useEffectiveInstrument` is set to false in "application.yml",
         #    output workspaces will be saved without converting their instruments to the reduced form.
-        #    Both of these alternatives are retained to allow some flexibility in what specifically 
+        #    Both of these alternatives are retained to allow some flexibility in what specifically
         #    is saved with the reduction data.
         #
 

--- a/src/snapred/backend/error/ContinueWarning.py
+++ b/src/snapred/backend/error/ContinueWarning.py
@@ -30,8 +30,7 @@ class ContinueWarning(Exception):
         return self.model.flags
 
     def __init__(self, message: str, flags: "Type" = 0):
-        ContinueWarning.Model.update_forward_refs()
-        ContinueWarning.Model.model_rebuild(force=True)
+        ContinueWarning.Model.model_rebuild(force=True)  # replaces: `update_forward_refs` method
         self.model = ContinueWarning.Model(message=message, flags=flags)
         super().__init__(message)
 

--- a/src/snapred/backend/error/RecoverableException.py
+++ b/src/snapred/backend/error/RecoverableException.py
@@ -37,8 +37,7 @@ class RecoverableException(Exception):
         return self.model.data
 
     def __init__(self, message: str, flags: "Type" = 0, data: Optional[Any] = None):
-        RecoverableException.Model.update_forward_refs()
-        RecoverableException.Model.model_rebuild(force=True)
+        RecoverableException.Model.model_rebuild(force=True)  # replaces: `update_forward_refs` method
         self.model = RecoverableException.Model(message=message, flags=flags, data=data)
         logger.error(f"{extractTrueStacktrace()}")
         super().__init__(message)

--- a/src/snapred/backend/recipe/PixelGroupingParametersCalculationRecipe.py
+++ b/src/snapred/backend/recipe/PixelGroupingParametersCalculationRecipe.py
@@ -36,7 +36,7 @@ class PixelGroupingParametersCalculationRecipe:
             "Calling algorithm",
             Ingredients=ingredients.json(),
             GroupingWorkspace=groceries["groupingWorkspace"],
-            MaskWorkspace=groceries.get("MaskWorkspace", ""),
+            MaskWorkspace=groceries.get("maskWorkspace", ""),
         )
         self.mantidSnapper.executeQueue()
         # NOTE contradictory issues with Callbacks between GUI and unit tests

--- a/src/snapred/backend/recipe/Recipe.py
+++ b/src/snapred/backend/recipe/Recipe.py
@@ -47,7 +47,7 @@ class Recipe(ABC, Generic[Ingredients]):
     @abstractmethod
     def queueAlgos(self):
         """
-        Queues up the procesing algorithms for the recipe.
+        Queues up the processing algorithms for the recipe.
         Requires: unbagged groceries and chopped ingredients.
         """
 

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -104,7 +104,7 @@ class SousChef(Service):
             ingredients.useLiteMode,
             groupingSchema,
             ingredients.calibrantSamplePath,
-            pixelMask
+            pixelMask,
         )
         if key not in self._pixelGroupCache:
             focusGroup = self.prepFocusGroup(ingredients)
@@ -116,10 +116,7 @@ class SousChef(Service):
             self.groceryClerk.name("groupingWorkspace").fromRun(ingredients.runNumber).grouping(
                 focusGroup.name
             ).useLiteMode(ingredients.useLiteMode).add()
-            groceries = self.groceryService.fetchGroceryDict(
-                self.groceryClerk.buildDict(),
-                maskWorkspace=pixelMask
-            )
+            groceries = self.groceryService.fetchGroceryDict(self.groceryClerk.buildDict(), maskWorkspace=pixelMask)
             data = PixelGroupingParametersCalculationRecipe().executeRecipe(pixelIngredients, groceries)
 
             self._pixelGroupCache[key] = PixelGroup(
@@ -131,9 +128,7 @@ class SousChef(Service):
         return deepcopy(self._pixelGroupCache[key])
 
     def prepManyPixelGroups(
-        self,
-        ingredients: FarmFreshIngredients,
-        pixelMask: Optional[WorkspaceName] = None
+        self, ingredients: FarmFreshIngredients, pixelMask: Optional[WorkspaceName] = None
     ) -> List[PixelGroup]:
         pixelGroups = []
         ingredients_ = ingredients.model_copy()
@@ -267,9 +262,7 @@ class SousChef(Service):
         return ingredients, smoothingParameter, calibrantSamplePath
 
     def prepReductionIngredients(
-        self,
-        ingredients: FarmFreshIngredients,
-        combinedPixelMask: Optional[WorkspaceName] = None
+        self, ingredients: FarmFreshIngredients, combinedPixelMask: Optional[WorkspaceName] = None
     ) -> ReductionIngredients:
         ingredients_ = ingredients.model_copy()
         # some of the reduction ingredients MUST match those used in the calibration/normalization processes

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -1,7 +1,7 @@
 import os
 from copy import deepcopy
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import pydantic
 
@@ -31,6 +31,7 @@ from snapred.backend.service.CrystallographicInfoService import Crystallographic
 from snapred.backend.service.Service import Service
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Singleton import Singleton
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
 logger = snapredLogger.getLogger(__name__)
 
@@ -94,13 +95,16 @@ class SousChef(Service):
             groupingMap = self.dataFactoryService.getGroupingMap(ingredients.runNumber)
             return groupingMap.getMap(ingredients.useLiteMode)[ingredients.focusGroup.name]
 
-    def prepPixelGroup(self, ingredients: FarmFreshIngredients) -> PixelGroup:
+    def prepPixelGroup(
+        self, ingredients: FarmFreshIngredients, pixelMask: Optional[WorkspaceName] = None
+    ) -> PixelGroup:
         groupingSchema = ingredients.focusGroup.name
         key = (
             ingredients.runNumber,
             ingredients.useLiteMode,
             groupingSchema,
             ingredients.calibrantSamplePath,
+            pixelMask
         )
         if key not in self._pixelGroupCache:
             focusGroup = self.prepFocusGroup(ingredients)
@@ -112,7 +116,10 @@ class SousChef(Service):
             self.groceryClerk.name("groupingWorkspace").fromRun(ingredients.runNumber).grouping(
                 focusGroup.name
             ).useLiteMode(ingredients.useLiteMode).add()
-            groceries = self.groceryService.fetchGroceryDict(self.groceryClerk.buildDict())
+            groceries = self.groceryService.fetchGroceryDict(
+                self.groceryClerk.buildDict(),
+                maskWorkspace=pixelMask
+            )
             data = PixelGroupingParametersCalculationRecipe().executeRecipe(pixelIngredients, groceries)
 
             self._pixelGroupCache[key] = PixelGroup(
@@ -123,12 +130,16 @@ class SousChef(Service):
             )
         return deepcopy(self._pixelGroupCache[key])
 
-    def prepManyPixelGroups(self, ingredients: FarmFreshIngredients) -> List[PixelGroup]:
+    def prepManyPixelGroups(
+        self,
+        ingredients: FarmFreshIngredients,
+        pixelMask: Optional[WorkspaceName] = None
+    ) -> List[PixelGroup]:
         pixelGroups = []
         ingredients_ = ingredients.model_copy()
         for focusGroup in ingredients.focusGroups:
             ingredients_.focusGroup = focusGroup
-            pixelGroups.append(self.prepPixelGroup(ingredients_))
+            pixelGroups.append(self.prepPixelGroup(ingredients_, pixelMask))
         return pixelGroups
 
     def _getInstrumentDefinitionFilename(self, useLiteMode: bool) -> str:
@@ -243,7 +254,7 @@ class SousChef(Service):
     def _pullNormalizationRecordFFI(
         self,
         ingredients: FarmFreshIngredients,
-    ) -> Tuple[FarmFreshIngredients, float]:
+    ) -> Tuple[FarmFreshIngredients, float, Optional[str]]:
         normalizationRecord = self.dataFactoryService.getNormalizationRecord(
             ingredients.runNumber, ingredients.useLiteMode, ingredients.versions.normalization
         )
@@ -255,7 +266,11 @@ class SousChef(Service):
         # TODO: Should smoothing parameter be an ingredient?
         return ingredients, smoothingParameter, calibrantSamplePath
 
-    def prepReductionIngredients(self, ingredients: FarmFreshIngredients) -> ReductionIngredients:
+    def prepReductionIngredients(
+        self,
+        ingredients: FarmFreshIngredients,
+        combinedPixelMask: Optional[WorkspaceName] = None
+    ) -> ReductionIngredients:
         ingredients_ = ingredients.model_copy()
         # some of the reduction ingredients MUST match those used in the calibration/normalization processes
         ingredients_ = self._pullCalibrationRecordFFI(ingredients_)
@@ -266,7 +281,8 @@ class SousChef(Service):
             runNumber=ingredients_.runNumber,
             useLiteMode=ingredients_.useLiteMode,
             timestamp=ingredients_.timestamp,
-            pixelGroups=self.prepManyPixelGroups(ingredients_),
+            pixelGroups=self.prepManyPixelGroups(ingredients_, combinedPixelMask),
+            unmaskedPixelGroups=self.prepManyPixelGroups(ingredients_),
             smoothingParameter=smoothingParameter,
             calibrantSamplePath=ingredients_.calibrantSamplePath,
             peakIntensityThreshold=self._getThresholdFromCalibrantSample(ingredients_.calibrantSamplePath),

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -102,6 +102,12 @@ calibration:
   fitting:
     minSignal2Noise: 0.0
 
+reduction:
+  output:
+    extension: .nxs
+    # convert the instrument for the output workspaces into the reduced form
+    useEffectiveInstrument: false
+
 mantid:
   workspace:
     nameTemplate:

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -408,7 +408,7 @@ class DiffCalWorkflow(WorkflowImplementer):
                     self._tweakPeakView,
                     "Too Few Peaks",
                     "Purging would result in fewer than the required 2 peaks for calibration.  "
-                    "The current set of peaks will be retained.",
+                    + "The current set of peaks will be retained.",
                     QMessageBox.Ok,
                 )
             else:

--- a/tests/cis_tests/effective_instrument_script.py
+++ b/tests/cis_tests/effective_instrument_script.py
@@ -1,0 +1,119 @@
+from datetime import datetime
+from functools import partial
+import math
+import numpy as np
+from pathlib import Path
+import re
+import sys
+
+from mantid.simpleapi import mtd
+
+import snapred
+SNAPRed_module_root = Path(snapred.__file__).parent.parent
+
+from snapred.backend.dao.request.FarmFreshIngredients import FarmFreshIngredients
+from snapred.backend.dao.request.ReductionRequest import ReductionRequest
+from snapred.backend.data.DataFactoryService import DataFactoryService
+from snapred.backend.service.SousChef import SousChef
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
+from snapred.meta.Config import Config
+
+# -----------------------------
+# Test helper utility routines:
+sys.path.insert(0, str(Path(SNAPRed_module_root).parent / 'tests'))
+from util.IPTS_override import IPTS_override
+# from util.helpers import timestampFromString
+
+def timestampFromString(timestamp_str) -> float:
+    # Recover a float timestamp from a non-isoformat timestamp string
+    regx = re.compile(r"([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2})([0-9]{2})([0-9]{2})")
+    Y, M, D, H, m, s = tuple([int(s) for s in regx.match(timestamp_str).group(1, 2, 3, 4, 5, 6)])
+    return datetime(Y, M, D, H, m, s).timestamp()
+
+###########################################################
+# If necessary, override the IPTS search directories:    ##
+#   remember to set your "IPTS.root" in "application.yml!##
+###########################################################
+with IPTS_override(): # defaults to `Config["IPTS.root"]`
+
+    #######################################################################################################################   
+    # Step 1: Generate a set of reduction data.  Take a look under the output folder and see what its timestamp string is.#
+    #######################################################################################################################
+
+    runNumber = "46680"
+    useLiteMode = True
+    timestamp_str = "2024-11-15T133125" # Unfortunately, not in iso format
+    timestamp = timestampFromString(timestamp_str)
+
+    ###################################################################################
+    # Step 2: Reload the reduction record, and all of the reduction output workspaces.#
+    ###################################################################################
+    dataService = DataFactoryService()
+    sousChef = SousChef()
+
+    reductionRecord = dataService.getReductionData(runNumber, useLiteMode, timestamp)
+
+    #########################################################################################################
+    # Step 3: Load the required grouping workspaces, and compute their _unmasked_ pixel-grouping parameters.#
+    # (Note here that the `ReductionRecord` itself retains only the _masked_ PGP.)                          #
+    #########################################################################################################
+
+    #  ... this duplicates the setup part of the reduction process ...
+    groupingMap = dataService.getGroupingMap(runNumber).getMap(useLiteMode)
+    request = ReductionRequest(
+        runNumber=runNumber,
+        useLiteMode=useLiteMode,
+        timestamp=timestamp,
+        focusGroups = list(groupingMap.values()),
+        keepUnfocused=False,
+        convertUnitsTo="TOF"
+    )
+    farmFresh = FarmFreshIngredients(
+        runNumber=request.runNumber,
+        useLiteMode=request.useLiteMode,
+        timestamp=request.timestamp,
+        focusGroups=request.focusGroups,
+        keepUnfocused=request.keepUnfocused,
+        convertUnitsTo=request.convertUnitsTo,
+        versions=request.versions,
+    )
+    ingredients = sousChef.prepReductionIngredients(farmFresh)
+    #  ... now the required PGP are available in `ingredients.unmaskedPixelGroups: List[PixelGroup]` ...
+    unmaskedPixelGroups = {pg.focusGroup.name: pg for pg in ingredients.unmaskedPixelGroups}
+
+    ##################################################################################################################
+    # Step 4: For the output workspace corresponding to each grouping, verify that the effective instrument consists #
+    #   of one pixel per group-id, with its location matching the _unmasked_ PGP for that grouping and group-id.     #
+    ##################################################################################################################
+
+    # For each grouping, verify that the output workspace's effective instrument has been set up as expected.
+    for grouping in unmaskedPixelGroups:
+        # We need to rebuild the workspace name, because the `WorkspaceName` of the loaded `ReductionRecord` will only retain its string component.
+        reducedOutputWs = wng.reductionOutput().runNumber(runNumber).group(grouping).timestamp(timestamp).build()
+        assert reducedOutputWs in reductionRecord.workspaceNames
+        assert mtd.doesExist(reducedOutputWs)
+
+        outputWs = mtd[reducedOutputWs]
+
+        effectiveInstrument = outputWs.getInstrument()
+
+        # verify the new instrument name
+        assert effectiveInstrument.getName() == f"SNAP_{grouping}"
+
+        # there should be one pixel per output spectrum
+        assert effectiveInstrument.getNumberDetectors(True) == outputWs.getNumberHistograms()
+
+        detectorInfo = outputWs.detectorInfo()
+        pixelGroup = unmaskedPixelGroups[grouping]
+
+        isclose = partial(math.isclose, rel_tol=10.0 * np.finfo(float).eps, abs_tol=10.0 * np.finfo(float).eps)
+        for n, gid in enumerate(pixelGroup.groupIDs):
+            # Spectra are in the same index order as the group IDs:
+            assert isclose(pixelGroup.L2[n], detectorInfo.l2(n))
+            assert isclose(pixelGroup.twoTheta[n], detectorInfo.twoTheta(n))
+            assert isclose(pixelGroup.azimuth[n], detectorInfo.azimuthal(n))
+
+    print("*************************************************************")
+    print("*** Test of effective instrument substitution successful! ***")
+    print("*************************************************************")
+        

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -103,6 +103,11 @@ calibration:
   fitting:
     minSignal2Noise: 10
 
+reduction:
+  output:
+    extension: .nxs
+    # convert the instrument for the output workspaces into the reduced form
+    useEffectiveInstrument: false
 
 mantid:
     workspace:

--- a/tests/resources/inputs/calibration/ReductionIngredients.json
+++ b/tests/resources/inputs/calibration/ReductionIngredients.json
@@ -2,6 +2,7 @@
   "runNumber": "57514",
   "useLiteMode": true,
   "timestamp": 1722893493.2375631,
+
   "pixelGroups": [
     {
       "pixelGroupingParameters": {
@@ -200,6 +201,207 @@
       "binningMode": -1
     }
   ],
+
+  "unmaskedPixelGroups": [
+    {
+      "pixelGroupingParameters": {
+        "1": {
+          "groupID": 1,
+          "isMasked": false,
+          "L2": 10.0,
+          "twoTheta": 1.4888167719149363,
+          "azimuth": 0.0,
+          "dResolution": {
+            "minimum": 0.35983386414596874,
+            "maximum": 4.355830260153734
+          },
+          "dRelativeResolution": 0.009342020503289764
+        }
+      },
+      "nBinsAcrossPeakWidth": 10,
+      "focusGroup": {
+        "name": "All",
+        "definition": "/SNS/users/wqp/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_All.lite.hdf"
+      },
+      "timeOfFlight": {
+        "minimum": 2546.742533573784,
+        "binWidth": 0.0009342020503289763,
+        "maximum": 12000,
+        "binningMode": -1
+      },
+      "binningMode": -1
+    },
+    {
+      "pixelGroupingParameters": {
+        "1": {
+          "groupID": 1,
+          "isMasked": false,
+          "L2": 10.0,
+          "twoTheta": 1.8230747956560218,
+          "azimuth": 0.0,
+          "dResolution": {
+            "minimum": 0.35983386414596874,
+            "maximum": 2.3643065241537378
+          },
+          "dRelativeResolution": 0.006510460909679324
+        },
+        "2": {
+          "groupID": 2,
+          "isMasked": false,
+          "L2": 10.0,
+          "twoTheta": 1.1545587481738246,
+          "azimuth": 0.0,
+          "dResolution": {
+            "minimum": 0.46173472918300634,
+            "maximum": 4.355830260153734
+          },
+          "dRelativeResolution": 0.01149611207805968
+        }
+      },
+      "nBinsAcrossPeakWidth": 10,
+      "focusGroup": {
+        "name": "Bank",
+        "definition": "/SNS/users/wqp/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_Bank.lite.hdf"
+      },
+      "timeOfFlight": {
+        "minimum": 2546.742533573784,
+        "binWidth": 0.0006510460909679324,
+        "maximum": 12000,
+        "binningMode": -1
+      },
+      "binningMode": -1
+    },
+    {
+      "pixelGroupingParameters": {
+        "1": {
+          "groupID": 1,
+          "isMasked": false,
+          "L2": 10.0,
+          "twoTheta": 2.1108948177427838,
+          "azimuth": 0.0,
+          "dResolution": {
+            "minimum": 0.35983386414596874,
+            "maximum": 1.8446004591300944
+          },
+          "dRelativeResolution": 0.005285822142225365
+        },
+        "2": {
+          "groupID": 2,
+          "isMasked": false,
+          "L2": 10.0,
+          "twoTheta": 1.82310673131693,
+          "azimuth": 0.0,
+          "dResolution": {
+            "minimum": 0.3897805853492433,
+            "maximum": 2.0555564929623205
+          },
+          "dRelativeResolution": 0.006281306679209721
+        },
+        "3": {
+          "groupID": 3,
+          "isMasked": false,
+          "L2": 10.0,
+          "twoTheta": 1.5352228379083572,
+          "azimuth": 0.0,
+          "dResolution": {
+            "minimum": 0.43925160115545075,
+            "maximum": 2.3643065241537378
+          },
+          "dRelativeResolution": 0.007730690425302433
+        },
+        "4": {
+          "groupID": 4,
+          "isMasked": false,
+          "L2": 10.0,
+          "twoTheta": 1.440276389170165,
+          "azimuth": 0.0,
+          "dResolution": {
+            "minimum": 0.46173472918300634,
+            "maximum": 2.5221224737819017
+          },
+          "dRelativeResolution": 0.008321708397955027
+        },
+        "5": {
+          "groupID": 5,
+          "isMasked": false,
+          "L2": 10.0,
+          "twoTheta": 1.1543988461042238,
+          "azimuth": 0.0,
+          "dResolution": {
+            "minimum": 0.5352414154696261,
+            "maximum": 3.194134388808033
+          },
+          "dRelativeResolution": 0.01064966864886483
+        },
+        "6": {
+          "groupID": 6,
+          "isMasked": false,
+          "L2": 10.0,
+          "twoTheta": 0.8690010092470938,
+          "azimuth": 0.0,
+          "dResolution": {
+            "minimum": 0.6591133268028296,
+            "maximum": 4.355830260153734
+          },
+          "dRelativeResolution": 0.014622431594735495
+        }
+      },
+      "nBinsAcrossPeakWidth": 10,
+      "focusGroup": {
+        "name": "Column",
+        "definition": "/SNS/users/wqp/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_Column.lite.hdf"
+      },
+      "timeOfFlight": {
+        "minimum": 2546.742533573784,
+        "binWidth": 0.0005285822142225365,
+        "maximum": 12000,
+        "binningMode": -1
+      },
+      "binningMode": -1
+    },
+    {
+      "pixelGroupingParameters": {
+        "1": {
+          "groupID": 1,
+          "isMasked": false,
+          "L2": 10.0,
+          "twoTheta": 1.7273751940345703,
+          "azimuth": 0.0,
+          "dResolution": {
+            "minimum": 0.35983386414596874,
+            "maximum": 2.5221224737819017
+          },
+          "dRelativeResolution": 0.007007302163279077
+        },
+        "2": {
+          "groupID": 2,
+          "isMasked": false,
+          "L2": 10.0,
+          "twoTheta": 1.011699927675655,
+          "azimuth": 0.0,
+          "dResolution": {
+            "minimum": 0.5352414154696261,
+            "maximum": 4.355830260153734
+          },
+          "dRelativeResolution": 0.012791226447712764
+        }
+      },
+      "nBinsAcrossPeakWidth": 10,
+      "focusGroup": {
+        "name": "2_4",
+        "definition": "/SNS/users/wqp/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/SNAPFocGroup_2_4.lite.hdf"
+      },
+      "timeOfFlight": {
+        "minimum": 2546.742533573784,
+        "binWidth": 0.0007007302163279077,
+        "maximum": 12000,
+        "binningMode": -1
+      },
+      "binningMode": -1
+    }
+  ],
+
+
   "detectorPeaksMany": [
     [
       {

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -1,4 +1,5 @@
 import hashlib
+import time
 import unittest
 import unittest.mock as mock
 from pathlib import Path
@@ -80,6 +81,7 @@ class TestDataFactoryService(unittest.TestCase):
 
     def setUp(self):
         self.version = randint(2, 120)
+        self.timestamp = time.time()
         self.instance = DataFactoryService()
         self.instance.lookupService = self.mockLookupService
         assert isinstance(self.instance, DataFactoryService)
@@ -274,18 +276,18 @@ class TestDataFactoryService(unittest.TestCase):
 
     def test_getReductionDataPath(self):
         for useLiteMode in [True, False]:
-            actual = self.instance.getReductionDataPath("12345", useLiteMode, self.version)
-            assert actual == self.expected("12345", useLiteMode, self.version)
+            actual = self.instance.getReductionDataPath("12345", useLiteMode, self.timestamp)
+            assert actual == self.expected("12345", useLiteMode, self.timestamp)
 
     def test_getReductionRecord(self):
         for useLiteMode in [True, False]:
-            actual = self.instance.getReductionRecord("12345", useLiteMode, self.version)
-            assert actual == self.expected("12345", useLiteMode, self.version)
+            actual = self.instance.getReductionRecord("12345", useLiteMode, self.timestamp)
+            assert actual == self.expected("12345", useLiteMode, self.timestamp)
 
     def test_getReductionData(self):
         for useLiteMode in [True, False]:
-            actual = self.instance.getReductionData("12345", useLiteMode, self.version)
-            assert actual == self.expected("12345", useLiteMode, self.version)
+            actual = self.instance.getReductionData("12345", useLiteMode, self.timestamp)
+            assert actual == self.expected("12345", useLiteMode, self.timestamp)
 
     ##### TEST WORKSPACE METHODS ####
 

--- a/tests/unit/backend/recipe/test_EffectiveInstrumentRecipe.py
+++ b/tests/unit/backend/recipe/test_EffectiveInstrumentRecipe.py
@@ -1,0 +1,192 @@
+import numpy as np
+
+from mantid.simpleapi import EditInstrumentGeometry
+
+from snapred.backend.dao.ingredients import EffectiveInstrumentIngredients as Ingredients
+from snapred.backend.dao.state.FocusGroup import FocusGroup
+from snapred.backend.dao.state.PixelGroup import PixelGroup
+from snapred.backend.error.AlgorithmException import AlgorithmException
+from snapred.backend.recipe.algorithm.Utensils import Utensils
+from snapred.backend.recipe.EffectiveInstrumentRecipe import EffectiveInstrumentRecipe
+from snapred.meta.Config import Resource
+
+from util.SculleryBoy import SculleryBoy
+
+from unittest import mock
+import pytest
+
+class TestEffectiveInstrumentRecipe:
+    fakeInstrumentFilePath = Resource.getPath("inputs/testInstrument/fakeSNAP_Definition.xml")
+    sculleryBoy = SculleryBoy()
+
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.ingredients = mock.Mock(
+            spec=Ingredients,
+            unmaskedPixelGroup=mock.Mock(
+                spec=PixelGroup,
+                L2=mock.Mock(),
+                twoTheta=mock.Mock(),
+                azimuth=mock.Mock(),
+                focusGroup=FocusGroup(name="a_grouping", definition="a/grouping/path"),
+            ),
+        )
+        self.ingredients1 = mock.Mock(
+            spec=Ingredients,
+            unmaskedPixelGroup=mock.Mock(
+                spec=PixelGroup,
+                L2=mock.Mock(),
+                twoTheta=mock.Mock(),
+                azimuth=mock.Mock(),
+                focusGroup=FocusGroup(name="another_grouping", definition="another/grouping/path"),
+            ),
+        )
+        self.ingredientss = [self.ingredients, self.ingredients1]
+
+        yield
+
+        # teardown follows ...
+        pass
+
+    def test_chopIngredients(self):
+        recipe = EffectiveInstrumentRecipe()
+        ingredients = self.ingredients
+        recipe.chopIngredients(ingredients)
+        assert recipe.unmaskedPixelGroup == ingredients.unmaskedPixelGroup
+
+    def test_unbagGroceries(self):
+        recipe = EffectiveInstrumentRecipe()
+        groceries = {"inputWorkspace": mock.Mock(), "outputWorkspace": mock.Mock()}
+        recipe.unbagGroceries(groceries)
+        assert recipe.inputWS == groceries["inputWorkspace"]
+        assert recipe.outputWS == groceries["outputWorkspace"]
+
+    def test_unbagGroceries_output_default(self):
+        recipe = EffectiveInstrumentRecipe()
+        groceries = {"inputWorkspace": mock.Mock()}
+        recipe.unbagGroceries(groceries)
+        assert recipe.inputWS == groceries["inputWorkspace"]
+        assert recipe.outputWS == groceries["inputWorkspace"]
+
+    def test_queueAlgos(self):
+        recipe = EffectiveInstrumentRecipe()
+        ingredients = self.ingredients
+        groceries = {"inputWorkspace": mock.Mock(), "outputWorkspace": mock.Mock()}
+        recipe.prep(ingredients, groceries)
+        recipe.queueAlgos()
+
+        queuedAlgos = recipe.mantidSnapper._algorithmQueue
+
+        cloneWorkspaceTuple = queuedAlgos[0]
+        assert cloneWorkspaceTuple[0] == "CloneWorkspace"
+        assert cloneWorkspaceTuple[2]["InputWorkspace"] == groceries["inputWorkspace"]
+        assert cloneWorkspaceTuple[2]["OutputWorkspace"] == groceries["outputWorkspace"]
+
+        editInstrumentGeometryTuple = queuedAlgos[1]
+        assert editInstrumentGeometryTuple[0] == "EditInstrumentGeometry"
+        assert editInstrumentGeometryTuple[2]["Workspace"] == groceries["outputWorkspace"]
+
+    def test_queueAlgos_default(self):
+        recipe = EffectiveInstrumentRecipe()
+        ingredients = self.ingredients
+        groceries = {"inputWorkspace": mock.Mock()}
+        recipe.prep(ingredients, groceries)
+        recipe.queueAlgos()
+
+        queuedAlgos = recipe.mantidSnapper._algorithmQueue
+
+        editInstrumentGeometryTuple = queuedAlgos[0]
+        assert editInstrumentGeometryTuple[0] == "EditInstrumentGeometry"
+        assert editInstrumentGeometryTuple[2]["Workspace"] == groceries["inputWorkspace"]
+
+    def test_cook(self):
+        utensils = Utensils()
+        mockSnapper = mock.Mock()
+        utensils.mantidSnapper = mockSnapper
+        recipe = EffectiveInstrumentRecipe(utensils=utensils)
+        ingredients = self.ingredients
+        groceries = {"inputWorkspace": mock.Mock(), "outputWorkspace": mock.Mock()}
+
+        output = recipe.cook(ingredients, groceries)
+
+        assert output == groceries["outputWorkspace"]
+
+        assert mockSnapper.executeQueue.called
+        mockSnapper.CloneWorkspace.assert_called_once_with(
+            "Clone workspace for reduced instrument",
+            OutputWorkspace=groceries["outputWorkspace"],
+            InputWorkspace=groceries["inputWorkspace"],
+        )
+        mockSnapper.EditInstrumentGeometry.assert_called_once_with(
+            f"Editing instrument geometry for grouping '{ingredients.unmaskedPixelGroup.focusGroup.name}'",
+            Workspace=groceries["outputWorkspace"],
+            L2=ingredients.unmaskedPixelGroup.L2,
+            Polar=np.rad2deg(ingredients.unmaskedPixelGroup.twoTheta),
+            Azimuthal=np.rad2deg(ingredients.unmaskedPixelGroup.azimuth),
+            InstrumentName=f"SNAP_{ingredients.unmaskedPixelGroup.focusGroup.name}",
+        )
+
+    def test_cook_default(self):
+        utensils = Utensils()
+        mockSnapper = mock.Mock()
+        utensils.mantidSnapper = mockSnapper
+        recipe = EffectiveInstrumentRecipe(utensils=utensils)
+        ingredients = self.ingredients
+        groceries = {"inputWorkspace": mock.Mock()}
+
+        output = recipe.cook(ingredients, groceries)
+
+        assert output == groceries["inputWorkspace"]
+
+        assert mockSnapper.executeQueue.called
+        mockSnapper.CloneWorkspace.assert_not_called()
+        mockSnapper.EditInstrumentGeometry.assert_called_once_with(
+            f"Editing instrument geometry for grouping '{ingredients.unmaskedPixelGroup.focusGroup.name}'",
+            Workspace=groceries["inputWorkspace"],
+            L2=ingredients.unmaskedPixelGroup.L2,
+            Polar=np.rad2deg(ingredients.unmaskedPixelGroup.twoTheta),
+            Azimuthal=np.rad2deg(ingredients.unmaskedPixelGroup.azimuth),
+            InstrumentName=f"SNAP_{ingredients.unmaskedPixelGroup.focusGroup.name}",
+        )
+
+    def test_cook_fail(self):
+        # Test that `AlgorithmException` is routed to `RuntimeError`.
+        utensils = Utensils()
+        mockSnapper = mock.Mock()
+        mockSnapper.executeQueue = mock.Mock(side_effect=AlgorithmException("EditInstrumentGeometry"))
+        utensils.mantidSnapper = mockSnapper
+        recipe = EffectiveInstrumentRecipe(utensils=utensils)
+        ingredients = self.ingredients
+        groceries = {"inputWorkspace": mock.Mock()}
+
+        with pytest.raises(RuntimeError, match=r".*EditInstrumentGeometry.*"):
+            recipe.cook(ingredients, groceries)
+
+    def test_cater(self):
+        untensils = Utensils()
+        mockSnapper = mock.Mock()
+        untensils.mantidSnapper = mockSnapper
+        recipe = EffectiveInstrumentRecipe(utensils=untensils)
+        ingredientss = self.ingredientss
+
+        groceriess = [{"inputWorkspace": mock.Mock()}, {"inputWorkspace": mock.Mock()}]
+
+        recipe.cater(zip(ingredientss, groceriess))
+
+        assert mockSnapper.EditInstrumentGeometry.call_count == 2
+        mockSnapper.EditInstrumentGeometry.assert_any_call(
+            f"Editing instrument geometry for grouping '{ingredientss[0].unmaskedPixelGroup.focusGroup.name}'",
+            Workspace=groceriess[0]["inputWorkspace"],
+            L2=ingredientss[0].unmaskedPixelGroup.L2,
+            Polar=np.rad2deg(ingredientss[0].unmaskedPixelGroup.twoTheta),
+            Azimuthal=np.rad2deg(ingredientss[0].unmaskedPixelGroup.azimuth),
+            InstrumentName=f"SNAP_{ingredientss[0].unmaskedPixelGroup.focusGroup.name}",
+        )
+        mockSnapper.EditInstrumentGeometry.assert_any_call(
+            f"Editing instrument geometry for grouping '{ingredientss[1].unmaskedPixelGroup.focusGroup.name}'",
+            Workspace=groceriess[1]["inputWorkspace"],
+            L2=ingredientss[1].unmaskedPixelGroup.L2,
+            Polar=np.rad2deg(ingredientss[1].unmaskedPixelGroup.twoTheta),
+            Azimuthal=np.rad2deg(ingredientss[1].unmaskedPixelGroup.azimuth),
+            InstrumentName=f"SNAP_{ingredientss[1].unmaskedPixelGroup.focusGroup.name}",
+        )

--- a/tests/unit/backend/recipe/test_EffectiveInstrumentRecipe.py
+++ b/tests/unit/backend/recipe/test_EffectiveInstrumentRecipe.py
@@ -1,6 +1,8 @@
-import numpy as np
+from unittest import mock
 
-from mantid.simpleapi import EditInstrumentGeometry
+import numpy as np
+import pytest
+from util.SculleryBoy import SculleryBoy
 
 from snapred.backend.dao.ingredients import EffectiveInstrumentIngredients as Ingredients
 from snapred.backend.dao.state.FocusGroup import FocusGroup
@@ -10,10 +12,6 @@ from snapred.backend.recipe.algorithm.Utensils import Utensils
 from snapred.backend.recipe.EffectiveInstrumentRecipe import EffectiveInstrumentRecipe
 from snapred.meta.Config import Resource
 
-from util.SculleryBoy import SculleryBoy
-
-from unittest import mock
-import pytest
 
 class TestEffectiveInstrumentRecipe:
     fakeInstrumentFilePath = Resource.getPath("inputs/testInstrument/fakeSNAP_Definition.xml")

--- a/tests/unit/backend/recipe/test_PreprocessReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_PreprocessReductionRecipe.py
@@ -6,12 +6,14 @@ from mantid.simpleapi import (
     LoadInstrument,
     mtd,
 )
+
+from snapred.backend.dao.ingredients import PreprocessReductionIngredients as Ingredients
+from snapred.backend.recipe.algorithm.Utensils import Utensils
+from snapred.backend.recipe.PreprocessReductionRecipe import PreprocessReductionRecipe
+from snapred.meta.Config import Resource
+
 from util.helpers import createCompatibleMask
 from util.SculleryBoy import SculleryBoy
-
-from snapred.backend.recipe.algorithm.Utensils import Utensils
-from snapred.backend.recipe.PreprocessReductionRecipe import Ingredients, PreprocessReductionRecipe
-from snapred.meta.Config import Resource
 
 
 class PreprocessReductionRecipeTest(unittest.TestCase):
@@ -19,9 +21,9 @@ class PreprocessReductionRecipeTest(unittest.TestCase):
     sculleryBoy = SculleryBoy()
 
     def _make_groceries(self):
-        sampleWS = mtd.unique_name(prefix="test_applynorm")
-        calibWS = mtd.unique_name(prefix="test_applynorm")
-        maskWS = mtd.unique_name(prefix="test_applynorm")
+        sampleWS = mtd.unique_name(prefix="test_preprocess_reduction")
+        calibWS = mtd.unique_name(prefix="test_preprocess_reduction")
+        maskWS = mtd.unique_name(prefix="test_preprocess_reduction")
 
         # Create sample workspace:
         #   * warning: `createCompatibleMask` does not work correctly with
@@ -98,10 +100,10 @@ class PreprocessReductionRecipeTest(unittest.TestCase):
         assert applyDiffCalTuple[2]["CalibrationWorkspace"] == groceries["diffcalWorkspace"]
 
     def test_cook(self):
-        untensils = Utensils()
+        utensils = Utensils()
         mockSnapper = unittest.mock.Mock()
-        untensils.mantidSnapper = mockSnapper
-        recipe = PreprocessReductionRecipe(utensils=untensils)
+        utensils.mantidSnapper = mockSnapper
+        recipe = PreprocessReductionRecipe(utensils=utensils)
         ingredients = Ingredients()
         groceries = self._make_groceries()
         del groceries["maskWorkspace"]

--- a/tests/unit/backend/recipe/test_PreprocessReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_PreprocessReductionRecipe.py
@@ -6,14 +6,13 @@ from mantid.simpleapi import (
     LoadInstrument,
     mtd,
 )
+from util.helpers import createCompatibleMask
+from util.SculleryBoy import SculleryBoy
 
 from snapred.backend.dao.ingredients import PreprocessReductionIngredients as Ingredients
 from snapred.backend.recipe.algorithm.Utensils import Utensils
 from snapred.backend.recipe.PreprocessReductionRecipe import PreprocessReductionRecipe
 from snapred.meta.Config import Resource
-
-from util.helpers import createCompatibleMask
-from util.SculleryBoy import SculleryBoy
 
 
 class PreprocessReductionRecipeTest(unittest.TestCase):

--- a/tests/unit/backend/recipe/test_ReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionRecipe.py
@@ -3,6 +3,8 @@ from unittest import TestCase, mock
 
 import pytest
 from mantid.simpleapi import CreateSingleValuedWorkspace, mtd
+from util.Config_helpers import Config_override
+from util.SculleryBoy import SculleryBoy
 
 from snapred.backend.dao.ingredients import ReductionIngredients
 from snapred.backend.recipe.ReductionRecipe import (
@@ -15,8 +17,6 @@ from snapred.backend.recipe.ReductionRecipe import (
 )
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 
-from util.SculleryBoy import SculleryBoy
-from util.Config_helpers import Config_override
 
 class ReductionRecipeTest(TestCase):
     sculleryBoy = SculleryBoy()
@@ -478,7 +478,6 @@ class ReductionRecipeTest(TestCase):
         assert recipe._deleteWorkspace.call_count == len(recipe._prepGroupingWorkspaces.return_value)
         assert result["outputs"][0] == "sample_grouped"
 
-
     @mock.patch("mantid.simpleapi.mtd", create=True)
     def test_execute_useEffectiveInstrument(self, mockMtd):
         with Config_override("reduction.output.useEffectiveInstrument", True):
@@ -491,7 +490,9 @@ class ReductionRecipeTest(TestCase):
             mockGroupWorkspace.readY.return_value = [0] * 10
             mockMaskworkspace.readY.return_value = [0] * 10
 
-            mockMtd.__getitem__.side_effect = lambda ws_name: mockMaskworkspace if ws_name == "mask" else mockGroupWorkspace
+            mockMtd.__getitem__.side_effect = (
+                lambda ws_name: mockMaskworkspace if ws_name == "mask" else mockGroupWorkspace
+            )
 
             recipe = ReductionRecipe()
             recipe.mantidSnapper = mockMantidSnapper

--- a/tests/unit/backend/recipe/test_ReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionRecipe.py
@@ -3,11 +3,11 @@ from unittest import TestCase, mock
 
 import pytest
 from mantid.simpleapi import CreateSingleValuedWorkspace, mtd
-from util.SculleryBoy import SculleryBoy
 
 from snapred.backend.dao.ingredients import ReductionIngredients
 from snapred.backend.recipe.ReductionRecipe import (
     ApplyNormalizationRecipe,
+    EffectiveInstrumentRecipe,
     GenerateFocussedVanadiumRecipe,
     PreprocessReductionRecipe,
     ReductionGroupProcessingRecipe,
@@ -15,6 +15,8 @@ from snapred.backend.recipe.ReductionRecipe import (
 )
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 
+from util.SculleryBoy import SculleryBoy
+from util.Config_helpers import Config_override
 
 class ReductionRecipeTest(TestCase):
     sculleryBoy = SculleryBoy()
@@ -398,6 +400,9 @@ class ReductionRecipeTest(TestCase):
         recipe.ingredients.applyNormalization = mock.Mock(
             return_value=lambda groupingIndex: f"applyNormalization_{groupingIndex}"
         )
+        recipe.ingredients.effectiveInstrument = mock.Mock(
+            return_value=lambda groupingIndex: f"unmaskedPixelGroup_{groupingIndex}"
+        )
 
         # Mock internal methods of recipe
         recipe._applyRecipe = mock.Mock()
@@ -463,17 +468,136 @@ class ReductionRecipeTest(TestCase):
             normalizationWorkspace="norm_grouped",
         )
 
-        artNormCalls = recipe._prepareArtificialNormalization.call_args_list
-        anCall1 = artNormCalls[0]
-        anCall2 = artNormCalls[1]
-        assert anCall1[0][0] == "sample_grouped"
-        assert anCall2[0][0] == "sample_grouped"
-        assert anCall1[0][1] == 0
-        assert anCall2[0][1] == 1
+        recipe._prepareArtificialNormalization.call_count == 2
+        recipe._prepareArtificialNormalization.assert_any_call("sample_grouped", 0)
+        recipe._prepareArtificialNormalization.assert_any_call("sample_grouped", 1)
+
+        recipe.ingredients.effectiveInstrument.assert_not_called()
 
         recipe._deleteWorkspace.assert_called_with("norm_grouped")
         assert recipe._deleteWorkspace.call_count == len(recipe._prepGroupingWorkspaces.return_value)
         assert result["outputs"][0] == "sample_grouped"
+
+
+    @mock.patch("mantid.simpleapi.mtd", create=True)
+    def test_execute_useEffectiveInstrument(self, mockMtd):
+        with Config_override("reduction.output.useEffectiveInstrument", True):
+            mockMantidSnapper = mock.Mock()
+
+            mockMaskworkspace = mock.Mock()
+            mockGroupWorkspace = mock.Mock()
+
+            mockGroupWorkspace.getNumberHistograms.return_value = 10
+            mockGroupWorkspace.readY.return_value = [0] * 10
+            mockMaskworkspace.readY.return_value = [0] * 10
+
+            mockMtd.__getitem__.side_effect = lambda ws_name: mockMaskworkspace if ws_name == "mask" else mockGroupWorkspace
+
+            recipe = ReductionRecipe()
+            recipe.mantidSnapper = mockMantidSnapper
+            recipe.mantidSnapper.mtd = mockMtd
+            recipe._prepareArtificialNormalization = mock.Mock()
+            recipe._prepareArtificialNormalization.return_value = "norm_grouped"
+
+            # Set up ingredients and other variables for the recipe
+            recipe.groceries = {}
+            recipe.ingredients = mock.Mock()
+            recipe.ingredients.artificialNormalizationIngredients = "test"
+            recipe.ingredients.groupProcessing = mock.Mock(
+                return_value=lambda groupingIndex: f"groupProcessing_{groupingIndex}"
+            )
+            recipe.ingredients.generateFocussedVanadium = mock.Mock(
+                return_value=lambda groupingIndex: f"generateFocussedVanadium_{groupingIndex}"
+            )
+            recipe.ingredients.applyNormalization = mock.Mock(
+                return_value=lambda groupingIndex: f"applyNormalization_{groupingIndex}"
+            )
+            recipe.ingredients.effectiveInstrument = mock.Mock(
+                return_value=lambda groupingIndex: f"unmaskedPixelGroup_{groupingIndex}"
+            )
+
+            # Mock internal methods of recipe
+            recipe._applyRecipe = mock.Mock()
+            recipe._cloneIntermediateWorkspace = mock.Mock()
+            recipe._deleteWorkspace = mock.Mock()
+            recipe._prepareUnfocusedData = mock.Mock()
+            recipe._prepGroupingWorkspaces = mock.Mock()
+            recipe._prepGroupingWorkspaces.return_value = ("sample_grouped", "norm_grouped")
+
+            # Set up other recipe variables
+            recipe.sampleWs = "sample"
+            recipe.maskWs = "mask"
+            recipe.normalizationWs = "norm"
+            recipe.groupingWorkspaces = ["group1", "group2"]
+            recipe.keepUnfocused = True
+            recipe.convertUnitsTo = "TOF"
+
+            # Execute the recipe
+            result = recipe.execute()
+
+            # Perform assertions
+            recipe._applyRecipe.assert_any_call(
+                PreprocessReductionRecipe,
+                recipe.ingredients.preprocess(),
+                inputWorkspace=recipe.sampleWs,
+                maskWorkspace=recipe.maskWs,
+            )
+            recipe._applyRecipe.assert_any_call(
+                PreprocessReductionRecipe,
+                recipe.ingredients.preprocess(),
+                inputWorkspace=recipe.normalizationWs,
+                maskWorkspace=recipe.maskWs,
+            )
+
+            recipe._applyRecipe.assert_any_call(
+                ReductionGroupProcessingRecipe, recipe.ingredients.groupProcessing(0), inputWorkspace="sample_grouped"
+            )
+            recipe._applyRecipe.assert_any_call(
+                ReductionGroupProcessingRecipe, recipe.ingredients.groupProcessing(1), inputWorkspace="norm_grouped"
+            )
+
+            recipe._applyRecipe.assert_any_call(
+                GenerateFocussedVanadiumRecipe,
+                recipe.ingredients.generateFocussedVanadium(0),
+                inputWorkspace="norm_grouped",
+            )
+            recipe._applyRecipe.assert_any_call(
+                GenerateFocussedVanadiumRecipe,
+                recipe.ingredients.generateFocussedVanadium(1),
+                inputWorkspace="norm_grouped",
+            )
+
+            recipe._applyRecipe.assert_any_call(
+                ApplyNormalizationRecipe,
+                recipe.ingredients.applyNormalization(0),
+                inputWorkspace="sample_grouped",
+                normalizationWorkspace="norm_grouped",
+            )
+            recipe._applyRecipe.assert_any_call(
+                ApplyNormalizationRecipe,
+                recipe.ingredients.applyNormalization(1),
+                inputWorkspace="sample_grouped",
+                normalizationWorkspace="norm_grouped",
+            )
+
+            recipe._prepareArtificialNormalization.call_count == 2
+            recipe._prepareArtificialNormalization.assert_any_call("sample_grouped", 0)
+            recipe._prepareArtificialNormalization.assert_any_call("sample_grouped", 1)
+
+            recipe._applyRecipe.assert_any_call(
+                EffectiveInstrumentRecipe,
+                recipe.ingredients.effectiveInstrument(0),
+                inputWorkspace="sample_grouped",
+            )
+            recipe._applyRecipe.assert_any_call(
+                EffectiveInstrumentRecipe,
+                recipe.ingredients.effectiveInstrument(1),
+                inputWorkspace="sample_grouped",
+            )
+
+            recipe._deleteWorkspace.assert_called_with("norm_grouped")
+            assert recipe._deleteWorkspace.call_count == len(recipe._prepGroupingWorkspaces.return_value)
+            assert result["outputs"][0] == "sample_grouped"
 
     @mock.patch("mantid.simpleapi.mtd", create=True)
     def test_isGroupFullyMasked(self, mockMtd):

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -180,7 +180,7 @@ class TestSousChef(unittest.TestCase):
             self.ingredients.useLiteMode,
             self.ingredients.focusGroup.name,
             self.ingredients.calibrantSamplePath,
-            None
+            None,
         )
 
         # ensure there is no cached value
@@ -213,14 +213,13 @@ class TestSousChef(unittest.TestCase):
 
     @mock.patch(thisService + "PixelGroupingParametersCalculationRecipe")
     def test_prepPixelGroup_cache(self, PixelGroupingParametersCalculationRecipe):
-
         # ensure the cache is prepared
         key = (
             self.ingredients.runNumber,
             self.ingredients.useLiteMode,
             self.ingredients.focusGroup.name,
             self.ingredients.calibrantSamplePath,
-            self.pixelMask
+            self.pixelMask,
         )
         self.instance._pixelGroupCache[key] = mock.sentinel.pixel
 
@@ -230,14 +229,13 @@ class TestSousChef(unittest.TestCase):
         assert res == self.instance._pixelGroupCache[key]
 
     def test_prepPixelGroup_cache_not_altered(self):
-
         # ensure the cache is prepared
         key = (
             self.ingredients.runNumber,
             self.ingredients.useLiteMode,
             self.ingredients.focusGroup.name,
             self.ingredients.calibrantSamplePath,
-            None
+            None,
         )
         self.instance._pixelGroupCache[key] = PixelGroup.construct(timeOfFlight={"minimum": 0})
 

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -26,6 +26,7 @@ class TestSousChef(unittest.TestCase):
             cifPath="path/to/cif",
             maxChiSq=100.0,
         )
+        self.pixelMask = mock.Mock()
 
     def tearDown(self):
         del self.instance
@@ -59,9 +60,9 @@ class TestSousChef(unittest.TestCase):
 
     def test_prepManyPixelGroups(self):
         self.instance.prepPixelGroup = mock.Mock()
-        res = self.instance.prepManyPixelGroups(self.ingredients)
+        res = self.instance.prepManyPixelGroups(self.ingredients, self.pixelMask)
         assert res[0] == self.instance.prepPixelGroup.return_value
-        self.instance.prepPixelGroup.assert_called_once_with(self.ingredients)
+        self.instance.prepPixelGroup.assert_called_once_with(self.ingredients, self.pixelMask)
 
     def test_prepFocusGroup_exists(self):
         # create a temp file to be used a the path for the focus group
@@ -172,13 +173,17 @@ class TestSousChef(unittest.TestCase):
     ):
         self.instance = SousChef()
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
-        # ensure there is no cached value
+
+        # Warning: key now includes pixel mask name.
         key = (
             self.ingredients.runNumber,
             self.ingredients.useLiteMode,
             self.ingredients.focusGroup.name,
             self.ingredients.calibrantSamplePath,
+            None
         )
+
+        # ensure there is no cached value
         assert self.instance._pixelGroupCache == {}
 
         # mock the calibration, which will give the instrument state
@@ -208,27 +213,31 @@ class TestSousChef(unittest.TestCase):
 
     @mock.patch(thisService + "PixelGroupingParametersCalculationRecipe")
     def test_prepPixelGroup_cache(self, PixelGroupingParametersCalculationRecipe):
+
         # ensure the cache is prepared
         key = (
             self.ingredients.runNumber,
             self.ingredients.useLiteMode,
             self.ingredients.focusGroup.name,
             self.ingredients.calibrantSamplePath,
+            self.pixelMask
         )
         self.instance._pixelGroupCache[key] = mock.sentinel.pixel
 
-        res = self.instance.prepPixelGroup(self.ingredients)
+        res = self.instance.prepPixelGroup(self.ingredients, self.pixelMask)
 
         assert not PixelGroupingParametersCalculationRecipe.called
         assert res == self.instance._pixelGroupCache[key]
 
     def test_prepPixelGroup_cache_not_altered(self):
+
         # ensure the cache is prepared
         key = (
             self.ingredients.runNumber,
             self.ingredients.useLiteMode,
             self.ingredients.focusGroup.name,
             self.ingredients.calibrantSamplePath,
+            None
         )
         self.instance._pixelGroupCache[key] = PixelGroup.construct(timeOfFlight={"minimum": 0})
 
@@ -463,49 +472,57 @@ class TestSousChef(unittest.TestCase):
     @mock.patch(thisService + "ReductionIngredients")
     def test_prepReductionIngredients(self, ReductionIngredients, mockOS):  # noqa: ARG002
         calibrationCalibrantSamplePath = "a/sample.x"
-        record = mock.Mock(
-            smoothingParamter=1.0,
+        calibrationRecord = mock.Mock(
+            smoothingParameter=mock.Mock(),
             calculationParameters=mock.Mock(
                 calibrantSamplePath=calibrationCalibrantSamplePath,
             ),
-            calibrantSamplePath=calibrationCalibrantSamplePath,
         )
-        normalRecord = mock.Mock(
-            smoothingParamter=1.0,
-            calculationParameters=mock.Mock(
-                calibrantSamplePath=calibrationCalibrantSamplePath,
-            ),
-            normalizationCalibrantSamplePath=calibrationCalibrantSamplePath,
+        normalizationCalibrantSamplePath = "b/sample.x"
+        normalizationRecord = mock.Mock(
+            smoothingParameter=mock.Mock(),
+            calculationParameters=mock.Mock(),
+            normalizationCalibrantSamplePath=normalizationCalibrantSamplePath,
         )
         self.instance.prepCalibrantSample = mock.Mock()
         self.instance.prepRunConfig = mock.Mock()
-        self.instance.prepManyPixelGroups = mock.Mock()
+        prepPixelGroupsReturnValues = [mock.Mock(), mock.Mock()]
+        self.instance.prepManyPixelGroups = mock.Mock(side_effect=prepPixelGroupsReturnValues)
         self.instance.prepManyDetectorPeaks = mock.Mock()
+        self.instance._getThresholdFromCalibrantSample = mock.Mock(return_value=mock.Mock())
         self.instance.dataFactoryService.getCifFilePath = mock.Mock()
         self.instance.dataFactoryService.getReductionState = mock.Mock()
-        self.instance.dataFactoryService.getNormalizationRecord = mock.Mock(return_value=normalRecord)
-        self.instance.dataFactoryService.getCalibrationRecord = mock.Mock(return_value=record)
+        self.instance.dataFactoryService.getCalibrationRecord = mock.Mock(return_value=calibrationRecord)
+        self.instance.dataFactoryService.getNormalizationRecord = mock.Mock(return_value=normalizationRecord)
 
+        # Modifications to a copy of `ingredients` during the first part of `prepReductionIngredients`,
+        #   before the `prepManyPixelGroups` calls:
         ingredients_ = self.ingredients.model_copy()
         # ... from calibration record:
-        ingredients_.calibrantSamplePath = calibrationCalibrantSamplePath
         ingredients_.cifPath = self.instance.dataFactoryService.getCifFilePath.return_value
         # ... from normalization record:
-        ingredients_.peakIntensityThreshold = self.instance._getThresholdFromCalibrantSample(
-            "calibrationCalibrantSamplePath"
-        )
-        result = self.instance.prepReductionIngredients(ingredients_)
+        ingredients_.calibrantSamplePath = normalizationCalibrantSamplePath
 
-        self.instance.prepManyPixelGroups.assert_called_once_with(ingredients_)
+        combinedMask = mock.Mock()
+        # Note that `prepReductionIngredients` is called with the _unmodified_ ingredients.
+        result = self.instance.prepReductionIngredients(self.ingredients, combinedMask)
+
+        assert self.instance.prepManyPixelGroups.call_count == 2
+
+        self.instance.prepManyPixelGroups.assert_any_call(ingredients_)
+        self.instance.prepManyPixelGroups.assert_any_call(ingredients_, combinedMask)
+
         self.instance.dataFactoryService.getCifFilePath.assert_called_once_with("sample")
+
         ReductionIngredients.assert_called_once_with(
             runNumber=ingredients_.runNumber,
             useLiteMode=ingredients_.useLiteMode,
             timestamp=ingredients_.timestamp,
-            pixelGroups=self.instance.prepManyPixelGroups.return_value,
-            smoothingParameter=normalRecord.smoothingParameter,
+            pixelGroups=prepPixelGroupsReturnValues[0],
+            unmaskedPixelGroups=prepPixelGroupsReturnValues[1],
+            smoothingParameter=normalizationRecord.smoothingParameter,
             calibrantSamplePath=ingredients_.calibrantSamplePath,
-            peakIntensityThreshold=ingredients_.peakIntensityThreshold,
+            peakIntensityThreshold=self.instance._getThresholdFromCalibrantSample.return_value,
             detectorPeaksMany=self.instance.prepManyDetectorPeaks.return_value,
             keepUnfocused=ingredients_.keepUnfocused,
             convertUnitsTo=ingredients_.convertUnitsTo,

--- a/tests/unit/ui/workflow/test_DiffCalWorkflow.py
+++ b/tests/unit/ui/workflow/test_DiffCalWorkflow.py
@@ -8,6 +8,7 @@ from mantid.simpleapi import (
     mtd,
 )
 from qtpy.QtWidgets import QMessageBox
+
 from snapred.meta.mantid.FitPeaksOutput import FIT_PEAK_DIAG_SUFFIX, FitOutputEnum
 from snapred.meta.pointer import create_pointer
 from snapred.ui.workflow.DiffCalWorkflow import DiffCalWorkflow

--- a/tests/unit/ui/workflow/test_DiffCalWorkflow.py
+++ b/tests/unit/ui/workflow/test_DiffCalWorkflow.py
@@ -1,4 +1,3 @@
-import threading
 from random import randint
 from unittest.mock import MagicMock, patch
 
@@ -8,9 +7,7 @@ from mantid.simpleapi import (
     GroupWorkspaces,
     mtd,
 )
-from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QApplication, QMessageBox
-
+from qtpy.QtWidgets import QMessageBox
 from snapred.meta.mantid.FitPeaksOutput import FIT_PEAK_DIAG_SUFFIX, FitOutputEnum
 from snapred.meta.pointer import create_pointer
 from snapred.ui.workflow.DiffCalWorkflow import DiffCalWorkflow
@@ -136,16 +133,29 @@ def test_purge_bad_peaks_too_few(workflowRequest, qtbot):  # noqa: ARG001
     )
     diffcalWorkflow.fitPeaksDiagnostic = diagWS
 
-    def execute_click():
-        w = QApplication.activeWindow()
-        if isinstance(w, QMessageBox):
-            close_button = w.button(QMessageBox.Ok)
-            qtbot.mouseClick(close_button, Qt.LeftButton)
-
     # setup the qtbot to intercept the window
     qtbot.addWidget(diffcalWorkflow._tweakPeakView)
-    threading.Timer(0.2, execute_click).start()
+
+    #
+    # Using a mock here bypasses the following issues:
+    #
+    #   * which thread the messagebox will be running on (may cause a segfault);
+    #
+    #   * how long to wait for the messagebox to instantiate.
+    #
+    def _tooFewPeaksQuery(_parent, title, text, _buttons):
+        if title == "Too Few Peaks":
+            return QMessageBox.Ok
+        raise RuntimeError(f"unexpected `QMessageBox.critical`: title: {title}, text: {text}")
+
+    mockTooFewPeaksQuery = patch("qtpy.QtWidgets.QMessageBox.critical", _tooFewPeaksQuery)
+
+    # Use `start` and `stop` rather than `with patch...` in order to apply the mock even in the case of exceptions.
+    mockTooFewPeaksQuery.start()
     diffcalWorkflow.purgeBadPeaks(maxChiSq)
+
+    # Remember to remove the mock.
+    mockTooFewPeaksQuery.stop()
 
     assert diffcalWorkflow.ingredients.groupedPeakLists[0].peaks == peaks
     assert diffcalWorkflow.ingredients.groupedPeakLists[0].peaks != good_peaks

--- a/tests/util/SculleryBoy.py
+++ b/tests/util/SculleryBoy.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 from unittest import mock
 
 import pydantic
@@ -18,6 +18,7 @@ from snapred.backend.dao.state.PixelGroup import PixelGroup
 from snapred.backend.dao.state.PixelGroupingParameters import PixelGroupingParameters
 from snapred.backend.recipe.GenericRecipe import DetectorPeakPredictorRecipe
 from snapred.meta.Config import Resource
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 from snapred.meta.redantic import parse_file_as
 
 
@@ -92,7 +93,9 @@ class SculleryBoy:
         except (TypeError, AttributeError):
             return [mock.Mock(spec_set=GroupPeakList)]
 
-    def prepReductionIngredients(self, ingredients: FarmFreshIngredients):  # noqa ARG002
+    def prepReductionIngredients(
+        self, _ingredients: FarmFreshIngredients, _combinedPixelMask: Optional[WorkspaceName] = None
+    ):
         path = Resource.getPath("/inputs/calibration/ReductionIngredients.json")
         return parse_file_as(ReductionIngredients, path)
 


### PR DESCRIPTION
## Description of work

At the end of the reduction process, the instrument associated with each output workspace is modified.  A new _effective_ instrument is substituted for the instrument attached to each workspace.  This instrument has the same number of pixels as there are group-ids, and the location of each pixel is set to the mean location of the _unmasked_ original pixels participating in that pixel group.  By implication, this substitution results in there being one pixel per spectrum in each output workspace.  (An exception to this substitution is the _combined pixel-mask_ workspace, which is not modified.)


## Explanation of work

This commit includes the following changes:

  * A new `EffectiveInstrumentRecipe` implemented as a subrecipe called by `ReductionRecipe` for each grouping;

  * Modification of `ReductionIngredients` to include the _unmasked_ `PixelGroup`s;

  * Modification of `SousChef.prepReductionIngredients` to include the _unmasked_ `PixelGroup`s;

  * Modification of existing unit tests, and implementation of new unit tests to verify the new subrecipe's execution.

A known issue: `EditInstrumentGeometry` deletes, but does not regenerate the XML associated with the newly-edited instrument.  Unfortunately, this tends to generate a lot of misleading log messages when the associated workspaces are saved, and then reloaded.  This isn't so much an issue with `EditInstrumentGeometry` specifically, but rather with the Mantid instrument framework.


## To test
Existing unit tests have been modified, and new unit tests have been added to cover the new subrecipe.  A new CIS-test script has been added at `tests/cis_tests/effective_instrument_script.py`.

### Dev testing
In addition to running the unit tests, and the CIS-test script, the GUI-panels should be run for the full set of workflows.  There should be no _observable_ behavior changes.   (With the exception of the log messages associated with the new output changes, and a warning message associated with the "known issue" indicated above.)  **Note that you'll also need the _newly-saved_ output from the reduction workflow to test this PR.** 

The instrument associated with any output workspace can be examined directly.  It should now have the same number of pixels as there are spectra in the workspace.  Please see (and run through) the new  CIS-test script at: `tests/cis_tests/effective_instrument_script.py`.  
 
### CIS testing
The new changes function _automatically_ as part of the reduction process.
The instruments attached to the reduction-output workspaces should be examined, and verified to be as expected.
For comparison purposes, or in the case a work-around is required, the "application.yml" flag `reduction.output.useEffectiveInstrument` can be used to turn off the effective-instrument substitution.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#6549](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=6549)

### Verification

- [ x] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

1) Where possible, all new changes are covered by unit tests.

2) Reduction output workspaces will have a new effective instrument that has the same number of pixels as there are spectra in the workspace.  (And by assumption, these workspaces will have a number of spectra that correspond to the number of group-ids in the associated grouping.)

3) The name of the effective instrument will be "SNAP_\<grouping name\>".

4) Locations of each effective pixel will correspond to those of the _unmasked_ PGP values for that pixel's group-id.  Note that `tests/cis_tests/effective_instrument_script.py` can be used to obtain and verify these values.  Mantid-workbench _instrument view_ might also be a useful way to verify this quickly.

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] acceptance criterion 1
- [ ] acceptance criterion 2
- [ ] acceptance criterion 3
- [ ] acceptance criterion 4
