### PR TITLE
Cache groupings by state

### DIFF
--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -3,6 +3,7 @@ from typing import Any, ClassVar, Literal, Optional, get_args
 from pydantic import BaseModel, model_validator
 
 from snapred.backend.log.logger import snapredLogger
+from snapred.meta.InternalConstants import ReservedRunNumber
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 
 logger = snapredLogger.getLogger(__name__)
@@ -32,9 +33,9 @@ class GroceryListItem(BaseModel):
     """
 
     # Reserved instrument-cache run-number values:
-    RESERVED_NATIVE_RUNNUMBER: ClassVar[str] = "000000"  # unmodified _native_ instrument:
+    RESERVED_NATIVE_RUNNUMBER: ClassVar[str] = ReservedRunNumber.NATIVE  # unmodified _native_ instrument:
     #   from 'SNAP_Definition.xml'
-    RESERVED_LITE_RUNNUMBER: ClassVar[str] = "000001"  # unmodified _lite_ instrument  :
+    RESERVED_LITE_RUNNUMBER: ClassVar[str] = ReservedRunNumber.LITE  # unmodified _lite_ instrument  :
     #   from 'SNAPLite.xml'
 
     workspaceType: GroceryTypes

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -25,7 +25,7 @@ from snapred.backend.recipe.FetchGroceriesRecipe import FetchGroceriesRecipe
 from snapred.backend.service.WorkspaceMetadataService import WorkspaceMetadataService
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Singleton import Singleton
-from snapred.meta.InternalConstants import ReservedRunNumber, ReservedStateId
+from snapred.meta.InternalConstants import ReservedRunNumber
 from snapred.meta.mantid.WorkspaceNameGenerator import (
     NameBuilder,
     WorkspaceName,
@@ -863,10 +863,7 @@ class GroceryService:
 
         :rtype: Dict[str, Any]
         """
-        if item.runNumber in ReservedRunNumber.values():
-            stateId = ReservedStateId.forRun(item.runNumber)
-        else:
-            stateId, _ = self.dataService.generateStateId(item.runNumber)
+        stateId, _ = self.dataService.generateStateId(item.runNumber)
         key = self._key(item.groupingScheme, stateId, item.useLiteMode)
         workspaceName = self._createGroupingWorkspaceName(item.groupingScheme, item.runNumber, item.useLiteMode)
         workspaceName = self._loadedGroupings.get(key, workspaceName)

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -25,6 +25,7 @@ from snapred.backend.recipe.FetchGroceriesRecipe import FetchGroceriesRecipe
 from snapred.backend.service.WorkspaceMetadataService import WorkspaceMetadataService
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Singleton import Singleton
+from snapred.meta.InternalConstants import ReservedRunNumber, ReservedStateId
 from snapred.meta.mantid.WorkspaceNameGenerator import (
     NameBuilder,
     WorkspaceName,
@@ -563,10 +564,7 @@ class GroceryService:
 
                 # Initialize the instrument parameters
                 # (Reserved run-numbers will use the unmodified instrument.)
-                if (
-                    runNumber != GroceryListItem.RESERVED_NATIVE_RUNNUMBER
-                    and runNumber != GroceryListItem.RESERVED_LITE_RUNNUMBER
-                ):
+                if runNumber not in ReservedRunNumber.values():
                     detectorState: DetectorState = self._getDetectorState(runNumber)
                     self.updateInstrumentParameters(wsName, detectorState)
             self._loadedInstruments[key] = wsName
@@ -865,13 +863,17 @@ class GroceryService:
 
         :rtype: Dict[str, Any]
         """
-        key = self._key(item.groupingScheme, item.runNumber, item.useLiteMode)
+        if item.runNumber in ReservedRunNumber.values():
+            stateId = ReservedStateId.forRun(item.runNumber)
+        else:
+            stateId, _ = self.dataService.generateStateId(item.runNumber)
+        key = self._key(item.groupingScheme, stateId, item.useLiteMode)
         workspaceName = self._createGroupingWorkspaceName(item.groupingScheme, item.runNumber, item.useLiteMode)
+        workspaceName = self._loadedGroupings.get(key, workspaceName)
 
         self._updateGroupingCacheFromADS(key, workspaceName)
-        groupingIsLoaded = self._loadedGroupings.get(key) is not None
 
-        if groupingIsLoaded:
+        if key in self._loadedGroupings:
             data = {
                 "result": True,
                 "loader": "cached",

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -51,6 +51,7 @@ from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
 from snapred.meta.decorators.ExceptionHandler import ExceptionHandler
 from snapred.meta.decorators.Singleton import Singleton
+from snapred.meta.InternalConstants import ReservedRunNumber, ReservedStateId
 from snapred.meta.mantid.WorkspaceNameGenerator import (
     ValueFormatter as wnvf,
 )
@@ -288,8 +289,11 @@ class LocalDataService:
     @lru_cache
     @ExceptionHandler(StateValidationException)
     def generateStateId(self, runId: str) -> Tuple[str, str]:
-        detectorState = self.readDetectorState(runId)
-        SHA = self._stateIdFromDetectorState(detectorState)
+        if runId in ReservedRunNumber.values():
+            SHA = ObjectSHA(hex=ReservedStateId.forRun(runId))
+        else:
+            detectorState = self.readDetectorState(runId)
+            SHA = self._stateIdFromDetectorState(detectorState)
         return SHA.hex, SHA.decodedKey
 
     def _stateIdFromDetectorState(self, detectorState: DetectorState) -> ObjectSHA:

--- a/src/snapred/backend/service/ReductionService.py
+++ b/src/snapred/backend/service/ReductionService.py
@@ -81,7 +81,7 @@ class ReductionService(Service):
         self.registerPath("checkWritePermissions", self.checkReductionWritePermissions)
         self.registerPath("getSavePath", self.getSavePath)
         self.registerPath("getStateIds", self.getStateIds)
-        self.registerPath("validateReduction", self.validateReduction)
+        self.registerPath("validate", self.validateReduction)
         self.registerPath("artificialNormalization", self.artificialNormalization)
         self.registerPath("grabWorkspaceforArtificialNorm", self.grabWorkspaceforArtificialNorm)
         return

--- a/src/snapred/meta/InternalConstants.py
+++ b/src/snapred/meta/InternalConstants.py
@@ -1,0 +1,20 @@
+from snapred.backend.dao.ObjectSHA import ObjectSHA
+from snapred.meta.Enum import StrEnum
+
+
+class ReservedRunNumber(StrEnum):
+    NATIVE: str = "000000"
+    LITE: str = "000001"
+
+
+class ReservedStateId(StrEnum):
+    NATIVE: str = ObjectSHA(hex="0000000000000000").hex
+    LITE: str = ObjectSHA(hex="0000000000000001").hex
+
+    @classmethod
+    def forRun(cls, runNumber):
+        match runNumber:
+            case ReservedRunNumber.NATIVE.value:
+                return cls.NATIVE
+            case ReservedRunNumber.LITE.value:
+                return cls.LITE

--- a/src/snapred/ui/view/reduction/ReductionRequestView.py
+++ b/src/snapred/ui/view/reduction/ReductionRequestView.py
@@ -1,12 +1,12 @@
 from typing import Callable, List, Optional
 
-from qtpy.QtCore import Signal, Slot
+from qtpy.QtCore import Slot
 from qtpy.QtWidgets import (
     QHBoxLayout,
     QLineEdit,
+    QListWidget,
     QMessageBox,
     QPushButton,
-    QTextEdit,
     QVBoxLayout,
 )
 from snapred.backend.dao.state.RunNumber import RunNumber
@@ -20,8 +20,6 @@ logger = snapredLogger.getLogger(__name__)
 
 @Resettable
 class ReductionRequestView(BackendRequestView):
-    signalRemoveRunNumber = Signal(int)
-
     def __init__(
         self,
         parent=None,
@@ -49,8 +47,8 @@ class ReductionRequestView(BackendRequestView):
         self.runNumberLayout.addLayout(self.runNumberButtonLayout)
 
         # Run number display
-        self.runNumberDisplay = QTextEdit()
-        self.runNumberDisplay.setReadOnly(True)
+        self.runNumberDisplay = QListWidget()
+        self.runNumberDisplay.setSortingEnabled(False)
 
         # Lite mode toggle, pixel masks dropdown, and retain unfocused data checkbox
         self.liteModeToggle = self._labeledField("Lite Mode", Toggle(parent=self, state=True))
@@ -77,8 +75,6 @@ class ReductionRequestView(BackendRequestView):
         # Connect buttons to methods
         self.enterRunNumberButton.clicked.connect(self.addRunNumber)
         self.clearButton.clicked.connect(self.clearRunNumbers)
-
-        self.signalRemoveRunNumber.connect(self._removeRunNumber)
 
     @Slot()
     def addRunNumber(self):
@@ -127,32 +123,20 @@ class ReductionRequestView(BackendRequestView):
 
         return [str(num) for num in runs]
 
-    @Slot()
-    def removeRunNumber(self, runNumber):
-        self.signalRemoveRunNumber.emit(runNumber)
-
-    @Slot()
-    def _removeRunNumber(self, runNumber):
-        if runNumber not in self.runNumbers:
-            logger.warning(
-                f"[ReductionRequestView]: attempting to remove run {runNumber} not in the list {self.runNumbers}"
-            )
-            return
-        self.runNumbers.remove(runNumber)
-        self.updateRunNumberList()
-
     def updateRunNumberList(self):
-        self.runNumberDisplay.setText("\n".join(map(str, sorted(self.runNumbers))))
+        self.runNumberDisplay.clear()
+        self.runNumberDisplay.addItems(self.runNumbers)
 
     def clearRunNumbers(self):
         self.runNumbers.clear()
         self.runNumberDisplay.clear()
 
     def verify(self):
-        currentText = self.runNumberDisplay.toPlainText()
-        runNumbers = [num.strip() for num in currentText.split("\n") if num.strip()]
+        runNumbers = [self.runNumberDisplay.item(x).text() for x in range(self.runNumberDisplay.count())]
         if not runNumbers:
             raise ValueError("Please enter at least one run number.")
+        if runNumbers != self.runNumbers:
+            raise ValueError("Unexpected issue verifying run numbers.  Please clear and re-enter.")
         for runNumber in runNumbers:
             if not runNumber.isdigit():
                 raise ValueError(

--- a/tests/integration/test_workflow_panels_happy_path.py
+++ b/tests/integration/test_workflow_panels_happy_path.py
@@ -607,8 +607,10 @@ class TestGUIPanels:
             #    enter a "Run Number":
             requestView.runNumberInput.setText(reductionRunNumber)
             qtbot.mouseClick(requestView.enterRunNumberButton, Qt.MouseButton.LeftButton)
+
             _count = range(requestView.runNumberDisplay.count())
             _runNumbers = [requestView.runNumberDisplay.item(x).text() for x in range(_count)]
+
             assert reductionRunNumber in _runNumbers
 
             """
@@ -1257,8 +1259,8 @@ class TestGUIPanels:
             requestView.runNumberInput.setText(reductionRunNumber)
             qtbot.mouseClick(requestView.enterRunNumberButton, Qt.MouseButton.LeftButton)
 
-            _currentText = requestView.runNumberDisplay.toPlainText()
-            _runNumbers = [num.strip() for num in _currentText.split("\n") if num.strip()]
+            _count = range(requestView.runNumberDisplay.count())
+            _runNumbers = [requestView.runNumberDisplay.item(x).text() for x in range(_count)]
 
             assert reductionRunNumber in _runNumbers
 

--- a/tests/integration/test_workflow_panels_happy_path.py
+++ b/tests/integration/test_workflow_panels_happy_path.py
@@ -607,7 +607,7 @@ class TestGUIPanels:
             #    enter a "Run Number":
             requestView.runNumberInput.setText(reductionRunNumber)
             qtbot.mouseClick(requestView.enterRunNumberButton, Qt.MouseButton.LeftButton)
-            _count = range(self.runNumberDisplay.count())
+            _count = range(requestView.runNumberDisplay.count())
             _runNumbers = [requestView.runNumberDisplay.item(x).text() for x in range(_count)]
             assert reductionRunNumber in _runNumbers
 

--- a/tests/integration/test_workflow_panels_happy_path.py
+++ b/tests/integration/test_workflow_panels_happy_path.py
@@ -608,7 +608,7 @@ class TestGUIPanels:
             requestView.runNumberInput.setText(reductionRunNumber)
             qtbot.mouseClick(requestView.enterRunNumberButton, Qt.MouseButton.LeftButton)
 
-            _count = range(requestView.runNumberDisplay.count())
+            _count = requestView.runNumberDisplay.count()
             _runNumbers = [requestView.runNumberDisplay.item(x).text() for x in range(_count)]
 
             assert reductionRunNumber in _runNumbers
@@ -1259,7 +1259,7 @@ class TestGUIPanels:
             requestView.runNumberInput.setText(reductionRunNumber)
             qtbot.mouseClick(requestView.enterRunNumberButton, Qt.MouseButton.LeftButton)
 
-            _count = range(requestView.runNumberDisplay.count())
+            _count = requestView.runNumberDisplay.count()
             _runNumbers = [requestView.runNumberDisplay.item(x).text() for x in range(_count)]
 
             assert reductionRunNumber in _runNumbers

--- a/tests/integration/test_workflow_panels_happy_path.py
+++ b/tests/integration/test_workflow_panels_happy_path.py
@@ -607,8 +607,8 @@ class TestGUIPanels:
             #    enter a "Run Number":
             requestView.runNumberInput.setText(reductionRunNumber)
             qtbot.mouseClick(requestView.enterRunNumberButton, Qt.MouseButton.LeftButton)
-            _currentText = requestView.runNumberDisplay.toPlainText()
-            _runNumbers = [num.strip() for num in _currentText.split("\n") if num.strip()]
+            _count = range(self.runNumberDisplay.count())
+            _runNumbers = [requestView.runNumberDisplay.item(x).text() for x in range(_count)]
             assert reductionRunNumber in _runNumbers
 
             """

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -1030,7 +1030,7 @@ class TestGroceryService(unittest.TestCase):
         """
         groupMapFilepath = Resource.getPath("inputs/testInstrument/fakeSNAPLiteGroupMap.xml")
         self.instance._fetchInstrumentDonor = mock.Mock(return_value=self.sampleWS)
-        self.instance._createGroupingWorkspaceName = mock.Mock(return_value="lite_map")
+        # self.instance._createGroupingWorkspaceName = mock.Mock(return_value="lite_map")
         self.instance._createGroupingFilename = mock.Mock(return_value=groupMapFilepath)
         # have to subvert the validation methods in grocerylistitem
         mockLiteMapGroceryItem = GroceryListItem(
@@ -1043,9 +1043,10 @@ class TestGroceryService(unittest.TestCase):
         stateId, _ = self.instance.dataService.generateStateId(mockLiteMapGroceryItem.runNumber)
 
         # call once and load
-        testItem = ("Lite", stateId, False)
+        testItem = ("Lite", ReservedRunNumber.NATIVE, False)
+        testKey = ("Lite", stateId, False)
         groupingWorkspaceName = self.instance._createGroupingWorkspaceName(*testItem)
-        groupKey = self.instance._key(*testItem)
+        groupKey = self.instance._key(*testKey)
 
         res = self.instance.fetchLiteDataMap()
         assert res == groupingWorkspaceName

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -31,7 +31,7 @@ from snapred.backend.dao.state import DetectorState
 from snapred.backend.dao.WorkspaceMetadata import UNSET, DiffcalStateMetadata, WorkspaceMetadata
 from snapred.backend.data.GroceryService import GroceryService
 from snapred.meta.Config import Config, Resource
-from snapred.meta.InternalConstants import ReservedStateId
+from snapred.meta.InternalConstants import ReservedRunNumber
 from snapred.meta.mantid.WorkspaceNameGenerator import ValueFormatter as wnvf
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceType
@@ -1035,14 +1035,15 @@ class TestGroceryService(unittest.TestCase):
         # have to subvert the validation methods in grocerylistitem
         mockLiteMapGroceryItem = GroceryListItem(
             workspaceType="grouping",
-            runNumber=self.runNumber,
+            runNumber=ReservedRunNumber.NATIVE,
             groupingScheme="Lite",
         )
         mockLiteMapGroceryItem.instrumentSource = self.instrumentFilePath
         mockGroceryList.builder.return_value.grouping.return_value.build.return_value = mockLiteMapGroceryItem
+        stateId, _ = self.instance.dataService.generateStateId(mockLiteMapGroceryItem.runNumber)
 
         # call once and load
-        testItem = ("Lite", ReservedStateId.NATIVE, False)
+        testItem = ("Lite", stateId, False)
         groupingWorkspaceName = self.instance._createGroupingWorkspaceName(*testItem)
         groupKey = self.instance._key(*testItem)
 

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -31,6 +31,7 @@ from snapred.backend.dao.state import DetectorState
 from snapred.backend.dao.WorkspaceMetadata import UNSET, DiffcalStateMetadata, WorkspaceMetadata
 from snapred.backend.data.GroceryService import GroceryService
 from snapred.meta.Config import Config, Resource
+from snapred.meta.InternalConstants import ReservedStateId
 from snapred.meta.mantid.WorkspaceNameGenerator import ValueFormatter as wnvf
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceType
@@ -133,6 +134,7 @@ class TestGroceryService(unittest.TestCase):
 
     def setUp(self):
         self.instance = GroceryService(dataService=self.fridge)
+        self.stateId, _ = self.instance.dataService.generateStateId(self.runNumber)
         self.groupingItem = (
             GroceryListItem.builder()
             .fromRun(self.runNumber)
@@ -996,10 +998,11 @@ class TestGroceryService(unittest.TestCase):
         groupFilepath = Resource.getPath("inputs/testInstrument/fakeSNAPFocGroup_Natural.xml")
         self.instance._createGroupingFilename = mock.Mock(return_value=groupFilepath)
         testItem = (self.groupingItem.groupingScheme, self.runNumber, self.groupingItem.useLiteMode)
+        testKey = (self.groupingItem.groupingScheme, self.stateId, self.groupingItem.useLiteMode)
 
         # call once and load
         groupingWorkspaceName = self.instance._createGroupingWorkspaceName(*testItem)
-        groupKey = self.instance._key(*testItem)
+        groupKey = self.instance._key(*testKey)
         res = self.instance.fetchGroupingDefinition(self.groupingItem)
         assert res["result"]
         assert res["loader"] == "LoadGroupingDefinition"
@@ -1039,7 +1042,7 @@ class TestGroceryService(unittest.TestCase):
         mockGroceryList.builder.return_value.grouping.return_value.build.return_value = mockLiteMapGroceryItem
 
         # call once and load
-        testItem = ("Lite", GroceryListItem.RESERVED_NATIVE_RUNNUMBER, False)
+        testItem = ("Lite", ReservedStateId.NATIVE, False)
         groupingWorkspaceName = self.instance._createGroupingWorkspaceName(*testItem)
         groupKey = self.instance._key(*testItem)
 

--- a/tests/unit/meta/test_InternalConstants.py
+++ b/tests/unit/meta/test_InternalConstants.py
@@ -1,0 +1,11 @@
+import unittest
+
+from snapred.meta.InternalConstants import ReservedRunNumber, ReservedStateId
+
+
+class TestCallback(unittest.TestCase):
+    def test_state_from_run(self):
+        reservedRunNumbers = ReservedRunNumber.values()
+        reservedStateIds = ReservedStateId.values()
+        for x, y in zip(reservedRunNumbers, reservedStateIds):
+            assert y == ReservedStateId.forRun(x)


### PR DESCRIPTION
## Description of work

A grouping should apply to all runs with the same state.  However, currently they are cached by run number.  Caching by run number causes reduction to re-load the same groupings multiple times.

This changes how grouping workspaces are cached inside `GroceryService` to better streamline reduction.

## Explanation of work

Changes `GroceryService` to cache grouping workspaces by state ID, instead of run number.

This requires special handling for the `LiteMap`, which uses a reserved run number.  Most of the changes are to make handling the reserved run numbers more robust.

## To test

### Dev testing

To verify that SNAPRed is still correctly handling grouping workspaces inside the grocery cache:

1. Pick two runs from the same state.  I recently found 46802, 46803, 46805, which are relatively small files.
2. Open diffcal panel, run with 46802.  Use any sample, use any grouping (my favorite is Bank).  Continue to tweak peak stage.
3. Verify that the grouping workspace exists in the workspace list, and that its name includes 46802 and Bank (see image).
4. Verify the data is grouped correctly (see image).
![image](https://github.com/user-attachments/assets/b2f6ab9f-a43d-41a1-98c3-357eef56c6a7)
5. Close the calibration panel window.  Do NOT cancel or continue, just close the window so that the workspace list and grocery cache are maintained.
5. Open diffcal panel again, run with 46803.  Use any sample, pick the _same_ grouping as before (e.g. Bank).  Continue to tweak peak stage.
6. Verify that the data has been grouped correctly (see image).
7. Verify that the grouping workspace with 46802 exists in workspace list (see image).
8. Verify there is NOT a grouping workspace with 46803 in its name (see image).
![image](https://github.com/user-attachments/assets/501ee192-ff7f-4783-b45c-d428473c588b)

This verifies that `GroceryService` is correctly caching and using grouping workspaces by their state ID and not by their run number.

Now run calibration and normalization  with _any_ run number (e.g. 46680) to verify everything works.

In Reduction, pick a set of three runs from same state with a normalization (I like 46802, 46803, 46805).  Run with these.  As reduction is calculating, observe the workspace list.  The same set of groupings should remain for all three runs, and not be deleted.  The other temporary workspaces should disappear.  These groupings will disappear when the reduction workflow finishes.

**NOTE**: this story does not fix a defect that has already been noted in [Defect 8287](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=8287) related to running with multiple runs and artificial normalizations.  You can **not** run multiple runs in reduction without a prior normalization for the state,

### CIS testing

1. Run calibration with a preferred run
2. Run normalization with preferred set of runs
3. Run reduction with two runs.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

There is no story for this, but it came out of work on [Defect 8287](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=8287)

### Verification

N/A

### Acceptance Criteria

N/A
