### PR TITLE
updated normalization workflow to default to diffcal runnumber for its appliesTo field

### DIFF
--- a/src/snapred/backend/dao/response/NormalizationResponse.py
+++ b/src/snapred/backend/dao/response/NormalizationResponse.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel
 
@@ -22,4 +22,8 @@ class NormalizationResponse(BaseModel):
     focusedVanadium: str
     smoothedVanadium: str
     detectorPeaks: List[GroupPeakList]
-    calibrationRunNumber: str
+
+    # This is returned on first go of the normalization process
+    # Follow up recalc operations reuse this response object
+    # but do not need to return calibrationRunNumber
+    calibrationRunNumber: Optional[str] = None

--- a/src/snapred/backend/dao/response/NormalizationResponse.py
+++ b/src/snapred/backend/dao/response/NormalizationResponse.py
@@ -22,3 +22,4 @@ class NormalizationResponse(BaseModel):
     focusedVanadium: str
     smoothedVanadium: str
     detectorPeaks: List[GroupPeakList]
+    calibrationRunNumber: str

--- a/src/snapred/backend/service/Service.py
+++ b/src/snapred/backend/service/Service.py
@@ -32,7 +32,6 @@ Register = _makeRegister()
 
 class Service(ABC):
     _pathDelimiter = Config["orchestration.path.delimiter"]
-    _registrar = None
 
     def __init__(self):
         self._paths: Dict[str, Any] = self._getInstancePaths()

--- a/src/snapred/backend/service/Service.py
+++ b/src/snapred/backend/service/Service.py
@@ -9,12 +9,41 @@ from snapred.meta.Config import Config
 GroupingLambda = Callable[[List[SNAPRequest]], Dict[str, List[SNAPRequest]]]
 
 
+def _makeRegister():
+    registry = {}
+
+    def register(path):
+        def reg(func):
+            clazzQualName = ".".join(func.__qualname__.split(".")[:-1])
+            methodName = func.__qualname__.split(".")[-1]
+            if clazzQualName not in registry:
+                registry[clazzQualName] = {}
+            registry[clazzQualName][path] = methodName
+            return func
+
+        return reg
+
+    register.all = registry
+    return register
+
+
+Register = _makeRegister()
+
+
 class Service(ABC):
     _pathDelimiter = Config["orchestration.path.delimiter"]
+    _registrar = None
 
     def __init__(self):
-        self._paths: Dict[str, Any] = {}
+        self._paths: Dict[str, Any] = self._getInstancePaths()
         self._lambdas: Dict[str, List[GroupingLambda]] = {}
+
+    def _getInstancePaths(self):
+        instPaths = {}
+        clsPaths = Register.all.get(self.__class__.__qualname__, {})
+        for key, value in clsPaths.items():
+            instPaths[key] = self.__getattribute__(value)
+        return instPaths
 
     @abstractmethod
     def name(self):

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -183,6 +183,7 @@ class NormalizationWorkflow(WorkflowImplementer):
         focusWorkspace = self.responses[-1].data["focusedVanadium"]
         smoothWorkspace = self.responses[-1].data["smoothedVanadium"]
         peaks = self.responses[-1].data["detectorPeaks"]
+        self.calibrationRunNumber = self.responses[-1].data["calibrationRunNumber"]
 
         self._tweakPeakView.updateWorkspaces(focusWorkspace, smoothWorkspace, peaks)
         self.initializationComplete = True
@@ -209,7 +210,7 @@ class NormalizationWorkflow(WorkflowImplementer):
         view = workflowPresenter.widget.tabView
         runNumber = view.fieldRunNumber.get()
         version = view.fieldVersion.get()
-        appliesTo = view.fieldAppliesTo.get(f">={runNumber}")
+        appliesTo = view.fieldAppliesTo.get(f">={self.calibrationRunNumber}")
         # validate version number
         version = VersionedObject.parseVersion(version, exclude_default=True)
         # validate appliesTo field

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -250,6 +250,7 @@ class TestNormalizationService(unittest.TestCase):
         self.instance.dataFactoryService.getThisOrLatestCalibrationVersion = mock.Mock(return_value=1)
         self.instance.dataExportService.getCalibrationStateRoot = mock.Mock(return_value="lah/dee/dah")
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
+        self.instance.dataFactoryService.getCalibrationRecord = mock.Mock(return_value=mock.Mock(runNumber="12345"))
         self.instance.dataExportService.checkWritePermissions = mock.Mock(return_value=True)
 
         result = self.instance.normalization(self.request)


### PR DESCRIPTION
## Description of work

* updated normalization workflow to default to diffcal runnumber for its appliesTo field
* created @Register decorator for co-locate method/path registration in Services

## To test

Run normalization workflow with your choice of Caibrations on disk
Confirm that the `'appliesTo' field defaults to ">={diffractionCalibrationRunNumber}"
Perform other regression tests as need be (like specifying a custom appliesTo)

I use 58810 for the run number and 58813 fr the background run number.  The Calibrant Sample can be whatever.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#4614](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4614)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] the run number of the diffraction calibration applied to normalization during the normalization workflow shall be the default runnumber in its 'appliesTo' field of the normalization 
- [x] In the case of a default calibration you should still be able to refer to the runnumber listed in the index.
