### PR TITLE
Get Rid of Noisy FigureManager error log

### DIFF
--- a/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
+++ b/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
@@ -11,6 +11,7 @@ from mantid.simpleapi import (
     DeleteWorkspace,
     ExtractSingleSpectrum,
     GroupWorkspaces,
+    RenameWorkspace,
     UnGroupWorkspace,
     mtd,
 )
@@ -73,10 +74,16 @@ class ConjoinDiagnosticWorkspaces(PythonAlgorithm):
 
         if index == 0:
             for old, new in zip(oldNames, newNames):
-                CloneWorkspace(
-                    InputWorkspace=old,
-                    OutputWorkspace=new,
-                )
+                if self.autoDelete:
+                    RenameWorkspace(
+                        InputWorkspace=old,
+                        OutputWorkspace=new,
+                    )
+                else:
+                    CloneWorkspace(
+                        InputWorkspace=old,
+                        OutputWorkspace=new,
+                    )
                 if isinstance(mtd[new], MatrixWorkspace) and index < mtd[new].getNumberHistograms():
                     ExtractSingleSpectrum(
                         InputWorkspace=new,

--- a/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
+++ b/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
@@ -11,7 +11,6 @@ from mantid.simpleapi import (
     DeleteWorkspace,
     ExtractSingleSpectrum,
     GroupWorkspaces,
-    RenameWorkspace,
     UnGroupWorkspace,
     mtd,
 )
@@ -74,16 +73,10 @@ class ConjoinDiagnosticWorkspaces(PythonAlgorithm):
 
         if index == 0:
             for old, new in zip(oldNames, newNames):
-                if self.autoDelete:
-                    RenameWorkspace(
-                        InputWorkspace=old,
-                        OutputWorkspace=new,
-                    )
-                else:
-                    CloneWorkspace(
-                        InputWorkspace=old,
-                        OutputWorkspace=new,
-                    )
+                CloneWorkspace(
+                    InputWorkspace=old,
+                    OutputWorkspace=new,
+                )
                 if isinstance(mtd[new], MatrixWorkspace) and index < mtd[new].getNumberHistograms():
                     ExtractSingleSpectrum(
                         InputWorkspace=new,

--- a/src/snapred/ui/plotting/Factory.py
+++ b/src/snapred/ui/plotting/Factory.py
@@ -1,0 +1,28 @@
+def mantidAxisFactory(ax):
+    """
+    Refurbish the axis object with a new rename_workspace method
+    """
+
+    def rename_workspace(old_name, new_name):
+        """
+        Rename a workspace, and update the artists, creation arguments and tracked workspaces accordingly
+        :param new_name : the new name of workspace
+        :param old_name : the old name of workspace
+        """
+        for cargs in ax.creation_args:
+            # NEW CHECK
+            func_name = cargs["function"]
+            if func_name not in ["axhline", "axvline"] and cargs["workspaces"] == old_name:
+                cargs["workspaces"] = new_name
+            # Alternatively,
+            # if cargs.get("workspaces") == old_name:
+            #     cargs["workspaces"] = new_name
+        for ws_name, ws_artist_list in list(ax.tracked_workspaces.items()):
+            for ws_artist in ws_artist_list:
+                if ws_artist.workspace_name == old_name:
+                    ws_artist.rename_data(new_name)
+            if ws_name == old_name:
+                ax.tracked_workspaces[new_name] = ax.tracked_workspaces.pop(old_name)
+
+    ax.rename_workspace = rename_workspace
+    return ax

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -226,6 +226,9 @@ class DiffCalTweakPeakView(BackendRequestView):
             self.badPeaks[wkspIndex] = [peak for chi2, peak in zip(chisq, peaks) if chi2 >= maxChiSq]
             # prepare the plot area
             ax = self.figure.add_subplot(nrows, ncols, wkspIndex + 1, projection="mantid")
+            # NOTE: Mutate the ax object to remove the workspace renaming,
+            # not sure why but cargs["workspaces"] is missing
+            ax.rename_workspace = lambda x, y: None  # noqa: ARG005
             ax.tick_params(direction="in")
             ax.set_title(f"Group ID: {wkspIndex + 1}")
             # plot the data and fitted

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -21,6 +21,7 @@ from snapred.meta.Config import Config
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
 from snapred.meta.mantid.FitPeaksOutput import FitOutputEnum
+from snapred.ui.plotting.Factory import mantidAxisFactory
 from snapred.ui.view.BackendRequestView import BackendRequestView
 from snapred.ui.widget.Toggle import Toggle
 
@@ -230,28 +231,7 @@ class DiffCalTweakPeakView(BackendRequestView):
 
             # NOTE: Mutate the ax object as the mantidaxis does not account for lines
             # TODO: Bubble this up to the mantid codebase and remove this mutation.
-            def rename_workspace(old_name, new_name):
-                """
-                Rename a workspace, and update the artists, creation arguments and tracked workspaces accordingly
-                :param new_name : the new name of workspace
-                :param old_name : the old name of workspace
-                """
-                for cargs in ax.creation_args:
-                    # NEW CHECK
-                    func_name = cargs["function"]
-                    if func_name not in ["axhline", "axvline"] and cargs["workspaces"] == old_name:
-                        cargs["workspaces"] = new_name
-                    # Alternatively,
-                    # if cargs.get("workspaces") == old_name:
-                    #     cargs["workspaces"] = new_name
-                for ws_name, ws_artist_list in list(ax.tracked_workspaces.items()):
-                    for ws_artist in ws_artist_list:
-                        if ws_artist.workspace_name == old_name:
-                            ws_artist.rename_data(new_name)
-                    if ws_name == old_name:
-                        ax.tracked_workspaces[new_name] = ax.tracked_workspaces.pop(old_name)
-
-            ax.rename_workspace = rename_workspace
+            ax = mantidAxisFactory(ax)
 
             ax.tick_params(direction="in")
             ax.set_title(f"Group ID: {wkspIndex + 1}")

--- a/src/snapred/ui/view/NormalizationTweakPeakView.py
+++ b/src/snapred/ui/view/NormalizationTweakPeakView.py
@@ -179,9 +179,31 @@ class NormalizationTweakPeakView(BackendRequestView):
         self.figure.clear()
         for i in range(numGraphs):
             ax = self.figure.add_subplot(nrows, ncols, i + 1, projection="mantid")
-            # NOTE: Mutate the ax object to remove the workspace renaming,
-            # not sure why but cargs["workspaces"] is missing
-            ax.rename_workspace = lambda x, y: None  # noqa: ARG005
+
+            # NOTE: Mutate the ax object as the mantidaxis does not account for lines
+            # TODO: Bubble this up to the mantid codebase and remove this mutation.
+            def rename_workspace(old_name, new_name):
+                """
+                Rename a workspace, and update the artists, creation arguments and tracked workspaces accordingly
+                :param new_name : the new name of workspace
+                :param old_name : the old name of workspace
+                """
+                for cargs in ax.creation_args:
+                    # NEW CHECK
+                    func_name = cargs["function"]
+                    if func_name not in ["axhline", "axvline"] and cargs["workspaces"] == old_name:
+                        cargs["workspaces"] = new_name
+                    # Alternatively,
+                    # if cargs.get("workspaces") == old_name:
+                    #     cargs["workspaces"] = new_name
+                for ws_name, ws_artist_list in list(ax.tracked_workspaces.items()):
+                    for ws_artist in ws_artist_list:
+                        if ws_artist.workspace_name == old_name:
+                            ws_artist.rename_data(new_name)
+                    if ws_name == old_name:
+                        ax.tracked_workspaces[new_name] = ax.tracked_workspaces.pop(old_name)
+
+            ax.rename_workspace = rename_workspace
             ax.plot(focusedWorkspace, wkspIndex=i, label="Focused Data", normalize_by_bin_width=True)
             ax.plot(smoothedWorkspace, wkspIndex=i, label="Smoothed Data", normalize_by_bin_width=True, linestyle="--")
             ax.legend()

--- a/src/snapred/ui/view/NormalizationTweakPeakView.py
+++ b/src/snapred/ui/view/NormalizationTweakPeakView.py
@@ -17,6 +17,7 @@ from workbench.plotting.toolbar import WorkbenchNavigationToolbar
 from snapred.backend.dao import GroupPeakList
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Resettable import Resettable
+from snapred.ui.plotting.Factory import mantidAxisFactory
 from snapred.ui.view.BackendRequestView import BackendRequestView
 from snapred.ui.widget.SmoothingSlider import SmoothingSlider
 
@@ -182,28 +183,8 @@ class NormalizationTweakPeakView(BackendRequestView):
 
             # NOTE: Mutate the ax object as the mantidaxis does not account for lines
             # TODO: Bubble this up to the mantid codebase and remove this mutation.
-            def rename_workspace(old_name, new_name):
-                """
-                Rename a workspace, and update the artists, creation arguments and tracked workspaces accordingly
-                :param new_name : the new name of workspace
-                :param old_name : the old name of workspace
-                """
-                for cargs in ax.creation_args:
-                    # NEW CHECK
-                    func_name = cargs["function"]
-                    if func_name not in ["axhline", "axvline"] and cargs["workspaces"] == old_name:
-                        cargs["workspaces"] = new_name
-                    # Alternatively,
-                    # if cargs.get("workspaces") == old_name:
-                    #     cargs["workspaces"] = new_name
-                for ws_name, ws_artist_list in list(ax.tracked_workspaces.items()):
-                    for ws_artist in ws_artist_list:
-                        if ws_artist.workspace_name == old_name:
-                            ws_artist.rename_data(new_name)
-                    if ws_name == old_name:
-                        ax.tracked_workspaces[new_name] = ax.tracked_workspaces.pop(old_name)
+            ax = mantidAxisFactory(ax)
 
-            ax.rename_workspace = rename_workspace
             ax.plot(focusedWorkspace, wkspIndex=i, label="Focused Data", normalize_by_bin_width=True)
             ax.plot(smoothedWorkspace, wkspIndex=i, label="Smoothed Data", normalize_by_bin_width=True, linestyle="--")
             ax.legend()

--- a/src/snapred/ui/view/NormalizationTweakPeakView.py
+++ b/src/snapred/ui/view/NormalizationTweakPeakView.py
@@ -179,6 +179,9 @@ class NormalizationTweakPeakView(BackendRequestView):
         self.figure.clear()
         for i in range(numGraphs):
             ax = self.figure.add_subplot(nrows, ncols, i + 1, projection="mantid")
+            # NOTE: Mutate the ax object to remove the workspace renaming,
+            # not sure why but cargs["workspaces"] is missing
+            ax.rename_workspace = lambda x, y: None  # noqa: ARG005
             ax.plot(focusedWorkspace, wkspIndex=i, label="Focused Data", normalize_by_bin_width=True)
             ax.plot(smoothedWorkspace, wkspIndex=i, label="Smoothed Data", normalize_by_bin_width=True, linestyle="--")
             ax.legend()

--- a/src/snapred/ui/view/reduction/ArtificialNormalizationView.py
+++ b/src/snapred/ui/view/reduction/ArtificialNormalizationView.py
@@ -11,6 +11,7 @@ from qtpy.QtWidgets import (
 )
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Resettable import Resettable
+from snapred.ui.plotting.Factory import mantidAxisFactory
 from snapred.ui.view.BackendRequestView import BackendRequestView
 from workbench.plotting.figuremanager import MantidFigureCanvas
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
@@ -136,28 +137,8 @@ class ArtificialNormalizationView(BackendRequestView):
 
             # NOTE: Mutate the ax object as the mantidaxis does not account for lines
             # TODO: Bubble this up to the mantid codebase and remove this mutation.
-            def rename_workspace(old_name, new_name):
-                """
-                Rename a workspace, and update the artists, creation arguments and tracked workspaces accordingly
-                :param new_name : the new name of workspace
-                :param old_name : the old name of workspace
-                """
-                for cargs in ax.creation_args:
-                    # NEW CHECK
-                    func_name = cargs["function"]
-                    if func_name not in ["axhline", "axvline"] and cargs["workspaces"] == old_name:
-                        cargs["workspaces"] = new_name
-                    # Alternatively,
-                    # if cargs.get("workspaces") == old_name:
-                    #     cargs["workspaces"] = new_name
-                for ws_name, ws_artist_list in list(ax.tracked_workspaces.items()):
-                    for ws_artist in ws_artist_list:
-                        if ws_artist.workspace_name == old_name:
-                            ws_artist.rename_data(new_name)
-                    if ws_name == old_name:
-                        ax.tracked_workspaces[new_name] = ax.tracked_workspaces.pop(old_name)
+            ax = mantidAxisFactory(ax)
 
-            ax.rename_workspace = rename_workspace
             ax.plot(diffractionWorkspace, wkspIndex=i, label="Diffcal Data", normalize_by_bin_width=True)
             ax.plot(
                 artificialNormWorkspace,

--- a/src/snapred/ui/view/reduction/ArtificialNormalizationView.py
+++ b/src/snapred/ui/view/reduction/ArtificialNormalizationView.py
@@ -133,9 +133,31 @@ class ArtificialNormalizationView(BackendRequestView):
         self.figure.clear()
         for i in range(numGraphs):
             ax = self.figure.add_subplot(nrows, ncols, i + 1, projection="mantid")
-            # NOTE: Mutate the ax object to remove the workspace renaming,
-            # not sure why but cargs["workspaces"] is missing
-            ax.rename_workspace = lambda x, y: None  # noqa: ARG005
+
+            # NOTE: Mutate the ax object as the mantidaxis does not account for lines
+            # TODO: Bubble this up to the mantid codebase and remove this mutation.
+            def rename_workspace(old_name, new_name):
+                """
+                Rename a workspace, and update the artists, creation arguments and tracked workspaces accordingly
+                :param new_name : the new name of workspace
+                :param old_name : the old name of workspace
+                """
+                for cargs in ax.creation_args:
+                    # NEW CHECK
+                    func_name = cargs["function"]
+                    if func_name not in ["axhline", "axvline"] and cargs["workspaces"] == old_name:
+                        cargs["workspaces"] = new_name
+                    # Alternatively,
+                    # if cargs.get("workspaces") == old_name:
+                    #     cargs["workspaces"] = new_name
+                for ws_name, ws_artist_list in list(ax.tracked_workspaces.items()):
+                    for ws_artist in ws_artist_list:
+                        if ws_artist.workspace_name == old_name:
+                            ws_artist.rename_data(new_name)
+                    if ws_name == old_name:
+                        ax.tracked_workspaces[new_name] = ax.tracked_workspaces.pop(old_name)
+
+            ax.rename_workspace = rename_workspace
             ax.plot(diffractionWorkspace, wkspIndex=i, label="Diffcal Data", normalize_by_bin_width=True)
             ax.plot(
                 artificialNormWorkspace,

--- a/src/snapred/ui/view/reduction/ArtificialNormalizationView.py
+++ b/src/snapred/ui/view/reduction/ArtificialNormalizationView.py
@@ -133,6 +133,9 @@ class ArtificialNormalizationView(BackendRequestView):
         self.figure.clear()
         for i in range(numGraphs):
             ax = self.figure.add_subplot(nrows, ncols, i + 1, projection="mantid")
+            # NOTE: Mutate the ax object to remove the workspace renaming,
+            # not sure why but cargs["workspaces"] is missing
+            ax.rename_workspace = lambda x, y: None  # noqa: ARG005
             ax.plot(diffractionWorkspace, wkspIndex=i, label="Diffcal Data", normalize_by_bin_width=True)
             ax.plot(
                 artificialNormWorkspace,


### PR DESCRIPTION

## Description of work

this is a bandaid fix, the more permanent fix is here: https://github.com/mantidproject/mantid/pull/38486


## To test

On `next`:
launch snapred via workbench
Perform Calibration and Recalc
Observer Error Log

On This Branch:
launch snapred via workbench
Perform Calibration and Recalc
Observer **NO** Error Log

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#7769](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7769)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] no random figure manager error log during normal unerror flow of any workflow.
