### PR TITLE
sous chef return deep copies of cached objects

### DIFF
--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -1,4 +1,5 @@
 import os
+from copy import deepcopy
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -115,7 +116,7 @@ class SousChef(Service):
                 timeOfFlight=data["tof"],
                 nBinsAcrossPeakWidth=ingredients.nBinsAcrossPeakWidth,
             )
-        return self._pixelGroupCache[key]
+        return deepcopy(self._pixelGroupCache[key])
 
     def prepManyPixelGroups(self, ingredients: FarmFreshIngredients) -> List[PixelGroup]:
         pixelGroups = []
@@ -138,7 +139,7 @@ class SousChef(Service):
         key = (ingredients.cifPath, ingredients.crystalDBounds.minimum, ingredients.crystalDBounds.maximum)
         if key not in self._xtalCache:
             self._xtalCache[key] = CrystallographicInfoService().ingest(*key)["crystalInfo"]
-        return self._xtalCache[key]
+        return deepcopy(self._xtalCache[key])
 
     def prepPeakIngredients(self, ingredients: FarmFreshIngredients) -> PeakIngredients:
         return PeakIngredients(
@@ -183,7 +184,7 @@ class SousChef(Service):
                 )
             self._peaksCache[key] = self.parseGroupPeakList(res)
 
-        return self._peaksCache[key]
+        return deepcopy(self._peaksCache[key])
 
     def prepManyDetectorPeaks(self, ingredients: FarmFreshIngredients) -> List[List[GroupPeakList]]:
         # this also needs to check if it is in fact the default calibration

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -89,6 +89,8 @@ class DiffCalWorkflow(WorkflowImplementer):
         self._tweakPeakView.signalValueChanged.connect(self.onValueChange)
 
         self.prevFWHM = DiffCalTweakPeakView.FWHM
+        self.prevXtalDMin = DiffCalTweakPeakView.XTAL_DMIN
+        self.prevXtalDMax = DiffCalTweakPeakView.XTAL_DMAX
 
         # 1. input run number and other basic parameters
         # 2. display peak graphs, allow adjustments to view
@@ -224,6 +226,8 @@ class DiffCalWorkflow(WorkflowImplementer):
             convergenceThreshold=self.convergenceThreshold,
             nBinsAcrossPeakWidth=self.nBinsAcrossPeakWidth,
             fwhmMultipliers=self.prevFWHM,
+            crystalDMin=self.prevXtalDMin,
+            crystalDMax=self.prevXtalDMax,
             maxChiSq=self.maxChiSq,
             skipPixelCalibration=self._tweakPeakView.skipPixelCalToggle.field.getState(),
             removeBackground=self.removeBackground,
@@ -234,8 +238,8 @@ class DiffCalWorkflow(WorkflowImplementer):
 
         # set "previous" values -- this is their initialization
         # these are used to compare if the values have changed
-        self.prevXtalDMin = payload.crystalDMin
-        self.prevXtalDMax = payload.crystalDMax
+        self.prevXtalDMin = payload.crystalDMin  # NOTE set in __init__ to defaults
+        self.prevXtalDMax = payload.crystalDMax  # NOTE set in __init__ to defaults
         self.prevFWHM = payload.fwhmMultipliers  # NOTE set in __init__ to defaults
         self.prevGroupingIndex = view.groupingFileDropdown.currentIndex()
         self.fitPeaksDiagnostic = f"fit_peak_diag_{self.runNumber}_{self.prevGroupingIndex}_pre"


### PR DESCRIPTION
## Description of work

It was possible for code in SNAPRed to edit the cached ingredients objects in SousChef, resulting in globally different sets of parameters.

This fixes that.

## Explanation of work

Used `deepcopy` of the cached objects to prevent the original being overwritten.

Shallow copies cannot work here, as it is still possible to change things in a shallow copy that reflect in the original.

There are new tests to ensure the cached objects cannot be changed.

## To test

### Dev testing

Run diffcal, save, continue, run again same run, at tweak peak stage make sure the same peaks are there and same settings.

Run normal, make sure the tweak peak stage appears.  If so, should be good.

Double check the unit tests.

### CIS testing

N/A, but will be apparent in testing of PR #480 

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

No ticket, but arose in development:

[EWM#7388](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7388)

Was discovered during testing of PR #480

### Verification

N/A

### Acceptance Criteria

N/A
