### PR TITLE
Create some auxiliary algorithms

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,12 +2,12 @@ name: SNAPRed
 channels:
 - conda-forge
 - default
-- mantid/label/nightly
+- mantid-ornl/label/rc
 dependencies:
 - python=3.10
 - pip
 - pydantic>=2.7.3,<3
-- mantidworkbench>=6.10.20240909
+- mantidworkbench=6.10.0.2rc1
 - qtpy
 - pre-commit
 - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "A desktop application for Lifecycle Managment of data collected f
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "mantidworkbench >= 6.10.20240705",
+    "mantidworkbench >= 6.10.0.2rc1",
     "pyoncat ~= 1.6"
 ]
 readme = "README.md"

--- a/src/snapred/backend/recipe/algorithm/GroupedDetectorIDs.py
+++ b/src/snapred/backend/recipe/algorithm/GroupedDetectorIDs.py
@@ -16,8 +16,6 @@ class GroupedDetectorIDs(PythonAlgorithm):
     as a dictionary {groupID: list_of_detector_IDs}
     """
 
-    NOTHING = 0
-
     def category(self):
         return "SNAPRed Diffraction Calibration"
 
@@ -35,7 +33,7 @@ class GroupedDetectorIDs(PythonAlgorithm):
             doc="Workspace containing the grouping information",
         )
         self.declareProperty(
-            ULongLongPropertyWithValue("GroupWorkspaceIndices", id(self.NOTHING), direction=Direction.Output),
+            ULongLongPropertyWithValue("GroupWorkspaceIndices", None, direction=Direction.Output),
             doc="A pointer to the output dictionary (must be cast to object from memory address).",
         )
         self.setRethrows(True)

--- a/src/snapred/backend/recipe/algorithm/GroupedDetectorIDs.py
+++ b/src/snapred/backend/recipe/algorithm/GroupedDetectorIDs.py
@@ -16,6 +16,8 @@ class GroupedDetectorIDs(PythonAlgorithm):
     as a dictionary {groupID: list_of_detector_IDs}
     """
 
+    NOTHING = 0
+
     def category(self):
         return "SNAPRed Diffraction Calibration"
 
@@ -33,7 +35,7 @@ class GroupedDetectorIDs(PythonAlgorithm):
             doc="Workspace containing the grouping information",
         )
         self.declareProperty(
-            ULongLongPropertyWithValue("GroupWorkspaceIndices", 0, direction=Direction.Output),
+            ULongLongPropertyWithValue("GroupWorkspaceIndices", id(self.NOTHING), direction=Direction.Output),
             doc="A pointer to the output dictionary (must be cast to object from memory address).",
         )
         self.setRethrows(True)

--- a/src/snapred/backend/recipe/algorithm/GroupedDetectorIDs.py
+++ b/src/snapred/backend/recipe/algorithm/GroupedDetectorIDs.py
@@ -33,7 +33,7 @@ class GroupedDetectorIDs(PythonAlgorithm):
             doc="Workspace containing the grouping information",
         )
         self.declareProperty(
-            ULongLongPropertyWithValue("GroupWorkspaceIndices", None, direction=Direction.Output),
+            ULongLongPropertyWithValue("GroupWorkspaceIndices", id(None), direction=Direction.Output),
             doc="A pointer to the output dictionary (must be cast to object from memory address).",
         )
         self.setRethrows(True)

--- a/src/snapred/backend/recipe/algorithm/GroupedDetectorIDs.py
+++ b/src/snapred/backend/recipe/algorithm/GroupedDetectorIDs.py
@@ -1,4 +1,3 @@
-import json
 from typing import Dict, List
 
 from mantid.api import (
@@ -8,7 +7,7 @@ from mantid.api import (
     PythonAlgorithm,
     mtd,
 )
-from mantid.kernel import Direction
+from mantid.kernel import Direction, ULongLongPropertyWithValue
 
 
 class GroupedDetectorIDs(PythonAlgorithm):
@@ -33,7 +32,10 @@ class GroupedDetectorIDs(PythonAlgorithm):
             MatrixWorkspaceProperty("GroupingWorkspace", "", Direction.Input, PropertyMode.Mandatory),
             doc="Workspace containing the grouping information",
         )
-        self.declareProperty("GroupWorkspaceIndices", "", direction=Direction.Output)
+        self.declareProperty(
+            ULongLongPropertyWithValue("GroupWorkspaceIndices", 0, direction=Direction.Output),
+            doc="A pointer to the output dictionary (must be cast to object from memory address).",
+        )
         self.setRethrows(True)
 
     def PyExec(self):
@@ -43,7 +45,7 @@ class GroupedDetectorIDs(PythonAlgorithm):
         groupWorkspaceIndices: Dict[int, List[int]] = {}
         for groupID in [int(x) for x in focusWS.getGroupIDs()]:
             groupWorkspaceIndices[groupID] = [int(x) for x in focusWS.getDetectorIDsOfGroup(groupID)]
-        self.setProperty("GroupWorkspaceIndices", json.dumps(groupWorkspaceIndices))
+        self.setProperty("GroupWorkspaceIndices", id(groupWorkspaceIndices))
 
 
 # Register algorithm with Mantid

--- a/src/snapred/backend/recipe/algorithm/GroupedDetectorIDs.py
+++ b/src/snapred/backend/recipe/algorithm/GroupedDetectorIDs.py
@@ -1,0 +1,50 @@
+import json
+from typing import Dict, List
+
+from mantid.api import (
+    AlgorithmFactory,
+    MatrixWorkspaceProperty,
+    PropertyMode,
+    PythonAlgorithm,
+    mtd,
+)
+from mantid.kernel import Direction
+
+
+class GroupedDetectorIDs(PythonAlgorithm):
+    """
+    From a grouping workspace, extract  detector IDs corresponding to each group,
+    as a dictionary {groupID: list_of_detector_IDs}
+    """
+
+    def category(self):
+        return "SNAPRed Diffraction Calibration"
+
+    def validateInputs(self) -> Dict[str, str]:
+        err = {}
+        focusWS = mtd[self.getPropertyValue("GroupingWorkspace")]
+        if focusWS.id() != "GroupingWorkspace":
+            err["GroupingWorkspace"] = "The workspace must be a GroupingWorkspace"
+        return err
+
+    def PyInit(self):
+        # declare properties
+        self.declareProperty(
+            MatrixWorkspaceProperty("GroupingWorkspace", "", Direction.Input, PropertyMode.Mandatory),
+            doc="Workspace containing the grouping information",
+        )
+        self.declareProperty("GroupWorkspaceIndices", "", direction=Direction.Output)
+        self.setRethrows(True)
+
+    def PyExec(self):
+        # get handle to group focusing workspace and retrieve workspace indices for all detectors in each group
+        focusWSname: str = str(self.getPropertyValue("GroupingWorkspace"))
+        focusWS = mtd[focusWSname]
+        groupWorkspaceIndices: Dict[int, List[int]] = {}
+        for groupID in [int(x) for x in focusWS.getGroupIDs()]:
+            groupWorkspaceIndices[groupID] = [int(x) for x in focusWS.getDetectorIDsOfGroup(groupID)]
+        self.setProperty("GroupWorkspaceIndices", json.dumps(groupWorkspaceIndices))
+
+
+# Register algorithm with Mantid
+AlgorithmFactory.subscribe(GroupedDetectorIDs)

--- a/src/snapred/backend/recipe/algorithm/OffsetStatistics.py
+++ b/src/snapred/backend/recipe/algorithm/OffsetStatistics.py
@@ -16,6 +16,7 @@ class OffsetStatistics(PythonAlgorithm):
     """
 
     OFFSETWKSPPROP = "OffsetsWorkspace"
+    NOTHING = 0
 
     def category(self):
         return "SNAPRed Diffraction Calibration"
@@ -27,7 +28,7 @@ class OffsetStatistics(PythonAlgorithm):
             doc="Workspace containing the TOF neutron data",
         )
         self.declareProperty(
-            ULongLongPropertyWithValue("Data", 0, direction=Direction.Output),
+            ULongLongPropertyWithValue("Data", id(self.NOTHING), direction=Direction.Output),
             doc="A pointer to the output dictionary (must be cast to object from memory address).",
         )
         self.setRethrows(True)

--- a/src/snapred/backend/recipe/algorithm/OffsetStatistics.py
+++ b/src/snapred/backend/recipe/algorithm/OffsetStatistics.py
@@ -1,0 +1,51 @@
+import numpy as np
+from mantid.api import (
+    AlgorithmFactory,
+    MatrixWorkspaceProperty,
+    PropertyMode,
+    PythonAlgorithm,
+)
+from mantid.kernel import Direction, PropertyManagerProperty
+
+
+class OffsetStatistics(PythonAlgorithm):
+    """
+    Given an Offsets workspace, return statistical information
+    of the offsets.  Can be used to help gauge convergence of
+    the diffcal process.
+    """
+
+    OFFSETWKSPPROP = "OffsetsWorkspace"
+
+    def category(self):
+        return "SNAPRed Diffraction Calibration"
+
+    def PyInit(self):
+        # declare properties
+        self.declareProperty(
+            MatrixWorkspaceProperty(self.OFFSETWKSPPROP, "", Direction.Input, PropertyMode.Mandatory),
+            doc="Workspace containing the TOF neutron data",
+        )
+        self.declareProperty(PropertyManagerProperty("Data", dict(), direction=Direction.Output))
+        self.setRethrows(True)
+        self._counts = 0
+
+    def PyExec(self) -> None:
+        self.log().notice("Calculate the statistics of an offsets workspace")
+        offsets = list(self.getProperty(self.OFFSETWKSPPROP).value.extractY().ravel())
+        absOffsets = [abs(offset) for offset in offsets]
+
+        data = {}
+        # (Warning: `median(abs(offsets))` vs. `abs(median(offsets)`: the former introduces oscillation artifacts.)
+        data["medianOffset"] = float(abs(np.median(offsets)))
+        data["meanOffset"] = float(abs(np.mean(offsets)))
+        data["minOffset"] = float(np.min(offsets))
+        data["maxOffset"] = float(np.max(offsets))
+        data["maxAbsoluteOffset"] = float(np.max(absOffsets))
+        data["minAbsoluteOFfset"] = float(np.min(absOffsets))
+
+        self.setProperty("Data", data)
+
+
+# Register algorithm with Mantid
+AlgorithmFactory.subscribe(OffsetStatistics)

--- a/src/snapred/backend/recipe/algorithm/OffsetStatistics.py
+++ b/src/snapred/backend/recipe/algorithm/OffsetStatistics.py
@@ -27,7 +27,7 @@ class OffsetStatistics(PythonAlgorithm):
             doc="Workspace containing the TOF neutron data",
         )
         self.declareProperty(
-            ULongLongPropertyWithValue("Data", None, direction=Direction.Output),
+            ULongLongPropertyWithValue("Data", id(None), direction=Direction.Output),
             doc="A pointer to the output dictionary (must be cast to object from memory address).",
         )
         self.setRethrows(True)

--- a/src/snapred/backend/recipe/algorithm/OffsetStatistics.py
+++ b/src/snapred/backend/recipe/algorithm/OffsetStatistics.py
@@ -16,7 +16,6 @@ class OffsetStatistics(PythonAlgorithm):
     """
 
     OFFSETWKSPPROP = "OffsetsWorkspace"
-    NOTHING = 0
 
     def category(self):
         return "SNAPRed Diffraction Calibration"
@@ -28,7 +27,7 @@ class OffsetStatistics(PythonAlgorithm):
             doc="Workspace containing the TOF neutron data",
         )
         self.declareProperty(
-            ULongLongPropertyWithValue("Data", id(self.NOTHING), direction=Direction.Output),
+            ULongLongPropertyWithValue("Data", None, direction=Direction.Output),
             doc="A pointer to the output dictionary (must be cast to object from memory address).",
         )
         self.setRethrows(True)

--- a/src/snapred/backend/recipe/algorithm/OffsetStatistics.py
+++ b/src/snapred/backend/recipe/algorithm/OffsetStatistics.py
@@ -5,7 +5,7 @@ from mantid.api import (
     PropertyMode,
     PythonAlgorithm,
 )
-from mantid.kernel import Direction, PropertyManagerProperty
+from mantid.kernel import Direction, ULongLongPropertyWithValue
 
 
 class OffsetStatistics(PythonAlgorithm):
@@ -26,7 +26,10 @@ class OffsetStatistics(PythonAlgorithm):
             MatrixWorkspaceProperty(self.OFFSETWKSPPROP, "", Direction.Input, PropertyMode.Mandatory),
             doc="Workspace containing the TOF neutron data",
         )
-        self.declareProperty(PropertyManagerProperty("Data", dict(), direction=Direction.Output))
+        self.declareProperty(
+            ULongLongPropertyWithValue("Data", 0, direction=Direction.Output),
+            doc="A pointer to the output dictionary (must be cast to object from memory address).",
+        )
         self.setRethrows(True)
         self._counts = 0
 
@@ -35,16 +38,16 @@ class OffsetStatistics(PythonAlgorithm):
         offsets = list(self.getProperty(self.OFFSETWKSPPROP).value.extractY().ravel())
         absOffsets = [abs(offset) for offset in offsets]
 
-        data = {}
+        self.data = {}
         # (Warning: `median(abs(offsets))` vs. `abs(median(offsets)`: the former introduces oscillation artifacts.)
-        data["medianOffset"] = float(abs(np.median(offsets)))
-        data["meanOffset"] = float(abs(np.mean(offsets)))
-        data["minOffset"] = float(np.min(offsets))
-        data["maxOffset"] = float(np.max(offsets))
-        data["maxAbsoluteOffset"] = float(np.max(absOffsets))
-        data["minAbsoluteOFfset"] = float(np.min(absOffsets))
+        self.data["medianOffset"] = float(abs(np.median(offsets)))
+        self.data["meanOffset"] = float(abs(np.mean(offsets)))
+        self.data["minOffset"] = float(np.min(offsets))
+        self.data["maxOffset"] = float(np.max(offsets))
+        self.data["maxAbsoluteOffset"] = float(np.max(absOffsets))
+        self.data["minAbsoluteOFfset"] = float(np.min(absOffsets))
 
-        self.setProperty("Data", data)
+        self.setProperty("Data", id(self.data))
 
 
 # Register algorithm with Mantid

--- a/src/snapred/meta/redantic.py
+++ b/src/snapred/meta/redantic.py
@@ -1,3 +1,4 @@
+import ctypes
 import json
 from pathlib import Path
 from typing import Any, List, Type, TypeVar, Union
@@ -40,6 +41,10 @@ def list_from_raw(type_: Any, src: str) -> List[BaseModel]:
     ):
         raise TypeError(f"target type must derive from 'List[BaseModel]' not {type_}")
     return TypeAdapter(type_).validate_json(src)
+
+
+def access_pointer(pointer: int) -> Any:
+    return ctypes.cast(pointer, ctypes.py_object).value
 
 
 def write_model(baseModel: BaseModel, path):

--- a/tests/unit/backend/recipe/algorithm/test_GroupedDetectorIDs.py
+++ b/tests/unit/backend/recipe/algorithm/test_GroupedDetectorIDs.py
@@ -1,12 +1,11 @@
 import unittest
-from typing import Dict, List
 
 from mantid.simpleapi import (
     CreateSingleValuedWorkspace,
     mtd,
 )
-from pydantic import TypeAdapter
 from snapred.backend.recipe.algorithm.GroupedDetectorIDs import GroupedDetectorIDs as Algo
+from snapred.meta.redantic import access_pointer
 from util.diffraction_calibration_synthetic_data import SyntheticData
 
 
@@ -44,5 +43,5 @@ class TestGroupedDetectorIDs(unittest.TestCase):
         algo.initialize()
         algo.setProperty("GroupingWorkspace", self.fakeGroupingWorkspace)
         assert algo.execute()
-        data = TypeAdapter(Dict[int, List[int]]).validate_json(algo.getPropertyValue("GroupWorkspaceIndices"))
+        data = access_pointer(algo.getProperty("GroupWorkspaceIndices").value)
         assert data == {2: [2, 4, 11, 14], 3: [0, 5, 10, 15], 7: [1, 7, 8, 13], 11: [3, 6, 9, 12]}

--- a/tests/unit/backend/recipe/algorithm/test_GroupedDetectorIDs.py
+++ b/tests/unit/backend/recipe/algorithm/test_GroupedDetectorIDs.py
@@ -1,0 +1,48 @@
+import unittest
+from typing import Dict, List
+
+from mantid.simpleapi import (
+    CreateSingleValuedWorkspace,
+    mtd,
+)
+from pydantic import TypeAdapter
+from snapred.backend.recipe.algorithm.GroupedDetectorIDs import GroupedDetectorIDs as Algo
+from util.diffraction_calibration_synthetic_data import SyntheticData
+
+
+class TestGroupedDetectorIDs(unittest.TestCase):
+    def setUp(self):
+        inputs = SyntheticData()
+        self.fakeIngredients = inputs.ingredients
+
+        runNumber = self.fakeIngredients.runConfig.runNumber
+        self.fakeData = f"_test_remove_event_background_{runNumber}"
+        self.fakeGroupingWorkspace = f"_test_remove_event_background_{runNumber}_grouping"
+        self.fakeMaskWorkspace = f"_test_remove_event_background_{runNumber}_mask"
+        inputs.generateWorkspaces(self.fakeData, self.fakeGroupingWorkspace, self.fakeMaskWorkspace)
+
+    def tearDown(self) -> None:
+        mtd.clear()
+        assert len(mtd.getObjectNames()) == 0
+        return super().tearDown()
+
+    def test_init(self):
+        algo = Algo()
+        algo.initialize()
+
+    def test_validate(self):
+        not_a_grouping_ws = mtd.unique_name(5, "grpid")
+        CreateSingleValuedWorkspace(OutputWorkspace=not_a_grouping_ws)
+        algo = Algo()
+        algo.initialize()
+        algo.setProperty("GroupingWorkspace", not_a_grouping_ws)
+        err = algo.validateInputs()
+        assert "GroupingWorkspace" in err
+
+    def test_execute(self):
+        algo = Algo()
+        algo.initialize()
+        algo.setProperty("GroupingWorkspace", self.fakeGroupingWorkspace)
+        assert algo.execute()
+        data = TypeAdapter(Dict[int, List[int]]).validate_json(algo.getPropertyValue("GroupWorkspaceIndices"))
+        assert data == {2: [2, 4, 11, 14], 3: [0, 5, 10, 15], 7: [1, 7, 8, 13], 11: [3, 6, 9, 12]}

--- a/tests/unit/backend/recipe/algorithm/test_OffsetStatistics.py
+++ b/tests/unit/backend/recipe/algorithm/test_OffsetStatistics.py
@@ -1,14 +1,13 @@
 import unittest
 from random import random
-from typing import Dict
 
 import numpy as np
 from mantid.simpleapi import (
     CreateWorkspace,
+    OffsetStatistics,
     mtd,
 )
-from pydantic import TypeAdapter
-from snapred.backend.recipe.algorithm.OffsetStatistics import OffsetStatistics as Algo
+from snapred.meta.redantic import access_pointer
 
 
 class TestGOffsetStatistics(unittest.TestCase):
@@ -17,14 +16,7 @@ class TestGOffsetStatistics(unittest.TestCase):
         assert len(mtd.getObjectNames()) == 0
         return super().tearDown()
 
-    def test_init(self):
-        algo = Algo()
-        algo.initialize()
-
     def test_random(self):
-        algo = Algo()
-        algo.initialize()
-
         xVal = []
         yVal = []
         for i in range(100):
@@ -37,9 +29,8 @@ class TestGOffsetStatistics(unittest.TestCase):
             DataY=yVal,
         )
 
-        algo.setProperty("OffsetsWorkspace", wksp)
-        assert algo.execute()
-        data = TypeAdapter(Dict[str, float]).validate_json(algo.getPropertyValue("Data"))
+        data = OffsetStatistics(wksp)
+        data = access_pointer(data)
         assert data["medianOffset"] >= 0
         assert data["meanOffset"] >= 0
         assert data["medianOffset"] == abs(np.median(yVal))

--- a/tests/unit/backend/recipe/algorithm/test_OffsetStatistics.py
+++ b/tests/unit/backend/recipe/algorithm/test_OffsetStatistics.py
@@ -1,0 +1,48 @@
+import unittest
+from random import random
+from typing import Dict
+
+import numpy as np
+from mantid.simpleapi import (
+    CreateWorkspace,
+    mtd,
+)
+from pydantic import TypeAdapter
+from snapred.backend.recipe.algorithm.OffsetStatistics import OffsetStatistics as Algo
+
+
+class TestGOffsetStatistics(unittest.TestCase):
+    def tearDown(self) -> None:
+        mtd.clear()
+        assert len(mtd.getObjectNames()) == 0
+        return super().tearDown()
+
+    def test_init(self):
+        algo = Algo()
+        algo.initialize()
+
+    def test_random(self):
+        algo = Algo()
+        algo.initialize()
+
+        xVal = []
+        yVal = []
+        for i in range(100):
+            xVal.append(i)
+            yVal.append(random() * 2 - 1)
+        wksp = mtd.unique_name(5, "offset_stats_")
+        CreateWorkspace(
+            OutputWorkspace=wksp,
+            DataX=xVal,
+            DataY=yVal,
+        )
+
+        algo.setProperty("OffsetsWorkspace", wksp)
+        assert algo.execute()
+        data = TypeAdapter(Dict[str, float]).validate_json(algo.getPropertyValue("Data"))
+        assert data["medianOffset"] >= 0
+        assert data["meanOffset"] >= 0
+        assert data["medianOffset"] == abs(np.median(yVal))
+        assert data["meanOffset"] == abs(np.mean(yVal))
+        assert data["minOffset"] >= -1
+        assert data["maxOffset"] <= 1

--- a/tests/unit/backend/recipe/algorithm/test_OffsetStatistics.py
+++ b/tests/unit/backend/recipe/algorithm/test_OffsetStatistics.py
@@ -10,7 +10,7 @@ from mantid.simpleapi import (
 from snapred.meta.redantic import access_pointer
 
 
-class TestGOffsetStatistics(unittest.TestCase):
+class TestOffsetStatistics(unittest.TestCase):
     def tearDown(self) -> None:
         mtd.clear()
         assert len(mtd.getObjectNames()) == 0


### PR DESCRIPTION
## Description of work


These two algorithms will be used inside the new `PixelDifCalRecipe`.  They take some of the functionality that required breaking the algorithm queue and separate it out to distinct algorithms.

## Explanation of work

The two algorithms are:
- `GroupedDetectorIDs`, which returns a pointer to a `Dict[int, List[int]]`.
- `OffsetStatistics`, which is a good mantid merge candidate, takes an offsets workspace and returns a pointer to a dictionary of results.

Note these algorithms work by *POINTERS*, which is a new conceit I had recently.  Is this a good idea?

## To test

### Dev testing

I think the unit tests are convincing.  Please check if there are any missing edge cases or scenarios to consider.

### CIS testing

This is an enabler - CIS testing not required.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#7561](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7561)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] an algorithm will extract and return a dictionary of detector IDs corresponding to each group
- [x] an algorithm will extract and return a set of statistics of an OffsetsWorkspace
