### PR TITLE
Enable remove background toggle in CIS mode

### DIFF
--- a/src/snapred/ui/view/DiffCalRequestView.py
+++ b/src/snapred/ui/view/DiffCalRequestView.py
@@ -1,3 +1,4 @@
+from snapred.meta.Config import Config
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
 from snapred.ui.view.BackendRequestView import BackendRequestView
@@ -34,9 +35,9 @@ class DiffCalRequestView(BackendRequestView):
         self.peakFunctionDropdown = self._sampleDropDown("Peak Function", [p.value for p in SymmetricPeakEnum])
 
         # checkbox for removing background
-        # NOTE not enabled until remove event background is fixed
+        # NOTE not enabled unless in CIS mode until remove event background is fixed -- then re-enable
         self.removeBackgroundToggle = self._labeledField("RemoveBackground", Toggle(parent=self, state=False))
-        self.removeBackgroundToggle.setEnabled(False)
+        self.removeBackgroundToggle.setEnabled(Config["cis_mode"])
 
         # set field properties
         self.litemodeToggle.setEnabled(True)


### PR DESCRIPTION
## Description of work

Enable the toggle in CIS mode to make it easier for CIS testing

## Explanation of work

The toggle's enable state is pegged to CIS mode in the config.

## To test

### Dev testing

Launch the calibration workflow with CIS mode OFF.  The toggle cannot be interacted with.

Launch the calibration workflow with CIS mode ON.  The toggle can be switched on or off.

It is not necessary to test any other behavior of the toggle for this PR.

### CIS testing

Unneeded, but will enable testing for PR #473 

## Link to EWM item
N/A

### Verification
N/A

### Acceptance Criteria

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] the remove background toggle is enabled in CIS mode, and disabled otherwise
