### PR TITLE
make minor fix to test loading by instrument name

### DIFF
--- a/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
+++ b/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
@@ -264,7 +264,7 @@ class TestLoadGroupingDefinition(unittest.TestCase):
     def do_test_load_with_instrument_name(self, ext: str):
         outputWorkspace = "test_ext"
         with amend_config(**{"instrumentDefinition.directory": Resource.getPath("inputs/testInstrument/")}):
-            ConfigService.updateFacilities("inputs/testInstrument/Facilities.xml")
+            ConfigService.updateFacilities(Resource.getPath("inputs/testInstrument/Facilities.xml"))
             ConfigService.setFacility("TestSNAP")
             loadingAlgo = LoadingAlgo()
             loadingAlgo.initialize()


### PR DESCRIPTION
## Description of work

A  test randomly stopped working for me, due to failing to load the `Facilities.xml` file.

I have no idea why this stopped suddenly.

This single-line fix got it working again.

I have no idea why this  stopped working.  Given the fix, I also have no idea why it ever used to work.  But now it works.

## Explanation of work

:man_shrugging: 

## To test

### Dev testing

Make sure `test_LoadGroupingDefinition` passes in the unit tests.

### CIS testing

N/A

## Link to EWM item

N/A

### Verification

N/A

### Acceptance Criteria

N/A
