### PR TITLE
Handle multiple reduction runs

### DIFF
--- a/src/snapred/backend/dao/request/MatchRunsRequest.py
+++ b/src/snapred/backend/dao/request/MatchRunsRequest.py
@@ -1,0 +1,8 @@
+from typing import List
+
+from pydantic import BaseModel
+
+
+class MatchRunsRequest(BaseModel):
+    runNumbers: List[str]
+    useLiteMode: bool

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -5,6 +5,7 @@ from qtpy.QtCore import Slot
 from snapred.backend.dao.ingredients import ArtificialNormalizationIngredients
 from snapred.backend.dao.request import (
     CreateArtificialNormalizationRequest,
+    MatchRunsRequest,
     ReductionExportRequest,
     ReductionRequest,
 )
@@ -181,27 +182,48 @@ class ReductionWorkflow(WorkflowImplementer):
         response = self.request(path="reduction/groupings", payload=request_)
         self._keeps = set(response.data["groupingWorkspaces"])
 
-        for runNumber in self.runNumbers:
-            self._artificialNormalizationView.updateRunNumber(runNumber)
-            request_ = self._createReductionRequest(runNumber)
+        # get the calibration and normalization versions for all runs to be processed
+        matchRequest = MatchRunsRequest(runNumbers=self.runNumbers, useLiteMode=self.useLiteMode)
+        loadedCalibrations, calVersions = self.request(path="calibration/fetchMatches", payload=matchRequest).data
+        loadedNormalizations, normVersions = self.request(path="normalization/fetchMatches", payload=matchRequest).data
+        self._keeps.update(loadedCalibrations)
+        self._keeps.update(loadedNormalizations)
 
-            # Validate reduction; if artificial normalization is needed, handle it
-            response = self.request(path="reduction/validate", payload=request_)
-            if ContinueWarning.Type.MISSING_NORMALIZATION in self.continueAnywayFlags:
+        distinctNormVersions = set(normVersions.values())
+        if len(distinctNormVersions) > 1 and None in distinctNormVersions:
+            raise RuntimeError(
+                "Some of your workspaces require Artificial Normalization.  "
+                "SNAPRed can currently only handle the situation where all, or none "
+                "of the runs require Artificial Normalization.  Please clear the list "
+                "and try again."
+            )
+
+        # Validate reduction; if artificial normalization is needed, handle it
+        # NOTE: this logic ONLY works because we are forbidding mixed cases of artnorm or loaded norm
+        response = self.request(path="reduction/validate", payload=request_)
+        if ContinueWarning.Type.MISSING_NORMALIZATION in self.continueAnywayFlags:
+            if len(self.runNumbers) > 1:
+                raise RuntimeError(
+                    "Currently, Artificial Normalization can only be performed on a "
+                    "single run at a time.  Please clear your run list and try again."
+                )
+            for runNumber in self.runNumbers:
+                self._artificialNormalizationView.updateRunNumber(runNumber)
                 self._artificialNormalizationView.showAdjustView()
+                request_ = self._createReductionRequest(runNumber)
                 response = self.request(path="reduction/grabWorkspaceforArtificialNorm", payload=request_)
                 self._artificialNormalization(workflowPresenter, response.data, runNumber)
-            else:
-                # Proceed with reduction if artificial normalization is not needed
+        else:
+            for runNumber in self.runNumbers:
                 self._artificialNormalizationView.showSkippedView()
+                request_ = self._createReductionRequest(runNumber)
                 response = self.request(path="reduction/", payload=request_)
                 if response.code == ResponseCode.OK:
-                    record, unfocusedData = response.data.record, response.data.unfocusedData
-                    self._finalizeReduction(record, unfocusedData)
-            # after each run, clean workspaces except groupings, calibrations, normalizations, and outputs
-            self._keeps.update(self.outputs)
-            self._clearWorkspaces(exclude=self._keeps, clearCachedWorkspaces=True)
-        workflowPresenter.advanceWorkflow()
+                    self._finalizeReduction(response.data.record, response.data.unfocusedData)
+                # after each run, clean workspaces except groupings, calibrations, normalizations, and outputs
+                self._keeps.update(self.outputs)
+                self._clearWorkspaces(exclude=self._keeps, clearCachedWorkspaces=True)
+            workflowPresenter.advanceWorkflow()
         # SPECIAL FOR THE REDUCTION WORKFLOW: clear everything _except_ the output workspaces
         #   _before_ transitioning to the "save" panel.
         # TODO: make '_clearWorkspaces' a public method (i.e make this combination a special `cleanup` method).

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -207,6 +207,33 @@ class TestNormalizationService(unittest.TestCase):
             SmoothingParameter=mockRequest.smoothingParameter,
         )
 
+    def test_matchRuns(self):
+        self.instance.dataFactoryService.getThisOrLatestNormalizationVersion = mock.Mock(
+            side_effect=[mock.sentinel.version1, mock.sentinel.version2],
+        )
+        request = mock.Mock(runNumbers=[mock.sentinel.run1, mock.sentinel.run2], useLiteMode=True)
+        response = self.instance.matchRunsToNormalizationVersions(request)
+        assert response == {
+            mock.sentinel.run1: mock.sentinel.version1,
+            mock.sentinel.run2: mock.sentinel.version2,
+        }
+
+    def test_fetchRuns(self):
+        mockCalibrations = {
+            mock.sentinel.run1: mock.sentinel.version1,
+            mock.sentinel.run2: mock.sentinel.version2,
+            mock.sentinel.run3: mock.sentinel.version2,
+        }
+        mockGroceries = [mock.sentinel.grocery1, mock.sentinel.grocery2, mock.sentinel.grocery2]
+        self.instance.matchRunsToNormalizationVersions = mock.Mock(return_value=mockCalibrations)
+        self.instance.groceryService.fetchGroceryList = mock.Mock(return_value=mockGroceries)
+        self.instance.groceryClerk = mock.Mock()
+
+        request = mock.Mock(runNumbers=[mock.sentinel.run1, mock.sentinel.run2], useLiteMode=True)
+        groceries, cal = self.instance.fetchMatchingNormalizations(request)
+        assert groceries == {mock.sentinel.grocery1, mock.sentinel.grocery2}
+        assert cal == mockCalibrations
+
     def test_normalizationAssessment(self):
         self.instance = NormalizationService()
         self.instance.sousChef = SculleryBoy()


### PR DESCRIPTION
## Description of work

The Artificial Normalization screen requires the workflow to load a screen for adjusting parameters to create a false background.  However, workflow's don't enable going forward or backward or optionally skipping screens, which prevents handling arbitrary cases of Artificial Normalization in run lists.

There are two "happy path" situations which may be considered, and which are enabled in this PR.  
1. user has single run requiring Artificial Normalization
2. user has many runs, all using previously calculated normalizations from disk

The other paths have been turned off by giving the user a warning.

## Explanation of work

The CalibrationService and NormalizationService were updated with the ability to load a set of calibration/normalizations for a list of run numbers.  Also, return a dictionary matching a list of runs to each corresponding version.

If all runs have a matching normalization version (which is not None), then reduction works as normal over the entire list, as intended.

If any of the runs requires artificial normalization, then the workflow will throw an error dialog box requiring the user to enter only a single run.

## To test

### Dev testing

**Setup**

Download files 46802, 46803, 46805.  They are in IPTS-24641 and under 1GB.  These are in a new state, so use SNAPRed to create a calibration and a normalization for these runs.  They do not have to be good.  Just use 46803 and whichever sample and step through it until both save.

Run from WORKBENCH and not just stand-alone GUI.

**Hide the normalization**

Hide the normalizations you just made, most easily by changing the directory name.  Run reduction with 46802, 46803, 46805.  SNAPRed will not let you, and require you to clear the run list and try again with a single run.

Run reduction with just 46802.  It will warn about needing artificial normalization.  Continue, create an art norm, then continue to the end of the workflow.

**Unhide the normalization**

Close SNAPRed.

Navigate to the `NormalizationIndex.json` file for this state.  Edit the "appliesTo" field to "46802".

Run normalization with 46802, 46803, 46805.  It will complain that you must have either all or none of the runs needing artificial normalization.

Edit the "appliesTo" field to ">=46802".

Run normalization with 46802, 46803, 46805.  It will run smoothly and without issue.  Observe that the grouping workspaces, calibration tables, and normalizations are not being deleted, until the very end.  At the end, you will have output workspaces for all three runs.

### CIS testing

Follow steps similar to the above, but using the original runs 61991:61993, and valid normalizations and calibrations.  They are located in `/SNS/SNAP/shared/Calibration_next`.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#8287](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8287)

See also:
[EWM#8230](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8230)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] When running reduction on severall runs (must be >=3 to reproduce original error) which all have valid calibrations and normalizations, SNAPRed automatically reduces all three without stopping on any screens or asking the user for further continuation
- [x] There are no crashes and the Mantid crash screen never comes up (run in workbench to verify this)
- [x] At end of reduction process, output workspaces for all three runs in the list are present.
- [x] The case of Artificial Normalization is handled intelligently (here, because we can only perform on one run at a time, don't let the user try with more than one run)
