### PR TITLE
Ewm3143 apply diffcal during norm workflow

### DIFF
--- a/src/snapred/backend/dao/WorkspaceMetadata.py
+++ b/src/snapred/backend/dao/WorkspaceMetadata.py
@@ -1,38 +1,34 @@
-from typing import Literal, get_args
-
 from pydantic import BaseModel, ConfigDict
 
-# possible states for diffraction calibration
+from snapred.meta.Enum import StrEnum
 
 UNSET: str = "unset"
 
-DIFFCAL_METADATA_STATE = Literal[
-    UNSET,  # the default condition before any settings
-    "exists",  # the state exists and the corresponding .h5 file located
-    "alternate",  # the user supplied an alternate .h5 that they believe is usable.
-    "none",  # proceed using the defaul (IDF) geometry.
-]
 
-diffcal_metadata_state_list = list(get_args(DIFFCAL_METADATA_STATE))
+class DiffcalStateMetadata(StrEnum):
+    """Class to hold tags related to a workspace"""
+
+    UNSET: str = UNSET  # the default condition before any settings
+    DEFAULT: str = "default"  # the default condition before any settings
+    EXISTS: str = "exists"  # the state exists and the corresponding .h5 file located
+    ALTERNATE: str = "alternate"  # the user supplied an alternate .h5 that they believe is usable.
+    NONE: str = "none"  # proceed using the defaul (IDF) geometry.
 
 
-# possible states for normalization
+class NormalizationStateMetadata(StrEnum):
+    """Class to hold tags related to a workspace"""
 
-NORMCAL_METADATA_STATE = Literal[
-    UNSET,  # the default condition before any settings
-    "exists",  # the state exists and the corresponding .h5 file located
-    "alternate",  # the user supplied an alternate .h5 that they believe is usable
-    "none",  # proceed without applying any normalization
-    "fake",  # proceed by creating a "fake vanadium"
-]
-
-normcal_metadata_state_list = list(get_args(NORMCAL_METADATA_STATE))
+    UNSET: str = UNSET  # the default condition before any settings
+    EXISTS: str = "exists"  # the state exists and the corresponding .h5 file located
+    ALTERNATE: str = "alternate"  # the user supplied an alternate .h5 that they believe is usable
+    NONE: str = "none"  # proceed without applying any normalization
+    FAKE: str = "fake"  # proceed by creating a "fake vanadium"
 
 
 class WorkspaceMetadata(BaseModel):
     """Class to hold tags related to a workspace"""
 
-    diffcalState: DIFFCAL_METADATA_STATE = UNSET
-    normalizationState: NORMCAL_METADATA_STATE = UNSET
+    diffcalState: DiffcalStateMetadata = UNSET
+    normalizationState: NormalizationStateMetadata = UNSET
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", use_enum_values=True)

--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -54,6 +54,9 @@ class DataFactoryService:
     def constructStateId(self, runId: str):
         return self.lookupService.generateStateId(runId)
 
+    def stateExists(self, runId: str):
+        return self.lookupService.stateExists(runId)
+
     def getCalibrantSample(self, filePath):
         return self.lookupService.readCalibrantSample(filePath)
 

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -17,6 +17,7 @@ from pydantic import validate_call
 from snapred.backend.dao.indexing.Versioning import VERSION_DEFAULT
 from snapred.backend.dao.ingredients import GroceryListItem
 from snapred.backend.dao.state import DetectorState
+from snapred.backend.dao.WorkspaceMetadata import WorkspaceMetadata
 from snapred.backend.data.LocalDataService import LocalDataService
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
@@ -461,6 +462,19 @@ class GroceryService:
         else:
             ws = None
         return ws
+
+    def writeWorkspaceMetadataAsTags(self, workspaceName: WorkspaceName, workspaceMetadata: WorkspaceMetadata):
+        """
+        Write workspace metadata to the workspace as tags.
+
+        :param workspaceName: the name of the workspace to write the metadata to
+        :type workspaceName: WorkspaceName
+        :param workspaceMetadata: the metadata to write to the workspace
+        :type workspaceMetadata: WorkspaceMetadata
+        """
+        metadata = workspaceMetadata.dict()
+        for logname in metadata.keys():
+            self.setWorkspaceTag(workspaceName, logname, metadata[logname])
 
     def getWorkspaceTag(self, workspaceName: str, logname: str):
         """

--- a/src/snapred/backend/data/Indexer.py
+++ b/src/snapred/backend/data/Indexer.py
@@ -20,7 +20,7 @@ from snapred.backend.dao.normalization.Normalization import Normalization
 from snapred.backend.dao.normalization.NormalizationRecord import NormalizationRecord
 from snapred.backend.dao.reduction.ReductionRecord import ReductionRecord
 from snapred.backend.log.logger import snapredLogger
-from snapred.meta.mantid.AllowedPeakTypes import StrEnum
+from snapred.meta.Enum import StrEnum
 from snapred.meta.mantid.WorkspaceNameGenerator import ValueFormatter as wnvf
 from snapred.meta.redantic import parse_file_as, write_model_list_pretty, write_model_pretty
 

--- a/src/snapred/backend/error/ContinueWarning.py
+++ b/src/snapred/backend/error/ContinueWarning.py
@@ -12,6 +12,7 @@ class ContinueWarning(Exception):
     class Type(Flag):
         UNSET = 0
         MISSING_DIFFRACTION_CALIBRATION = auto()
+        DEFAULT_DIFFRACTION_CALIBRATION = auto()
         MISSING_NORMALIZATION = auto()
         LOW_PEAK_COUNT = auto()
         NO_WRITE_PERMISSIONS = auto()

--- a/src/snapred/backend/error/RecoverableException.py
+++ b/src/snapred/backend/error/RecoverableException.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 from pydantic import BaseModel
 
 from snapred.backend.log.logger import snapredLogger
+from snapred.meta.decorators.ExceptionHandler import extractTrueStacktrace
 
 logger = snapredLogger.getLogger(__name__)
 
@@ -39,6 +40,7 @@ class RecoverableException(Exception):
         RecoverableException.Model.update_forward_refs()
         RecoverableException.Model.model_rebuild(force=True)
         self.model = RecoverableException.Model(message=message, flags=flags, data=data)
+        logger.error(f"{extractTrueStacktrace()}")
         super().__init__(message)
 
     def parse_raw(raw):

--- a/src/snapred/backend/recipe/PreprocessReductionRecipe.py
+++ b/src/snapred/backend/recipe/PreprocessReductionRecipe.py
@@ -31,6 +31,7 @@ class PreprocessReductionRecipe(Recipe[Ingredients]):
         self.sampleWs = groceries["inputWorkspace"]
         self.diffcalWs = groceries.get("diffcalWorkspace", "")
         self.maskWs = groceries.get("maskWorkspace", "")
+        self.outputWs = groceries.get("outputWorkspace", groceries["inputWorkspace"])
 
     def queueAlgos(self):
         """
@@ -38,16 +39,23 @@ class PreprocessReductionRecipe(Recipe[Ingredients]):
         Requires: unbagged groceries and chopped ingredients.
         """
 
+        if self.outputWs != self.sampleWs:
+            self.mantidSnapper.CloneWorkspace(
+                "Cloning workspace...",
+                InputWorkspace=self.sampleWs,
+                OutputWorkspace=self.outputWs,
+            )
+
         if self.maskWs:
             self.mantidSnapper.MaskDetectorFlags(
                 "Applying pixel mask...",
                 MaskWorkspace=self.maskWs,
-                OutputWorkspace=self.sampleWs,
+                OutputWorkspace=self.outputWs,
             )
 
         if self.diffcalWs:
             self.mantidSnapper.ApplyDiffCal(
-                "Applying diffcal..", InstrumentWorkspace=self.sampleWs, CalibrationWorkspace=self.diffcalWs
+                "Applying diffcal..", InstrumentWorkspace=self.outputWs, CalibrationWorkspace=self.diffcalWs
             )
 
     def cook(self, ingredients: Ingredients, groceries: Dict[str, str]) -> Dict[str, Any]:

--- a/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
+++ b/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
@@ -1,11 +1,10 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Set, Tuple
 
 from snapred.backend.dao.ingredients import ReductionGroupProcessingIngredients as Ingredients
 from snapred.backend.error.AlgorithmException import AlgorithmException
 from snapred.backend.log.logger import snapredLogger
-from snapred.backend.recipe.Recipe import Recipe
+from snapred.backend.recipe.Recipe import Recipe, WorkspaceName
 from snapred.meta.decorators.Singleton import Singleton
-from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
 logger = snapredLogger.getLogger(__name__)
 
@@ -70,8 +69,8 @@ class ReductionGroupProcessingRecipe(Recipe[Ingredients]):
         )
         self.outputWS = self.rawInput
 
-    def validateInputs(self, ingredients: Ingredients, groceries: Dict[str, WorkspaceName]):
-        pass
+    def mandatoryInputWorkspaces(self) -> Set[WorkspaceName]:
+        return {"inputWorkspace", "groupingWorkspace"}
 
     def execute(self):
         """

--- a/src/snapred/backend/recipe/ReductionRecipe.py
+++ b/src/snapred/backend/recipe/ReductionRecipe.py
@@ -126,11 +126,20 @@ class ReductionRecipe(Recipe[Ingredients]):
     def _applyRecipe(self, recipe: Type[Recipe], ingredients_, **kwargs):
         if "inputWorkspace" in kwargs:
             inputWorkspace = kwargs["inputWorkspace"]
+            if not inputWorkspace:
+                self.logger().debug(f"{recipe.__name__} :: Skipping recipe with default empty input workspace")
+                return
             if self.mantidSnapper.mtd.doesExist(inputWorkspace):
                 self.groceries.update(kwargs)
                 recipe().cook(ingredients_, self.groceries)
             else:
-                self.logger().warning(f"Skipping {type(recipe)} as {inputWorkspace} does not exist.")
+                raise RuntimeError(
+                    (
+                        f"{recipe.__name__} ::"
+                        " Missing non-default input workspace with groceries:"
+                        f" {self.groceries} and kwargs: {kwargs}"
+                    )
+                )
 
     def _prepGroupingWorkspaces(self, groupingIndex: int):
         # TODO:  We need the wng to be able to deconstruct the workspace name

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -264,7 +264,7 @@ class SousChef(Service):
             convertUnitsTo=ingredients_.convertUnitsTo,
         )
 
-    def _verifyCalibrationExists(self, runNumber: str, useLiteMode: bool) -> bool:
+    def verifyCalibrationExists(self, runNumber: str, useLiteMode: bool) -> bool:
         if not self.dataFactoryService.calibrationExists(runNumber, useLiteMode):
             recoveryData = {
                 "runNumber": runNumber,
@@ -277,7 +277,8 @@ class SousChef(Service):
             )
 
     def prepNormalizationIngredients(self, ingredients: FarmFreshIngredients) -> NormalizationIngredients:
-        self._verifyCalibrationExists(ingredients.runNumber, ingredients.useLiteMode)
+        # The calibration folder at the very least should be initialized with a default calibration
+        self.verifyCalibrationExists(ingredients.runNumber, ingredients.useLiteMode)
 
         return NormalizationIngredients(
             pixelGroup=self.prepPixelGroup(ingredients),
@@ -288,7 +289,7 @@ class SousChef(Service):
     def prepDiffractionCalibrationIngredients(
         self, ingredients: FarmFreshIngredients
     ) -> DiffractionCalibrationIngredients:
-        self._verifyCalibrationExists(ingredients.runNumber, ingredients.useLiteMode)
+        self.verifyCalibrationExists(ingredients.runNumber, ingredients.useLiteMode)
 
         return DiffractionCalibrationIngredients(
             runConfig=self.prepRunConfig(ingredients.runNumber),

--- a/src/snapred/meta/Enum.py
+++ b/src/snapred/meta/Enum.py
@@ -1,0 +1,7 @@
+import enum
+
+
+class StrEnum(str, enum.Enum):
+    @classmethod
+    def values(cls):
+        return [e.value for e in cls]

--- a/src/snapred/meta/mantid/AllowedPeakTypes.py
+++ b/src/snapred/meta/mantid/AllowedPeakTypes.py
@@ -1,5 +1,6 @@
-import enum
 from typing import Literal, get_args
+
+from snapred.meta.Enum import StrEnum
 
 ALLOWED_PEAK_TYPES = Literal[
     "AsymmetricPearsonVII",
@@ -18,10 +19,6 @@ ALLOWED_PEAK_TYPES = Literal[
 ]
 
 allowed_peak_type_list = list(get_args(ALLOWED_PEAK_TYPES))
-
-
-class StrEnum(str, enum.Enum):
-    pass
 
 
 _peakMap = zip([s.upper() for s in allowed_peak_type_list], allowed_peak_type_list)

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -161,6 +161,7 @@ class NormalizationWorkflow(WorkflowImplementer):
             calibrantSamplePath=str(self.samplePaths[self.sampleIndex]),
             focusGroup=self.focusGroups[self.focusGroupPath],
             crystalDBounds={"minimum": self.prevXtalDMin, "maximum": self.prevXtalDMax},
+            continueFlags=self.continueAnywayFlags,
         )
         # take the default smoothing param from the default payload value
         self.prevSmoothingParameter = payload.smoothingParameter

--- a/tests/integration/test_workflow_panels_happy_path.py
+++ b/tests/integration/test_workflow_panels_happy_path.py
@@ -172,10 +172,10 @@ class TestGUIPanels:
                 and "InstrumentDonor will only be used if GroupingFilename is in XML format." in self.detailedText()
             )
             else pytest.fail(
-                "unexpected QMessageBox.exec:\n"
-                + f"    args: {args}\n"
-                + f"    kwargs: {kwargs}\n"
-                + f"    text: '{self.text()}'\n"
+                "unexpected QMessageBox.exec:"
+                + f"    args: {args}"
+                + f"    kwargs: {kwargs}"
+                + f"    text: '{self.text()}'"
                 + f"    detailed text: '{self.detailedText()}'",
                 pytrace=False,
             ),
@@ -1068,6 +1068,7 @@ class TestGUIPanels:
                 #    (1) respond to the "initialize state" request
                 with qtbot.waitSignal(actionCompleted, timeout=60000):
                     qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+
                 qtbot.waitUntil(
                     lambda: len(
                         [
@@ -1090,13 +1091,19 @@ class TestGUIPanels:
                 questionMessageBox.stop()
                 successPrompt.stop()
 
+            warningMessageBox = mock.patch(  # noqa: PT008
+                "qtpy.QtWidgets.QMessageBox.warning",
+                lambda *args, **kwargs: QMessageBox.Yes,  # noqa: ARG005
+            )
+            warningMessageBox.start()
+
             #    (2) execute the normalization workflow
             with qtbot.waitSignal(actionCompleted, timeout=60000):
                 qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
             qtbot.waitUntil(
                 lambda: isinstance(workflowNodeTabs.currentWidget().view, NormalizationTweakPeakView), timeout=60000
             )
-
+            warningMessageBox.stop()
             tweakPeakView = workflowNodeTabs.currentWidget().view
 
             #    set "Smoothing", "xtal dMin", "xtal dMax", "intensity threshold", and "groupingDropDown"
@@ -1317,10 +1324,10 @@ class TestGUIPanels:
                 # State initialization dialog is "application modal" => no need to explicitly wait
                 questionMessageBox.stop()
                 successPrompt.stop()
-
             #    (2) execute the reduction workflow
             with qtbot.waitSignal(actionCompleted, timeout=120000):
                 qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+
             """
             #    set "author" and "comment"
             saveView.fieldAuthor.setText("kat")

--- a/tests/unit/backend/dao/test_WorkspaceMetadata.py
+++ b/tests/unit/backend/dao/test_WorkspaceMetadata.py
@@ -2,16 +2,16 @@ import pytest
 from pydantic import ValidationError
 from snapred.backend.dao.WorkspaceMetadata import (
     UNSET,
+    DiffcalStateMetadata,
+    NormalizationStateMetadata,
     WorkspaceMetadata,
-    diffcal_metadata_state_list,
-    normcal_metadata_state_list,
 )
 
 
 def test_literal_bad_diffcal():
     # test failure when adding bad value to diffraction calibration state
     bad = "not in list"
-    assert bad not in diffcal_metadata_state_list
+    assert bad not in DiffcalStateMetadata.values()
     with pytest.raises(ValidationError) as e:
         WorkspaceMetadata(diffcalState=bad)
     assert "diffcalState" in str(e.value)
@@ -20,14 +20,14 @@ def test_literal_bad_diffcal():
 def test_literal_bad_normcal():
     # test failure when adding bad value to normaliztion state
     bad = "not in list"
-    assert bad not in normcal_metadata_state_list
+    assert bad not in NormalizationStateMetadata.values()
     with pytest.raises(ValidationError) as e:
         WorkspaceMetadata(normalizationState=bad)
     assert "normalizationState" in str(e.value)
 
 
 def test_literal_good_diffcal():
-    for good in diffcal_metadata_state_list:
+    for good in DiffcalStateMetadata.values():
         try:
             x = WorkspaceMetadata(diffcalState=good)
             assert x.normalizationState == UNSET
@@ -36,7 +36,7 @@ def test_literal_good_diffcal():
 
 
 def test_literal_good_normcal():
-    for good in normcal_metadata_state_list:
+    for good in NormalizationStateMetadata.values():
         try:
             x = WorkspaceMetadata(normalizationState=good)
             assert x.diffcalState == UNSET

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -107,6 +107,11 @@ class TestDataFactoryService(unittest.TestCase):
         actual = self.instance.constructStateId(arg)
         assert actual == self.expected(arg)
 
+    def test_stateExists(self):
+        self.instance.lookupService.stateExists = mock.Mock(return_value=True)
+        actual = self.instance.stateExists("123")
+        assert actual
+
     def test_getGroupingMap(self):
         arg = mock.Mock()
         actual = self.instance.getGroupingMap(arg)

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -28,7 +28,7 @@ from mantid.simpleapi import (
 from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
 from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
 from snapred.backend.dao.state import DetectorState
-from snapred.backend.dao.WorkspaceMetadata import UNSET, WorkspaceMetadata, diffcal_metadata_state_list
+from snapred.backend.dao.WorkspaceMetadata import UNSET, DiffcalStateMetadata, WorkspaceMetadata
 from snapred.backend.data.GroceryService import GroceryService
 from snapred.meta.Config import Config, Resource
 from snapred.meta.mantid.WorkspaceNameGenerator import ValueFormatter as wnvf
@@ -684,7 +684,7 @@ class TestGroceryService(unittest.TestCase):
 
     def test_workspaceTagFunctions(self):
         wsname = mtd.unique_name(prefix="testWorkspaceTags_")
-        tagValues = diffcal_metadata_state_list
+        tagValues = DiffcalStateMetadata.values()
         properties = list(WorkspaceMetadata.model_json_schema()["properties"].keys())
         logName = properties[0]
 
@@ -707,6 +707,14 @@ class TestGroceryService(unittest.TestCase):
             self.instance.setWorkspaceTag(workspaceName=wsname, logname=logName, logvalue=tag)
             tagResult = self.instance.getWorkspaceTag(workspaceName=wsname, logname=logName)
             assert tagResult == tag
+
+    def test_writeWorkspaceMetadataAsTags(self):
+        self.instance.setWorkspaceTag = mock.Mock()
+        wsName = "testWsName"
+        metadata = WorkspaceMetadata()
+        self.instance.writeWorkspaceMetadataAsTags(wsName, metadata)
+        assert self.instance.setWorkspaceTag.call_count == len(metadata.dict().keys())
+        self.instance.setWorkspaceTag.assert_called_with(wsName, "normalizationState", "unset")
 
     ## TEST CLEANUP METHODS
 

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -53,6 +53,7 @@ from snapred.backend.dao.state.GroupingMap import GroupingMap
 from snapred.backend.data.Indexer import IndexerType
 from snapred.backend.data.LocalDataService import LocalDataService
 from snapred.backend.data.NexusHDF5Metadata import NexusHDF5Metadata as n5m
+from snapred.backend.error.RecoverableException import RecoverableException
 from snapred.meta.Config import Config, Resource
 from snapred.meta.mantid.WorkspaceNameGenerator import (
     ValueFormatter as wnvf,
@@ -522,6 +523,14 @@ def test_writeGroupingMap_relative_paths():
     assert relativePathCount > 0
 
 
+def test_stateExists():
+    # Test that the 'stateExists' method returns True when the state exists.
+    localDataService = LocalDataService()
+    localDataService.constructCalibrationStateRoot = mock.Mock(return_value=Path("."))
+    localDataService.generateStateId = mock.Mock(return_value=(ENDURING_STATE_ID, None))
+    assert localDataService.stateExists("12345")
+
+
 @mock.patch(ThisService + "GetIPTS")
 def test_calibrationFileExists(GetIPTS):  # noqa ARG002
     localDataService = LocalDataService()
@@ -934,6 +943,11 @@ def test_constructNormalizationStatePath():
         assert ans.parts[-1] == "normalization"
         assert ans.parts[-2] == "lite" if useLiteMode else "native"
         assert ans.parts[:-2] == localDataService.constructCalibrationStateRoot(fakeState).parts
+
+
+def test_hasWritePermissionsCalibrationStateRoot():
+    localDataService = LocalDataService()
+    assert localDataService._hasWritePermissionsCalibrationStateRoot() is True
 
 
 def test_constructReductionStateRoot():
@@ -1857,6 +1871,27 @@ def test_readWriteCalibrationState():
             localDataService.writeCalibrationState(calibration)
             ans = localDataService.readCalibrationState(runNumber, useLiteMode)
         assert ans == calibration
+
+
+def test_readWriteCalibrationState_noWritePermissions():
+    localDataService = LocalDataService()
+    localDataService.calibrationExists = mock.Mock(return_value=False)
+    localDataService._hasWritePermissionsCalibrationStateRoot = mock.Mock(return_value=False)
+
+    with pytest.raises(
+        RuntimeError,
+        match=r".*No calibration exists, and you lack permissions to create one. Please contact your CIS.*",
+    ):
+        localDataService.readCalibrationState("123", True)
+
+
+def test_readCalibrationState_hasWritePermissions():
+    localDataService = LocalDataService()
+    localDataService.calibrationExists = mock.Mock(return_value=False)
+    localDataService._hasWritePermissionsCalibrationStateRoot = mock.Mock(return_value=True)
+
+    with pytest.raises(RecoverableException, match="State uninitialized"):
+        localDataService.readCalibrationState("123", True)
 
 
 @mock.patch("snapred.backend.data.GroceryService.GroceryService.createDiffcalTableWorkspaceName")

--- a/tests/unit/backend/recipe/test_PreprocessReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_PreprocessReductionRecipe.py
@@ -128,6 +128,19 @@ class PreprocessReductionRecipeTest(unittest.TestCase):
         assert mockSnapper.ApplyDiffCal.called
         assert mockSnapper.MaskDetectorFlags.called
 
+        groceries["outputWorkspace"] = "output"
+        output = recipe.cook(ingredients, groceries)
+
+        assert recipe.sampleWs == groceries["inputWorkspace"]
+        assert recipe.diffcalWs == groceries["diffcalWorkspace"]
+        assert recipe.maskWs == groceries["maskWorkspace"]
+        assert recipe.outputWs == groceries["outputWorkspace"]
+
+        assert mockSnapper.executeQueue.called
+        assert mockSnapper.ApplyDiffCal.called
+        assert mockSnapper.MaskDetectorFlags.called
+        assert mockSnapper.CloneWorkspace.called
+
     def test_cater(self):
         untensils = Utensils()
         mockSnapper = unittest.mock.Mock()

--- a/tests/unit/backend/recipe/test_Recipe.py
+++ b/tests/unit/backend/recipe/test_Recipe.py
@@ -15,6 +15,11 @@ class Ingredients(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class FakeIngredients(BaseModel):
+    name: str
+    name2: str
+
+
 class DummyRecipe(Recipe[Ingredients]):
     """
     An instantiation with no abstract classes
@@ -44,6 +49,9 @@ class RecipeTest(unittest.TestCase):
     def test_init(self):
         DummyRecipe()
 
+    def test_Ingredients(self):
+        assert Ingredients(name="test") == DummyRecipe.Ingredients(name="test")
+
     def test_init_reuseUtensils(self):
         utensils = Utensils()
         utensils.PyInit()
@@ -67,6 +75,20 @@ class RecipeTest(unittest.TestCase):
         worseGroceries = {}
         with pytest.raises(RuntimeError, match="The workspace property ws was not found in the groceries"):
             recipe.validateInputs(ingredients, worseGroceries)
+
+    def test_validate_grocery(self):
+        groceries = self._make_groceries()
+        recipe = DummyRecipe()
+
+        with pytest.raises(ValueError, match="The key for the grocery must be a string."):
+            recipe._validateGrocery(123, groceries["ws"])
+
+    def test_validate_ingredients_fail(self):
+        fakeIngredients = FakeIngredients(name="fake", name2="fake2")
+        recipe = DummyRecipe()
+
+        with pytest.raises(ValueError, match=r".*Invalid ingredients*"):
+            recipe._validateIngredients(fakeIngredients)
 
     def test_cook(self):
         untensils = Utensils()

--- a/tests/unit/backend/recipe/test_ReductionGroupProcessingRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionGroupProcessingRecipe.py
@@ -38,6 +38,8 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
 
     def test_queueAlgos(self):
         recipe = ReductionGroupProcessingRecipe()
+        recipe._validateIngredients = unittest.mock.Mock(return_value=True)
+        recipe._validateGrocery = unittest.mock.Mock(return_value=True)
         groceries = {
             "inputWorkspace": "input",
             "groupingWorkspace": "groupingWS",
@@ -64,6 +66,7 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
         mockSnapper = unittest.mock.Mock()
         untensils.mantidSnapper = mockSnapper
         recipe = ReductionGroupProcessingRecipe(utensils=untensils)
+        recipe._validateIngredients = unittest.mock.Mock(return_value=True)
         groceries = {
             "inputWorkspace": "input",
             "outputWorkspace": "output",
@@ -88,6 +91,7 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
         mockSnapper = unittest.mock.Mock()
         untensils.mantidSnapper = mockSnapper
         recipe = ReductionGroupProcessingRecipe(utensils=untensils)
+        recipe._validateIngredients = unittest.mock.Mock(return_value=True)
         groceries = {
             "inputWorkspace": "input",
             "outputWorkspace": "output",

--- a/tests/unit/backend/recipe/test_ReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionRecipe.py
@@ -240,9 +240,24 @@ class ReductionRecipeTest(TestCase):
         recipe.logger.return_value = mock.Mock()
         recipe.logger().warning = mock.Mock()
 
-        recipe._applyRecipe(mock.Mock(), recipe.ingredients, inputWorkspace="input")
+        with pytest.raises(RuntimeError, match=r".*Missing non-default input workspace.*"):
+            recipe._applyRecipe(mock.MagicMock(__name__="SomeRecipe"), recipe.ingredients, inputWorkspace="input")
 
-        recipe.logger().warning.assert_called_once()
+    def test_applyRecipe_default_empty_input_workspace(self):
+        recipe = ReductionRecipe()
+        recipe.groceries = {}
+        recipe.ingredients = mock.Mock()
+        recipe.mantidSnapper = mock.Mock()
+        recipe.mantidSnapper.mtd = mock.Mock()
+        recipe.mantidSnapper.mtd.doesExist = mock.Mock()
+        recipe.mantidSnapper.mtd.doesExist.return_value = False
+        recipe.logger = mock.Mock()
+        recipe.logger.return_value = mock.Mock()
+        recipe.logger().warning = mock.Mock()
+
+        recipe._applyRecipe(mock.MagicMock(__name__="SomeRecipe"), recipe.ingredients, inputWorkspace="")
+
+        recipe.logger().debug.assert_called_once()
 
     def test_prepGroupingWorkspaces(self):
         recipe = ReductionRecipe()

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -218,12 +218,14 @@ class TestNormalizationService(unittest.TestCase):
 
     @patch(thisService + "FarmFreshIngredients")
     @patch(thisService + "RawVanadiumCorrectionRecipe")
-    @patch(thisService + "FocusSpectraRecipe")
+    @patch(thisService + "PreprocessReductionRecipe")
+    @patch(thisService + "ReductionGroupProcessingRecipe")
     @patch(thisService + "SmoothDataExcludingPeaksRecipe")
     def test_normalization(
         self,
         mockSmoothDataExcludingPeaks,
-        mockFocusSpectra,
+        mockReductionGroupProcessing,  # noqa: ARG002
+        mockPreprocessReduction,
         mockVanadiumCorrection,
         FarmFreshIngredients,
     ):
@@ -237,7 +239,7 @@ class TestNormalizationService(unittest.TestCase):
         }
         mockGroceryService.workspaceDoesExist.return_value = False
         mockVanadiumCorrection.executeRecipe.return_value = "corrected_vanadium_ws"
-        mockFocusSpectra.executeRecipe.return_value = "focussed_vanadium_ws"
+        mockPreprocessReduction.executeRecipe.return_value = "focussed_vanadium_ws"
         mockSmoothDataExcludingPeaks.executeRecipe.return_value = "smoothed_output_ws"
 
         self.instance = NormalizationService()
@@ -245,7 +247,9 @@ class TestNormalizationService(unittest.TestCase):
         self.instance.sousChef = SculleryBoy()
         self.instance.groceryService = mockGroceryService
         self.instance.dataFactoryService.getCifFilePath = MagicMock(return_value="path/to/cif")
+        self.instance.dataFactoryService.getThisOrLatestCalibrationVersion = mock.Mock(return_value=1)
         self.instance.dataExportService.getCalibrationStateRoot = mock.Mock(return_value="lah/dee/dah")
+        self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
         self.instance.dataExportService.checkWritePermissions = mock.Mock(return_value=True)
 
         result = self.instance.normalization(self.request)
@@ -256,12 +260,14 @@ class TestNormalizationService(unittest.TestCase):
         self.assertIn("smoothedVanadium", result)  # noqa: PT009
         mockGroceryService.fetchGroceryDict.assert_called_once()
         mockVanadiumCorrection.assert_called_once()
-        mockFocusSpectra.assert_called_once()
+        mockPreprocessReduction.assert_called_once()
         mockSmoothDataExcludingPeaks.assert_called_once()
 
     def test_validateRequest(self):
         # test `validateRequest` internal calls
         self.instance._sameStates = mock.Mock(return_value=True)
+        self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
+        self.instance.dataFactoryService.getThisOrLatestCalibrationVersion = mock.Mock(return_value=1)
         permissionsRequest = CalibrationWritePermissionsRequest(
             runNumber=self.request.runNumber, continueFlags=self.request.continueFlags
         )
@@ -269,6 +275,27 @@ class TestNormalizationService(unittest.TestCase):
             self.instance.validateRequest(self.request)
             self.instance._sameStates.assert_called_once_with(self.request.runNumber, self.request.backgroundRunNumber)
             mockValidateWritePermissions.assert_called_once_with(permissionsRequest)
+
+    def test_validateDiffractionCalibrationExists_failure(self):
+        request = mock.Mock(runNumber="12345", backgroundRunNumber="67890", continueFlags=ContinueWarning.Type.UNSET)
+        self.instance.sousChef = SculleryBoy()
+        self.instance.dataFactoryService.getThisOrLatestCalibrationVersion = mock.Mock(return_value=-1)
+
+        with pytest.raises(
+            ContinueWarning,
+            match=r".*Continue anyway*",
+        ):
+            self.instance._validateDiffractionCalibrationExists(request)
+
+    def test_validateDiffractionCalibrationExists_success_contineuAnyway(self):
+        request = mock.Mock(
+            runNumber="12345",
+            backgroundRunNumber="67890",
+            continueFlags=ContinueWarning.Type.DEFAULT_DIFFRACTION_CALIBRATION,
+        )
+        self.instance.sousChef = SculleryBoy()
+        self.instance.dataFactoryService.getThisOrLatestCalibrationVersion = mock.Mock(return_value=-1)
+        self.instance._validateDiffractionCalibrationExists(request)
 
     def test_validateRequest_different_states(self):
         # test `validateRequest` raises `ValueError`
@@ -312,6 +339,8 @@ class TestNormalizationService(unittest.TestCase):
         self.instance.groceryService.workSpaceDoesExist = mock.Mock(return_value=True)
         self.instance.dataFactoryService.getCifFilePath = mock.Mock(return_value="path/to/cif")
         self.instance.dataExportService.getCalibrationStateRoot = mock.Mock(return_value="lah/dee/dah")
+        self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
+        self.instance.dataFactoryService.getThisOrLatestCalibrationVersion = mock.Mock(return_value=1)
         self.instance.dataExportService.checkWritePermissions = mock.Mock(return_value=True)
         result = self.instance.normalization(self.request)
 

--- a/tests/unit/backend/service/test_ReductionService.py
+++ b/tests/unit/backend/service/test_ReductionService.py
@@ -144,7 +144,7 @@ class TestReductionService(unittest.TestCase):
         self.instance.dataFactoryService.stateExists = mock.Mock(return_value=False)
         self.instance.checkWritePermissions = mock.Mock(return_value=True)
         with pytest.raises(RecoverableException, match="State uninitialized"):
-            self.instance.reduction(mockRequest)
+            self.instance.validateReduction(mockRequest)
 
     def test_reduction_noState_noWritePerms(self):
         mockRequest = mock.Mock()
@@ -152,7 +152,7 @@ class TestReductionService(unittest.TestCase):
         self.instance.checkWritePermissions = mock.Mock(return_value=False)
         self.instance.getSavePath = mock.Mock(return_value="path")
         with pytest.raises(RuntimeError, match=r".*It looks like you don't have permissions to write to*"):
-            self.instance.reduction(mockRequest)
+            self.instance.validateReduction(mockRequest)
 
     def test_markWorkspaceMetadata(self):
         request = mock.Mock(continueFlags=ContinueWarning.Type.UNSET)

--- a/tests/util/SculleryBoy.py
+++ b/tests/util/SculleryBoy.py
@@ -102,6 +102,9 @@ class SculleryBoy:
             detectorPeaks=self.prepDetectorPeaks(ingredients),
         )
 
+    def verifyCalibrationExists(self, runNumber: str, useLiteMode: bool) -> bool:  # noqa ARG002
+        return True
+
     def prepDiffractionCalibrationIngredients(
         self, ingredients: FarmFreshIngredients
     ) -> DiffractionCalibrationIngredients:


### PR DESCRIPTION
## Description of work

This supplies the features requested in ewm3143:
- The application of a diffraction calibration to the normaliztion data in the Normalization Workflow for user assessment
- The logging of metadata on the workspace if it uses the default calibration in the Normalization Workflow

This also supplies features in the neighborhood of what it asked for: 
- The logging of metadata on the workspaces if diffraction calibration/normalization is missing in the Reduction Workflow

I have also refactored:
- `StrEnum` to live in a seperate `Enum` module.  
- `WorkspaceMetadata` now uses `StrEnum` instead of literals.
- Recipes now can supply an init method for their given Ingredients.

## To test

NOTE:  Use the View Sample Logs option when right clicking on a workspace to confirm it has the snapred metadata.

```
For reduction
Runnumber: 59039 

for calib:
sample: LA11b6
Grouping: Column
Peak Intensity Thresh: 0.01
Chi: 200
dmin: 1

for norm:
rnunumber: 58810
bgrunnumber: 58813
```
Attempt to run either [Normalization Worflow, Reduction Workflow] -> [without a state, with a default state, with a valid state]
### Normalization
#### without a state

1. should return a runtime error if you lack permission to init state
2. should ask you to init state if you have write permission

#### with a default state
1. Should prompt with a continue anyway informing the user that the output will be marked as potentially inaccurate by means of it using a default state.

#### with a valid state
1. Continue as normal

### Reduction

As it is in `next` except:
- it actually loads the diffcal mask
- the outputs should have appropriately marked metadata

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#3143](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3143)
[EWM#7758](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7758)

### Verification

- [x] the author has read the EWM story and acceptance critera (Malcolm has additionally review and asked me to add AC)
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM
<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

~~Unfortunately there is not an explicity Acceptance Criteria outlined in the story, what I can infer from it are as follows~~
Malcolm has since reviewed the AC and made clarifications.

- [x] in the normalisation workflow, the raw vanadium data shall be treated *exactly the same* as the sample data being Reduced for examination.
- [x] in the normalisation workflow, If there is only a default diffcal (This workflow requires at least an initialized state), there should be a warning that the output will be labeled as using such default diffcal and proceed anyway prompt.
- [x] The outputs should have a log on them denoting the existence/status of diffcal/normalization.
- [ ] in the normalisation workflow, the raw vanadium data shall be treated exactly the same as the sample data being Reduced for examination.
- [x] the difcal index is queried to find available difcal for the normalization run 
- [x] if found the diffcal is applied to the raw 
- [x] Any corresponding diffcal mask is also applied to the raw vanadium

7758
- [x]  The correct behaviour would be to warn the user that the state does not exist, prompt user to create the state (probably with a notice that only an instrument scientist can actually do this)
- [x] if state is initialized as above and the user elects to proceed with default calibration, it should not fail trying to load such calibration