### PR TITLE
reduction: apply pixelmask to unfocused data

### DIFF
--- a/src/snapred/backend/recipe/ReductionRecipe.py
+++ b/src/snapred/backend/recipe/ReductionRecipe.py
@@ -87,7 +87,9 @@ class ReductionRecipe(Recipe[Ingredients]):
         )
         self.mantidSnapper.executeQueue()
 
-    def _prepareUnfocusedData(self, workspace: WorkspaceName, mask: Optional[WorkspaceName], units: str) -> WorkspaceName:
+    def _prepareUnfocusedData(
+        self, workspace: WorkspaceName, mask: Optional[WorkspaceName], units: str
+    ) -> WorkspaceName:
         unitsAbrev = ""
         match units:
             case "Wavelength":
@@ -111,7 +113,7 @@ class ReductionRecipe(Recipe[Ingredients]):
                 MaskWorkspace=mask,
                 OutputWorkspace=self.unfocWs,
             )
-        
+
         self.mantidSnapper.ConvertUnits(
             f"Converting unfocused data to {units} units",
             InputWorkspace=self.unfocWs,

--- a/tests/unit/backend/recipe/test_ReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionRecipe.py
@@ -142,19 +142,17 @@ class ReductionRecipeTest(TestCase):
         recipe._prepareUnfocusedData(workspace, None, units)
         recipe.mantidSnapper.MaskDetectorFlags.assert_not_called()
         recipe.mantidSnapper.reset_mock()
-        
+
         recipe._prepareUnfocusedData(workspace, maskWs, units)
 
         recipe.mantidSnapper.MaskDetectorFlags.assert_called_once_with(
-            "Applying pixel mask to unfocused data",
-            MaskWorkspace=maskWs,
-            OutputWorkspace=outputWs
+            "Applying pixel mask to unfocused data", MaskWorkspace=maskWs, OutputWorkspace=outputWs
         )
         recipe.mantidSnapper.ConvertUnits.assert_called_once_with(
             f"Converting unfocused data to {units} units",
             InputWorkspace=outputWs,
             OutputWorkspace=outputWs,
-            Target=units
+            Target=units,
         )
         recipe.mantidSnapper.executeQueue.assert_called()
         recipe.mantidSnapper.reset_mock()


### PR DESCRIPTION
## Description of work

Before the start of the reduction process.  If the unfocused data is to be retained, a clone is made of the input data.  This clone is then masked and converted to the units requested.

## Explanation of work

The existing method `_cloneAndConvertWorkspace` has been renamed to `_prepareUnfocusedData`.  This method now includes an optional mask-application step, which is triggered when a mask exists.

## To test

A unit test has been added to verify that the mask is applied to the unfocused data.

### Dev testing

1. Launch SNAPRed using `python -m workbench`.
2. Load a suitable input-data workspace.
3. Using "instrument view" create a MaskWorkspace that has some pixels masked:  it should automatically be named correctly to be picked up by the pixelmask dropdown: e.g. `MaskWorkspace`
4. Run through the reduction process, selecting this `MaskWorkspace`, and electing to retain unfocused data.
5. Verify that the final unfocused data workspace has the masking applied.

### CIS testing
Same as for dev testing.

## Link to EWM item

[EWM#7760](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=7760)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

  1. When the unfocused data is retained/treated as part of the Reduction Workflow the combined mask should be applied.

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] acceptance criterion 1
