### PR TITLE
Remove unneeded file creation from APIService test

### DIFF
--- a/tests/unit/backend/api/test_APIService.py
+++ b/tests/unit/backend/api/test_APIService.py
@@ -49,8 +49,6 @@ class TestAPIService:
         mockService = MockService()
         serviceDirectory.registerService(mockService)
         validPaths = apiService.getValidPaths()
-        with Resource.open("/outputs/APIServicePaths.json.new", "w") as f:
-            f.write(json.dumps(validPaths, indent=2))
         with Resource.open("/outputs/APIServicePaths.json", "r") as f:
             actualValidPaths = json.load(f)
             assert validPaths == actualValidPaths


### PR DESCRIPTION
## Description of work

Whenever the unit tests run, a file called `APIServicePaths.json,new` is created and stays there.

This file apparently serves no purpose, and annoyingly pops up in the git status every time it is re-created.

## Explanation of work

I removed the lines in the unit test that created this file.

There appears to be no need to save the file, as it is never touched again.

## To test

### Dev testing

Just wait for all tests to pass.

### CIS testing

N/A

## Link to EWM item

N/A

### Acceptance Criteria

N/A
