### PR TITLE
small fix for skipping pixel cal

### DIFF
--- a/src/snapred/backend/recipe/PixelDiffCalRecipe.py
+++ b/src/snapred/backend/recipe/PixelDiffCalRecipe.py
@@ -110,7 +110,7 @@ class PixelDiffCalRecipe(Recipe[Ingredients]):
                 BinWidth=self.dBin,
             )
         else:
-            self.mantidSnapper.RenameWorkspace(
+            self.mantidSnapper.CloneWorkspace(
                 "Begin DIFC table at previous",
                 InputWorkspace=self.DIFCprev,
                 OutputWorkspace=self.DIFCpixel,


### PR DESCRIPTION
## Description of work

Fixes an issue if trying to skip pixel calibration after already trying to run without skipping.

## To test

### Dev testing

Run calibration using 46680 and Diamond (and grouping) with Skip Pixel Calibration toggle OFF.

You will get an error saying to skip pixel calibration.  Switch the toggle.  Run again.

At tweak peak, set FHWM Right to 4.  Continue all the way to saving.
