### PR TITLE
Enable MantidSnapper and algos to use pointer properties

### DIFF
--- a/src/snapred/backend/recipe/algorithm/GroupedDetectorIDs.py
+++ b/src/snapred/backend/recipe/algorithm/GroupedDetectorIDs.py
@@ -9,6 +9,8 @@ from mantid.api import (
 )
 from mantid.kernel import Direction, ULongLongPropertyWithValue
 
+from snapred.meta.pointer import create_pointer
+
 
 class GroupedDetectorIDs(PythonAlgorithm):
     """
@@ -45,7 +47,7 @@ class GroupedDetectorIDs(PythonAlgorithm):
         groupWorkspaceIndices: Dict[int, List[int]] = {}
         for groupID in [int(x) for x in focusWS.getGroupIDs()]:
             groupWorkspaceIndices[groupID] = [int(x) for x in focusWS.getDetectorIDsOfGroup(groupID)]
-        self.setProperty("GroupWorkspaceIndices", id(groupWorkspaceIndices))
+        self.setProperty("GroupWorkspaceIndices", create_pointer(groupWorkspaceIndices))
 
 
 # Register algorithm with Mantid

--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 
 from mantid.api import AlgorithmManager, Progress, mtd
 from mantid.kernel import Direction
+from mantid.kernel import ULongLongPropertyWithValue as PointerProperty
 
 from snapred.backend.error.AlgorithmException import AlgorithmException
 from snapred.backend.log.logger import snapredLogger
@@ -9,6 +10,7 @@ from snapred.backend.log.logger import snapredLogger
 # must import to register with AlgorithmManager
 from snapred.meta.Callback import callback
 from snapred.meta.Config import Resource
+from snapred.meta.pointer import access_pointer, create_pointer
 
 logger = snapredLogger.getLogger(__name__)
 
@@ -37,36 +39,30 @@ class MantidSnapper:
 
     def __init__(self, parentAlgorithm, name):
         """
-        MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
-        MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMWWMWNXWMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
-        MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMWNNOdOkllxkkKNWWMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
-        MMMMMMMMMMMMMMMMMMMMMMMMMMMMMW0ol:;:::::;:lodO0KWMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
-        MMMMMMMMMMMMMMMMMMMMMMMMMMMMN0o;;;;;::;;:::::::lxO0XNWMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
-        MMMMMMMMMMMMMMMMMMMMMMMMMMMWOc:;;;;::;;:;:::::::;:clldO0XNNNNWWWMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
-        MMMMMMMMMMMMMMMMMMMMMMMWNXKOo;;,,,,,,,;;;;;;::::::::::::clcclddxk0XWMMMMMMMMMMMMMMMMMMMMMMMMMMMMWWNW
-        MMMMMMMMMMMMMMMMMMMNKOxdlcc:::cccccccccc::::;;:;;:::;;;;,,,,;;;,,;cdk0KNWMMMMMMMMMMMMMMMMMMWNX0kxlo0
-        MMMMMMMMMMMMMMMNKOxl:;:cllooddxxxkkkOkkxxxddooollccc::;,,,,,,,,,,;;;;::ldOXWMMMMMMMMMMMMWXOxol::;,oX
-        MMMMMMMMMMMMN0dlccccclodxxxxkkxkxxkkkxxkkkkkkkkkkxxxdoolc:;,,,,,,,,,,;;;;:dXWMMMMMMMMWXOdlcccc:;,:OW
-        MMMMMMMMMWKxl;,;:clodxxkkkkxkkkkkkkkkkkkkkkkxxkkkkkkkkxxddollc:;;,,,,;;;:oONMMMMMMMN0dcccllcccc:,dNM
-        MMMMMMWXko:;,,;:cloodxxkkkkOOOOOOOOOOOOkkkkkkOOOOOOOkkkkkkkxxxdolcc:;:cdOKNWWWWWNKOo:;:cccllccc;,xWM
-        MMMWNOo::c:,..',cooooddkOOOOOOOOOOOOOOOOkOOOOOOOOOOOOOOOOOOOOkkkxxxdolclloddddddolcc::::clllccc;;kWM
-        MNKxc;;:odo;'..;dxxxkOO0K000000000000000OOOOOOOO00000OO000000OOOOOkkkxxxxdddddxxxxdolc:cccccc::,,xWM
-        0o:cloodxkkxoodk0OkO0KKKK000KKKKKK00OOOkkkkxxxkkxxkkk0KKKKKKKKKKKKK000000000OOOOOOkxdllcclllc:;..xWM
-        0doodxkkkkkkOO00kkkO0K00K00OOOkkxdoooooooolllllodxOO0KXXXXXXXXXXXXXXKXKKKKKKKKKKK000Odlcccccc:,..kMM
-        0xxdoodk0OkxxkkkxkkO0KXK00OdolccccllloooolllodkO0KXXXXXXXXXXXXXXXK0OkkxxxxxxxxxxkkOOkdlcccc:c:;';0MM
-        WXKOkdddxkxxxxxkOOOO0000KKKOdllllloooooooodk0KXXNNNXXXXXKKXXKK00kxdodxO0KKKXXXK0Oxdooolccccc::;';0MM
-        MMMWWXK0Okxxxxxkkkkkkk0XXXXKklccloodddddkOKKXXXXXXKXXKK00OOOkxdoollodxOXWMMMMMMMMWXOxoolcccc::;';OMM
-        MMMMMMMMWNNXKOkxddoddk0000K0OdoooooddxkO00KK0000000OOkkddooolllllooodxxkXWMMMMMMMMMMWKkdlcc:::;,'dWM
-        MMMMMMMMMMMMMMWNXKK00OOkkxxxxxddddddddxxxxxxxxddxxxxxxdollllllllloddxxddkXWMMMMMMMMMMMWN0xl:;;;,':0M
-        MMMMMMMMMMMMMMMMMMMMMMWWWNXXKxlllldkOOO00000KKKXXNNNNWNKkdooooddooddxxdddkXWMMMMMMMMMMMMMMN0xo:,''oN
-        MMMMMMMMMMMMMMMMMMMMMMMMMMMMWXxlllodkXWMMMMMMMMMMMMMMMMMWNKO0K000OOOOOOO0KXNMMMMMMMMMMMMMMMMMWX0OxkX
-        MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMXkollloONMMMMMMMMMMMMMMMMMMMMMMMMMMWMMMWMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
-        MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMNkolloOWMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
-        MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMN0dlo0WMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
-        MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMWXOOXMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
-        MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMWWMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
-        MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
-        MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+                                        :;:::::;:
+                                      ;;;;;::;;:::::::
+                                     :;;;;::;;:;:::::::;:
+                                   ;;,,,,,,,;;;;;;::::::::::::
+                               cc:::cccccccccc::::;;:;;:::;;;;,,,,;;;,,;                             kxl
+                          l:;:cllooddxxxkkkOkkxxxddooollccc::;,,,,,,,,,,;;;;::                    xol::;,
+                     dlccccclodxxxxkkxkxxkkkxxkkkkkkkkkkxxxdoolc:;,,,,,,,,,,;;;;:              dlcccc:;,:
+                   l;,;:clodxxkkkkxkkkkkkkkkkkkkkkkxxkkkkkkkkxxddollc:;;,,,,;;;:            dcccllcccc:,
+                o:;,,;:cloodxxkkkkOOOOOOOOOOOOkkkkkkOOOOOOOkkkkkkkxxxdolcc:;:             o:;:cccllccc;,
+             o::c:,..',cooooddkOOOOOOOOOOOOOOOOkOOOOOOOOOOOOOOOOOOOOkkkxxxdolclloddddddolcc::::clllccc;;
+           c;;:odo;'..;dxxxkOO0K000000000000000OOOOOOOO00000OO000000OOOOOkkkxxxxdddddxxxxdolc:cccccc::,,
+         :cloodxkkxoodk0OkO0KKKK000KKKKKK00OOOkkkkxxxkkxxkkk0KKKKKKKKKKKKK000000000OOOOOOkxdllcclllc:;..
+        doodxkkkkkkOO00kkkO0K00K00OOOkkxdoooooooolllllodxOO0KXXXXXXXXXXXXXXKXKKKKKKKKKKK000Odlcccccc:,..
+        xxdoodk0OkxxkkkxkkO0KXK00OdolccccllloooolllodkO0KXXXXXXXXXXXXXXXK0OkkxxxxxxxxxxkkOOkdlcccc:c:;';
+           kdddxkxxxxxkOOOO0000KKKOdllllloooooooodk0KXXNNNXXXXXKKXXKK00kxdodxO0         xdooolccccc::;';
+                kxxxxxkkkkkkk0XXXXKklccloodddddkOKKXXXXXXKXXKK00OOOkxdoollodxO             xoolcccc::;';
+                     kxddoddk0000K0OdoooooddxkO00KK0000000OOkkddooolllllooodxxk              kdlcc:::;,'
+                            OOkkxxxxxddddddddxxxxxxxxddxxxxxxdollllllllloddxxddk                xl:;;;,':
+                                    xlllldkOOO00000            kdooooddooddxxdddk                  xo:,''
+                                     xlllodk
+                                      kollloO
+                                       kolloO
+                                        0dlo0
+                                          OO
         """
         self.parentAlgorithm = parentAlgorithm
         self._name = name
@@ -148,7 +144,9 @@ class MantidSnapper:
                     val = val.get()
                 if val is None:
                     continue
-
+                # turn pydantic objects into pointers
+                if isinstance(algorithm.getProperty(prop), PointerProperty):
+                    val = create_pointer(val)
                 algorithm.setProperty(prop, val)
             if not algorithm.execute():
                 raise RuntimeError(f"{name} failed to execute")
@@ -160,6 +158,8 @@ class MantidSnapper:
                 returnVal = getattr(algorithm.getProperty(prop), "value", None)
                 if returnVal is None:
                     returnVal = getattr(algorithm.getProperty(prop), "valueAsStr", None)
+                if isinstance(algorithm.getProperty(prop), PointerProperty):
+                    returnVal = access_pointer(returnVal)
                 val.update(returnVal)
         except (RuntimeError, TypeError) as e:
             logger.error(f"Algorithm {name} failed for the following arguments: \n {kwargs}")

--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -144,7 +144,9 @@ class MantidSnapper:
                     val = val.get()
                 if val is None:
                     continue
-                # turn pydantic objects into pointers
+                # for pointer property, set via its pointer
+                # allows for "pass-by-reference"-like behavior
+                # this is safe even if the memory address is directly passed
                 if isinstance(algorithm.getProperty(prop), PointerProperty):
                     val = create_pointer(val)
                 algorithm.setProperty(prop, val)

--- a/src/snapred/backend/recipe/algorithm/OffsetStatistics.py
+++ b/src/snapred/backend/recipe/algorithm/OffsetStatistics.py
@@ -7,6 +7,8 @@ from mantid.api import (
 )
 from mantid.kernel import Direction, ULongLongPropertyWithValue
 
+from snapred.meta.pointer import create_pointer
+
 
 class OffsetStatistics(PythonAlgorithm):
     """
@@ -38,16 +40,16 @@ class OffsetStatistics(PythonAlgorithm):
         offsets = list(self.getProperty(self.OFFSETWKSPPROP).value.extractY().ravel())
         absOffsets = [abs(offset) for offset in offsets]
 
-        self.data = {}
+        data = {}
         # (Warning: `median(abs(offsets))` vs. `abs(median(offsets)`: the former introduces oscillation artifacts.)
-        self.data["medianOffset"] = float(abs(np.median(offsets)))
-        self.data["meanOffset"] = float(abs(np.mean(offsets)))
-        self.data["minOffset"] = float(np.min(offsets))
-        self.data["maxOffset"] = float(np.max(offsets))
-        self.data["maxAbsoluteOffset"] = float(np.max(absOffsets))
-        self.data["minAbsoluteOFfset"] = float(np.min(absOffsets))
+        data["medianOffset"] = float(abs(np.median(offsets)))
+        data["meanOffset"] = float(abs(np.mean(offsets)))
+        data["minOffset"] = float(np.min(offsets))
+        data["maxOffset"] = float(np.max(offsets))
+        data["maxAbsoluteOffset"] = float(np.max(absOffsets))
+        data["minAbsoluteOFfset"] = float(np.min(absOffsets))
 
-        self.setProperty("Data", id(self.data))
+        self.setProperty("Data", create_pointer(data))
 
 
 # Register algorithm with Mantid

--- a/src/snapred/backend/recipe/algorithm/RemoveEventBackground.py
+++ b/src/snapred/backend/recipe/algorithm/RemoveEventBackground.py
@@ -9,7 +9,8 @@ from mantid.api import (
     PythonAlgorithm,
     WorkspaceUnitValidator,
 )
-from mantid.kernel import Direction, ULongLongPropertyWithValue
+from mantid.kernel import Direction
+from mantid.kernel import ULongLongPropertyWithValue as PointerProperty
 from mantid.simpleapi import (
     ConvertToMatrixWorkspace,
     ConvertUnits,
@@ -50,7 +51,7 @@ class RemoveEventBackground(PythonAlgorithm):
             doc="Histogram workspace representing the extracted background",
         )
         self.declareProperty(
-            ULongLongPropertyWithValue("DetectorPeaks", id(None)),
+            PointerProperty("DetectorPeaks", id(None)),
             "The memory adress pointing to the list of grouped peaks.",
         )
         self.declareProperty(
@@ -77,7 +78,8 @@ class RemoveEventBackground(PythonAlgorithm):
         # get handle to group focusing workspace and retrieve all detector IDs in each group
         focusWSname: str = str(self.getPropertyValue("GroupingWorkspace"))
         # get a list of the detector IDs in each group
-        self.groupDetectorIDs = access_pointer(GroupedDetectorIDs(focusWSname))
+        result_ptr: PointerProperty = GroupedDetectorIDs(focusWSname)
+        self.groupDetectorIDs = access_pointer(result_ptr)
         self.groupIDs: List[int] = list(self.groupDetectorIDs.keys())
         peakgroupIDs = [peakList.groupID for peakList in predictedPeaksList]
         if self.groupIDs != peakgroupIDs:
@@ -96,7 +98,8 @@ class RemoveEventBackground(PythonAlgorithm):
         self.log().notice("Extracting background")
 
         # get the peak predictions from user input
-        predictedPeaksList = access_pointer(self.getProperty("DetectorPeaks").value)
+        peak_ptr: PointerProperty = self.getProperty("DetectorPeaks").value
+        predictedPeaksList = access_pointer(peak_ptr)
         self.chopIngredients(predictedPeaksList)
         self.unbagGroceries()
 

--- a/src/snapred/backend/recipe/algorithm/__init__.py
+++ b/src/snapred/backend/recipe/algorithm/__init__.py
@@ -3,7 +3,7 @@ from glob import glob
 
 moduleDir = os.path.dirname(os.path.abspath(__file__))
 modules = glob(f"{moduleDir}/*.py")
-all_module_names = [module[:-3].split("/")[-1] for module in modules if not module.endswith("__init__.py")]
+all_module_names = {module[:-3].split("/")[-1] for module in modules if not module.endswith("__init__.py")}
 
 
 def loadModule(x):
@@ -12,13 +12,16 @@ def loadModule(x):
     from mantid.api import AlgorithmFactory
     from mantid.simpleapi import _create_algorithm_function
 
-    while True:
+    for i in range(30):
         try:
             module = importlib.import_module(f"{__name__}.{x}", x)
             break
         except ImportError as e:
-            if e.name in all_module_names:
-                loadModule(e.name)
+            y = str(e).split("'")[1]
+            if y in all_module_names:
+                loadModule(y)
+            else:
+                importlib.import_module(e.name)
             continue
 
     # get just the class name

--- a/src/snapred/backend/recipe/algorithm/__init__.py
+++ b/src/snapred/backend/recipe/algorithm/__init__.py
@@ -12,7 +12,7 @@ def loadModule(x):
     from mantid.api import AlgorithmFactory
     from mantid.simpleapi import _create_algorithm_function
 
-    for i in range(30):
+    for i in range(len(all_module_names)):
         try:
             module = importlib.import_module(f"{__name__}.{x}", x)
             break

--- a/src/snapred/meta/pointer.py
+++ b/src/snapred/meta/pointer.py
@@ -1,0 +1,22 @@
+import ctypes
+from typing import Any
+
+OBJCACHE = {}
+
+
+def create_pointer(thing: Any) -> int:
+    """
+    Returns a memory address to be used as a pointer, and retains a handle to the object
+    to ensure the memory can be accessed later.
+    @param the object whose pointer is required
+    @return the pointer to the object
+    """
+    OBJCACHE[id(thing)] = thing
+    return id(thing)
+
+
+def access_pointer(pointer: int) -> Any:
+    thing = ctypes.cast(pointer, ctypes.py_object).value
+    if pointer in OBJCACHE:
+        del OBJCACHE[pointer]
+    return thing

--- a/src/snapred/meta/redantic.py
+++ b/src/snapred/meta/redantic.py
@@ -1,4 +1,3 @@
-import ctypes
 import json
 from pathlib import Path
 from typing import Any, List, Type, TypeVar, Union
@@ -41,10 +40,6 @@ def list_from_raw(type_: Any, src: str) -> List[BaseModel]:
     ):
         raise TypeError(f"target type must derive from 'List[BaseModel]' not {type_}")
     return TypeAdapter(type_).validate_json(src)
-
-
-def access_pointer(pointer: int) -> Any:
-    return ctypes.cast(pointer, ctypes.py_object).value
 
 
 def write_model(baseModel: BaseModel, path):

--- a/tests/unit/backend/recipe/algorithm/test_GroupedDetectorIDs.py
+++ b/tests/unit/backend/recipe/algorithm/test_GroupedDetectorIDs.py
@@ -5,7 +5,8 @@ from mantid.simpleapi import (
     mtd,
 )
 from snapred.backend.recipe.algorithm.GroupedDetectorIDs import GroupedDetectorIDs as Algo
-from snapred.meta.redantic import access_pointer
+from snapred.backend.recipe.algorithm.Utensils import Utensils
+from snapred.meta.pointer import access_pointer
 from util.diffraction_calibration_synthetic_data import SyntheticData
 
 
@@ -44,4 +45,14 @@ class TestGroupedDetectorIDs(unittest.TestCase):
         algo.setProperty("GroupingWorkspace", self.fakeGroupingWorkspace)
         assert algo.execute()
         data = access_pointer(algo.getProperty("GroupWorkspaceIndices").value)
+        assert data == {2: [2, 4, 11, 14], 3: [0, 5, 10, 15], 7: [1, 7, 8, 13], 11: [3, 6, 9, 12]}
+
+    def test_execute_from_mantidSnapper(self):
+        utensils = Utensils()
+        utensils.PyInit()
+        data = utensils.mantidSnapper.GroupedDetectorIDs(
+            "Run in mantid snapper",
+            GroupingWorkspace=self.fakeGroupingWorkspace,
+        )
+        utensils.mantidSnapper.executeQueue()
         assert data == {2: [2, 4, 11, 14], 3: [0, 5, 10, 15], 7: [1, 7, 8, 13], 11: [3, 6, 9, 12]}

--- a/tests/unit/backend/recipe/algorithm/test_OffsetStatistics.py
+++ b/tests/unit/backend/recipe/algorithm/test_OffsetStatistics.py
@@ -7,7 +7,8 @@ from mantid.simpleapi import (
     OffsetStatistics,
     mtd,
 )
-from snapred.meta.redantic import access_pointer
+from snapred.backend.recipe.algorithm.Utensils import Utensils
+from snapred.meta.pointer import access_pointer
 
 
 class TestOffsetStatistics(unittest.TestCase):
@@ -37,3 +38,24 @@ class TestOffsetStatistics(unittest.TestCase):
         assert data["meanOffset"] == abs(np.mean(yVal))
         assert data["minOffset"] >= -1
         assert data["maxOffset"] <= 1
+
+    def test_execute_from_mantidSnapper(self):
+        xVal = [1, 2, 3, 4, 5]
+        yVal = [2, 2, 3, 4, 4]
+        wksp = mtd.unique_name(5, "offset_stats_")
+        CreateWorkspace(
+            OutputWorkspace=wksp,
+            DataX=xVal,
+            DataY=yVal,
+        )
+        utensils = Utensils()
+        utensils.PyInit()
+        data = utensils.mantidSnapper.OffsetStatistics(
+            "Run in mantid snapper",
+            OffsetsWorkspace=wksp,
+        )
+        utensils.mantidSnapper.executeQueue()
+        assert data["medianOffset"] == 3
+        assert data["meanOffset"] == 3
+        assert data["minOffset"] == 2
+        assert data["maxOffset"] == 4

--- a/tests/unit/backend/recipe/algorithm/test_RemoveEventBackground.py
+++ b/tests/unit/backend/recipe/algorithm/test_RemoveEventBackground.py
@@ -6,6 +6,7 @@ from mantid.simpleapi import (
 )
 from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.recipe.algorithm.RemoveEventBackground import RemoveEventBackground as Algo
+from snapred.backend.recipe.algorithm.Utensils import Utensils
 from snapred.meta.pointer import create_pointer
 from util.diffraction_calibration_synthetic_data import SyntheticData
 
@@ -172,3 +173,21 @@ class TestRemoveEventBackground(unittest.TestCase):
 
         assert "output_test_ws" in mtd, "Output workspace not found in the Mantid workspace dictionary"
         output_ws = mtd["output_test_ws"]  # noqa: F841
+
+    def test_execute_from_mantidSnapper(self):
+        peaks = self.create_test_peaks()
+        ConvertToEventWorkspace(
+            InputWorkspace=self.fakeData,
+            OutputWorkspace=self.fakeData,
+        )
+        utensils = Utensils()
+        utensils.PyInit()
+        utensils.mantidSnapper.RemoveEventBackground(
+            "Run in mantid snapper",
+            InputWorkspace=self.fakeData,
+            GroupingWorkspace=self.fakeGroupingWorkspace,
+            DetectorPeaks=peaks,  # NOTE passed as object, not pointer
+            OutputWorkspace="output_test_ws",
+        )
+        utensils.mantidSnapper.executeQueue()
+        assert "output_test_ws" in mtd

--- a/tests/unit/backend/recipe/algorithm/test_RemoveEventBackground.py
+++ b/tests/unit/backend/recipe/algorithm/test_RemoveEventBackground.py
@@ -6,7 +6,7 @@ from mantid.simpleapi import (
 )
 from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.recipe.algorithm.RemoveEventBackground import RemoveEventBackground as Algo
-from snapred.meta.redantic import list_to_raw
+from snapred.meta.pointer import create_pointer
 from util.diffraction_calibration_synthetic_data import SyntheticData
 
 
@@ -41,7 +41,7 @@ class TestRemoveEventBackground(unittest.TestCase):
         algo = Algo()
         algo.initialize()
         algo.setProperty("GroupingWorkspace", self.fakeGroupingWorkspace)
-        algo.setProperty("DetectorPeaks", list_to_raw(peaks))
+        algo.setProperty("DetectorPeaks", create_pointer(peaks))
 
         algo.chopIngredients(peaks)
 
@@ -75,7 +75,7 @@ class TestRemoveEventBackground(unittest.TestCase):
         algo.initialize()
         algo.setProperty("InputWorkspace", self.fakeData)
         algo.setProperty("GroupingWorkspace", self.fakeGroupingWorkspace)
-        algo.setProperty("DetectorPeaks", list_to_raw(peaks))
+        algo.setProperty("DetectorPeaks", create_pointer(peaks))
         algo.setProperty("OutputWorkspace", "output_test_ws")
         assert algo.execute()
 
@@ -87,7 +87,7 @@ class TestRemoveEventBackground(unittest.TestCase):
         algo = Algo()
         algo.initialize()
         algo.setProperty("GroupingWorkspace", self.fakeGroupingWorkspace)
-        algo.setProperty("DetectorPeaks", list_to_raw(peaks))
+        algo.setProperty("DetectorPeaks", create_pointer(peaks))
 
         with self.assertRaises(RuntimeError) as context:  # noqa: PT027
             algo.chopIngredients(peaks)
@@ -98,8 +98,9 @@ class TestRemoveEventBackground(unittest.TestCase):
         algo = Algo()
         algo.initialize()
 
+        noPeaks = []
         algo.setProperty("GroupingWorkspace", self.fakeGroupingWorkspace)
-        algo.setProperty("DetectorPeaks", list_to_raw([]))
+        algo.setProperty("DetectorPeaks", create_pointer(noPeaks))
 
         with self.assertRaises(RuntimeError):  # noqa: PT027
             algo.execute()
@@ -112,7 +113,7 @@ class TestRemoveEventBackground(unittest.TestCase):
         algo = Algo()
         algo.initialize()
         algo.setProperty("InputWorkspace", self.fakeData)
-        algo.setProperty("DetectorPeaks", list_to_raw([]))
+        algo.setProperty("DetectorPeaks", create_pointer(noPeaks))
 
         with self.assertRaises(RuntimeError):  # noqa: PT027
             algo.execute()
@@ -135,7 +136,7 @@ class TestRemoveEventBackground(unittest.TestCase):
         algo.initialize()
         algo.setProperty("InputWorkspace", self.fakeData)
         algo.setProperty("GroupingWorkspace", self.fakeGroupingWorkspace)
-        algo.setProperty("DetectorPeaks", list_to_raw(peaks))
+        algo.setProperty("DetectorPeaks", create_pointer(peaks))
         algo.setProperty("SmoothingParameter", 0)
         algo.setProperty("OutputWorkspace", "output_test_ws_no_smoothing")
 
@@ -164,7 +165,7 @@ class TestRemoveEventBackground(unittest.TestCase):
         algo.initialize()
         algo.setProperty("InputWorkspace", self.fakeData)
         algo.setProperty("GroupingWorkspace", self.fakeGroupingWorkspace)
-        algo.setProperty("DetectorPeaks", list_to_raw(peaks))
+        algo.setProperty("DetectorPeaks", create_pointer(peaks))
         algo.setProperty("OutputWorkspace", "output_test_ws")
 
         assert algo.execute()

--- a/tests/unit/meta/test_pointer.py
+++ b/tests/unit/meta/test_pointer.py
@@ -1,10 +1,8 @@
-from unittest.mock import sentinel
-
 from snapred.meta.pointer import access_pointer, create_pointer
 
 
 def test_create_and_access_pointer():
-    a = sentinel.some_object
+    a = {"one": 2, 3: "four"}
     pa = create_pointer(a)
     aa = access_pointer(pa)
     assert a == aa

--- a/tests/unit/meta/test_pointer.py
+++ b/tests/unit/meta/test_pointer.py
@@ -1,16 +1,44 @@
+import ctypes
+import gc
+
 from snapred.meta.pointer import access_pointer, create_pointer
 
 
+def make_a():
+    """Create an object that will be accessed by pointer"""
+    return {"one": 2, 3: "four"}
+
+
+def called_func1():
+    """Return the memory address of a temporary object by id"""
+    return id(make_a())
+
+
+def called_func2():
+    """Return the memory object of a temporary object using create_pointer"""
+    return create_pointer(make_a())
+
+
 def test_create_and_access_pointer():
-    a = {"one": 2, 3: "four"}
+    """Ensure reflexive property"""
+    a = make_a()
     pa = create_pointer(a)
     aa = access_pointer(pa)
     assert a == aa
 
 
 def test_pointer_persistence():
-    a = {"one": 2, 3: "four"}
-    pa = create_pointer(a)
-    del a
+    """Ensure pointers accessed in this way are safe from garbage collection"""
+    # if accessed only through id, this can fail
+    pa = called_func1()
+    gc.collect()
+    aa = ctypes.cast(pa, ctypes.py_object)
+    assert aa.__dict__ == {}
+    # NOTE trying to access aa any further will create a segfault
+
+    # if accessed through these methods, safe from garbage collection
+    pa = called_func2()
+    gc.collect()
     aa = access_pointer(pa)
-    assert create_pointer(aa) == pa
+    assert aa.__dir__() != {}
+    assert aa == make_a()

--- a/tests/unit/meta/test_pointer.py
+++ b/tests/unit/meta/test_pointer.py
@@ -1,0 +1,18 @@
+from unittest.mock import sentinel
+
+from snapred.meta.pointer import access_pointer, create_pointer
+
+
+def test_create_and_access_pointer():
+    a = sentinel.some_object
+    pa = create_pointer(a)
+    aa = access_pointer(pa)
+    assert a == aa
+
+
+def test_pointer_persistence():
+    a = {"one": 2, 3: "four"}
+    pa = create_pointer(a)
+    del a
+    aa = access_pointer(pa)
+    assert create_pointer(aa) == pa


### PR DESCRIPTION
## Description of work

Will make seamless use of pydantic objects as arguments to algos using pointers instead of string-cassting.

## Explanation of work

Algos can now possess "pointer" properties by using `ULongLongPropertyWithValue`.  

If any algorithm is supposed to take a `ULongLongPropertyWithValue` as an argument, MantidSnapper will automagically handle the casting to/from pointers.  There is currently nothing in mantid or SNAPRed that is using `ULongLongProperty` for any other reason, so this should be safe.

The `pointer.py` module should be used to create and access these objects.  The `create_pointer` function will also store that pointer in a cache so that a leash remains on it until it is accessed again.  The `access_pointer` removes it from the cache, so these pointers are only supposed to be used for passing to/from `PythonAlgorithm`s.

## To test

### Dev testing

Run all tests locally.

Perform manual testing of just the diffcal process up to saving (this is only one implicated by changes)

### CIS testing

N/A

## Link to EWM item

N/A

### Acceptance Criteria

N/A
