### PR TITLE
EWM7751 replaced save tab of reduction with pop up, removed some noisy warnings

### DIFF
--- a/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
@@ -94,7 +94,7 @@ class LoadGroupingDefinition(PythonAlgorithm):
 
         if groupingFileExt not in self.supported_xml_file_extensions:
             if not self.getProperty("InstrumentDonor").isDefault:
-                logger.warning("InstrumentDonor will only be used if GroupingFilename is in XML format.")
+                logger.debug("InstrumentDonor will only be used if GroupingFilename is in XML format.")
 
         instrumentSources = ["InstrumentDonor", "InstrumentName", "InstrumentFilename"]
         specifiedSources = [s for s in instrumentSources if not self.getProperty(s).isDefault]

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -223,3 +223,8 @@ docs:
 
 metadata:
   tagPrefix: SNAPRed_
+
+ui:
+  default:
+    workflow:
+      completionMessage: "‧₊‧₊The workflow has been completed successfully!‧₊‧₊"

--- a/src/snapred/ui/presenter/WorkflowPresenter.py
+++ b/src/snapred/ui/presenter/WorkflowPresenter.py
@@ -1,7 +1,7 @@
 from typing import Callable, List
 
 from qtpy.QtCore import QObject, Signal, Slot
-from qtpy.QtWidgets import QMainWindow
+from qtpy.QtWidgets import QMainWindow, QMessageBox
 
 from snapred.backend.api.InterfaceController import InterfaceController
 from snapred.backend.error.ContinueWarning import ContinueWarning
@@ -29,6 +29,7 @@ class WorkflowPresenter(QObject):
         iterateLambda=None,
         resetLambda=None,
         cancelLambda=None,
+        completionMessage=None,
         parent=None,
     ):
         super().__init__()
@@ -36,6 +37,8 @@ class WorkflowPresenter(QObject):
         # 'WorkerPool' is a singleton:
         #    declaring it as an instance attribute, rather than a class attribute,
         #    allows singleton reset during testing.
+        self.completionMessage = completionMessage
+
         self.worker_pool = WorkerPool()
 
         self.view = WorkflowView(model, parent)
@@ -138,11 +141,10 @@ class WorkflowPresenter(QObject):
 
     def advanceWorkflow(self):
         if self.view.currentTab >= self.view.totalNodes - 1:
-            ActionPrompt.prompt(
-                "‧₊Workflow Complete‧₊",
-                "‧₊‧₊The workflow has been completed successfully!‧₊‧₊",
-                lambda: None,
+            QMessageBox.information(
                 self.view,
+                "‧₊Workflow Complete‧₊",
+                self.completionMessage,
             )
             self.reset()
         else:

--- a/src/snapred/ui/presenter/WorkflowPresenter.py
+++ b/src/snapred/ui/presenter/WorkflowPresenter.py
@@ -29,7 +29,7 @@ class WorkflowPresenter(QObject):
         iterateLambda=None,
         resetLambda=None,
         cancelLambda=None,
-        completionMessage=None,
+        completionMessageLambda=None,
         parent=None,
     ):
         super().__init__()
@@ -37,7 +37,7 @@ class WorkflowPresenter(QObject):
         # 'WorkerPool' is a singleton:
         #    declaring it as an instance attribute, rather than a class attribute,
         #    allows singleton reset during testing.
-        self.completionMessage = completionMessage
+        self.completionMessageLambda = completionMessageLambda
 
         self.worker_pool = WorkerPool()
 
@@ -144,7 +144,7 @@ class WorkflowPresenter(QObject):
             QMessageBox.information(
                 self.view,
                 "‧₊Workflow Complete‧₊",
-                self.completionMessage,
+                self.completionMessageLambda(),
             )
             self.reset()
         else:

--- a/src/snapred/ui/widget/Workflow.py
+++ b/src/snapred/ui/widget/Workflow.py
@@ -11,7 +11,7 @@ class Workflow:
         iterateLambda=None,
         resetLambda=None,
         cancelLambda=None,
-        completionMessage=None,
+        completionMessageLambda=None,
         parent=None,
     ):
         # default loading subview
@@ -21,7 +21,7 @@ class Workflow:
             iterateLambda=iterateLambda,
             resetLambda=resetLambda,
             cancelLambda=cancelLambda,
-            completionMessage=completionMessage,
+            completionMessageLambda=completionMessageLambda,
             parent=parent,
         )
 

--- a/src/snapred/ui/widget/Workflow.py
+++ b/src/snapred/ui/widget/Workflow.py
@@ -11,6 +11,7 @@ class Workflow:
         iterateLambda=None,
         resetLambda=None,
         cancelLambda=None,
+        completionMessage=None,
         parent=None,
     ):
         # default loading subview
@@ -20,6 +21,7 @@ class Workflow:
             iterateLambda=iterateLambda,
             resetLambda=resetLambda,
             cancelLambda=cancelLambda,
+            completionMessage=completionMessage,
             parent=parent,
         )
 

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -42,6 +42,9 @@ class ReductionWorkflow(WorkflowImplementer):
                 startLambda=self.start,
                 # Retain reduction-output workspaces.
                 resetLambda=lambda: self.reset(True),
+                completionMessage=(
+                    "Reduction has completed successfully.\n" "Your workspaces are available in the workspace list."
+                ),
                 parent=parent,
             )
             .addNode(
@@ -50,7 +53,7 @@ class ReductionWorkflow(WorkflowImplementer):
                 "Reduction",
                 continueAnywayHandler=self._continueAnywayHandler,
             )
-            .addNode(self._nothing, self._reductionSaveView, "Save")
+            # .addNode(self._nothing, self._reductionSaveView, "Save")
             .build()
         )
 

--- a/src/snapred/ui/workflow/WorkflowBuilder.py
+++ b/src/snapred/ui/workflow/WorkflowBuilder.py
@@ -1,14 +1,25 @@
+from snapred.meta.Config import Config
 from snapred.ui.model.WorkflowNodeModel import WorkflowNodeModel
 from snapred.ui.widget.Workflow import Workflow
 
 
 class WorkflowBuilder:
-    def __init__(self, *, startLambda=None, iterateLambda=None, resetLambda=None, cancelLambda=None, parent=None):
+    def __init__(
+        self,
+        *,
+        startLambda=None,
+        iterateLambda=None,
+        resetLambda=None,
+        cancelLambda=None,
+        parent=None,
+        completionMessage=Config["ui.default.workflow.completionMessage"],
+    ):
         self.parent = parent
         self._startLambda = startLambda
         self._iterateLambda = iterateLambda
         self._resetLambda = resetLambda
         self._cancelLambda = cancelLambda
+        self._completionMessage = completionMessage
         self._workflow = None
 
     def addNode(
@@ -46,5 +57,6 @@ class WorkflowBuilder:
             iterateLambda=self._iterateLambda,
             resetLambda=self._resetLambda,
             cancelLambda=self._cancelLambda,
+            completionMessage=self._completionMessage,
             parent=self.parent,
         )

--- a/src/snapred/ui/workflow/WorkflowBuilder.py
+++ b/src/snapred/ui/workflow/WorkflowBuilder.py
@@ -12,14 +12,14 @@ class WorkflowBuilder:
         resetLambda=None,
         cancelLambda=None,
         parent=None,
-        completionMessage=Config["ui.default.workflow.completionMessage"],
+        completionMessageLambda=lambda: Config["ui.default.workflow.completionMessage"],
     ):
         self.parent = parent
         self._startLambda = startLambda
         self._iterateLambda = iterateLambda
         self._resetLambda = resetLambda
         self._cancelLambda = cancelLambda
-        self._completionMessage = completionMessage
+        self._completionMessageLambda = completionMessageLambda
         self._workflow = None
 
     def addNode(
@@ -57,6 +57,6 @@ class WorkflowBuilder:
             iterateLambda=self._iterateLambda,
             resetLambda=self._resetLambda,
             cancelLambda=self._cancelLambda,
-            completionMessage=self._completionMessage,
+            completionMessageLambda=self._completionMessageLambda,
             parent=self.parent,
         )

--- a/src/snapred/ui/workflow/WorkflowImplementer.py
+++ b/src/snapred/ui/workflow/WorkflowImplementer.py
@@ -11,6 +11,7 @@ from snapred.backend.dao.request import (
 )
 from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.log.logger import snapredLogger
+from snapred.meta.Config import Config
 from snapred.ui.handler.SNAPResponseHandler import SNAPResponseHandler
 from snapred.ui.widget.Workflow import Workflow
 
@@ -116,6 +117,9 @@ class WorkflowImplementer(QObject):
     def complete(self):
         for hook in self.resetHooks:
             hook()
+
+    def completionMessage(self):
+        return Config["ui.default.workflow.completionMessage"]
 
     def _request(self, request: SNAPRequest):
         response = self.interfaceController.executeRequest(request)

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -237,3 +237,8 @@ constants:
 
 metadata:
   tagPrefix: testSNAPfuntime_
+
+ui:
+  default:
+    workflow:
+      completionMessage: "‧₊‧₊The workflow has been completed successfully!‧₊‧₊"


### PR DESCRIPTION
## Description of work

This exposes the workflow completion message to the `WorkflowBuilder` to enable an implemented workflow to display a custom message upon completion.
This was then utilized to replace the Save step of the `ReductionWorkflow` (which does nothing) with a simple pop up that accomplishes the same goal: Informing the user that redcution has completed successfully.

This turns off a particularly noisy in-actionable warning message too.

## To test

Run Reduction with run number `59039`, observe that it completes.
Ensure the reduction results are in the workspace list and are also persisted to disk. 

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#7751](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7751)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] The new desired solution is to skip the final step (The Reduction Save View) on the reduction workflow and instead simply drop an a prompt informing the user that Reduction had completed successfully
- [x] The user no longer has the opportunity to create workspaces that will accidentally be deleted at the end of the Reduction Workflow (i.e. painstakingly created masks)
