### PR TITLE
Fix algo importing so that they may be imported through `mantid.simpleapi` from other algos

### DIFF
--- a/src/snapred/__main__.py
+++ b/src/snapred/__main__.py
@@ -2,6 +2,7 @@ import sys
 
 from mantid.kernel import amend_config
 
+import snapred.backend.recipe.algorithm  # noqa: F401
 from snapred import __version__ as snapred_version
 from snapred.backend.log.logger import snapredLogger
 from snapred.meta.Config import Resource

--- a/src/snapred/backend/recipe/algorithm/__init__.py
+++ b/src/snapred/backend/recipe/algorithm/__init__.py
@@ -18,7 +18,15 @@ for x in all_module_names:
         # but it also is dead code and never used
         continue
 
-    module = importlib.import_module(f"{__name__}.{x}", x)
+    while True:
+        try:
+            module = importlib.import_module(f"{__name__}.{x}", x)
+            break
+        except ImportError as e:
+            print(f"{x} : {e.name}")
+            if e.name in all_module_names:
+                import e.name
+            break
 
     # for the leftovers algos, this gets just the class name
     x = x.split(".")[-1]

--- a/src/snapred/backend/recipe/algorithm/__init__.py
+++ b/src/snapred/backend/recipe/algorithm/__init__.py
@@ -1,13 +1,36 @@
-import importlib
 import os
 from glob import glob
-
-from mantid.api import AlgorithmFactory
-from mantid.simpleapi import _create_algorithm_function
 
 moduleDir = os.path.dirname(os.path.abspath(__file__))
 modules = glob(f"{moduleDir}/*.py")
 all_module_names = [module[:-3].split("/")[-1] for module in modules if not module.endswith("__init__.py")]
+
+
+def loadModule(x):
+    import importlib
+
+    from mantid.api import AlgorithmFactory
+    from mantid.simpleapi import _create_algorithm_function
+
+    while True:
+        try:
+            module = importlib.import_module(f"{__name__}.{x}", x)
+            break
+        except ImportError as e:
+            if e.name in all_module_names:
+                loadModule(e.name)
+            continue
+
+    # get just the class name
+    x = x.split(".")[-1]
+
+    # NOTE all algorithms must have same class name as filename
+    algoClass = getattr(module, x)
+    AlgorithmFactory.subscribe(algoClass)
+    algo = algoClass()
+    algo.initialize()
+    _create_algorithm_function(x, 1, algo)
+
 
 for x in all_module_names:
     if x == "MantidSnapper":
@@ -18,29 +41,8 @@ for x in all_module_names:
         # but it also is dead code and never used
         continue
 
-    while True:
-        try:
-            module = importlib.import_module(f"{__name__}.{x}", x)
-            break
-        except ImportError as e:
-            print(f"{x} : {e.name}")
-            if e.name in all_module_names:
-                import e.name
-            break
-
-    # for the leftovers algos, this gets just the class name
-    x = x.split(".")[-1]
-
-    # NOTE all algorithms must have same class name as filename
-    algoClass = getattr(module, x)
-    AlgorithmFactory.subscribe(algoClass)
-    algo = algoClass()
-    algo.initialize()
-    _create_algorithm_function(x, 1, algo)
+    loadModule(x)
 
 # cleanup
-del _create_algorithm_function
-del AlgorithmFactory
 del glob
 del os
-del importlib


### PR DESCRIPTION
## Description of work

Following a design meeting several weeks ago, it was decided `MantidSnapper` is better-used within `Recipe`s, and `Algorithm`s should only be implemented to handle the features requiring direct manipulation of workspace components.

In order to achieve that, we sometimes need for SNAPRed algorithms to import and call other SNAPRed algorithms without `MantidSnapper`.

## Explanation of work

The `__init__.py` file loads all the algorithms then puts them into `mantid.simpleapi`.  However, it does this in order.  If one algorithm first in the order needs one later in the order, that algo is not in `mantid.simpleapi` so the import fails.

This puts a `try-catch` block around the loading, and if an algorithm fails to load from `mantid.simpleapi`, it loads it first then tries again.

## To test

### Dev testing

Run all tests locally.

Launch the GUI locally.  Just launching it should be enough.

### CIS testing

N/A

## Link to EWM item

None

### Verification

N/A

### Acceptance Criteria

N/A
