### PR TITLE
Purge bad peaks :mountain: :axe:

### DIFF
--- a/docs/source/api/snapred.ui.view.rst
+++ b/docs/source/api/snapred.ui.view.rst
@@ -52,7 +52,7 @@ snapred.ui.view.DiffCalTweakPeakView module
 .. automodule:: snapred.ui.view.DiffCalTweakPeakView
    :members:
    :undoc-members:
-   :exclude-members: signalRunNumberUpdate, signalValueChanged, signalUpdateRecalculationButton, signalPeakThresholdUpdate, signalMaxChiSqUpdate, signalContinueAnyway
+   :exclude-members: signalRunNumberUpdate, signalValueChanged, signalUpdateRecalculationButton, signalPeakThresholdUpdate, signalMaxChiSqUpdate, signalContinueAnyway, signalPurgeBadPeaks
    :show-inheritance:
 
 

--- a/src/snapred/backend/dao/request/SimpleDiffCalRequest.py
+++ b/src/snapred/backend/dao/request/SimpleDiffCalRequest.py
@@ -1,0 +1,11 @@
+from typing import Dict
+
+from pydantic import BaseModel
+
+from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients
+
+
+class SimpleDiffCalRequest(BaseModel):
+    ingredients: DiffractionCalibrationIngredients
+    groceries: Dict[str, str]
+    skipPixelCalibration: bool

--- a/tests/unit/ui/workflow/test_DiffCalWorkflow.py
+++ b/tests/unit/ui/workflow/test_DiffCalWorkflow.py
@@ -1,0 +1,150 @@
+import threading
+from random import randint
+from unittest.mock import MagicMock, patch
+
+from mantid.simpleapi import (
+    CreateSingleValuedWorkspace,
+    CreateTableWorkspace,
+    GroupWorkspaces,
+    mtd,
+)
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication, QMessageBox
+from snapred.meta.mantid.FitPeaksOutput import FIT_PEAK_DIAG_SUFFIX, FitOutputEnum
+from snapred.meta.pointer import create_pointer
+from snapred.ui.workflow.DiffCalWorkflow import DiffCalWorkflow
+
+
+@patch("snapred.ui.workflow.DiffCalWorkflow.WorkflowImplementer.request")
+def test_purge_bad_peaks(workflowRequest, qtbot):  # noqa: ARG001
+    """
+    Test that when purge peaks is called, improper peaks are removed.
+    """
+    diffcalWorkflow = DiffCalWorkflow()
+
+    maxChiSq = 100
+    num_peaks = 100
+    peaks = list(range(num_peaks))
+    is_good_peak = [bool(randint(0, 1)) for peak in peaks]
+    good_peaks = [peak for is_good, peak in zip(is_good_peak, peaks) if is_good]
+
+    wsindex = [0] * num_peaks
+    chi2 = [0 if is_good else maxChiSq for is_good in is_good_peak]
+
+    # setup some mocks
+    diffcalWorkflow.ingredients = MagicMock(groupedPeakLists=[MagicMock(peaks=peaks)])
+    diagWS = mtd.unique_name(prefix="difc_wf_tab_")
+    ws1 = diagWS + FIT_PEAK_DIAG_SUFFIX[FitOutputEnum.PeakPosition]
+    ws2 = diagWS + FIT_PEAK_DIAG_SUFFIX[FitOutputEnum.ParameterError]
+    tabWS = diagWS + FIT_PEAK_DIAG_SUFFIX[FitOutputEnum.Parameters]
+    CreateSingleValuedWorkspace(OutputWorkspace=ws1)
+    CreateSingleValuedWorkspace(OutputWorkspace=ws2)
+    CreateTableWorkspace(
+        OutputWorkspace=tabWS,
+        Data=create_pointer({"wsindex": wsindex, "chi2": chi2}),
+    )
+    GroupWorkspaces(
+        OutputWorkspace=diagWS,
+        InputWorkspaces=[ws1, ws2, tabWS],
+    )
+    diffcalWorkflow.fitPeaksDiagnostic = diagWS
+
+    diffcalWorkflow.purgeBadPeaks(maxChiSq)
+    assert diffcalWorkflow.ingredients.groupedPeakLists[0].peaks == good_peaks
+
+
+@patch("snapred.ui.workflow.DiffCalWorkflow.WorkflowImplementer.request")
+def test_purge_bad_peaks_two_wkspindex(workflowRequest, qtbot):  # noqa: ARG001
+    """
+    Test that purge bad peaks can handle several workspace index
+    """
+    diffcalWorkflow = DiffCalWorkflow()
+
+    maxChiSq = 100
+    num_peaks = 4
+    peaks1 = list(range(num_peaks))
+    peaks2 = list(range(num_peaks))
+    is_good_peak1 = [0, 1, 0, 1]
+    is_good_peak2 = [1, 0, 1, 0]
+    good_peaks1 = [peak for is_good, peak in zip(is_good_peak1, peaks1) if is_good]
+    good_peaks2 = [peak for is_good, peak in zip(is_good_peak2, peaks2) if is_good]
+
+    wsindex = [0, 0, 0, 0, 1, 1, 1, 1]
+    chi2 = [0 if is_good else maxChiSq for is_good in is_good_peak1]
+    chi2.extend([0 if is_good else maxChiSq for is_good in is_good_peak2])
+
+    # setup some mocks
+    diffcalWorkflow.ingredients = MagicMock(
+        groupedPeakLists=[
+            MagicMock(peaks=peaks1),
+            MagicMock(peaks=peaks2),
+        ]
+    )
+    diagWS = mtd.unique_name(prefix="difc_wf_tab_")
+    ws1 = diagWS + FIT_PEAK_DIAG_SUFFIX[FitOutputEnum.PeakPosition]
+    ws2 = diagWS + FIT_PEAK_DIAG_SUFFIX[FitOutputEnum.ParameterError]
+    tabWS = diagWS + FIT_PEAK_DIAG_SUFFIX[FitOutputEnum.Parameters]
+    CreateSingleValuedWorkspace(OutputWorkspace=ws1)
+    CreateSingleValuedWorkspace(OutputWorkspace=ws2)
+    CreateTableWorkspace(
+        OutputWorkspace=tabWS,
+        Data=create_pointer({"wsindex": wsindex, "chi2": chi2}),
+    )
+    GroupWorkspaces(
+        OutputWorkspace=diagWS,
+        InputWorkspaces=[ws1, ws2, tabWS],
+    )
+    diffcalWorkflow.fitPeaksDiagnostic = diagWS
+
+    diffcalWorkflow.purgeBadPeaks(maxChiSq)
+    assert diffcalWorkflow.ingredients.groupedPeakLists[0].peaks == good_peaks1
+    assert diffcalWorkflow.ingredients.groupedPeakLists[1].peaks == good_peaks2
+
+
+@patch("snapred.ui.workflow.DiffCalWorkflow.WorkflowImplementer.request")
+def test_purge_bad_peaks_too_few(workflowRequest, qtbot):  # noqa: ARG001
+    """
+    Test that if too few peaks would be generated, a warning is raised
+    """
+    diffcalWorkflow = DiffCalWorkflow()
+
+    maxChiSq = 100
+    num_peaks = 3
+    peaks = list(range(num_peaks))
+    is_good_peak = [0, 0, 1]
+    good_peaks = [peak for is_good, peak in zip(is_good_peak, peaks) if is_good]
+
+    wsindex = [0] * num_peaks
+    chi2 = [0 if is_good else maxChiSq for is_good in is_good_peak]
+
+    # setup some mocks
+    diffcalWorkflow.ingredients = MagicMock(groupedPeakLists=[MagicMock(peaks=peaks)])
+    diagWS = mtd.unique_name(prefix="difc_wf_tab_")
+    ws1 = diagWS + FIT_PEAK_DIAG_SUFFIX[FitOutputEnum.PeakPosition]
+    ws2 = diagWS + FIT_PEAK_DIAG_SUFFIX[FitOutputEnum.ParameterError]
+    tabWS = diagWS + FIT_PEAK_DIAG_SUFFIX[FitOutputEnum.Parameters]
+    CreateSingleValuedWorkspace(OutputWorkspace=ws1)
+    CreateSingleValuedWorkspace(OutputWorkspace=ws2)
+    CreateTableWorkspace(
+        OutputWorkspace=tabWS,
+        Data=create_pointer({"wsindex": wsindex, "chi2": chi2}),
+    )
+    GroupWorkspaces(
+        OutputWorkspace=diagWS,
+        InputWorkspaces=[ws1, ws2, tabWS],
+    )
+    diffcalWorkflow.fitPeaksDiagnostic = diagWS
+
+    def execute_click():
+        w = QApplication.activeWindow()
+        if isinstance(w, QMessageBox):
+            close_button = w.button(QMessageBox.Ok)
+            qtbot.mouseClick(close_button, Qt.LeftButton)
+
+    # setup the qtbot to intercept the window
+    qtbot.addWidget(diffcalWorkflow._tweakPeakView)
+    threading.Timer(0.1, execute_click).start()
+    diffcalWorkflow.purgeBadPeaks(maxChiSq)
+
+    assert diffcalWorkflow.ingredients.groupedPeakLists[0].peaks == peaks
+    assert diffcalWorkflow.ingredients.groupedPeakLists[0].peaks != good_peaks


### PR DESCRIPTION
## Description of work

The diffcal workflow will not allow users to proceed beyond the peak tweak stage if there are _any_ bad peaks.  This requires users to adjust things to try to make all peaks good.  But sometimes bad peaks just can't go away.

This adds a button which makes the bad peaks go away.

The purged list is then passed forward to all future calculations.

## Explanation of work

Added an extra service endpoint.  The older `calibration/diffraction` endpoint will take a DiffCalRequest, create the ingredients and groceries from it, and pass it to the recipe.  The new `calibration/calibrate` endpoint is expected a request with the ingredients and groceries already in it.  This allows for refining the ingredients before the calibration begins.

Within the diffraction workflow, there is now logic to remove peaks above the $\chi^2$ threshold.

This logic is triggered by the "Purge Bad Peaks" button.

## To test

### Dev testing

Run diff cal with the following:
- run: 58882
- sample: silicon
- grouping: Bank

At tweak peak, you should see two groups each with three bad peaks.  Press to purge the peaks.

The red filled regions have vanished.  There are still three good peaks.  Now continue to the saving screen.

Inspect the workspaces present, in particular from the PDCalibration diagnosis group.  In the `_params` table, for instance, you should see six rows for the six peaks (three in two groups).  The column for peak index should go 0, 1, 2 twice, while workspace index 0, 0, 0, 1, 1, 1.  The `_fitted` workspace should show two graphs with three peaks each.  Etc.

Check the other fit peaks outputs (cyan = workspace group = fit peaks output).

Save, run again.  At Tweak Peak, **the previously purged peaks will be back**.

Run with 46680 and Bank, and try purging peaks.  It will fail, as it would result in no peaks on the right grouping.

### CIS testing

Perform the dev steps above, but please also confirm the values, the goodness of fits and DIFC values, and check for some other runs.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#6242](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6242)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] TweakPeak view has a button to purge bad peaks
- [x] Clicking this button removes peaks with $\chi^2$ > threshold from the peaks list, then re-graphs with the bad peaks removed
- [x] If removing peaks would result in fewer than two peaks in a spectrum, an error dialog box is raised and no peaks are removed from that spectrum
- [x] The same peaks list, with the removed peaks, is passed forward to all future operations in the diffcal workflow
