### PR TITLE
more auxiliary algos

### DIFF
--- a/src/snapred/backend/recipe/algorithm/CalibrationMetricExtractionAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/CalibrationMetricExtractionAlgorithm.py
@@ -7,8 +7,8 @@ from mantid.kernel import Direction
 
 from snapred.backend.dao.calibration.CalibrationMetric import CalibrationMetric
 from snapred.backend.dao.state import PixelGroup
-from snapred.backend.recipe.algorithm.FitMultiplePeaksAlgorithm import FitOutputEnum
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
+from snapred.meta.mantid.FitPeaksOutput import FitOutputEnum
 
 
 class CalibrationMetricExtractionAlgorithm(PythonAlgorithm):
@@ -54,6 +54,7 @@ class CalibrationMetricExtractionAlgorithm(PythonAlgorithm):
         pixelGroup = PixelGroup.model_validate_json(self.getPropertyValue("PixelGroup"))
         pixelGroupingParameters = list(pixelGroup.pixelGroupingParameters.values())
         # collect all params and peak positions
+        inputWorkspace.sortByName()
         peakPos = inputWorkspace.getItem(FitOutputEnum.PeakPosition.value)
         parameters = inputWorkspace.getItem(FitOutputEnum.Parameters.value)
         workspace = inputWorkspace.getItem(FitOutputEnum.Workspace.value)  # noqa: F841

--- a/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
+++ b/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
@@ -1,0 +1,108 @@
+from mantid.api import PythonAlgorithm, WorkspaceGroupProperty
+from mantid.kernel import Direction, IntPropertyWithValue
+from mantid.simpleapi import (
+    BufferMissingColumnsAlgo,
+    ConjoinTableWorkspaces,
+    ConjoinWorkspaces,
+    DeleteWorkspace,
+    ExtractSingleSpectrum,
+    GroupWorkspaces,
+    RenameWorkspaces,
+    UnGroupWorkspace,
+    mtd,
+)
+
+from snapred.backend.recipe.algorithm.FitMultiplePeaksAlgorithm import FitOutputEnum
+
+
+class ConjoinDiagnosticWorkspaces(PythonAlgorithm):
+    """
+    Given the grouped diagnostic output from PDCalibration run on one spectum at a time,
+    combine the sub-workspaces in an intelligent way.
+    """
+
+    INPUTGRPPROP1 = "DiagnosticWorkspace"
+    OUTPUTGRPPROP = "TotalDiagnosticWorkspace"
+
+    def category(self):
+        return "SNAPRed Diffraction Calibration"
+
+    def PyInit(self):
+        # declare properties
+        self.declareProperty(
+            WorkspaceGroupProperty(self.INPUTGRPPROP1, "", direction=Direction.Input),
+            doc="Table workspace from peak-fitting diagnosis.",
+        )
+        self.declareProperty(IntPropertyWithValue("AddAtIndex", 0))
+        self.declareProperty(
+            WorkspaceGroupProperty(self.OUTPUTGRPPROP, "", direction=Direction.Output),
+            doc="Result of conjoining the diagnostic workspaces",
+        )
+        self.declareProperty("AutoDelete", False)
+        self.setRethrows(True)
+        self.diagnosticSuffix = {
+            FitOutputEnum.PeakPosition.value: "_dspacing",
+            FitOutputEnum.Parameters.value: "_fitparam",
+            FitOutputEnum.Workspace.value: "_fitted",
+        }
+
+    def PyExec(self) -> None:
+        self.autoDelete = self.getProperty("AutoDelete").value
+        index = self.getProperty("AddAtIndex").value
+        diag1 = self.getPropertyValue(self.INPUTGRPPROP1)
+        outws = self.getPropertyValue(self.OUTPUTGRPPROP)
+
+        # on first index, clone the diagnostic workspace group
+        UnGroupWorkspace(
+            InputWorkspace=diag1,
+        )
+
+        oldNames = [f"{diag1}{suffix}" for suffix in self.diagnosticSuffix.values()]
+        newNames = [f"{outws}{suffix}" for suffix in self.diagnosticSuffix.values()]
+
+        if index == 0:
+            RenameWorkspaces(
+                InputWorkspaces=oldNames,
+                WorkspaceNames=newNames,
+            )
+            GroupWorkspaces(
+                InputWorkspaces=newNames,
+                OutputWorkspace=outws,
+            )
+        else:
+            for old, new in zip(oldNames, newNames):
+                ws = mtd[old]
+                if ws.id() == "MatrixWorkspace":
+                    self.conjoinMatrixWorkspaces(old, new, index)
+                elif ws.id() == "TableWorkspace":
+                    self.conjoinTableWorkspaces(old, new, index)
+        self.setProperty(self.OUTPUTGRPPROP, mtd[outws])
+
+    def conjoinMatrixWorkspaces(self, inws, outws, index):
+        ExtractSingleSpectrum(
+            InputWorkspace=inws,
+            Outputworkspace=inws,
+            WorkspaceIndex=index,
+        )
+        ConjoinWorkspaces(
+            InputWorkspace1=inws,
+            InputWorkspace2=outws,
+            CheckOverlapping=False,
+        )
+        if self.autoDelete:
+            DeleteWorkspace(inws)
+
+    def conjoinTableWorkspaces(self, inws, outws, index):  # noqa: ARG002
+        BufferMissingColumnsAlgo(
+            Workspace1=inws,
+            Workspace2=outws,
+        )
+        BufferMissingColumnsAlgo(
+            Workspace1=outws,
+            Workspace2=inws,
+        )
+        ConjoinTableWorkspaces(
+            InputWorkspace1=outws,
+            InputWorkspace2=inws,
+            AutoDelete=self.autoDelete,
+        )

--- a/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
+++ b/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
@@ -10,6 +10,7 @@ from mantid.simpleapi import (
     ExtractSingleSpectrum,
     GroupWorkspaces,
     RenameWorkspace,
+    UnGroupWorkspace,
     mtd,
 )
 
@@ -61,6 +62,10 @@ class ConjoinDiagnosticWorkspaces(PythonAlgorithm):
         oldNames = mtd[diag1].getNames()
         toInclude = [suffix for suffix in self.diagnosticSuffix.values() if suffix in (" ").join(oldNames)]
         newNames = [f"{outws}{suffix}" for suffix in toInclude]
+
+        # if the input is expected to autodelete, it must be ungrouped first
+        if self.autoDelete:
+            UnGroupWorkspace(diag1)
 
         if index == 0:
             for old, new in zip(oldNames, newNames):

--- a/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
+++ b/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
@@ -104,6 +104,11 @@ class ConjoinDiagnosticWorkspaces(PythonAlgorithm):
                 else:
                     raise RuntimeError(f"Unrecognized workspace type {type(ws)}")
 
+        if self.autoDelete:
+            for oldName in oldNames:
+                if oldName in mtd:
+                    DeleteWorkspace(oldName)
+
         self.setProperty(self.OUTPUTGRPPROP, mtd[outws])
 
     def conjoinMatrixWorkspaces(self, inws, outws, index):

--- a/src/snapred/backend/recipe/algorithm/CreateTableWorkspace.py
+++ b/src/snapred/backend/recipe/algorithm/CreateTableWorkspace.py
@@ -1,0 +1,50 @@
+from mantid.api import PythonAlgorithm
+from mantid.dataobjects import TableWorkspaceProperty
+from mantid.kernel import Direction
+from mantid.kernel import ULongLongPropertyWithValue as PointerProperty
+from mantid.simpleapi import CreateEmptyTableWorkspace
+
+from snapred.meta.pointer import access_pointer
+
+
+class CreateTableWorkspace(PythonAlgorithm):
+    def category(self):
+        return "SNAPRed Internal"
+
+    def PyInit(self):
+        self.declareProperty(
+            TableWorkspaceProperty("OutputWorkspace", "", Direction.Output),
+            doc="The table workspace created from the input",
+        )
+        self.declareProperty(
+            PointerProperty("Data", id(None), Direction.Input),
+            doc="A dictionary with column names as keys, corresponding to a list for the column values",
+        )
+        self.setRethrows(True)
+
+    def PyExec(self):
+        data = access_pointer(self.getProperty("Data").value)
+        colnames = list(data.keys())
+        length = len(data[colnames[0]])
+        for col in data.values():
+            if len(col) != length:
+                raise RuntimeError(f"Column mismatch: length {len(col)} vs {length}")
+
+        outputWorkspace = self.getPropertyValue("OutputWorkspace")
+        ws = CreateEmptyTableWorkspace(
+            OutputWorkspace=outputWorkspace,
+        )
+        # add the columns
+        for colname in colnames:
+            coltype = type((data[colname][-1:] or [""])[0])
+            if coltype is float:
+                coltype = "double"
+            else:
+                coltype = coltype.__name__
+
+            ws.addColumn(type=coltype, name=colname)
+        # now add all the data in the columns
+        for i in range(length):
+            ws.addRow({colname: data[colname][i] for colname in colnames})
+
+        self.setProperty("OutputWorkspace", ws)

--- a/src/snapred/backend/recipe/algorithm/FitMultiplePeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FitMultiplePeaksAlgorithm.py
@@ -125,7 +125,7 @@ class FitMultiplePeaksAlgorithm(PythonAlgorithm):
             )
             self.mantidSnapper.WashDishes(
                 "Deleting fitting workspace...",
-                Workspace="ws2fit",
+                Workspace=tmpSpecName,
             )
 
         self.mantidSnapper.executeQueue()

--- a/src/snapred/backend/recipe/algorithm/VerifyChiSquared.py
+++ b/src/snapred/backend/recipe/algorithm/VerifyChiSquared.py
@@ -1,0 +1,89 @@
+from typing import Dict
+
+from mantid.api import PythonAlgorithm
+from mantid.dataobjects import TableWorkspaceProperty
+from mantid.kernel import Direction, FloatPropertyWithValue, ULongLongPropertyWithValue
+
+from snapred.backend.log.logger import snapredLogger
+from snapred.meta.pointer import create_pointer
+
+logger = snapredLogger.getLogger(__name__)
+
+
+class VerifyChiSquared(PythonAlgorithm):
+    """
+    Given a table workspace with fitting diagnosing information and a maximum threshold for chisq,
+    returns a list of good peaks and a list of bad peaks.
+    """
+
+    TABLEWKSPPROP = "InputWorkspace"
+
+    def category(self):
+        return "SNAPRed Diffraction Calibration"
+
+    def validateInputs(self) -> Dict[str, str]:
+        err = {}
+        tab = self.getProperty(self.TABLEWKSPPROP).value
+        colnames = set(tab.toDict().keys())
+        mandatorynames = {"chi2", "wsindex", "centre"}
+        errors = []
+        for name in mandatorynames:
+            if name not in colnames:
+                errors.append(name)
+        if errors != []:
+            err[self.TABLEWKSPPROP] = "Missing mandatory columns: "
+            for name in errors:
+                err[self.TABLEWKSPPROP] += f"{name}, "
+        return err
+
+    def PyInit(self):
+        # declare properties
+        self.declareProperty(
+            TableWorkspaceProperty(self.TABLEWKSPPROP, "", direction=Direction.Input),
+            doc="Table workspace from peak-fitting diagnoses.",
+        )
+        self.declareProperty(
+            FloatPropertyWithValue("MaximumChiSquared", 0, direction=Direction.Input),
+            doc="The threshold value for chisq to be considered 'good.'",
+        )
+        self.declareProperty(
+            ULongLongPropertyWithValue("GoodPeaks", id(None), direction=Direction.Output),
+            doc="Pointer to a list of good peaks (chi2<max), as JSON objects with Spectrum, Peak Location. Chi2.",
+        )
+        self.declareProperty(
+            ULongLongPropertyWithValue("BadPeaks", id(None), direction=Direction.Output),
+            doc="Pointer to a list of bad peaks (chi2 >= max), as JSON objects with Spectrum, Peak Location. Chi2.",
+        )
+        self.declareProperty("LogResults", False, direction=Direction.Input)
+        self.setRethrows(True)
+
+    def PyExec(self) -> None:
+        maxChiSq = self.getProperty("MaximumChiSquared").value
+        tab = self.getProperty(self.TABLEWKSPPROP).value
+        tabDict = tab.toDict()
+        chi2 = tabDict["chi2"]
+        goodPeaks = []
+        badPeaks = []
+        for index, item in enumerate(chi2):
+            peakJSON = {
+                "Spectrum": tabDict["wsindex"][index],
+                "Peak Location": tabDict["centre"][index],
+                "Chi2": tabDict["chi2"][index],
+            }
+            if item < maxChiSq:
+                goodPeaks.append(peakJSON)
+            else:
+                badPeaks.append(peakJSON)
+
+        if self.getProperty("LogResults").value:
+            if len(goodPeaks) < 2:
+                logger.warning(
+                    f"Insufficient number of well-fitted peaks (chi2 < {maxChiSq})."
+                    + "Try to adjust parameters in Tweak Peak Peek tab"
+                    + f"Bad peaks info: {badPeaks}"
+                )
+            else:
+                logger.info(f"Sufficient number of well-fitted peaks (chi2 < {maxChiSq}).: {len(goodPeaks)}")
+
+        self.setProperty("GoodPeaks", create_pointer(goodPeaks))
+        self.setProperty("BadPeaks", create_pointer(badPeaks))

--- a/src/snapred/backend/recipe/algorithm/__init__.py
+++ b/src/snapred/backend/recipe/algorithm/__init__.py
@@ -21,7 +21,7 @@ def loadModule(x):
             if y in all_module_names:
                 loadModule(y)
             else:
-                importlib.import_module(e.name)
+                raise e
             continue
 
     # get just the class name
@@ -45,11 +45,6 @@ for x in all_module_names:
         continue
 
     if x == "PixelDiffractionCalibration":
-        # this is actually a recipe being temporarily stored here
-        # move it to recipe folder and delete this once review passes
-        continue
-
-    if x == "GroupDiffractionCalibration":
         # this is actually a recipe being temporarily stored here
         # move it to recipe folder and delete this once review passes
         continue

--- a/src/snapred/backend/recipe/algorithm/__init__.py
+++ b/src/snapred/backend/recipe/algorithm/__init__.py
@@ -49,6 +49,11 @@ for x in all_module_names:
         # move it to recipe folder and delete this once review passes
         continue
 
+    if x == "GroupDiffractionCalibration":
+        # this is actually a recipe being temporarily stored here
+        # move it to recipe folder and delete this once review passes
+        continue
+
     loadModule(x)
 
 # cleanup

--- a/src/snapred/meta/mantid/FitPeaksOutput.py
+++ b/src/snapred/meta/mantid/FitPeaksOutput.py
@@ -1,0 +1,29 @@
+from enum import Enum
+
+"""
+NOTE child workspaces from a workspace group can ONLY be accessed by index,
+and not by anything reasonable like the name.  Therefore the order of these
+elements is critically important.  They MUST be in alphabetical order by suffix, as
+alphabetical ordering is the only way to impose consistent order of the workspaces.
+"""
+
+"""
+NOTE PDCalibration using the suffix '_dspacing', whereas FitPeaks prefers
+the suffix '_peakpos'. The easiest solution is to change the FitPeaks output
+to match PDCalibration, '_dspacing'.
+"""
+
+
+class FitOutputEnum(Enum):
+    PeakPosition = 0
+    ParameterError = 1
+    Parameters = 2
+    Workspace = 3
+
+
+FIT_PEAK_DIAG_SUFFIX = {
+    FitOutputEnum.PeakPosition: "_dspacing",
+    FitOutputEnum.ParameterError: "_fiterror",
+    FitOutputEnum.Parameters: "_fitparam",
+    FitOutputEnum.Workspace: "_fitted",
+}

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -17,10 +17,10 @@ from workbench.plotting.toolbar import WorkbenchNavigationToolbar
 from snapred.backend.dao import GroupPeakList
 from snapred.backend.dao.Limit import Pair
 from snapred.backend.error.ContinueWarning import ContinueWarning
-from snapred.backend.recipe.algorithm.FitMultiplePeaksAlgorithm import FitOutputEnum
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
+from snapred.meta.mantid.FitPeaksOutput import FitOutputEnum
 from snapred.ui.view.BackendRequestView import BackendRequestView
 from snapred.ui.widget.Toggle import Toggle
 

--- a/tests/unit/backend/recipe/algorithm/test_ConjoinDiagnosticWorkspaces.py
+++ b/tests/unit/backend/recipe/algorithm/test_ConjoinDiagnosticWorkspaces.py
@@ -1,0 +1,247 @@
+import unittest
+
+from mantid.api import WorkspaceGroup
+from mantid.simpleapi import (
+    CalculateDiffCalTable,
+    ConjoinDiagnosticWorkspaces,
+    CreateTableWorkspace,
+    CreateWorkspace,
+    DiffractionFocussing,
+    ExtractSingleSpectrum,
+    PDCalibration,
+    mtd,
+)
+from mantid.testing import assert_almost_equal
+
+# the algorithm to test
+from snapred.backend.recipe.algorithm.ConjoinDiagnosticWorkspaces import (
+    ConjoinDiagnosticWorkspaces as Algo,  # noqa: E402
+)
+from snapred.meta.pointer import create_pointer
+from util.diffraction_calibration_synthetic_data import SyntheticData
+from util.helpers import deleteWorkspaceNoThrow
+
+
+class TestConjoinDiagnosticWorkspaces(unittest.TestCase):
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """
+        Delete all workspaces created by this test, and remove any created files.
+        This is run once at the end of this test suite.
+        """
+        for ws in mtd.getObjectNames():
+            deleteWorkspaceNoThrow(ws)
+        return super().tearDownClass()
+
+    def test_simple_success_table(self):
+        # make group 1
+        name1 = mtd.unique_name()
+        group1 = WorkspaceGroup()
+        tab1 = CreateTableWorkspace(
+            OutputWorkspace=f"{name1}_fitted",
+            Data=create_pointer({"col1": [1, 2], "col3": [4, 5]}),
+        )
+        group1.addWorkspace(tab1)
+        mtd.add(name1, group1)
+
+        # make group 2
+        name2 = mtd.unique_name()
+        group2 = WorkspaceGroup()
+        tab2 = CreateTableWorkspace(
+            OutputWorkspace=f"{name2}_fitted",
+            Data=create_pointer({"col1": [11, 12], "col2": [3, 6]}),
+        )
+        group2.addWorkspace(tab2)
+        mtd.add(name2, group2)
+
+        finalname = mtd.unique_name()
+
+        # add in the first group
+        algo = Algo()
+        algo.initialize()
+        algo.diagnosticSuffix = {0: "_fitted"}
+        algo.setProperty("DiagnosticWorkspace", name1)
+        algo.setProperty("TotalDiagnosticWorkspace", finalname)
+        algo.setProperty("AddAtIndex", 0)
+        algo.execute()
+
+        finalGroup = mtd[algo.getPropertyValue("TotalDiagnosticWorkspace")]
+        tabDict = finalGroup.getItem(0).toDict()
+        assert tabDict == {"col1": [1, 2], "col3": [4, 5]}
+
+        # add in the second group
+        algo = Algo()
+        algo.initialize()
+        algo.diagnosticSuffix = {0: "_fitted"}
+        algo.setProperty("DiagnosticWorkspace", name2)
+        algo.setProperty("TotalDiagnosticWorkspace", finalname)
+        algo.setProperty("AddAtIndex", 1)
+        algo.execute()
+
+        finalGroup = mtd[algo.getPropertyValue("TotalDiagnosticWorkspace")]
+        tabDict = finalGroup.getItem(0).toDict()
+        assert tabDict == {"col1": [1, 2, 11, 12], "col2": [0, 0, 3, 6], "col3": [4, 5, 0, 0]}
+
+    def test_simple_success_workspace(self):
+        bigwksp = CreateWorkspace(
+            DataX=[0, 1, 2, 0, 1, 2],
+            DataY=[2, 2, 3, 3],
+            NSpec=2,
+        )
+        # group 1
+        name1 = mtd.unique_name(prefix="group1_")
+        group1 = WorkspaceGroup()
+        wksp1 = ExtractSingleSpectrum(
+            InputWorkspace=bigwksp,
+            OutputWorkspace=f"{name1}_dspacing",
+            WorkspaceIndex=0,
+        )
+        group1.addWorkspace(wksp1)
+        mtd.add(name1, group1)
+
+        # group 2
+        name2 = mtd.unique_name(prefix="group2_")
+        group2 = WorkspaceGroup()
+        wksp2 = CreateWorkspace(
+            OutputWorkspace=f"{name2}_dspacing",
+            DataX=[0, 0, 0, 0, 1, 2],
+            DataY=[1000, 1000, 3, 3],
+            NSpec=2,
+        )
+        group2.addWorkspace(wksp2)
+        mtd.add(name2, group2)
+
+        finalname = mtd.unique_name(prefix="final_")
+
+        # add in the first workspace
+
+        algo = Algo()
+        algo.initialize()
+        algo.diagnosticSuffix = {0: "_dspacing"}
+        algo.setProperty("DiagnosticWorkspace", name1)
+        algo.setProperty("TotalDiagnosticWorkspace", finalname)
+        algo.setProperty("AddAtIndex", 0)
+        algo.execute()
+
+        finalGroup = mtd[finalname]
+        wksp = finalGroup.getItem(0)
+        assert_almost_equal(wksp, wksp1)
+
+        # add in the second workspace
+
+        algo = Algo()
+        algo.initialize()
+        algo.diagnosticSuffix = {0: "_dspacing"}
+        algo.setProperty("DiagnosticWorkspace", name2)
+        algo.setProperty("TotalDiagnosticWorkspace", finalname)
+        algo.setProperty("AddAtIndex", 1)
+        algo.execute()
+
+        finalGroup = mtd[finalname]
+        wksp = finalGroup.getItem(0)
+        # for some reason the spectrum numbers do not correspond...
+        assert_almost_equal(wksp, bigwksp, CheckSpectraMap=False)
+
+    def test_success(self):
+        """Create a set of mocked ingredients for calculating DIFC corrected by offsets"""
+        syntheticInputs = SyntheticData()
+        ingredients = syntheticInputs.ingredients
+        dBin = max([abs(d) for d in ingredients.pixelGroup.dBin()])
+
+        runNumber = ingredients.runConfig.runNumber
+        rawData = f"_test_groupcal_{runNumber}"
+        groupingWorkspace = f"_test_groupcal_difc_{runNumber}"
+        maskWorkspace = f"_test_groupcal_difc_{runNumber}_mask"
+        difcWS = f"_{runNumber}_difcs_test"
+        syntheticInputs.generateWorkspaces(rawData, groupingWorkspace, maskWorkspace)
+
+        # create the DIFCprev table
+        CalculateDiffCalTable(
+            InputWorkspace=rawData,
+            CalibrationTable=difcWS,
+            OffsetMode="Signed",
+            BinWidth=dBin,
+        )
+
+        DiffractionFocussing(
+            InputWorkspace=rawData,
+            GroupingWorkspace=groupingWorkspace,
+            OutputWorkspace=rawData,
+        )
+
+        nDetectors = mtd[groupingWorkspace].getNumberHistograms()
+        nGroups = mtd[rawData].getNumberHistograms()
+
+        groupIDs = []
+        groupedPeaks = {}
+        groupedPeakBoundaries = {}
+        for peakList in ingredients.groupedPeakLists:
+            groupIDs.append(peakList.groupID)
+            allPeaks = []
+            allPeakBoundaries = []
+            for peak in peakList.peaks:
+                allPeaks.append(peak.value)
+                allPeakBoundaries.append(peak.minimum)
+                allPeakBoundaries.append(peak.maximum)
+            groupedPeaks[peakList.groupID] = allPeaks
+            groupedPeakBoundaries[peakList.groupID] = allPeakBoundaries
+
+        finalname = mtd.unique_name(prefix="final_diag_")
+
+        ref_col_names_position = set()
+        ref_col_names_fitparam = set()
+        ref_peak_num_fitparam = set()
+
+        for index, groupID in enumerate(groupIDs):
+            DIFCpd = mtd.unique_name(prefix=f"temp_DIFCgroup_{groupID}_")
+            diagnosticWSgroup = mtd.unique_name(prefix=f"temp_diag_{groupID}_")
+            PDCalibration(
+                # in common with FitPeaks
+                InputWorkspace=rawData,
+                PeakFunction="Gaussian",
+                PeakPositions=groupedPeaks[groupID],
+                PeakWindow=groupedPeakBoundaries[groupID],
+                BackgroundType="Linear",
+                ConstrainPeakPositions=True,
+                HighBackground=True,
+                DiagnosticWorkspaces=diagnosticWSgroup,
+                # specific to PDCalibration
+                TofBinning=ingredients.pixelGroup.timeOfFlight.params,
+                MaxChiSq=ingredients.maxChiSq,
+                CalibrationParameters="DIFC",
+                OutputCalibrationTable=DIFCpd,
+                MaskWorkspace=maskWorkspace,
+                # limit to specific spectrum
+                StartWorkspaceIndex=index,
+                StopWorkspaceIndex=index,
+            )
+            tempGroup = mtd[diagnosticWSgroup]
+            ref_col_names_position.update(tempGroup.getItem(2).getColumnNames())
+            ref_col_names_fitparam.update(tempGroup.getItem(0).getColumnNames())
+            print(ref_col_names_fitparam)
+            ref_peak_num_fitparam.update(tempGroup.getItem(0).column("centre"))
+            ConjoinDiagnosticWorkspaces(
+                DiagnosticWorkspace=diagnosticWSgroup,
+                TotalDiagnosticWorkspace=finalname,
+                AddAtIndex=index,
+            )
+
+        finalGroup = mtd[finalname]
+        # check the fitted peaks table
+        tab1 = finalGroup.getItem(0)
+        assert set(tab1.getColumnNames()) == ref_col_names_position
+        assert set(tab1.column("detid")) == set(range(nDetectors))
+        assert len(tab1.column("chisq")) == nDetectors
+        for chi2 in tab1.column("chisq"):
+            assert chi2 < 1.0e-5
+        # check the fit paramerer table
+        tab2 = finalGroup.getItem(1)
+        assert set(tab2.getColumnNames()) == ref_col_names_fitparam
+        assert len(tab2.column("peakindex")) == len(ref_peak_num_fitparam)
+        nPeaks = int(len(ref_peak_num_fitparam) / nGroups)
+        assert set(tab2.column("peakindex")) == set(range(nPeaks))
+        assert set(tab2.column("wsindex")) == set(range(nGroups))
+
+        # check the fitted peaks workspace
+        wksp1 = finalGroup.getItem(2)
+        assert wksp1.getNumberHistograms() == nGroups

--- a/tests/unit/backend/recipe/algorithm/test_ConjoinDiagnosticWorkspaces.py
+++ b/tests/unit/backend/recipe/algorithm/test_ConjoinDiagnosticWorkspaces.py
@@ -33,6 +33,13 @@ class TestConjoinDiagnosticWorkspaces(unittest.TestCase):
             deleteWorkspaceNoThrow(ws)
         return super().tearDownClass()
 
+    def test_naming(self):
+        oldNames = ["xyz_d4_dspacing_2", "not_in_list", "feg_abc_fitted_fx"]
+        expNames = ["fun_dspacing", "fun_fitted"]
+        algo = Algo()
+        algo.initialize()
+        assert expNames == algo.newNamesFromOld(oldNames, "fun")
+
     def test_simple_success_table(self):
         # make group 1
         name1 = mtd.unique_name()

--- a/tests/unit/backend/recipe/algorithm/test_ConjoinTableWorkspaces.py
+++ b/tests/unit/backend/recipe/algorithm/test_ConjoinTableWorkspaces.py
@@ -13,7 +13,7 @@ from snapred.backend.recipe.algorithm.ConjoinTableWorkspaces import (
 )
 
 
-class TestConjoinWorkspaces(unittest.TestCase):
+class TestConjoinTableWorkspaces(unittest.TestCase):
     def setUp(self):
         self.correct_ints = [1, 2]
         self.correct_doubles = [1.0, 2.0]

--- a/tests/unit/backend/recipe/algorithm/test_CreateTableWorkspace.py
+++ b/tests/unit/backend/recipe/algorithm/test_CreateTableWorkspace.py
@@ -1,0 +1,94 @@
+import unittest
+
+import pytest
+from mantid.simpleapi import (
+    CreateEmptyTableWorkspace,
+    DeleteWorkspace,
+    mtd,
+)
+from mantid.testing import assert_almost_equal
+
+# the algorithm to test
+from snapred.backend.recipe.algorithm.CreateTableWorkspace import (
+    CreateTableWorkspace as Algo,  # noqa: E402
+)
+from snapred.meta.pointer import create_pointer
+
+
+class TestCreateTableWorkspace(unittest.TestCase):
+    def setUp(self):
+        self.correct_ints = [1, 2]
+        self.correct_doubles = [1.0, 2.0]
+        self.correct_strings = ["one", "two"]
+
+        self.ref_wksp = CreateEmptyTableWorkspace(OutputWorkspace="ref_wksp")
+        self.ref_wksp.addColumn(type="int", name="int-col")
+        self.ref_wksp.addColumn(type="double", name="double-col")
+        self.ref_wksp.addColumn(type="str", name="str-col")
+        for i in range(len(self.correct_doubles)):
+            self.ref_wksp.addRow(
+                {
+                    "int-col": self.correct_ints[i],
+                    "double-col": self.correct_doubles[i],
+                    "str-col": self.correct_strings[i],
+                },
+            )
+
+    def tearDown(self) -> None:
+        for ws in mtd.getObjectNames():
+            try:
+                DeleteWorkspace(ws)
+            except:  # noqa: E722
+                pass
+        return super().tearDown()
+
+    def test_success(self):
+        wksp = mtd.unique_name(prefix="createtab_")
+        data = {"int-col": self.correct_ints, "double-col": self.correct_doubles, "str-col": self.correct_strings}
+        algo = Algo()
+        algo.initialize()
+        algo.setPropertyValue("OutputWorkspace", wksp)
+        algo.setProperty("Data", create_pointer(data))
+        algo.execute()
+
+        assert_almost_equal(wksp, self.ref_wksp)
+        tab = mtd[wksp]
+        assert tab.column("int-col") == self.correct_ints
+        assert tab.column("double-col") == self.correct_doubles
+        assert tab.column("str-col") == self.correct_strings
+
+    def test_validate_fail_collen(self):
+        wksp = mtd.unique_name(prefix="createtab_")
+        incorrect_ints = self.correct_ints.copy()
+        incorrect_ints.append(5)
+        data = {"int-col": incorrect_ints, "double-col": self.correct_doubles, "str-col": self.correct_strings}
+        algo = Algo()
+        algo.initialize()
+        algo.setPropertyValue("OutputWorkspace", wksp)
+        algo.setProperty("Data", create_pointer(data))
+        with pytest.raises(RuntimeError) as e:
+            algo.execute()
+        assert "Column mismatch: length" in str(e.value)
+
+    def test_success_inline(self):
+        wksp = mtd.unique_name(prefix="createtab_")
+        algo = Algo()
+        algo.initialize()
+        algo.setPropertyValue("OutputWorkspace", wksp)
+        algo.setProperty("Data", create_pointer({"col1": [3, 4], "col2": ["x", "a"]}))
+        algo.execute()
+
+        tab = mtd[wksp].toDict()
+        assert tab["col1"] == [3, 4]
+        assert tab["col2"] == ["x", "a"]
+
+    def test_success_nothing(self):
+        wksp = mtd.unique_name(prefix="createtab_")
+        algo = Algo()
+        algo.initialize()
+        algo.setPropertyValue("OutputWorkspace", wksp)
+        algo.setProperty("Data", create_pointer({"col1": []}))
+        algo.execute()
+
+        tab = mtd[wksp].toDict()
+        assert tab["col1"] == []

--- a/tests/unit/backend/recipe/algorithm/test_FitMultiplePeaksAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FitMultiplePeaksAlgorithm.py
@@ -57,10 +57,10 @@ with mock.patch.dict(
         assert wsGroupName == "fitPeaksWSGroup"
         wsGroup = list(mtd[wsGroupName].getNames())
         expected = [
-            "fitPeaksWSGroup_peakpos",
+            "fitPeaksWSGroup_dspacing",
+            "fitPeaksWSGroup_fiterror",
             "fitPeaksWSGroup_fitparam",
             "fitPeaksWSGroup_fitted",
-            "fitPeaksWSGroup_fiterror",
         ]
         assert wsGroup == expected
         assert not mtd.doesExist("fitPeaksWSGroup_fitted_1")

--- a/tests/unit/backend/recipe/algorithm/test_FitMultiplePeaksAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FitMultiplePeaksAlgorithm.py
@@ -4,6 +4,7 @@ from typing import List
 
 import pydantic
 from snapred.backend.dao.request.FarmFreshIngredients import FarmFreshIngredients
+from snapred.meta.mantid.FitPeaksOutput import FIT_PEAK_DIAG_SUFFIX
 
 with mock.patch.dict(
     "sys.modules",
@@ -56,12 +57,7 @@ with mock.patch.dict(
         wsGroupName = fmpAlgo.getProperty("OutputWorkspaceGroup").value
         assert wsGroupName == "fitPeaksWSGroup"
         wsGroup = list(mtd[wsGroupName].getNames())
-        expected = [
-            "fitPeaksWSGroup_dspacing",
-            "fitPeaksWSGroup_fiterror",
-            "fitPeaksWSGroup_fitparam",
-            "fitPeaksWSGroup_fitted",
-        ]
+        expected = [f"{wsGroupName}{suffix}" for suffix in FIT_PEAK_DIAG_SUFFIX.values()]
         assert wsGroup == expected
         assert not mtd.doesExist("fitPeaksWSGroup_fitted_1")
         assert not mtd.doesExist("fitPeaksWSGroup_fitparam_1")

--- a/tests/unit/backend/recipe/algorithm/test_VerifyChiSquared.py
+++ b/tests/unit/backend/recipe/algorithm/test_VerifyChiSquared.py
@@ -1,0 +1,165 @@
+import importlib
+import logging
+import unittest
+
+from mantid.simpleapi import (
+    CreateTableWorkspace,
+    DeleteWorkspace,
+    mtd,
+)
+
+# the algorithm to test
+from snapred.backend.recipe.algorithm.VerifyChiSquared import (
+    VerifyChiSquared as Algo,  # noqa: E402
+)
+from snapred.meta.pointer import access_pointer, create_pointer
+
+VC2Module = importlib.import_module(Algo.__module__)
+
+
+class TestVerifyChiSquared(unittest.TestCase):
+    def setUp(self):
+        self.goodChi2 = 0.0
+        self.badChi2 = 100.0
+        self.indices = [1, 2, 3, 4]
+        self.centres = [0.5, 1.0, 1.5, 2.0]
+        goodDict = {
+            "chi2": [self.goodChi2] * len(self.indices),
+            "wsindex": self.indices,
+            "centre": self.centres,
+        }
+        badDict = {
+            "chi2": [self.badChi2] * len(self.indices),
+            "wsindex": self.indices,
+            "centre": self.centres,
+        }
+        mixedDict = {
+            "chi2": [self.goodChi2, self.badChi2, self.badChi2, self.goodChi2],
+            "wsindex": self.indices,
+            "centre": self.centres,
+        }
+        self.all_good = CreateTableWorkspace(Data=create_pointer(goodDict), OutputWorkspace=mtd.unique_name())
+        self.all_bad = CreateTableWorkspace(Data=create_pointer(badDict), OutputWorkspace=mtd.unique_name())
+        self.mixed = CreateTableWorkspace(Data=create_pointer(mixedDict), OutputWorkspace=mtd.unique_name())
+
+    def tearDown(self) -> None:
+        for ws in mtd.getObjectNames():
+            try:
+                DeleteWorkspace(ws)
+            except:  # noqa: E722
+                pass
+        return super().tearDownClass()
+
+    def test_validate_chi2(self):
+        invalid = {"wsindex": [], "centre": []}
+        ws = mtd.unique_name()
+        tab = CreateTableWorkspace(Data=create_pointer(invalid), OutputWorkspace=ws)
+        algo = Algo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", tab)
+        err = algo.validateInputs()
+        assert "InputWorkspace" in err
+        assert "chi2" in err["InputWorkspace"]
+        assert "wsindex" not in err["InputWorkspace"]
+        assert "centre" not in err["InputWorkspace"]
+
+    def test_validate_wsindex(self):
+        invalid = {"chi2": [], "centre": []}
+        tab = CreateTableWorkspace(OutputWorkspace=mtd.unique_name(), Data=create_pointer(invalid))
+        algo = Algo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", tab)
+        err = algo.validateInputs()
+        assert "InputWorkspace" in err
+        assert "chi2" not in err["InputWorkspace"]
+        assert "wsindex" in err["InputWorkspace"]
+        assert "centre" not in err["InputWorkspace"]
+
+    def test_validate_centre(self):
+        invalid = {"wsindex": [], "chi2": []}
+        tab = CreateTableWorkspace(OutputWorkspace=mtd.unique_name(), Data=create_pointer(invalid))
+        algo = Algo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", tab)
+        err = algo.validateInputs()
+        assert "InputWorkspace" in err
+        assert "chi2" not in err["InputWorkspace"]
+        assert "wsindex" not in err["InputWorkspace"]
+        assert "centre" in err["InputWorkspace"]
+
+    def test_validate_all(self):
+        invalid = {"notmuch": []}
+        tab = CreateTableWorkspace(OutputWorkspace=mtd.unique_name(), Data=create_pointer(invalid))
+        algo = Algo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", tab)
+        err = algo.validateInputs()
+        assert "InputWorkspace" in err
+        assert "chi2" in err["InputWorkspace"]
+        assert "wsindex" in err["InputWorkspace"]
+        assert "centre" in err["InputWorkspace"]
+
+    def test_success_all_good(self):
+        algo = Algo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", self.all_good)
+        algo.setProperty("MaximumChiSquared", self.badChi2)
+        algo.execute()
+        good = access_pointer(algo.getProperty("GoodPeaks").value)
+        bad = access_pointer(algo.getProperty("BadPeaks").value)
+
+        assert bad == []
+        assert len(good) == len(self.indices)
+        assert good == [
+            {"Spectrum": x, "Peak Location": y, "Chi2": self.goodChi2} for x, y in zip(self.indices, self.centres)
+        ]
+
+    def test_success_all_bad(self):
+        algo = Algo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", self.all_bad)
+        algo.setProperty("MaximumChiSquared", self.badChi2)
+        algo.execute()
+        good = access_pointer(algo.getProperty("GoodPeaks").value)
+        bad = access_pointer(algo.getProperty("BadPeaks").value)
+
+        assert good == []
+        assert len(bad) == len(self.indices)
+        assert bad == [
+            {"Spectrum": x, "Peak Location": y, "Chi2": self.badChi2} for x, y in zip(self.indices, self.centres)
+        ]
+
+    def test_success_mixed(self):
+        algo = Algo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", self.mixed)
+        algo.setProperty("MaximumChiSquared", self.badChi2)
+        algo.execute()
+        good = access_pointer(algo.getProperty("GoodPeaks").value)
+        bad = access_pointer(algo.getProperty("BadPeaks").value)
+
+        assert len(good) == 2
+        assert len(bad) == 2
+
+    def test_log_results_good(self):
+        algo = Algo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", self.all_good)
+        algo.setProperty("MaximumChiSquared", self.badChi2)
+        algo.setProperty("LogResults", True)
+        with self.assertLogs(logger=VC2Module.logger, level=logging.INFO) as cm:
+            algo.execute()
+        assert "Sufficient number of well-fitted peaks" in cm.output[0]
+        assert f"(chi2 < {self.badChi2})" in cm.output[0]
+        assert f"{len(self.indices)}" in cm.output[0]
+
+    def test_log_results_bad(self):
+        algo = Algo()
+        algo.initialize()
+        algo.setProperty("InputWorkspace", self.all_bad)
+        algo.setProperty("MaximumChiSquared", self.badChi2)
+        algo.setProperty("LogResults", True)
+        with self.assertLogs(logger=VC2Module.logger, level=logging.INFO) as cm:
+            algo.execute()
+        assert "Insufficient number of well-fitted peaks" in cm.output[0]
+        assert f"(chi2 < {self.badChi2})" in cm.output[0]


### PR DESCRIPTION
## Description of work

Parallel to PR #464.  These algorithms were separate methods inside the `GroupDiffractionCalibration` algorithm.

To more appropriately turn that into a `Recipe`, these chunks of code need to be extracted as standalone algorithms.

The particular algorithm `ConjoinDiagnosticWorkspaces` could be used in the different algos.  For the sake of easier later PRs I standardized both uses and incorporporated it.

## Explanation of work

I took code from inside `GroupDiffractionCalibration` that required an `executeQueue()`, or that took up a lot of space, and moved it into a separate algorithm.

These algorithms are very small, and could be of general use in Mantid.

Note the use of pointer properties in `VerifyChiSquared` and `CreateTableWorkspace`.  This can be corrected when `PythonObjectProperty` is completed.

Some of the work standardizes the output diagnostic from two algorithms that were performing the same operation more piecemeal.

## To test

### Dev testing

Ensure all tests run.  Launch manually.  Double-check added unit tests.

In the GUI.

Run calibration.  At the peak tweak stage, inspect the the workspace list.

There should only be diagnosis workspace group (it is cyan and has a expand arrow to show other workspaces).  It will be falled `fit_peak_diag_{run}_1_pre`.  It will have four workspaces, with the suffixes:
-  `_dspacing` --  information about the peak centers.
- `_fiterror` -- should have some fitting parameters like A0, A1, Height, Sigma, etc for peakindex and wsindex.
- '_fitparam` -- should have similar information.  Critically, it MUST have these columns
  - `chi2`
  - `wsindex`
  - `PeakCentre` (+/- British spelling)
- `_fitted` -- workspace should be plottable and show the fits to the peaks.

It is important that they are in EXACTLY THIS ORDER.

There should be NO OTHER cyan workspaces.

Manually inspect the workspaces to ensure they make sense.

Finish the run.  There should be THREE cyan workspaces.  The output of `GroupDiffractionCalibration` will be a grouping workspace of the form `{diagnostic_{grouping}_{run}`, and will have exactly these workspaces:
- `_dspacing` -- information on the peak locations.
- `_fitparam` -- should be roughly equivalent to the peak-fit output, but in dpsacing.
- `_fitted` -- graphs of the fits to the peaks
- `tof_unfoc_0{run}` -- the original peaks in TOF,  for diagnosis

### CIS testing

N/A

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#7388](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7388)

### Verification

N/A

### Acceptance Criteria

N/A

This is an enabler for the story, and doesn't by itself meet any criteria.
