### PR TITLE
actually skip pixel calibration, using default calibration as startin…

### DIFF
--- a/src/snapred/backend/dao/request/SimpleDiffCalRequest.py
+++ b/src/snapred/backend/dao/request/SimpleDiffCalRequest.py
@@ -8,3 +8,4 @@ from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients
 class SimpleDiffCalRequest(BaseModel):
     ingredients: DiffractionCalibrationIngredients
     groceries: Dict[str, str]
+    skipPixelCalibration: bool

--- a/src/snapred/backend/dao/request/SimpleDiffCalRequest.py
+++ b/src/snapred/backend/dao/request/SimpleDiffCalRequest.py
@@ -8,4 +8,3 @@ from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients
 class SimpleDiffCalRequest(BaseModel):
     ingredients: DiffractionCalibrationIngredients
     groceries: Dict[str, str]
-    skipPixelCalibration: bool

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -184,7 +184,7 @@ class CalibrationService(Service):
     @FromString
     def pixelCalibration(self, request: SimpleDiffCalRequest) -> PixelDiffCalServing:
         # cook recipe
-        if request.skipPixelCalibration:
+        if request.ingredients.skipPixelCalibration:
             self.groceryClerk.name("defaultCalibrationTable").diffcal_table(
                 request.ingredients.runConfig.runNumber, VERSION_DEFAULT
             ).useLiteMode(request.ingredients.runConfig.useLiteMode).add()

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -123,8 +123,6 @@ class CalibrationService(Service):
         )
         ingredients = self.sousChef.prepDiffractionCalibrationIngredients(farmFresh)
         ingredients.removeBackground = request.removeBackground
-        ingredients.skipPixelCalibration = request.skipPixelCalibration
-
         return ingredients
 
     @FromString
@@ -184,7 +182,7 @@ class CalibrationService(Service):
     @FromString
     def pixelCalibration(self, request: SimpleDiffCalRequest) -> PixelDiffCalServing:
         # cook recipe
-        if request.ingredients.skipPixelCalibration:
+        if request.skipPixelCalibration:
             self.groceryClerk.name("defaultCalibrationTable").diffcal_table(
                 request.ingredients.runConfig.runNumber, VERSION_DEFAULT
             ).useLiteMode(request.ingredients.runConfig.useLiteMode).add()

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -311,3 +311,6 @@ class DiffCalTweakPeakView(BackendRequestView):
             self._testContinueAnywayStates()
 
         return True
+
+    def getSkipPixelCalibration(self):
+        return self.skipPixelCalToggle.field.getState()

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -413,12 +413,9 @@ class DiffCalWorkflow(WorkflowImplementer):
         self.runNumber = view.runNumberField.text()
         self._saveView.updateRunNumber(self.runNumber)
         self.focusGroupPath = view.groupingFileDropdown.currentText()
-
-        payload = SimpleDiffCalRequest(
-            ingredients=self.ingredients,
-            groceries=self.groceries,
-            skipPixelCalibration=self._tweakPeakView.skipPixelCalToggle.field.getState(),
-        )
+        self.ingredients.skipPixelCalibration = self._tweakPeakView.skipPixelCalToggle.field.getState()
+        self.ingredients.runConfig.useLiteMode = self.useLiteMode
+        payload = SimpleDiffCalRequest(ingredients=self.ingredients, groceries=self.groceries)
 
         response = self.request(path="calibration/diffractionWithIngredients", payload=payload.json())
 

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -413,9 +413,13 @@ class DiffCalWorkflow(WorkflowImplementer):
         self.runNumber = view.runNumberField.text()
         self._saveView.updateRunNumber(self.runNumber)
         self.focusGroupPath = view.groupingFileDropdown.currentText()
-        self.ingredients.skipPixelCalibration = self._tweakPeakView.skipPixelCalToggle.field.getState()
+
         self.ingredients.runConfig.useLiteMode = self.useLiteMode
-        payload = SimpleDiffCalRequest(ingredients=self.ingredients, groceries=self.groceries)
+        payload = SimpleDiffCalRequest(
+            ingredients=self.ingredients,
+            groceries=self.groceries,
+            skipPixelCalibration=self._tweakPeakView.getSkipPixelCalibration(),
+        )
 
         response = self.request(path="calibration/diffractionWithIngredients", payload=payload.json())
 


### PR DESCRIPTION
…g point.

## Description of work

This pushes the `skipPixelCalibration` flag to just one place, and then actually sets the utilized place, ie on `ingredients`
Since pixel calibration was now actually being successfully skipped DiffractionCalibration ran into the issue of not having a starting diffcal table that pixel calibration would normally provide.

As per consultation of Malcolm, the default diffcal table is loaded from disk and used as the base in this case.
This has the secondary purpose of priming calibration for when we eventually add the ability to choose a starting calibration.


## To test

Currently I kinda need help examining the data to confirm that it does what is expected.
I have confirmed codewise that pixel calibration is successfuly skipped when toggled, but the output workspace I was inspecting still kinda just looked the same.

I used the following in the diffcal flow.
59039
LA11b6

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#7617](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7617)

### Verification

- [ ] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

**The story is lacking explicit acceptance criteria, the title may suffice.**

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] acceptance criterion 1
- [ ] acceptance criterion 2
