### PR TITLE
Recipe ABC to enable mandatory input workspaces

### DIFF
--- a/src/snapred/backend/recipe/ApplyNormalizationRecipe.py
+++ b/src/snapred/backend/recipe/ApplyNormalizationRecipe.py
@@ -17,6 +17,9 @@ class ApplyNormalizationRecipe(Recipe[Ingredients]):
     NUM_BINS = Config["constants.ResampleX.NumberBins"]
     LOG_BINNING = True
 
+    def mandatoryInputWorkspaces(self):
+        return {"inputWorkspace"}
+
     def chopIngredients(self, ingredients: Ingredients):
         """
         Chops off the needed elements of the ingredients.

--- a/src/snapred/backend/recipe/PreprocessReductionRecipe.py
+++ b/src/snapred/backend/recipe/PreprocessReductionRecipe.py
@@ -1,9 +1,10 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Set, Tuple
 
 from snapred.backend.dao.ingredients import PreprocessReductionIngredients as Ingredients
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.Recipe import Recipe
 from snapred.meta.decorators.Singleton import Singleton
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
 logger = snapredLogger.getLogger(__name__)
 
@@ -17,6 +18,9 @@ class PreprocessReductionRecipe(Recipe[Ingredients]):
         Chops off the needed elements of the ingredients.
         """
         pass
+
+    def mandatoryInputWorkspaces(self) -> Set[WorkspaceName]:
+        return {"inputWorkspace"}
 
     def unbagGroceries(self, groceries: Dict[str, Any]):
         """

--- a/src/snapred/backend/recipe/ReadWorkspaceMetadata.py
+++ b/src/snapred/backend/recipe/ReadWorkspaceMetadata.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Set, Tuple
 
 from snapred.backend.dao.WorkspaceMetadata import UNSET, WorkspaceMetadata
 from snapred.backend.log.logger import snapredLogger
@@ -15,6 +15,9 @@ Pallet = Tuple[WorkspaceMetadata, Dict[str, WorkspaceName]]
 @Singleton
 class ReadWorkspaceMetadata(Recipe[WorkspaceMetadata]):
     TAG_PREFIX = Config["metadata.tagPrefix"]
+
+    def mandatoryInputWorkspaces(self) -> Set[WorkspaceName]:
+        return {"workspace"}
 
     def chopIngredients(self, ingredients):  # noqa ARG002
         """

--- a/src/snapred/backend/recipe/ReductionRecipe.py
+++ b/src/snapred/backend/recipe/ReductionRecipe.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple, Type
+from typing import Any, Dict, List, Set, Tuple, Type
 
 from snapred.backend.dao.ingredients import ReductionIngredients as Ingredients
 from snapred.backend.log.logger import snapredLogger
@@ -39,6 +39,9 @@ class ReductionRecipe(Recipe[Ingredients]):
 
     def logger(self):
         return logger
+
+    def mandatoryInputWorkspaces(self) -> Set[WorkspaceName]:
+        return {"inputWorkspace", "groupingWorkspaces"}
 
     def chopIngredients(self, ingredients: Ingredients):
         """
@@ -139,9 +142,6 @@ class ReductionRecipe(Recipe[Ingredients]):
             )
             self.groceries["normalizationWorkspace"] = normalizationClone
         return sampleClone, normalizationClone
-
-    def validateInputs(self, ingredients: Ingredients, groceries: Dict[str, WorkspaceName]):
-        pass
 
     def queueAlgos(self):
         pass

--- a/src/snapred/backend/recipe/WriteWorkspaceMetadata.py
+++ b/src/snapred/backend/recipe/WriteWorkspaceMetadata.py
@@ -1,4 +1,4 @@
-from typing import Dict, Set, Tuple
+from typing import Dict, Tuple
 
 from snapred.backend.dao.WorkspaceMetadata import UNSET, WorkspaceMetadata
 from snapred.backend.log.logger import snapredLogger
@@ -17,9 +17,6 @@ Pallet = Tuple[WorkspaceMetadata, Dict[str, str]]
 class WriteWorkspaceMetadata(Recipe[WorkspaceMetadata]):
     TAG_PREFIX = Config["metadata.tagPrefix"]
 
-    def mandatoryInputWorkspaces(self) -> Set[WorkspaceName]:
-        return {"workspace"}
-
     def chopIngredients(self, ingredients: WorkspaceMetadata):
         prevMetadata = ReadWorkspaceMetadata().cook({"workspace": self.workspace})
 
@@ -33,6 +30,11 @@ class WriteWorkspaceMetadata(Recipe[WorkspaceMetadata]):
         # create the needed lists of logs to add
         self.metadataNames = [f"{self.TAG_PREFIX}{prop}" for prop in self.properties]
         self.metadataValues = [metadata[prop] for prop in self.properties]
+
+    def validateInputs(self, ingredients: WorkspaceMetadata, groceries: Dict[str, WorkspaceName]):
+        WorkspaceMetadata.model_validate(ingredients)
+        if not self.mantidSnapper.mtd.doesExist(groceries["workspace"]):
+            raise RuntimeError(f"The indicated workspace {groceries['workspace']} not found in Mantid ADS.")
 
     def unbagGroceries(self, groceries: Dict[str, WorkspaceName]):
         self.workspace = groceries["workspace"]

--- a/src/snapred/backend/recipe/WriteWorkspaceMetadata.py
+++ b/src/snapred/backend/recipe/WriteWorkspaceMetadata.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple
+from typing import Dict, Set, Tuple
 
 from snapred.backend.dao.WorkspaceMetadata import UNSET, WorkspaceMetadata
 from snapred.backend.log.logger import snapredLogger
@@ -16,6 +16,9 @@ Pallet = Tuple[WorkspaceMetadata, Dict[str, str]]
 @Singleton
 class WriteWorkspaceMetadata(Recipe[WorkspaceMetadata]):
     TAG_PREFIX = Config["metadata.tagPrefix"]
+
+    def mandatoryInputWorkspaces(self) -> Set[WorkspaceName]:
+        return {"workspace"}
 
     def chopIngredients(self, ingredients: WorkspaceMetadata):
         prevMetadata = ReadWorkspaceMetadata().cook({"workspace": self.workspace})

--- a/src/snapred/backend/recipe/WriteWorkspaceMetadata.py
+++ b/src/snapred/backend/recipe/WriteWorkspaceMetadata.py
@@ -34,11 +34,6 @@ class WriteWorkspaceMetadata(Recipe[WorkspaceMetadata]):
         self.metadataNames = [f"{self.TAG_PREFIX}{prop}" for prop in self.properties]
         self.metadataValues = [metadata[prop] for prop in self.properties]
 
-    def validateInputs(self, ingredients: WorkspaceMetadata, groceries: Dict[str, WorkspaceName]):
-        WorkspaceMetadata.model_validate(ingredients)
-        if not self.mantidSnapper.mtd.doesExist(groceries["workspace"]):
-            raise RuntimeError(f"The indicated workspace {groceries['workspace']} not found in Mantid ADS.")
-
     def unbagGroceries(self, groceries: Dict[str, WorkspaceName]):
         self.workspace = groceries["workspace"]
 

--- a/tests/unit/backend/recipe/test_Recipe.py
+++ b/tests/unit/backend/recipe/test_Recipe.py
@@ -60,8 +60,13 @@ class RecipeTest(unittest.TestCase):
         with pytest.raises(ValueError, match="Ingredients must be a Pydantic BaseModel."):
             recipe.validateInputs(badIngredients, groceries)
         badGroceries = {"ws": mtd.unique_name(prefix="bad")}
-        with pytest.raises(RuntimeError):
+        with pytest.raises(
+            RuntimeError, match=f"The indicated workspace {badGroceries['ws']} not found in Mantid ADS."
+        ):
             recipe.validateInputs(ingredients, badGroceries)
+        worseGroceries = {}
+        with pytest.raises(RuntimeError, match="The workspace property ws was not found in the groceries"):
+            recipe.validateInputs(ingredients, worseGroceries)
 
     def test_cook(self):
         untensils = Utensils()

--- a/tests/unit/backend/recipe/test_Recipe.py
+++ b/tests/unit/backend/recipe/test_Recipe.py
@@ -1,11 +1,12 @@
 import unittest
-from typing import Dict
+from typing import Dict, Set
 
 import pytest
 from mantid.simpleapi import CreateSingleValuedWorkspace, mtd
 from pydantic import BaseModel, ConfigDict
 from snapred.backend.recipe.algorithm.Utensils import Utensils
 from snapred.backend.recipe.Recipe import Recipe
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 from util.SculleryBoy import SculleryBoy
 
 
@@ -18,6 +19,9 @@ class DummyRecipe(Recipe[Ingredients]):
     """
     An instantiation with no abstract classes
     """
+
+    def mandatoryInputWorkspaces(self) -> Set[WorkspaceName]:
+        return {"ws"}
 
     def chopIngredients(self, ingredients: Ingredients):
         pass

--- a/tests/unit/backend/recipe/test_ReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionRecipe.py
@@ -53,6 +53,11 @@ class ReductionRecipeTest(TestCase):
         with pytest.raises(KeyError):
             recipe.unbagGroceries(groceries)
 
+    def test_mandatory_inputs(self):
+        inputs = ReductionRecipe().mandatoryInputWorkspaces()
+        assert inputs == {"inputWorkspace", "groupingWorkspace"}
+        ReductionRecipe().logger().notice("logged")
+
     def test_cloneWorkspace(self):
         recipe = ReductionRecipe()
         recipe.mantidSnapper = mock.Mock()

--- a/tests/unit/backend/recipe/test_ReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionRecipe.py
@@ -249,11 +249,6 @@ class ReductionRecipeTest(TestCase):
         assert normClone is None
         recipe._deleteWorkspace.assert_not_called()
 
-    def test_stubs(self):
-        recipe = ReductionRecipe()
-        recipe.validateInputs(None, None)
-        recipe.queueAlgos()
-
     @mock.patch("snapred.backend.recipe.ReductionRecipe.ApplyNormalizationRecipe")
     def test_applyNormalization(self, mockApplyNormalizationRecipe):
         recipe = ReductionRecipe()

--- a/tests/unit/backend/recipe/test_ReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionRecipe.py
@@ -55,7 +55,7 @@ class ReductionRecipeTest(TestCase):
 
     def test_mandatory_inputs(self):
         inputs = ReductionRecipe().mandatoryInputWorkspaces()
-        assert inputs == {"inputWorkspace", "groupingWorkspace"}
+        assert inputs == {"inputWorkspace", "groupingWorkspaces"}
         ReductionRecipe().logger().notice("logged")
 
     def test_cloneWorkspace(self):

--- a/tests/unit/backend/recipe/test_ReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionRecipe.py
@@ -56,7 +56,7 @@ class ReductionRecipeTest(TestCase):
     def test_mandatory_inputs(self):
         inputs = ReductionRecipe().mandatoryInputWorkspaces()
         assert inputs == {"inputWorkspace", "groupingWorkspaces"}
-        ReductionRecipe().logger().notice("logged")
+        ReductionRecipe().logger()
 
     def test_cloneWorkspace(self):
         recipe = ReductionRecipe()


### PR DESCRIPTION
## Description of work

This updates the `Recipe` ABC to have a set of mandatory input workspaces.

## Explanation of work

The default `validateInputs` method on the `Recipe` ABC was setup to check for the existence of every workspace in the `groceries` dictionary, even if it is an output.

This specifies the set of mandatory inputs that must be in the `groceries`.  The others can be Outputs or optional InOuts, or just optional workspaces.  

This allows implementing recipes to use the default without needing to override.

## To test

### Dev testing

Make sure all unit tests pass.

Make sure manual testing can get to save.

### CIS testing

Enabler, no need

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

This came up as part of work on

[EWM#7388](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7388)

### Verification

N/A

### Acceptance Criteria

N/A
