### PR TITLE
Ewm8253 normcal index being misread

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "tests/data/snapred-data"]
 	path = tests/data/snapred-data
 	url = https://code.ornl.gov/sns-hfir-scse/infrastructure/test-data/snapred-data.git
+	branch = main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,8 @@ markers = [
   "integration: mark a test as an integration test",
   "mount_snap: mark a test as using /SNS/SNAP/ data mount",
   "golden_data(*, path=None, short_name=None, date=None): mark golden data to use with a test",
-  "datarepo: mark a test as using snapred-data repo"
+  "datarepo: mark a test as using snapred-data repo",
+  "ui: mark a test as a UI test",
 ]
 # The following will be overridden by the commandline option "-m integration"
 addopts = "-m 'not (integration or datarepo)'"

--- a/src/snapred/backend/dao/indexing/Versioning.py
+++ b/src/snapred/backend/dao/indexing/Versioning.py
@@ -1,79 +1,50 @@
-from typing import Any, Optional
-
-from numpy import integer
-from pydantic import BaseModel, computed_field, field_serializer
-
+from pydantic import BaseModel, ConfigDict, field_validator
 from snapred.meta.Config import Config
+from snapred.meta.Enum import StrEnum
 
 VERSION_START = Config["version.start"]
 VERSION_NONE_NAME = Config["version.friendlyName.error"]
-VERSION_DEFAULT_NAME = Config["version.friendlyName.default"]
 
-# VERSION_DEFAULT is a SNAPRed-internal "magic" integer:
-# * it is implicitely set during `Config` initialization.
-VERSION_DEFAULT = Config["version.default"]
+
+class VersionState(StrEnum):
+    DEFAULT = Config["version.friendlyName.default"]
+    LATEST = "latest"
+    NEXT = "next"
+
+
+# I'm not sure why ci is failing without this, it doesn't seem to be used anywhere
+VERSION_DEFAULT = VersionState.DEFAULT
+
+Version = int | VersionState
 
 
 class VersionedObject(BaseModel):
     # Base class for all versioned DAO
 
-    # In pydantic, a leading double underscore activates
-    # the `__pydantic_private__` feature, which limits the visibility
-    # of the attribute to the interior scope of its own class.
-    __version: Optional[int] = None
+    version: Version
 
-    @classmethod
-    def parseVersion(cls, version, *, exclude_none: bool = False, exclude_default: bool = False) -> int | None:
-        v: int | None
-        # handle two special cases
-        if (not exclude_none) and (version is None or version == VERSION_NONE_NAME):
-            v = None
-        elif (not exclude_default) and (version == VERSION_DEFAULT_NAME or version == VERSION_DEFAULT):
-            v = VERSION_DEFAULT
-        # parse integers
-        elif isinstance(version, int | integer):
-            if int(version) >= VERSION_START:
-                v = int(version)
-            else:
-                raise ValueError(f"Given version {version} is smaller than start version {VERSION_START}")
-        # otherwise this is an error
-        else:
-            raise ValueError(f"Cannot initialize version as {version}")
-        return v
+    @field_validator("version", mode="before")
+    def validate_version(cls, value: Version) -> Version:
+        if value in VersionState.values():
+            return value
 
-    @classmethod
-    def writeVersion(cls, version) -> int | str:
-        v: int | str
-        if version is None:
-            v = VERSION_NONE_NAME
-        elif version == VERSION_DEFAULT:
-            v = VERSION_DEFAULT_NAME
-        elif isinstance(version, int | integer):
-            v = int(version)
-        else:
-            raise ValueError("Version is not valid")
-        return v
+        if isinstance(value, str):
+            raise ValueError(f"Version must be an int or {VersionState.values()}")
 
-    def __init__(self, **kwargs):
-        version = kwargs.pop("version", None)
-        super().__init__(**kwargs)
-        self.__version = self.parseVersion(version)
+        if value is None:
+            raise ValueError("Version must be specified")
 
-    @field_serializer("version", check_fields=False, when_used="json")
-    def write_user_defaults(self, value: Any):  # noqa ARG002
-        return self.writeVersion(self.__version)
+        if value < VERSION_START:
+            raise ValueError(f"Version must be greater than {VERSION_START}")
 
-    # NOTE some serialization still using the dict() method
-    def dict(self, **kwargs):
-        res = super().dict(**kwargs)
-        res["version"] = self.writeVersion(res["version"])
-        return res
+        return value
 
-    @computed_field
-    @property
-    def version(self) -> int:
-        return self.__version
+    # NOTE: This approach was taken because 'field_serializer' was checking against the
+    #       INITIAL value of version for some reason.  This is a workaround.
+    #
+    def model_dump_json(self, *args, **kwargs):  # noqa ARG002
+        if self.version in VersionState.values():
+            raise ValueError(f"Version {self.version} must be flattened to an int before writing to JSON")
+        return super().model_dump_json(*args, **kwargs)
 
-    @version.setter
-    def version(self, v):
-        self.__version = self.parseVersion(v, exclude_none=True)
+    model_config = ConfigDict(use_enum_values=True, validate_assignment=True)

--- a/src/snapred/backend/dao/indexing/Versioning.py
+++ b/src/snapred/backend/dao/indexing/Versioning.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, ConfigDict, field_validator
+
 from snapred.meta.Config import Config
 from snapred.meta.Enum import StrEnum
 

--- a/src/snapred/backend/dao/normalization/NormalizationRecord.py
+++ b/src/snapred/backend/dao/normalization/NormalizationRecord.py
@@ -1,9 +1,9 @@
 from typing import Any, List
 
-from pydantic import field_serializer, field_validator
+from pydantic import field_validator
 
 from snapred.backend.dao.indexing.Record import Record
-from snapred.backend.dao.indexing.Versioning import VERSION_DEFAULT, VersionedObject
+from snapred.backend.dao.indexing.Versioning import VERSION_START, Version, VersionedObject
 from snapred.backend.dao.Limit import Limit
 from snapred.backend.dao.normalization.Normalization import Normalization
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
@@ -31,7 +31,7 @@ class NormalizationRecord(Record, extra="ignore"):
     smoothingParameter: float
     # detectorPeaks: List[DetectorPeak] # TODO: need to save this for reference during reduction
     workspaceNames: List[WorkspaceName] = []
-    calibrationVersionUsed: int = VERSION_DEFAULT
+    calibrationVersionUsed: Version = VERSION_START
     crystalDBounds: Limit[float]
     normalizationCalibrantSamplePath: str
 
@@ -44,8 +44,4 @@ class NormalizationRecord(Record, extra="ignore"):
     @field_validator("calibrationVersionUsed", mode="before")
     @classmethod
     def version_is_integer(cls, v: Any) -> Any:
-        return VersionedObject.parseVersion(v)
-
-    @field_serializer("calibrationVersionUsed", when_used="json")
-    def write_user_defaults(self, value: Any):  # noqa ARG002
-        return VersionedObject.writeVersion(self.calibrationVersionUsed)
+        return VersionedObject(version=v).version

--- a/src/snapred/backend/dao/request/CreateCalibrationRecordRequest.py
+++ b/src/snapred/backend/dao/request/CreateCalibrationRecordRequest.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, ConfigDict
 from snapred.backend.dao.calibration.Calibration import Calibration
 from snapred.backend.dao.calibration.FocusGroupMetric import FocusGroupMetric
 from snapred.backend.dao.CrystallographicInfo import CrystallographicInfo
+from snapred.backend.dao.indexing.Versioning import Version, VersionState
 from snapred.backend.dao.state.PixelGroup import PixelGroup
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName, WorkspaceType
 
@@ -18,7 +19,7 @@ class CreateCalibrationRecordRequest(BaseModel, extra="forbid"):
 
     runNumber: str
     useLiteMode: bool
-    version: Optional[int] = None
+    version: Version = VersionState.NEXT
     calculationParameters: Calibration
     crystalInfo: CrystallographicInfo
     pixelGroups: Optional[List[PixelGroup]] = None

--- a/src/snapred/backend/dao/request/CreateIndexEntryRequest.py
+++ b/src/snapred/backend/dao/request/CreateIndexEntryRequest.py
@@ -1,6 +1,6 @@
-from typing import Optional
-
 from pydantic import BaseModel
+
+from snapred.backend.dao.indexing.Versioning import Version, VersionState
 
 
 class CreateIndexEntryRequest(BaseModel):
@@ -10,7 +10,7 @@ class CreateIndexEntryRequest(BaseModel):
 
     runNumber: str
     useLiteMode: bool
-    version: Optional[int] = None
+    version: Version = VersionState.NEXT
     comments: str
     author: str
     appliesTo: str

--- a/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
+++ b/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, field_validator
 
-from snapred.backend.dao.indexing.Versioning import VERSION_DEFAULT
+from snapred.backend.dao.indexing.Versioning import Version, VersionState
 from snapred.backend.dao.Limit import Pair
 from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.backend.error.ContinueWarning import ContinueWarning
@@ -40,7 +40,7 @@ class DiffractionCalibrationRequest(BaseModel, extra="forbid"):
 
     continueFlags: Optional[ContinueWarning.Type] = ContinueWarning.Type.UNSET
 
-    startingTableVersion: int = VERSION_DEFAULT
+    startingTableVersion: Version = VersionState.DEFAULT
 
     @field_validator("fwhmMultipliers", mode="before")
     @classmethod

--- a/src/snapred/backend/dao/request/FarmFreshIngredients.py
+++ b/src/snapred/backend/dao/request/FarmFreshIngredients.py
@@ -27,14 +27,14 @@ class FarmFreshIngredients(BaseModel):
     # allow 'versions' to be accessed as a single version,
     #   or, to be accessed ambiguously
     @property
-    def version(self) -> Optional[int]:
+    def version(self) -> Version:
         if self.versions.calibration is not None and self.versions.normalization is not None:
             raise RuntimeError("accessing 'version' property when 'versions' is non-singular")
         return self.versions[0]
 
     @version.setter
-    def version(self, v: Optional[int]):
-        self.versions = Versions(v, None)
+    def version(self, v: Version):
+        self.versions = Versions(v, v)
 
     useLiteMode: bool
 

--- a/src/snapred/backend/dao/request/LoadCalibrationRecordRequest.py
+++ b/src/snapred/backend/dao/request/LoadCalibrationRecordRequest.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+from snapred.backend.dao import RunConfig
+from snapred.backend.dao.indexing.Versioning import Version
+
+
+class LoadCalibrationRecordRequest(BaseModel):
+    runConfig: RunConfig
+    version: Version

--- a/src/snapred/backend/dao/request/ReductionRequest.py
+++ b/src/snapred/backend/dao/request/ReductionRequest.py
@@ -2,13 +2,14 @@ from typing import List, NamedTuple, Optional, Tuple
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
+from snapred.backend.dao.indexing.Versioning import Version, VersionState
 from snapred.backend.dao.ingredients import ArtificialNormalizationIngredients
 from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 
-Versions = NamedTuple("Versions", [("calibration", Optional[int]), ("normalization", Optional[int])])
+Versions = NamedTuple("Versions", [("calibration", Version), ("normalization", Version)])
 
 
 class ReductionRequest(BaseModel):
@@ -22,7 +23,7 @@ class ReductionRequest(BaseModel):
 
     # Calibration and normalization versions:
     #   `None` => <use latest version>
-    versions: Versions = Versions(None, None)
+    versions: Versions = Versions(VersionState.LATEST, VersionState.LATEST)
 
     pixelMasks: List[WorkspaceName] = []
     artificialNormalizationIngredients: Optional[ArtificialNormalizationIngredients] = None
@@ -37,6 +38,10 @@ class ReductionRequest(BaseModel):
             if not isinstance(v, Tuple):
                 raise ValueError("'versions' must be a tuple: '(<calibration version>, <normalization version>)'")
             v = Versions(v)
+            if v.calibration is None:
+                raise ValueError("Calibration version must be specified")
+            if v.normalization is None:
+                raise ValueError("Normalization version must be specified")
         return v
 
     model_config = ConfigDict(

--- a/src/snapred/backend/data/DataExportService.py
+++ b/src/snapred/backend/data/DataExportService.py
@@ -1,6 +1,6 @@
 import time
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Tuple
 
 from pydantic import validate_call
 
@@ -64,11 +64,11 @@ class DataExportService:
         """
         self.dataService.writeCalibrationIndexEntry(entry)
 
-    def exportCalibrationRecord(self, record: CalibrationRecord):
+    def exportCalibrationRecord(self, record: CalibrationRecord, entry: Optional[IndexEntry] = None):
         """
         Record must have correct version set.
         """
-        self.dataService.writeCalibrationRecord(record)
+        self.dataService.writeCalibrationRecord(record, entry)
 
     def exportCalibrationWorkspaces(self, record: CalibrationRecord):
         """
@@ -94,11 +94,11 @@ class DataExportService:
         """
         self.dataService.writeNormalizationIndexEntry(entry)
 
-    def exportNormalizationRecord(self, record: NormalizationRecord):
+    def exportNormalizationRecord(self, record: NormalizationRecord, entry: Optional[IndexEntry] = None):
         """
         Record must have correct version set.
         """
-        self.dataService.writeNormalizationRecord(record)
+        self.dataService.writeNormalizationRecord(record, entry)
 
     def exportNormalizationWorkspaces(self, record: NormalizationRecord):
         """

--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -161,10 +161,6 @@ class DataFactoryService:
     def getLatestApplicableNormalizationVersion(self, runId: str, useLiteMode: bool):
         return self.lookupService.normalizationIndexer(runId, useLiteMode).latestApplicableVersion(runId)
 
-    @validate_call
-    def getLatestNormalizationVersion(self, runId: str, useLiteMode: bool):
-        return self.lookupService.normalizationIndexer(runId, useLiteMode).latestApplicableVersion(runId)
-
     ##### REDUCTION METHODS #####
 
     @validate_call

--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -1,11 +1,12 @@
 import os
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 from pydantic import validate_call
 
 from snapred.backend.dao.calibration.CalibrationRecord import CalibrationRecord
 from snapred.backend.dao.indexing.IndexEntry import IndexEntry
+from snapred.backend.dao.indexing.Versioning import Version, VersionState
 from snapred.backend.dao.InstrumentConfig import InstrumentConfig
 from snapred.backend.dao.normalization.NormalizationRecord import NormalizationRecord
 from snapred.backend.dao.reduction import ReductionRecord
@@ -81,7 +82,7 @@ class DataFactoryService:
         return self.lookupService.calibrationExists(runId, useLiteMode)
 
     @validate_call
-    def getCalibrationDataPath(self, runId: str, useLiteMode: bool, version: int):
+    def getCalibrationDataPath(self, runId: str, useLiteMode: bool, version: Version):
         return self.lookupService.calibrationIndexer(runId, useLiteMode).versionPath(version)
 
     def checkCalibrationStateExists(self, runId: str):
@@ -102,28 +103,22 @@ class DataFactoryService:
         return self.lookupService.calibrationIndexer(runId, useLiteMode).getIndex()
 
     @validate_call
-    def getCalibrationRecord(self, runId: str, useLiteMode: bool, version: Optional[int] = None) -> CalibrationRecord:
+    def getCalibrationRecord(
+        self, runId: str, useLiteMode: bool, version: Version = VersionState.LATEST
+    ) -> CalibrationRecord:
         """
         If no version is passed, will use the latest version applicable to runId
         """
         return self.lookupService.readCalibrationRecord(runId, useLiteMode, version)
 
     @validate_call
-    def getCalibrationDataWorkspace(self, runId: str, useLiteMode: bool, version: int, name: str):
+    def getCalibrationDataWorkspace(self, runId: str, useLiteMode: bool, version: Version, name: str):
         path = self.lookupService.calibrationIndexer(runId, useLiteMode).versionPath(version)
         return self.groceryService.fetchWorkspace(os.path.join(path, name) + ".nxs", name)
 
     @validate_call
-    def getThisOrCurrentCalibrationVersion(self, runId: str, useLiteMode: bool, version: Optional[int] = None):
-        return self.lookupService.calibrationIndexer(runId, useLiteMode).thisOrCurrentVersion(version)
-
-    @validate_call
-    def getThisOrNextCalibrationVersion(self, runId: str, useLiteMode: bool, version: Optional[int] = None):
-        return self.lookupService.calibrationIndexer(runId, useLiteMode).thisOrNextVersion(version)
-
-    @validate_call
-    def getThisOrLatestCalibrationVersion(self, runId: str, useLiteMode: bool, version: Optional[int] = None):
-        return self.lookupService.calibrationIndexer(runId, useLiteMode).thisOrLatestApplicableVersion(runId, version)
+    def getLatestApplicableCalibrationVersion(self, runId: str, useLiteMode: bool):
+        return self.lookupService.calibrationIndexer(runId, useLiteMode).latestApplicableVersion(runId)
 
     ##### NORMALIZATION METHODS #####
 
@@ -131,7 +126,7 @@ class DataFactoryService:
         return self.lookupService.normalizationExists(runId, useLiteMode)
 
     @validate_call
-    def getNormalizationDataPath(self, runId: str, useLiteMode: bool, version: int):
+    def getNormalizationDataPath(self, runId: str, useLiteMode: bool, version: Version):
         return self.lookupService.normalizationIndexer(runId, useLiteMode).versionPath(version)
 
     def createNormalizationIndexEntry(self, request: NormalizationExportRequest) -> IndexEntry:
@@ -149,28 +144,26 @@ class DataFactoryService:
         return self.lookupService.normalizationIndexer(runId, useLiteMode).getIndex()
 
     @validate_call
-    def getNormalizationRecord(self, runId: str, useLiteMode: bool, version: Optional[int] = None):
+    def getNormalizationRecord(
+        self, runId: str, useLiteMode: bool, version: Version = VersionState.LATEST
+    ) -> NormalizationRecord:
         """
         If no version is passed, will use the latest version applicable to runId
         """
         return self.lookupService.readNormalizationRecord(runId, useLiteMode, version)
 
     @validate_call
-    def getNormalizationDataWorkspace(self, runId: str, useLiteMode: bool, version: int, name: str):
+    def getNormalizationDataWorkspace(self, runId: str, useLiteMode: bool, version: Version, name: str):
         path = self.getNormalizationDataPath(runId, useLiteMode, version)
         return self.groceryService.fetchWorkspace(os.path.join(path, name) + ".nxs", name)
 
     @validate_call
-    def getThisOrCurrentNormalizationVersion(self, runId: str, useLiteMode: bool, version: Optional[int] = None):
-        return self.lookupService.normalizationIndexer(runId, useLiteMode).thisOrCurrentVersion(version)
+    def getLatestApplicableNormalizationVersion(self, runId: str, useLiteMode: bool):
+        return self.lookupService.normalizationIndexer(runId, useLiteMode).latestApplicableVersion(runId)
 
     @validate_call
-    def getThisOrNextNormalizationVersion(self, runId: str, useLiteMode: bool, version: Optional[int] = None):
-        return self.lookupService.normalizationIndexer(runId, useLiteMode).thisOrNextVersion(version)
-
-    @validate_call
-    def getThisOrLatestNormalizationVersion(self, runId: str, useLiteMode: bool, version: Optional[int] = None):
-        return self.lookupService.normalizationIndexer(runId, useLiteMode).thisOrLatestApplicableVersion(runId, version)
+    def getLatestNormalizationVersion(self, runId: str, useLiteMode: bool):
+        return self.lookupService.normalizationIndexer(runId, useLiteMode).latestApplicableVersion(runId)
 
     ##### REDUCTION METHODS #####
 

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -341,7 +341,7 @@ class GroceryService:
         """
         wsName = wng.diffCalTable().runNumber(runNumber).version(version).build()
         if version in [VersionState.DEFAULT, VERSION_START]:
-            wsName = wsName = wng.diffCalTable().runNumber("default").version(VersionState.DEFAULT).build()
+            wsName = wng.diffCalTable().runNumber("default").version(VersionState.DEFAULT).build()
         return wsName
 
     @validate_call

--- a/src/snapred/backend/data/Indexer.py
+++ b/src/snapred/backend/data/Indexer.py
@@ -126,7 +126,12 @@ class Indexer:
                     f"The following records were expected, but not available on disk: {missingRecords}"
                 )
             else:
-                logger.warning(f"The following records were expected, but not available on disk: {missingRecords}")
+                logger.warning(
+                    (
+                        f"The following records were expected, but not available on disk: {missingRecords}",
+                        "\n Please contact your IS or CIS about these missing records.",
+                    )
+                )
 
         # take the set of versions common to both
         commonVersions = self.dirVersions & indexVersions
@@ -363,7 +368,7 @@ class Indexer:
     def versionExists(self, version: Version):
         return self._flattenVersion(version) in self.index
 
-    def writeNewRecord(self, record: Record, entry: IndexEntry):
+    def writeNewVersion(self, record: Record, entry: IndexEntry):
         """
         Coupled write of a record and an index entry.
         As required for new records.

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -525,7 +525,7 @@ class LocalDataService:
         if entry is None:
             indexer.writeRecord(record)
         else:
-            indexer.writeNewRecord(record, entry)
+            indexer.writeNewVersion(record, entry)
         # separately write the normalization state
         indexer.writeParameters(record.calculationParameters)
 
@@ -587,7 +587,7 @@ class LocalDataService:
             indexer.writeRecord(record)
         else:
             # write record to file
-            indexer.writeNewRecord(record, entry)
+            indexer.writeNewVersion(record, entry)
         # separately write the calibration state
         indexer.writeParameters(record.calculationParameters)
 
@@ -1034,7 +1034,7 @@ class LocalDataService:
                 comments="The default configuration when loading StateConfig if none other is found",
             )
             # write the calibration state
-            indexer.writeNewRecord(record, entry)
+            indexer.writeNewVersion(record, entry)
             indexer.writeParameters(record.calculationParameters)
             # write the default diffcal table
             self._writeDefaultDiffCalTable(runId, liteMode)

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -850,8 +850,10 @@ class LocalDataService:
         return parameters
 
     @validate_call
-    def readNormalizationState(self, runId: str, useLiteMode: bool, version: Optional[Version] = VersionState.LATEST):
+    def readNormalizationState(self, runId: str, useLiteMode: bool, version: Version = VersionState.LATEST):
         indexer = self.normalizationIndexer(runId, useLiteMode)
+        if version is VersionState.LATEST:
+            version = indexer.latestApplicableVersion(runId)
         return indexer.readParameters(version)
 
     def writeCalibrationState(self, calibration: Calibration):

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -27,7 +27,7 @@ from snapred.backend.dao import (
 )
 from snapred.backend.dao.calibration import Calibration, CalibrationDefaultRecord, CalibrationRecord
 from snapred.backend.dao.indexing.IndexEntry import IndexEntry
-from snapred.backend.dao.indexing.Versioning import VERSION_DEFAULT
+from snapred.backend.dao.indexing.Versioning import Version, VersionState
 from snapred.backend.dao.Limit import Limit, Pair
 from snapred.backend.dao.normalization import Normalization, NormalizationRecord
 from snapred.backend.dao.reduction import ReductionRecord
@@ -142,7 +142,9 @@ class LocalDataService:
             raise _createFileNotFoundError("Instrument configuration file", self.instrumentConfigPath) from e
 
     def readStateConfig(self, runId: str, useLiteMode: bool) -> StateConfig:
-        diffCalibration = self.calibrationIndexer(runId, useLiteMode).readParameters()
+        indexer = self.calibrationIndexer(runId, useLiteMode)
+        version = indexer.latestApplicableVersion(runId)
+        diffCalibration = indexer.readParameters(version)
         stateId = str(diffCalibration.instrumentState.id)
 
         # Read the grouping-schema map associated with this `StateConfig`.
@@ -481,28 +483,37 @@ class LocalDataService:
 
     def createNormalizationIndexEntry(self, request: CreateIndexEntryRequest) -> IndexEntry:
         indexer = self.normalizationIndexer(request.runNumber, request.useLiteMode)
-        return indexer.createIndexEntry(**request.model_dump())
+        entryParams = request.model_dump()
+        entryParams["version"] = entryParams.get("version", VersionState.NEXT)
+        if entryParams["version"] is None:
+            entryParams["version"] = VersionState.NEXT
+        return indexer.createIndexEntry(**entryParams)
 
     def createNormalizationRecord(self, request: CreateNormalizationRecordRequest) -> NormalizationRecord:
         indexer = self.normalizationIndexer(request.runNumber, request.useLiteMode)
         return indexer.createRecord(**request.model_dump())
 
     def normalizationExists(self, runId: str, useLiteMode: bool) -> bool:
-        version = self.normalizationIndexer(runId, useLiteMode).currentVersion()
+        version = self.normalizationIndexer(runId, useLiteMode).latestApplicableVersion(runId)
         return version is not None
 
     @validate_call
-    def readNormalizationRecord(self, runId: str, useLiteMode: bool, version: Optional[int] = None):
+    def readNormalizationRecord(self, runId: str, useLiteMode: bool, version: Version = VersionState.LATEST):
         """
         Will return a normalization record for the given version.
         If no version given, will choose the latest applicable version from the index.
         """
         indexer = self.normalizationIndexer(runId, useLiteMode)
-        if version is None:
+        if version is VersionState.LATEST:
             version = indexer.latestApplicableVersion(runId)
-        return indexer.readRecord(version)
+        record = None
+        if version is not None:
+            record = indexer.readRecord(version)
+        logger.info(indexer.index)
+        logger.info(f"latest applicable version: {version} for runId: {runId} ")
+        return record
 
-    def writeNormalizationRecord(self, record: NormalizationRecord):
+    def writeNormalizationRecord(self, record: NormalizationRecord, entry: Optional[IndexEntry] = None):
         """
         Persists a `NormalizationRecord` to either a new version folder, or overwrites a specific version.
         Record must be set with correct version.
@@ -511,7 +522,10 @@ class LocalDataService:
 
         indexer = self.normalizationIndexer(record.runNumber, record.useLiteMode)
         # write the record to file
-        indexer.writeRecord(record)
+        if entry is None:
+            indexer.writeRecord(record)
+        else:
+            indexer.writeNewRecord(record, entry)
         # separately write the normalization state
         indexer.writeParameters(record.calculationParameters)
 
@@ -542,22 +556,25 @@ class LocalDataService:
         return indexer.createRecord(**request.model_dump())
 
     def calibrationExists(self, runId: str, useLiteMode: bool) -> bool:
-        version = self.calibrationIndexer(runId, useLiteMode).currentVersion()
+        version = self.calibrationIndexer(runId, useLiteMode).latestApplicableVersion(runId)
         return version is not None
 
     @validate_call
-    def readCalibrationRecord(self, runId: str, useLiteMode: bool, version: Optional[int] = None):
+    def readCalibrationRecord(self, runId: str, useLiteMode: bool, version: Version = VersionState.LATEST):
         """
         Will return a calibration record for the given version.
         If no version given, will choose the latest applicable version from the index.
         """
         indexer = self.calibrationIndexer(runId, useLiteMode)
-        if version is None:
-            # NOTE Indexer.readRecord defaults to currentVersion
+        if version is VersionState.LATEST:
             version = indexer.latestApplicableVersion(runId)
-        return indexer.readRecord(version)
+        record = None
+        if version is not None:
+            record = indexer.readRecord(version)
 
-    def writeCalibrationRecord(self, record: CalibrationRecord):
+        return record
+
+    def writeCalibrationRecord(self, record: CalibrationRecord, entry: Optional[IndexEntry] = None):
         """
         Persists a `CalibrationRecord` to either a new version folder, or overwrite a specific version.
         Record must be set with correct version.
@@ -565,8 +582,12 @@ class LocalDataService:
         """
 
         indexer = self.calibrationIndexer(record.runNumber, record.useLiteMode)
-        # write record to file
-        indexer.writeRecord(record)
+        if entry is None:
+            # write record to file
+            indexer.writeRecord(record)
+        else:
+            # write record to file
+            indexer.writeNewRecord(record, entry)
         # separately write the calibration state
         indexer.writeParameters(record.calculationParameters)
 
@@ -808,7 +829,7 @@ class LocalDataService:
     ##### READ / WRITE STATE METHODS #####
 
     @validate_call
-    def readCalibrationState(self, runId: str, useLiteMode: bool, version: Optional[int] = None):
+    def readCalibrationState(self, runId: str, useLiteMode: bool, version: Optional[Version] = VersionState.LATEST):
         if not self.calibrationExists(runId, useLiteMode):
             if self._hasWritePermissionsCalibrationStateRoot():
                 raise RecoverableException.stateUninitialized(runId, useLiteMode)
@@ -820,16 +841,17 @@ class LocalDataService:
 
         indexer = self.calibrationIndexer(runId, useLiteMode)
         # NOTE if we prefer latest version in index, uncomment below
-        # if version is None:
-        #     version = indexer.latestApplicableVersion(runId)
-        return indexer.readParameters(version)
+        parameters = None
+        if version is VersionState.LATEST:
+            version = indexer.latestApplicableVersion(runId)
+        if version is not None:
+            parameters = indexer.readParameters(version)
+
+        return parameters
 
     @validate_call
-    def readNormalizationState(self, runId: str, useLiteMode: bool, version: Optional[int] = None):
+    def readNormalizationState(self, runId: str, useLiteMode: bool, version: Optional[Version] = VersionState.LATEST):
         indexer = self.normalizationIndexer(runId, useLiteMode)
-        # NOTE if we prefer latest version in index, uncomment below
-        # if version is None:
-        #     version = indexer.latestApplicableVersion(runId)
         return indexer.readParameters(version)
 
     def writeCalibrationState(self, calibration: Calibration):
@@ -977,9 +999,9 @@ class LocalDataService:
             self._prepareStateRoot(stateId)
 
         # now save default versions of files in both lite and native resolution directories
-        version = VERSION_DEFAULT
         for liteMode in [True, False]:
             indexer = self.calibrationIndexer(runId, liteMode)
+            version = indexer.defaultVersion()
             calibration = indexer.createParameters(
                 instrumentState=instrumentState,
                 name=name,
@@ -1010,9 +1032,8 @@ class LocalDataService:
                 comments="The default configuration when loading StateConfig if none other is found",
             )
             # write the calibration state
-            indexer.writeRecord(record)
+            indexer.writeNewRecord(record, entry)
             indexer.writeParameters(record.calculationParameters)
-            indexer.addIndexEntry(entry)
             # write the default diffcal table
             self._writeDefaultDiffCalTable(runId, liteMode)
 

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -391,7 +391,9 @@ class NormalizationService(Service):
         """
         response = {}
         for runNumber in request.runNumbers:
-            response[runNumber] = self.dataFactoryService.getLatestNormalizationVersion(runNumber, request.useLiteMode)
+            response[runNumber] = self.dataFactoryService.getLatestApplicableNormalizationVersion(
+                runNumber, request.useLiteMode
+            )
         return response
 
     @FromString

--- a/src/snapred/backend/service/ReductionService.py
+++ b/src/snapred/backend/service/ReductionService.py
@@ -15,7 +15,6 @@ from snapred.backend.dao.request import (
     ReductionExportRequest,
     ReductionRequest,
 )
-from snapred.backend.dao.request.ReductionRequest import Versions
 from snapred.backend.dao.response.ReductionResponse import ReductionResponse
 from snapred.backend.dao.SNAPRequest import SNAPRequest
 from snapred.backend.dao.WorkspaceMetadata import DiffcalStateMetadata, NormalizationStateMetadata, WorkspaceMetadata
@@ -323,6 +322,9 @@ class ReductionService(Service):
         :return: The needed reduction ignredients.
         :rtype: ReductionIngredients
         """
+        if request.versions is None or request.versions.calibration is None or request.versions.normalization is None:
+            raise ValueError("Reduction request must have versions set")
+
         farmFresh = FarmFreshIngredients(
             runNumber=request.runNumber,
             useLiteMode=request.useLiteMode,
@@ -416,10 +418,6 @@ class ReductionService(Service):
                 request.useLiteMode
             ).add()
 
-        request.versions = Versions(
-            calVersion,
-            normVersion,
-        )
         groceries = self.groceryService.fetchGroceryDict(
             groceryDict=self.groceryClerk.buildDict(),
             **({"combinedPixelMask": combinedPixelMask} if combinedPixelMask else {}),

--- a/src/snapred/backend/service/ReductionService.py
+++ b/src/snapred/backend/service/ReductionService.py
@@ -367,7 +367,9 @@ class ReductionService(Service):
                 request.runNumber, request.useLiteMode
             )
         if ContinueWarning.Type.MISSING_NORMALIZATION not in request.continueFlags:
-            normVersion = self.dataFactoryService.getLatestNormalizationVersion(request.runNumber, request.useLiteMode)
+            normVersion = self.dataFactoryService.getLatestApplicableNormalizationVersion(
+                request.runNumber, request.useLiteMode
+            )
 
         # Fetch pixel masks
         residentMasks = {}

--- a/src/snapred/backend/service/ReductionService.py
+++ b/src/snapred/backend/service/ReductionService.py
@@ -363,13 +363,11 @@ class ReductionService(Service):
         calVersion = None
         normVersion = None
         if ContinueWarning.Type.MISSING_DIFFRACTION_CALIBRATION not in request.continueFlags:
-            calVersion = self.dataFactoryService.getThisOrLatestCalibrationVersion(
+            calVersion = self.dataFactoryService.getLatestApplicableCalibrationVersion(
                 request.runNumber, request.useLiteMode
             )
         if ContinueWarning.Type.MISSING_NORMALIZATION not in request.continueFlags:
-            normVersion = self.dataFactoryService.getThisOrLatestNormalizationVersion(
-                request.runNumber, request.useLiteMode
-            )
+            normVersion = self.dataFactoryService.getLatestNormalizationVersion(request.runNumber, request.useLiteMode)
 
         # Fetch pixel masks
         residentMasks = {}
@@ -496,7 +494,9 @@ class ReductionService(Service):
         for request in requests:
             runNumber = json.loads(request.payload)["runNumber"]
             useLiteMode = bool(json.loads(request.payload)["useLiteMode"])
-            normalizationVersion = self.dataFactoryService.getThisOrCurrentNormalizationVersion(runNumber, useLiteMode)
+            normalizationVersion = self.dataFactoryService.getLatestApplicableNormalizationVersion(
+                runNumber, useLiteMode
+            )
             version = "normalization_" + str(normalizationVersion)
             if versions.get(version) is None:
                 versions[version] = []

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -222,6 +222,8 @@ class SousChef(Service):
         self,
         ingredients: FarmFreshIngredients,
     ) -> FarmFreshIngredients:
+        if ingredients.versions.calibration is None:
+            raise ValueError("Calibration version must be specified")
         calibrationRecord = self.dataFactoryService.getCalibrationRecord(
             ingredients.runNumber, ingredients.useLiteMode, ingredients.versions.calibration
         )

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -8,11 +8,8 @@ from pydantic import WithJsonSchema
 from pydantic.functional_validators import BeforeValidator
 from typing_extensions import Annotated, Self
 
+from snapred.backend.dao.indexing.Versioning import VERSION_START, VersionState
 from snapred.meta.Config import Config
-
-# Bypass circular import:
-VERSION_DEFAULT = Config["version.default"]
-VERSION_DEFAULT_NAME = Config["version.friendlyName.default"]
 
 
 class WorkspaceName(str):
@@ -179,8 +176,8 @@ class ValueFormatter:
         # in those cases, format will be a user-specified string
 
         formattedVersion = ""
-        if version == VERSION_DEFAULT:
-            formattedVersion = f"v{VERSION_DEFAULT_NAME}"
+        if version == VersionState.DEFAULT:
+            formattedVersion = f"v{VERSION_START}"
         elif isinstance(version, int):
             formattedVersion = fmt.format(version=version)
         elif str(version).isdigit():
@@ -191,8 +188,8 @@ class ValueFormatter:
     def pathVersion(cls, version: int):
         # only one special case: default version
 
-        if version == VERSION_DEFAULT:
-            return f"v_{VERSION_DEFAULT_NAME}"
+        if version == VersionState.DEFAULT:
+            return f"v_{VersionState.DEFAULT}"
         return cls.formatVersion(version, fmt=cls.versionFormat.PATH)
 
     @classmethod

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -193,7 +193,7 @@ version:
   friendlyName:
     error: "uninitialized"  # alphanumeric
     default: 0 # alphanumeric
-  start: 1   # MUST be nonnegative integer
+  start: 0   # MUST be nonnegative integer
 
 cis_mode: false
 

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -3,7 +3,7 @@ from qtpy.QtCore import Slot
 
 from snapred.backend.dao import RunConfig
 from snapred.backend.dao.indexing.IndexEntry import IndexEntry
-from snapred.backend.dao.indexing.Versioning import VersionedObject
+from snapred.backend.dao.indexing.Versioning import VersionedObject, VersionState
 from snapred.backend.dao.Limit import Pair
 from snapred.backend.dao.request import (
     CalculateResidualRequest,
@@ -515,10 +515,10 @@ class DiffCalWorkflow(WorkflowImplementer):
     def _saveCalibration(self, workflowPresenter):
         view = workflowPresenter.widget.tabView
         runNumber = view.fieldRunNumber.get()
-        version = view.fieldVersion.get(None)
+        version = view.fieldVersion.get(VersionState.NEXT)
         appliesTo = view.fieldAppliesTo.get(f">={runNumber}")
         # validate the version number
-        version = VersionedObject.parseVersion(version, exclude_default=True)
+        version = VersionedObject(version=version).version
         # validate appliesTo field
         appliesTo = IndexEntry.appliesToFormatChecker(appliesTo)
 

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -1,7 +1,7 @@
 from qtpy.QtCore import Slot
 
 from snapred.backend.dao.indexing.IndexEntry import IndexEntry
-from snapred.backend.dao.indexing.Versioning import VersionedObject
+from snapred.backend.dao.indexing.Versioning import VersionedObject, VersionState
 from snapred.backend.dao.request import (
     CalibrationWritePermissionsRequest,
     CreateIndexEntryRequest,
@@ -217,10 +217,10 @@ class NormalizationWorkflow(WorkflowImplementer):
     def _saveNormalization(self, workflowPresenter):
         view = workflowPresenter.widget.tabView
         runNumber = view.fieldRunNumber.get()
-        version = view.fieldVersion.get()
+        version = view.fieldVersion.get(VersionState.NEXT)
         appliesTo = view.fieldAppliesTo.get(f">={self.calibrationRunNumber}")
         # validate version number
-        version = VersionedObject.parseVersion(version, exclude_default=True)
+        version = VersionedObject(version=version).version
         # validate appliesTo field
         appliesTo = IndexEntry.appliesToFormatChecker(appliesTo)
 

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -187,6 +187,10 @@ class ReductionWorkflow(WorkflowImplementer):
         response = self.request(path="reduction/groupings", payload=request_)
         self._keeps = set(response.data["groupingWorkspaces"])
 
+        # Validate reduction; if artificial normalization is needed, handle it
+        # NOTE: this logic ONLY works because we are forbidding mixed cases of artnorm or loaded norm
+        response = self.request(path="reduction/validate", payload=request_)
+
         # get the calibration and normalization versions for all runs to be processed
         matchRequest = MatchRunsRequest(runNumbers=self.runNumbers, useLiteMode=self.useLiteMode)
         loadedCalibrations, calVersions = self.request(path="calibration/fetchMatches", payload=matchRequest).data
@@ -203,9 +207,6 @@ class ReductionWorkflow(WorkflowImplementer):
                 "and try again."
             )
 
-        # Validate reduction; if artificial normalization is needed, handle it
-        # NOTE: this logic ONLY works because we are forbidding mixed cases of artnorm or loaded norm
-        response = self.request(path="reduction/validate", payload=request_)
         if ContinueWarning.Type.MISSING_NORMALIZATION in self.continueAnywayFlags:
             if len(self.runNumbers) > 1:
                 raise RuntimeError(

--- a/src/snapred/ui/workflow/WorkflowImplementer.py
+++ b/src/snapred/ui/workflow/WorkflowImplementer.py
@@ -101,6 +101,7 @@ class WorkflowImplementer(QObject):
         self.responses = []
         self.outputs = []
         self.collectedOutputs = []
+        self.continueAnywayFlags = ContinueWarning.Type.UNSET
 
         for hook in self.resetHooks:
             logger.info(f"Calling reset hook: {hook}")

--- a/tests/integration/test_workflow_panels_happy_path.py
+++ b/tests/integration/test_workflow_panels_happy_path.py
@@ -20,6 +20,7 @@ from util.Config_helpers import Config_override
 #   however, for the moment, the reduction-data output relocation fixture is defined in the current file.
 from snapred.backend.data.LocalDataService import LocalDataService
 from snapred.meta.Config import Config, Resource
+from snapred.meta.Enum import StrEnum
 from snapred.ui.main import SNAPRedGUI, prependDataSearchDirectories
 from snapred.ui.view import InitializeStateCheckView
 from snapred.ui.view.DiffCalAssessmentView import DiffCalAssessmentView
@@ -40,6 +41,64 @@ class InterruptWithBlock(BaseException):
 
 
 @pytest.fixture
+class TestSummary:
+    def __init__(self):
+        self._index = 0
+        self._steps = []
+
+    def SUCCESS(self):
+        step = self._steps[self._index]
+        step.status = self.TestStep.StepStatus.SUCCESS
+        self._index += 1
+
+    def FAILURE(self):
+        step = self._steps[self._index]
+        step.status = self.TestStep.StepStatus.FAILURE
+        self._index += 1
+
+    def isComplete(self):
+        return self._index == len(self._steps)
+
+    def isFailure(self):
+        return any(step.status == self.TestStep.StepStatus.FAILURE for step in self._steps)
+
+    def builder():
+        return TestSummary.TestSummaryBuilder()
+
+    def __str__(self):
+        longestStatus = max(len(step.status) for step in self._steps)
+        longestName = max(len(step.name) for step in self._steps)
+        tableCapStr = "#" * (longestName + longestStatus + 6)
+        tableStr = (
+            f"\n{tableCapStr}\n"
+            + "\n".join(f"# {step.name:{longestName}}: {step.status:{longestStatus}} #" for step in self._steps)
+            + f"\n{tableCapStr}\n"
+        )
+        return tableStr
+
+    class TestStep:
+        class StepStatus(StrEnum):
+            SUCCESS = "SUCCESS"
+            FAILURE = "FAILURE"
+            INCOMPLETE = "INCOMPLETE"
+
+        def __init__(self, name: str):
+            self.name = name
+            self.status = self.StepStatus.INCOMPLETE
+
+    class TestSummaryBuilder:
+        def __init__(self):
+            self.summary = TestSummary()
+
+        def step(self, name: str):
+            self.summary._steps.append(TestSummary.TestStep(name))
+            return self
+
+        def build(self):
+            return self.summary
+
+
+@pytest.fixture()
 def calibration_home_from_mirror():
     # Test fixture to create a copy of the calibration home directory from an existing mirror:
     # * creates a temporary calibration home directory under the optional `prefix` path;
@@ -196,7 +255,15 @@ class TestGUIPanels:
         # Establish context for each test: these normally run as part of `src/snapred/__main__.py`.
         self.exitStack = ExitStack()
         self.exitStack.enter_context(amend_config(data_dir=prependDataSearchDirectories(), prepend_datadir=True))
+
+        self.testSummary = None
         yield
+
+        if isinstance(self.testSummary, TestSummary):
+            if not self.testSummary.isComplete():
+                self.testSummary.FAILURE()
+            if self.testSummary.isFailure():
+                pytest.fail(f"Test Summary (-vv for full table): {self.testSummary}")
 
         # teardown...
         self._warningMessageBox.stop()
@@ -722,7 +789,18 @@ class TestGUIPanels:
         # Override the mirror with a new home directory, omitting any existing
         #   calibration or normalization data.
         tmpCalibrationHomeDirectory = calibration_home_from_mirror()  # noqa: F841
-
+        self.testSummary = (
+            TestSummary.builder()
+            .step("Open the GUI")
+            .step("Open the calibration panel")
+            .step("Set the diffraction calibration request")
+            .step("Execute the diffraction calibration request")
+            .step("Tweak the peaks")
+            .step("Assess the peaks")
+            .step("Save the diffraction calibration")
+            .step("Close the GUI")
+            .build()
+        )
         with (
             qtbot.captureExceptions() as exceptions,
             suppress(InterruptWithBlock),
@@ -750,6 +828,7 @@ class TestGUIPanels:
             """
 
             # Open the calibration panel:
+            self.testSummary.SUCCESS()
             # QPushButton* button = pWin->findChild<QPushButton*>("Button name");
             qtbot.mouseClick(gui.calibrationPanelButton, QtCore.Qt.LeftButton)
             if len(exceptions):
@@ -780,6 +859,7 @@ class TestGUIPanels:
 
             requestView = workflowNodeTabs.currentWidget().view
             assert isinstance(requestView, DiffCalRequestView)
+            self.testSummary.SUCCESS()
 
             #    set "Run Number", "Convergence Threshold", ,:
             requestView.runNumberField.setText("46680")
@@ -804,6 +884,7 @@ class TestGUIPanels:
             assert requestView.peakFunctionDropdown.currentIndex() == 0
             assert requestView.peakFunctionDropdown.currentText() == "Gaussian"
 
+            self.testSummary.SUCCESS()
             #    execute the request
 
             # TODO: make sure that there's no initialized state => abort the test if there is!
@@ -858,13 +939,17 @@ class TestGUIPanels:
                 questionMessageBox.stop()
                 successPrompt.stop()
 
+                # Now that there is a new state, we need to reselect the grouping file ... :
+                # Why was this error box being swallowed?
+                requestView.groupingFileDropdown.setCurrentIndex(1)
+
             #    (2) execute the calibration workflow
             with qtbot.waitSignal(actionCompleted, timeout=60000):
                 qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
             qtbot.waitUntil(
                 lambda: isinstance(workflowNodeTabs.currentWidget().view, DiffCalTweakPeakView), timeout=60000
             )
-
+            self.testSummary.SUCCESS()
             tweakPeakView = workflowNodeTabs.currentWidget().view
 
             # ---------------------------------------------------------------------------
@@ -896,6 +981,7 @@ class TestGUIPanels:
             #    continue to the next panel
             with qtbot.waitSignal(actionCompleted, timeout=80000):
                 qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+            self.testSummary.SUCCESS()
 
             qtbot.waitUntil(
                 lambda: isinstance(workflowNodeTabs.currentWidget().view, DiffCalAssessmentView), timeout=80000
@@ -913,6 +999,7 @@ class TestGUIPanels:
             #    continue to the next panel
             with qtbot.waitSignal(actionCompleted, timeout=80000):
                 qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
+            self.testSummary.SUCCESS()
 
             qtbot.waitUntil(lambda: isinstance(workflowNodeTabs.currentWidget().view, DiffCalSaveView), timeout=5000)
             saveView = workflowNodeTabs.currentWidget().view
@@ -924,7 +1011,7 @@ class TestGUIPanels:
             #    continue in order to save workspaces and to finish the workflow
             with qtbot.waitSignal(actionCompleted, timeout=60000):
                 qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
-
+            self.testSummary.SUCCESS()
             #   `ActionPrompt.prompt("..The workflow has completed successfully..)` gives immediate mocked response:
             #      Here we still need to wait until the ADS cleanup has occurred,
             #      or else it will happen in the middle of the next workflow. :(
@@ -938,6 +1025,7 @@ class TestGUIPanels:
 
             calibrationPanel.widget.close()
             gui.close()
+            self.testSummary.SUCCESS()
 
         #####################################################################
         # Force a printout of information about any exceptions that happened#
@@ -955,7 +1043,17 @@ class TestGUIPanels:
         # Override the mirror with a new home directory, omitting any existing
         #   calibration or normalization data.
         tmpCalibrationHomeDirectory = calibration_home_from_mirror()  # noqa: F841
-
+        self.testSummary = (
+            TestSummary.builder()
+            .step("Open the GUI")
+            .step("Open the Normalization panel")
+            .step("Set the normalization request")
+            .step("Execute the normalization request")
+            .step("Tweak the peaks")
+            .step("Save the normalization calibration")
+            .step("Close the GUI")
+            .build()
+        )
         with (
             qtbot.captureExceptions() as exceptions,
             suppress(InterruptWithBlock),
@@ -963,7 +1061,7 @@ class TestGUIPanels:
             gui = SNAPRedGUI(translucentBackground=True)
             gui.show()
             qtbot.addWidget(gui)
-
+            self.testSummary.SUCCESS()
             """
             SNAPRedGUI owns the following widgets:
 
@@ -1013,6 +1111,7 @@ class TestGUIPanels:
 
             requestView = workflowNodeTabs.currentWidget().view
             assert isinstance(requestView, NormalizationRequestView)
+            self.testSummary.SUCCESS()
 
             #    set "Run Number", "Background run number":
             requestView.runNumberField.setText("46680")
@@ -1031,7 +1130,7 @@ class TestGUIPanels:
             requestView.groupingFileDropdown.setCurrentIndex(1)
             assert requestView.groupingFileDropdown.currentIndex() == 1
             assert requestView.groupingFileDropdown.currentText() == "Bank"
-
+            self.testSummary.SUCCESS()
             """ # Why no "peak function" for normalization calibration?!
             requestView.peakFunctionDropdown.setCurrentIndex(0)
             assert requestView.peakFunctionDropdown.currentIndex() == 0
@@ -1093,6 +1192,10 @@ class TestGUIPanels:
                 questionMessageBox.stop()
                 successPrompt.stop()
 
+                # Now that there is a new state, we need to reselect the grouping file ... :
+                # Why was this error box being swallowed?
+                requestView.groupingFileDropdown.setCurrentIndex(1)
+
             warningMessageBox = mock.patch(  # noqa: PT008
                 "qtpy.QtWidgets.QMessageBox.warning",
                 lambda *args, **kwargs: QMessageBox.Yes,  # noqa: ARG005
@@ -1106,6 +1209,7 @@ class TestGUIPanels:
                 lambda: isinstance(workflowNodeTabs.currentWidget().view, NormalizationTweakPeakView), timeout=60000
             )
             warningMessageBox.stop()
+            self.testSummary.SUCCESS()
             tweakPeakView = workflowNodeTabs.currentWidget().view
 
             #    set "Smoothing", "xtal dMin", "xtal dMax", "intensity threshold", and "groupingDropDown"
@@ -1131,6 +1235,7 @@ class TestGUIPanels:
             qtbot.waitUntil(
                 lambda: isinstance(workflowNodeTabs.currentWidget().view, NormalizationSaveView), timeout=60000
             )
+            self.testSummary.SUCCESS()
             saveView = workflowNodeTabs.currentWidget().view
 
             #    set "author" and "comment"
@@ -1140,7 +1245,7 @@ class TestGUIPanels:
             #    continue in order to save workspaces and to finish the workflow
             with qtbot.waitSignal(actionCompleted, timeout=60000):
                 qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
-
+            self.testSummary.SUCCESS()
             #   `ActionPrompt.prompt("..The workflow has completed successfully..)` gives immediate mocked response:
             #      Here we still need to wait until the ADS cleanup has occurred,
             #      or else it will happen in the middle of the next workflow. :(
@@ -1154,7 +1259,7 @@ class TestGUIPanels:
 
             calibrationPanel.widget.close()
             gui.close()
-
+            self.testSummary.SUCCESS()
         #####################################################################
         # Force a printout of information about any exceptions that happened#
         #   within the Qt event loop.                                       #
@@ -1181,6 +1286,16 @@ class TestGUIPanels:
         #   under the existing location within the mirror.
         tmpReductionHomeDirectory = reduction_home_from_mirror(reductionRunNumber)  # noqa: F841
 
+        self.testSummary = (
+            TestSummary.builder()
+            .step("Open the GUI")
+            .step("Open the Reduction panel")
+            .step("Set the reduction request")
+            .step("Execute the reduction request")
+            .step("Close the GUI")
+            .build()
+        )
+
         self.completionMessageHasAppeared = False
 
         def completionMessageBoxAssert(*args, **kwargs):  # noqa: ARG001
@@ -1202,7 +1317,7 @@ class TestGUIPanels:
             gui = SNAPRedGUI(translucentBackground=True)
             gui.show()
             qtbot.addWidget(gui)
-
+            self.testSummary.SUCCESS()
             """
             SNAPRedGUI owns the following widgets:
 
@@ -1250,7 +1365,7 @@ class TestGUIPanels:
 
             requestView = workflowNodeTabs.currentWidget().view
             assert isinstance(requestView, ReductionRequestView)
-
+            self.testSummary.SUCCESS()
             # Without this next wait, the "run number entry" section happens too fast.
             # (And I'd love to understand _why_!  :(  )
             qtbot.wait(1000)
@@ -1263,7 +1378,7 @@ class TestGUIPanels:
             _runNumbers = [requestView.runNumberDisplay.item(x).text() for x in range(_count)]
 
             assert reductionRunNumber in _runNumbers
-
+            self.testSummary.SUCCESS()
             """
             request.liteModeToggle.setState(True);
             request.retainUnfocusedDataCheckbox.setValue(False);
@@ -1344,13 +1459,14 @@ class TestGUIPanels:
                 timeout=60000,
             )
             completionMessageBox.stop()
-
+            self.testSummary.SUCCESS()
             ###############################
             ########### END OF TEST #######
             ###############################
 
             calibrationPanel.widget.close()
             gui.close()
+            self.testSummary.SUCCESS()
 
         #####################################################################
         # Force a printout of information about any exceptions that happened#

--- a/tests/integration/test_workflow_panels_happy_path.py
+++ b/tests/integration/test_workflow_panels_happy_path.py
@@ -40,7 +40,6 @@ class InterruptWithBlock(BaseException):
     pass
 
 
-@pytest.fixture
 class TestSummary:
     def __init__(self):
         self._index = 0
@@ -98,7 +97,7 @@ class TestSummary:
             return self.summary
 
 
-@pytest.fixture()
+@pytest.fixture
 def calibration_home_from_mirror():
     # Test fixture to create a copy of the calibration home directory from an existing mirror:
     # * creates a temporary calibration home directory under the optional `prefix` path;

--- a/tests/resources/inputs/reduction/ReductionRecord_20240614T130420.json
+++ b/tests/resources/inputs/reduction/ReductionRecord_20240614T130420.json
@@ -761,6 +761,7 @@
             "fitted_strippedFocussedData_stripped_2"
         ],
         "version": 7,
+        "calibrationVersionUsed": 1,
         "crystalDBounds": {"minimum": 0.4, "maximum": 100.0},
         "normalizationCalibrantSamplePath": "/SNS/SNAP/shared/Calibration/Calibrants/Al2O3/Al2O3_20240614T130420.nxs"
     },

--- a/tests/unit/backend/dao/test_VersionedObject.py
+++ b/tests/unit/backend/dao/test_VersionedObject.py
@@ -9,10 +9,9 @@ from snapred.backend.dao.indexing.CalculationParameters import CalculationParame
 from snapred.backend.dao.indexing.IndexEntry import IndexEntry
 from snapred.backend.dao.indexing.Record import Record
 from snapred.backend.dao.indexing.Versioning import (
-    VERSION_DEFAULT,
-    VERSION_DEFAULT_NAME,
-    VERSION_NONE_NAME,
+    VERSION_START,
     VersionedObject,
+    VersionState,
 )
 
 
@@ -25,24 +24,19 @@ def test_init_bad():
         VersionedObject(version=1.2)
 
 
-def test_init_name_none():
-    vo = VersionedObject(version=VERSION_NONE_NAME)
-    assert vo.version is None
-
-
 def test_init_name_default():
-    vo = VersionedObject(version=VERSION_DEFAULT_NAME)
-    assert vo.version == VERSION_DEFAULT
+    vo = VersionedObject(version=VersionState.DEFAULT)
+    assert vo.version == VersionState.DEFAULT
 
 
 def test_init_none():
-    vo = VersionedObject(version=None)
-    assert vo.version is None
+    with pytest.raises(ValueError):
+        VersionedObject(version=None)
 
 
 def test_init_default():
-    vo = VersionedObject(version=VERSION_DEFAULT)
-    assert vo.version == VERSION_DEFAULT
+    vo = VersionedObject(version=VersionState.DEFAULT)
+    assert vo.version == VersionState.DEFAULT
 
 
 def test_init_int():
@@ -73,19 +67,16 @@ def test_write_version_int():
 
 
 def test_write_version_none():
-    vo = VersionedObject(version=None)
-    assert vo.version is None
-    assert vo.model_dump_json() == f'{{"version":"{VERSION_NONE_NAME}"}}'
-    assert vo.model_dump_json() != '{"version":null}'
-    assert vo.dict()["version"] == VERSION_NONE_NAME
+    with pytest.raises(ValueError):
+        VersionedObject(version=None)
 
 
 def test_write_version_default():
-    vo = VersionedObject(version=VERSION_DEFAULT_NAME)
-    assert vo.version == VERSION_DEFAULT
-    assert vo.model_dump_json() == f'{{"version":"{VERSION_DEFAULT_NAME}"}}'
-    assert vo.model_dump_json() != f'{{"version":{VERSION_DEFAULT}}}'
-    assert vo.dict()["version"] == VERSION_DEFAULT_NAME
+    vo = VersionedObject(version=VERSION_START)
+    assert vo.version == VERSION_START
+    assert vo.model_dump_json() == f'{{"version":{VERSION_START}}}'
+    assert vo.model_dump_json() != f'{{"version":"{VERSION_START}"}}'
+    assert vo.dict()["version"] == VERSION_START
 
 
 def test_can_set_valid():
@@ -95,11 +86,11 @@ def test_can_set_valid():
     vo.version = new_version
     assert vo.version == new_version
 
-    vo.version = VERSION_DEFAULT
-    assert vo.version == VERSION_DEFAULT
+    vo.version = VersionState.DEFAULT
+    assert vo.version == VersionState.DEFAULT
 
-    vo.version = VERSION_DEFAULT_NAME
-    assert vo.version == VERSION_DEFAULT
+    vo.version = VersionState.DEFAULT
+    assert vo.version == VersionState.DEFAULT
 
 
 def test_cannot_set_invalid():
@@ -117,17 +108,12 @@ def test_shaped_liked_itself():
     Make a versioned object.  Serialize it.  Then parse it back as itself.
     It should validate and create an identical object.
     """
-    # version is None
-    vo_old = VersionedObject(version=None)
-    vo_new = VersionedObject.model_validate(vo_old.model_dump())
-    assert vo_old == vo_new
-    vo_new = VersionedObject.model_validate(vo_old.dict())
-    assert vo_old == vo_new
-    vo_new = VersionedObject.model_validate_json(vo_old.model_dump_json())
-    assert vo_old == vo_new
 
     # version is default
-    vo_old = VersionedObject(version=VERSION_DEFAULT)
+    vo_old = VersionedObject(version=VersionState.DEFAULT)
+    with pytest.raises(ValueError, match="must be flattened to an int before writing to"):
+        vo_old.model_dump_json()
+    vo_old.version = VERSION_START
     vo_new = VersionedObject.model_validate(vo_old.model_dump())
     assert vo_old == vo_new
     vo_new = VersionedObject.model_validate(vo_old.dict())
@@ -172,17 +158,10 @@ def test_init_index_entry():
         vo = indexEntryWithVersion(version)
         assert vo.version == version
 
-    # init with none
-    vo = indexEntryWithVersion(VERSION_NONE_NAME)
-    assert vo.version is None
-    vo = indexEntryWithVersion(None)
-    assert vo.version is None
-
     # init with default
-    vo = indexEntryWithVersion(VERSION_DEFAULT_NAME)
-    assert vo.version == VERSION_DEFAULT
-    vo = indexEntryWithVersion(VERSION_DEFAULT)
-    assert vo.version == VERSION_DEFAULT
+    vo = indexEntryWithVersion(VersionState.DEFAULT)
+    # This must be flattened to an int before writing to JSON
+    assert vo.version == VersionState.DEFAULT
 
 
 def test_set_index_entry():
@@ -192,11 +171,8 @@ def test_set_index_entry():
     vo.version = new_version
     assert vo.version == new_version
 
-    vo.version = VERSION_DEFAULT
-    assert vo.version == VERSION_DEFAULT
-
-    vo.version = VERSION_DEFAULT_NAME
-    assert vo.version == VERSION_DEFAULT
+    vo.version = VERSION_START
+    assert vo.version == VERSION_START
 
     vo = indexEntryWithVersion(randint(0, 120))
     with pytest.raises(ValueError):
@@ -215,19 +191,16 @@ def test_write_version_index_entry():
         assert f'"version":{version}' in vo.model_dump_json()
         assert vo.dict()["version"] == version
 
-    # test write none
-    vo = indexEntryWithVersion(None)
-    assert vo.version is None
-    assert f'"version":"{VERSION_NONE_NAME}"' in vo.model_dump_json()
-    assert '"version":null' not in vo.model_dump_json()
-    assert vo.dict()["version"] == VERSION_NONE_NAME
-
     # test write default
-    vo = indexEntryWithVersion(VERSION_DEFAULT)
-    assert vo.version == VERSION_DEFAULT
-    assert f'"version":"{VERSION_DEFAULT_NAME}"' in vo.model_dump_json()
-    assert f'"version":{VERSION_DEFAULT}' not in vo.model_dump_json()
-    assert vo.dict()["version"] == VERSION_DEFAULT_NAME
+    vo = indexEntryWithVersion(VersionState.DEFAULT)
+
+    with pytest.raises(ValueError, match="must be flattened to an int before writing to"):
+        vo.model_dump_json()
+
+    vo.version = VERSION_START
+    assert f'"version":{VERSION_START}' in vo.model_dump_json()
+    assert f'"version":"{VERSION_START}"' not in vo.model_dump_json()
+    assert vo.dict()["version"] == VERSION_START
 
 
 ### TESTS OF RECORDS AS VERSIONED OBJECTS ###
@@ -258,17 +231,11 @@ def test_init_record():
         vo = recordWithVersion(version)
         assert vo.version == version
 
-    # init with none
-    vo = recordWithVersion(VERSION_NONE_NAME)
-    assert vo.version is None
-    vo = recordWithVersion(None)
-    assert vo.version is None
-
     # init with default
-    vo = recordWithVersion(VERSION_DEFAULT_NAME)
-    assert vo.version == VERSION_DEFAULT
-    vo = recordWithVersion(VERSION_DEFAULT)
-    assert vo.version == VERSION_DEFAULT
+    vo = recordWithVersion(VersionState.DEFAULT)
+    assert vo.version == VersionState.DEFAULT
+    vo = recordWithVersion(VersionState.DEFAULT)
+    assert vo.version == VersionState.DEFAULT
 
 
 def test_set_record():
@@ -278,11 +245,11 @@ def test_set_record():
     vo.version = new_version
     assert vo.version == new_version
 
-    vo.version = VERSION_DEFAULT
-    assert vo.version == VERSION_DEFAULT
+    vo.version = VersionState.DEFAULT
+    assert vo.version == VersionState.DEFAULT
 
-    vo.version = VERSION_DEFAULT_NAME
-    assert vo.version == VERSION_DEFAULT
+    vo.version = VersionState.DEFAULT
+    assert vo.version == VersionState.DEFAULT
 
     vo = recordWithVersion(randint(0, 120))
     with pytest.raises(ValueError):
@@ -301,16 +268,14 @@ def test_write_version_record():
         assert f'"version":{version}' in vo.model_dump_json()
         assert vo.dict()["version"] == version
 
-    # test write none
-    vo = recordWithVersion(None)
-    assert vo.version is None
-    assert f'"version":"{VERSION_NONE_NAME}"' in vo.model_dump_json()
-    assert '"version":null' not in vo.model_dump_json()
-    assert vo.dict()["version"] == VERSION_NONE_NAME
-
     # test write default
-    vo = recordWithVersion(VERSION_DEFAULT)
-    assert vo.version == VERSION_DEFAULT
-    assert f'"version":"{VERSION_DEFAULT_NAME}"' in vo.model_dump_json()
-    assert f'"version":{VERSION_DEFAULT}' not in vo.model_dump_json()
-    assert vo.dict()["version"] == VERSION_DEFAULT_NAME
+    vo = recordWithVersion(VersionState.DEFAULT)
+    assert vo.version == VersionState.DEFAULT
+
+    with pytest.raises(ValueError, match="must be flattened to an int before writing to"):
+        vo.model_dump_json()
+    vo.version = VERSION_START
+
+    assert f'"version":{VERSION_START}' in vo.model_dump_json()
+    assert f'"version":"{VERSION_START}"' not in vo.model_dump_json()
+    assert vo.dict()["version"] == VERSION_START

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -67,12 +67,12 @@ class TestDataFactoryService(unittest.TestCase):
         cls.mockLookupService.calibrationIndexer.return_value = mock.Mock(
             versionPath=mock.Mock(side_effect=lambda *x: cls.expected(cls, "Calibration", *x)),
             getIndex=mock.Mock(return_value=[cls.expected(cls, "Calibration")]),
-            getLatestApplicableVersion=mock.Mock(side_effect=lambda *x: cls.expected(cls, "Calibration", *x)),
+            latestApplicableVersion=mock.Mock(side_effect=lambda *x: cls.expected(cls, "Calibration", *x)),
         )
         cls.mockLookupService.normalizationIndexer.return_value = mock.Mock(
             versionPath=mock.Mock(side_effect=lambda *x: cls.expected(cls, "Normalization", *x)),
             getIndex=mock.Mock(return_value=[cls.expected(cls, "Normalization")]),
-            getLatestApplicableVersion=mock.Mock(side_effect=lambda *x: cls.expected(cls, "Normalization", *x)),
+            latestApplicableVersion=mock.Mock(side_effect=lambda *x: cls.expected(cls, "Normalization", *x)),
         )
 
     def setUp(self):

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -228,7 +228,7 @@ class TestDataFactoryService(unittest.TestCase):
 
     def test_getLatestNormalizationVersion(self):
         for useLiteMode in [True, False]:
-            actual = self.instance.getLatestNormalizationVersion("123", useLiteMode)
+            actual = self.instance.getLatestApplicableNormalizationVersion("123", useLiteMode)
             assert actual == self.expected("Normalization", "123")
 
     ## TEST REDUCTION METHODS

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -67,16 +67,12 @@ class TestDataFactoryService(unittest.TestCase):
         cls.mockLookupService.calibrationIndexer.return_value = mock.Mock(
             versionPath=mock.Mock(side_effect=lambda *x: cls.expected(cls, "Calibration", *x)),
             getIndex=mock.Mock(return_value=[cls.expected(cls, "Calibration")]),
-            thisOrNextVersion=mock.Mock(side_effect=lambda *x: cls.expected(cls, "Calibration", *x)),
-            thisOrCurrentVersion=mock.Mock(side_effect=lambda *x: cls.expected(cls, "Calibration", *x)),
-            thisOrLatestApplicableVersion=mock.Mock(side_effect=lambda *x: cls.expected(cls, "Calibration", *x)),
+            getLatestApplicableVersion=mock.Mock(side_effect=lambda *x: cls.expected(cls, "Calibration", *x)),
         )
         cls.mockLookupService.normalizationIndexer.return_value = mock.Mock(
             versionPath=mock.Mock(side_effect=lambda *x: cls.expected(cls, "Normalization", *x)),
             getIndex=mock.Mock(return_value=[cls.expected(cls, "Normalization")]),
-            thisOrNextVersion=mock.Mock(side_effect=lambda *x: cls.expected(cls, "Normalization", *x)),
-            thisOrCurrentVersion=mock.Mock(side_effect=lambda *x: cls.expected(cls, "Normalization", *x)),
-            thisOrLatestApplicableVersion=mock.Mock(side_effect=lambda *x: cls.expected(cls, "Normalization", *x)),
+            getLatestApplicableVersion=mock.Mock(side_effect=lambda *x: cls.expected(cls, "Normalization", *x)),
         )
 
     def setUp(self):
@@ -187,20 +183,10 @@ class TestDataFactoryService(unittest.TestCase):
             actual = self.instance.getCalibrationDataWorkspace("456", useLiteMode, self.version, "bunko")
             assert actual == self.instance.groceryService.fetchWorkspace.return_value
 
-    def test_getThisOrCurrentCalibrationVersion(self):
+    def test_getLatestCalibrationVersion(self):
         for useLiteMode in [True, False]:
-            actual = self.instance.getThisOrCurrentCalibrationVersion("123", useLiteMode, self.version)
-            assert actual == self.expected("Calibration", self.version)  # NOTE mock indexer called only with version
-
-    def test_getThisOrNextCalibrationVersion(self):
-        for useLiteMode in [True, False]:
-            actual = self.instance.getThisOrNextCalibrationVersion("123", useLiteMode, self.version)
-            assert actual == self.expected("Calibration", self.version)  # NOTE mock indexer called only with version
-
-    def test_getThisOrLatestCalibrationVersion(self):
-        for useLiteMode in [True, False]:
-            actual = self.instance.getThisOrLatestCalibrationVersion("123", useLiteMode, self.version)
-            assert actual == self.expected("Calibration", "123", self.version)
+            actual = self.instance.getLatestApplicableCalibrationVersion("123", useLiteMode)
+            assert actual == self.expected("Calibration", "123")
 
     ## TEST NORMALIZATION METHODS
 
@@ -240,20 +226,10 @@ class TestDataFactoryService(unittest.TestCase):
             actual = self.instance.getNormalizationDataWorkspace("456", useLiteMode, self.version, "bunko")
             assert actual == self.instance.groceryService.fetchWorkspace.return_value
 
-    def test_getThisOrCurrentNormalizationVersion(self):
+    def test_getLatestNormalizationVersion(self):
         for useLiteMode in [True, False]:
-            actual = self.instance.getThisOrCurrentNormalizationVersion("123", useLiteMode, self.version)
-            assert actual == self.expected("Normalization", self.version)  # NOTE mock indexer called only with version
-
-    def test_getThisOrNextNormalizationVersion(self):
-        for useLiteMode in [True, False]:
-            actual = self.instance.getThisOrNextNormalizationVersion("123", useLiteMode, self.version)
-            assert actual == self.expected("Normalization", self.version)  # NOTE mock indexer called only with version
-
-    def test_getThisOrLatestNormalizationVersion(self):
-        for useLiteMode in [True, False]:
-            actual = self.instance.getThisOrLatestNormalizationVersion("123", useLiteMode, self.version)
-            assert actual == self.expected("Normalization", "123", self.version)
+            actual = self.instance.getLatestNormalizationVersion("123", useLiteMode)
+            assert actual == self.expected("Normalization", "123")
 
     ## TEST REDUCTION METHODS
 

--- a/tests/unit/backend/data/test_Indexer.py
+++ b/tests/unit/backend/data/test_Indexer.py
@@ -282,10 +282,6 @@ class TestIndexer(unittest.TestCase):
         with pytest.raises(ValueError, match=r".*Version must be an int or*"):
             indexer._flattenVersion(None)
 
-        indexer.currentVersion = lambda: None
-        with pytest.raises(ValueError, match=r".*No available versions found during lookup using:*"):
-            indexer._flattenVersion(VersionState.LATEST)
-
     def test_writeNewRecord_noAppliesTo(self):
         # ensure that a new record is written to disk
         # and the index is updated to reflect the new record

--- a/tests/unit/backend/data/test_Indexer.py
+++ b/tests/unit/backend/data/test_Indexer.py
@@ -282,7 +282,7 @@ class TestIndexer(unittest.TestCase):
         with pytest.raises(ValueError, match=r".*Version must be an int or*"):
             indexer._flattenVersion(None)
 
-    def test_writeNewRecord_noAppliesTo(self):
+    def test_writeNewVersion_noAppliesTo(self):
         # ensure that a new record is written to disk
         # and the index is updated to reflect the new record
         indexer = self.initIndexer()
@@ -290,18 +290,18 @@ class TestIndexer(unittest.TestCase):
         record = self.record(version)
         entry = self.indexEntryFromRecord(record)
         entry.appliesTo = None
-        indexer.writeNewRecord(record, entry)
+        indexer.writeNewVersion(record, entry)
         assert self.recordPath(version).exists()
         assert indexer.index[version] == entry
 
-    def test_writeNewRecord_recordAlreadyExists(self):
+    def test_writeNewVersion_recordAlreadyExists(self):
         # ensure that a new record is written to disk
         # and the index is updated to reflect the new record
         indexer = self.initIndexer()
         version = randint(2, 120)
         record = self.record(version)
         entry = self.indexEntryFromRecord(record)
-        indexer.writeNewRecord(record, entry)
+        indexer.writeNewVersion(record, entry)
         assert self.recordPath(version).exists()
         assert indexer.index[version] == entry
 
@@ -311,7 +311,7 @@ class TestIndexer(unittest.TestCase):
         entry = self.indexEntryFromRecord(record)
 
         with pytest.raises(ValueError, match=".*already exists.*"):
-            indexer.writeNewRecord(record, entry)
+            indexer.writeNewVersion(record, entry)
 
     def test_currentVersion_add(self):
         # ensure current version advances when index entries are written
@@ -509,7 +509,7 @@ class TestIndexer(unittest.TestCase):
         # now write the record
         # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> WRITE 1 <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
         record = self.recordFromIndexEntry(entry)
-        indexer.writeNewRecord(record, entry)
+        indexer.writeNewVersion(record, entry)
         expectedIndex[here] = entry
 
         # the current version hasn't moved
@@ -550,7 +550,7 @@ class TestIndexer(unittest.TestCase):
         record = self.record(here)
         entry = self.indexEntryFromRecord(record)
         expectedIndex[entry.version] = entry
-        indexer.writeNewRecord(record, entry)
+        indexer.writeNewVersion(record, entry)
         assert indexer.nextVersion() == here + 1
         assert indexer.nextVersion() not in indexer.index
 
@@ -579,7 +579,7 @@ class TestIndexer(unittest.TestCase):
         entry = self.indexEntry(VersionState.DEFAULT)
         record = self.recordFromIndexEntry(entry)
         expectedIndex[VERSION_START] = entry
-        indexer.writeNewRecord(record, entry)
+        indexer.writeNewVersion(record, entry)
         assert self.recordPath(indexer.defaultVersion()).exists()
         # the current version is still the default version
         assert indexer.currentVersion() == indexer.defaultVersion()
@@ -601,7 +601,7 @@ class TestIndexer(unittest.TestCase):
         # now write the record -- ensure it is written at the
         record = self.recordFromIndexEntry(entry)
         entry = self.indexEntryFromRecord(record)
-        indexer.writeNewRecord(record, entry)
+        indexer.writeNewVersion(record, entry)
         assert self.recordPath(VERSION_START).exists()
         # ensure current still here
         assert indexer.currentVersion() == VERSION_START + 1
@@ -624,7 +624,7 @@ class TestIndexer(unittest.TestCase):
         record = self.record(VersionState.DEFAULT)
         entry = self.indexEntryFromRecord(record)
         assert indexer._flattenVersion(record.version) == VERSION_START
-        indexer.writeNewRecord(record, entry)
+        indexer.writeNewVersion(record, entry)
 
         # the current version is still the default version
         assert indexer.currentVersion() == VERSION_START
@@ -818,7 +818,7 @@ class TestIndexer(unittest.TestCase):
         # and the read / written records match
         record = self.record(nextVersion)
         entry = self.indexEntryFromRecord(record)
-        indexer.writeNewRecord(record, entry)
+        indexer.writeNewVersion(record, entry)
         res = indexer.readRecord(nextVersion)
         assert record.version == nextVersion
         assert res == record
@@ -832,7 +832,7 @@ class TestIndexer(unittest.TestCase):
         # write then read the record
         # make sure the record version was updated
         # and the read / written records match
-        indexer.writeNewRecord(record, entry)
+        indexer.writeNewVersion(record, entry)
         res = indexer.readRecord(version)
         assert record.version == version
         assert res == record
@@ -870,7 +870,7 @@ class TestIndexer(unittest.TestCase):
         record = self.record(version)
         entry = self.indexEntryFromRecord(record)
         indexer = self.initIndexer()
-        indexer.writeNewRecord(record, entry)
+        indexer.writeNewVersion(record, entry)
         assert record.version == version
         assert self.recordPath(version).exists()
         # read it back in and ensure it is the same
@@ -892,7 +892,7 @@ class TestIndexer(unittest.TestCase):
         # now write the record
         record = self.record(nextVersion)
         entry = self.indexEntryFromRecord(record)
-        indexer.writeNewRecord(record, entry)
+        indexer.writeNewVersion(record, entry)
         assert record.version == nextVersion
         assert self.recordPath(nextVersion).exists()
         res = parse_file_as(Record, self.recordPath(nextVersion))
@@ -910,7 +910,7 @@ class TestIndexer(unittest.TestCase):
         entry = self.indexEntryFromRecord(record)
         # write then read in the record
         indexer = self.initIndexer(IndexerType.CALIBRATION)
-        indexer.writeNewRecord(record, entry)
+        indexer.writeNewVersion(record, entry)
         res = indexer.readRecord(record.version)
         assert type(res) is CalibrationRecord
         assert res == record
@@ -922,7 +922,7 @@ class TestIndexer(unittest.TestCase):
         entry = self.indexEntryFromRecord(record)
         # write then read in the record
         indexer = self.initIndexer(IndexerType.NORMALIZATION)
-        indexer.writeNewRecord(record, entry)
+        indexer.writeNewVersion(record, entry)
         res = indexer.readRecord(record.version)
         assert type(res) is NormalizationRecord
         assert res == record

--- a/tests/unit/backend/data/test_Indexer.py
+++ b/tests/unit/backend/data/test_Indexer.py
@@ -10,6 +10,7 @@ from typing import List
 from unittest import mock
 
 import pytest
+from util.dao import DAOFactory
 
 from snapred.backend.dao.calibration.Calibration import Calibration
 from snapred.backend.dao.calibration.CalibrationRecord import CalibrationRecord
@@ -275,7 +276,6 @@ class TestIndexer(unittest.TestCase):
         indexer.currentVersion = lambda: 3
         indexer.nextVersion = lambda: 4
         assert indexer._flattenVersion(VersionState.DEFAULT) == indexer.defaultVersion()
-        assert indexer._flattenVersion(VersionState.LATEST) == indexer.currentVersion()
         assert indexer._flattenVersion(VersionState.NEXT) == indexer.nextVersion()
         assert indexer._flattenVersion(3) == 3
 

--- a/tests/unit/backend/data/test_Indexer.py
+++ b/tests/unit/backend/data/test_Indexer.py
@@ -10,15 +10,13 @@ from typing import List
 from unittest import mock
 
 import pytest
-from pydantic import ValidationError
-from util.dao import DAOFactory
 
 from snapred.backend.dao.calibration.Calibration import Calibration
 from snapred.backend.dao.calibration.CalibrationRecord import CalibrationRecord
 from snapred.backend.dao.indexing.CalculationParameters import CalculationParameters
 from snapred.backend.dao.indexing.IndexEntry import IndexEntry
 from snapred.backend.dao.indexing.Record import Record
-from snapred.backend.dao.indexing.Versioning import VERSION_DEFAULT, VERSION_START
+from snapred.backend.dao.indexing.Versioning import VERSION_START, VersionState
 from snapred.backend.dao.normalization.Normalization import Normalization
 from snapred.backend.dao.normalization.NormalizationRecord import NormalizationRecord
 from snapred.backend.data.Indexer import DEFAULT_RECORD_TYPE, Indexer, IndexerType
@@ -262,14 +260,62 @@ class TestIndexer(unittest.TestCase):
 
     def test_defaultVersion(self):
         indexer = self.initIndexer()
-        assert indexer.defaultVersion() == VERSION_DEFAULT
+        assert indexer.defaultVersion() == VERSION_START
 
     def test_currentVersion_none(self):
         # ensure the current version of an empty index is unitialized
         indexer = self.initIndexer()
         assert indexer.currentVersion() is None
-        # the path should go to the starting version
-        indexer.currentPath() == self.versionPath(VERSION_START)
+        # if there is no current version then there is no current path on disk.
+        with pytest.raises(ValueError, match=r".*The indexer has encountered an invalid version*"):
+            indexer.currentPath() == self.versionPath(VERSION_START)
+
+    def test_flattenVersion(self):
+        indexer = self.initIndexer()
+        indexer.currentVersion = lambda: 3
+        indexer.nextVersion = lambda: 4
+        assert indexer._flattenVersion(VersionState.DEFAULT) == indexer.defaultVersion()
+        assert indexer._flattenVersion(VersionState.LATEST) == indexer.currentVersion()
+        assert indexer._flattenVersion(VersionState.NEXT) == indexer.nextVersion()
+        assert indexer._flattenVersion(3) == 3
+
+        with pytest.raises(ValueError, match=r".*Version must be an int or*"):
+            indexer._flattenVersion(None)
+
+        indexer.currentVersion = lambda: None
+        with pytest.raises(ValueError, match=r".*No available versions found during lookup using:*"):
+            indexer._flattenVersion(VersionState.LATEST)
+
+    def test_writeNewRecord_noAppliesTo(self):
+        # ensure that a new record is written to disk
+        # and the index is updated to reflect the new record
+        indexer = self.initIndexer()
+        version = randint(2, 120)
+        record = self.record(version)
+        entry = self.indexEntryFromRecord(record)
+        entry.appliesTo = None
+        indexer.writeNewRecord(record, entry)
+        assert self.recordPath(version).exists()
+        assert indexer.index[version] == entry
+
+    def test_writeNewRecord_recordAlreadyExists(self):
+        # ensure that a new record is written to disk
+        # and the index is updated to reflect the new record
+        indexer = self.initIndexer()
+        version = randint(2, 120)
+        record = self.record(version)
+        entry = self.indexEntryFromRecord(record)
+        indexer.writeNewRecord(record, entry)
+        assert self.recordPath(version).exists()
+        assert indexer.index[version] == entry
+
+        # now write the record again
+        # ensure that the record is overwritten
+        record = self.record(version)
+        entry = self.indexEntryFromRecord(record)
+
+        with pytest.raises(ValueError, match=".*already exists.*"):
+            indexer.writeNewRecord(record, entry)
 
     def test_currentVersion_add(self):
         # ensure current version advances when index entries are written
@@ -378,23 +424,23 @@ class TestIndexer(unittest.TestCase):
     def test_latestApplicableVersion_returns_default(self):
         # ensure latest applicable version will be default if it is the only one
         runNumber = "123"
-        versionList = [VERSION_DEFAULT]
+        versionList = [VERSION_START]
         self.prepareVersions(versionList)
         indexer = self.initIndexer()
         # make it applicable
-        indexer.index[VERSION_DEFAULT].appliesTo = f">={runNumber}"
+        indexer.index[indexer.defaultVersion()].appliesTo = f">={runNumber}"
         # get latest apllicable
         latest = indexer.latestApplicableVersion(runNumber)
-        assert latest == VERSION_DEFAULT
+        assert latest == VERSION_START
 
     def test_latestApplicableVersion_excludes_default(self):
         # ensure latest applicable version will remove default if other runs exist
         runNumber = "123"
-        versionList = [VERSION_DEFAULT, 4, 5]
+        versionList = [VERSION_START, 4, 5]
         self.prepareVersions(versionList)
         indexer = self.initIndexer()
         # make some entries applicable
-        applicableVersions = [VERSION_DEFAULT, 4]
+        applicableVersions = [VERSION_START, 4]
         print(indexer.index)
         for version in applicableVersions:
             indexer.index[version].appliesTo = f">={runNumber}"
@@ -402,21 +448,7 @@ class TestIndexer(unittest.TestCase):
         latest = indexer.latestApplicableVersion(runNumber)
         assert latest == applicableVersions[-1]
 
-    def test_thisOrCurrentVersion(self):
-        version = randint(20, 120)
-        indexer = self.initIndexer()
-        assert indexer.thisOrCurrentVersion(None) == indexer.currentVersion()
-        assert indexer.thisOrCurrentVersion(VERSION_DEFAULT) == VERSION_DEFAULT
-        assert indexer.thisOrCurrentVersion(version) == version
-
-    def test_thisOrNextVersion(self):
-        version = randint(20, 120)
-        indexer = self.initIndexer()
-        assert indexer.thisOrNextVersion(None) == indexer.nextVersion()
-        assert indexer.thisOrNextVersion(VERSION_DEFAULT) == VERSION_DEFAULT
-        assert indexer.thisOrNextVersion(version) == version
-
-    def test_thisOrLatestApplicableVersion(self):
+    def test_getLatestApplicableVersion(self):
         # make one applicable entry
         version1 = randint(1, 10)
         entry1 = self.indexEntry(version1)
@@ -429,22 +461,19 @@ class TestIndexer(unittest.TestCase):
         indexer = self.initIndexer()
         indexer.index = {version1: entry1, version2: entry2}
         # only the applicable entry is returned
-        assert indexer.thisOrLatestApplicableVersion("123", None) == version1
-        assert indexer.thisOrLatestApplicableVersion("123", version1) == version1
-        assert indexer.thisOrLatestApplicableVersion("123", version2) == version1
+        assert indexer.latestApplicableVersion("123") == version1
 
     def test_isValidVersion(self):
         indexer = self.initIndexer()
         # the good
         for i in range(10):
-            assert indexer.isValidVersion(randint(2, 120))
-        assert indexer.isValidVersion(VERSION_DEFAULT)
+            assert indexer.validateVersion(randint(2, 120))
+        assert indexer.validateVersion(VersionState.DEFAULT)
         # the bad
-        assert not indexer.isValidVersion("bad")
-        assert not indexer.isValidVersion("*")
-        assert not indexer.isValidVersion(None)
-        assert not indexer.isValidVersion(-2)
-        assert not indexer.isValidVersion(1.2)
+        badInput = ["bad", "*", None, -2, 1.2]
+        for i in badInput:
+            with pytest.raises(ValueError, match=r".*The indexer has encountered an invalid version*"):
+                indexer.validateVersion(i)
 
     def test_nextVersion(self):
         # check that the current version advances as expected as
@@ -454,13 +483,9 @@ class TestIndexer(unittest.TestCase):
         expectedIndex = {}
         indexer = self.initIndexer()
         assert indexer.index == expectedIndex
-
         # there is no current version
         assert indexer.currentVersion() is None
-        assert indexer.currentVersion() is None
-
         # the first "next" version is the start
-        assert indexer.nextVersion() == VERSION_START
         assert indexer.nextVersion() == VERSION_START
 
         # add an entry to the calibration index
@@ -470,18 +495,26 @@ class TestIndexer(unittest.TestCase):
         indexer.addIndexEntry(entry)
         expectedIndex[here] = entry
         assert indexer.index == expectedIndex
-
         # the current version should be this version
-        assert indexer.currentVersion() == here
         assert indexer.currentVersion() == here
         # the next version also should be this version
         # until a record is written to disk
         assert indexer.nextVersion() == here
-        assert indexer.nextVersion() == here
+        expectedIndex.pop(here)
+        assert indexer.index == expectedIndex
+
+        # NOTE: At this point, the index will have been purged because
+        #       the entry did not have a corresponding record on disk.
+        # PREVIOUSLY: This had been testing against a ghost entry which
+        #             did not represent a record on disk,
+        #             but was still in the index.
+        #             This is no longer the case.
 
         # now write the record
+        # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> WRITE 1 <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
         record = self.recordFromIndexEntry(entry)
-        indexer.writeRecord(record)
+        indexer.writeNewRecord(record, entry)
+        expectedIndex[here] = entry
 
         # the current version hasn't moved
         assert indexer.currentVersion() == here
@@ -491,18 +524,12 @@ class TestIndexer(unittest.TestCase):
         assert indexer.currentVersion() == here
         assert indexer.nextVersion() == here + 1
 
-        # add another entry
-        here = here + 1
-        # ensure it is added at the next version
+        # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> WRITE 2 <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
         entry = self.indexEntry(indexer.nextVersion())
+        expectedIndex[entry.version] = entry
         indexer.addIndexEntry(entry)
-        expectedIndex[here] = entry
-        assert indexer.index == expectedIndex
-        assert indexer.currentVersion() == here
-        # the next version should be here
-        assert indexer.nextVersion() == here
-        # now write the record
         indexer.writeRecord(self.recordFromIndexEntry(entry))
+        here = here + 1
         # ensure current still here
         assert indexer.currentVersion() == here
         # ensure next is after here
@@ -511,37 +538,24 @@ class TestIndexer(unittest.TestCase):
         assert indexer.currentVersion() == here
         assert indexer.nextVersion() == here + 1
 
-        # now write a record FIRST, at the next version
-        here = here + 1
-        record = self.record(here)
-        indexer.writeRecord(record)
-        # the current version will point here
-        assert indexer.currentVersion() == here
-        assert indexer.currentVersion() == here
-        # the next version will point here
-        assert indexer.nextVersion() == here
-        assert indexer.nextVersion() == here
+        record = self.record(here + 1)
+        # NOTE: Writing aribitrary records to disk is not allowed.
+        #       Our code should never produce an unindexed record.
+        #       What value is there in writing a record that is
+        #       inherently missing metadata supplied by the index?
+        with pytest.raises(ValueError, match=".*not found in index, please write an index entry first.*"):
+            indexer.writeRecord(record)
 
-        # there is no index entry for this version
-        assert indexer.nextVersion() not in indexer.index
-
-        # add the entry
-        entry = self.indexEntryFromRecord(record)
-        indexer.addIndexEntry(entry)
-        expectedIndex[here] = entry
-        assert indexer.index == expectedIndex
-        # ensure current version points here, next points to next
-        assert indexer.currentVersion() == here
-        assert indexer.nextVersion() == here + 1
-        assert indexer.currentVersion() == here
-        assert indexer.nextVersion() == here + 1
+        # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> WRITE 3 <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
         # write a record first, at a much future version
         # then add an index entry, and ensure it matches
         here = here + 23
         record = self.record(here)
-        indexer.writeRecord(record)
-        assert indexer.nextVersion() == here
+        entry = self.indexEntryFromRecord(record)
+        expectedIndex[entry.version] = entry
+        indexer.writeNewRecord(record, entry)
+        assert indexer.nextVersion() == here + 1
         assert indexer.nextVersion() not in indexer.index
 
         # now add the entry
@@ -562,49 +576,41 @@ class TestIndexer(unittest.TestCase):
 
         # there is no current version
         assert indexer.currentVersion() is None
-
         # the first "next" version is the start
         assert indexer.nextVersion() == VERSION_START
 
         # add an entry at the default version
-        entry = self.indexEntry(VERSION_DEFAULT)
-        indexer.addIndexEntry(entry)
-        expectedIndex[VERSION_DEFAULT] = entry
-        assert indexer.index == expectedIndex
-        assert entry.version == VERSION_DEFAULT
-
-        # the current version is now the default version
-        assert indexer.currentVersion() == VERSION_DEFAULT
-        # the next version also should be the default version
-        # until a record is written to disk
-        assert indexer.nextVersion() == VERSION_DEFAULT
-
-        # now write the record -- it should write to default
+        entry = self.indexEntry(VersionState.DEFAULT)
         record = self.recordFromIndexEntry(entry)
-        indexer.writeRecord(record)
-        assert self.recordPath(VERSION_DEFAULT).exists()
-
+        expectedIndex[VERSION_START] = entry
+        indexer.writeNewRecord(record, entry)
+        assert self.recordPath(indexer.defaultVersion()).exists()
         # the current version is still the default version
-        assert indexer.currentVersion() == VERSION_DEFAULT
-        # the next version will be the starting version
-        assert indexer.nextVersion() == VERSION_START
+        assert indexer.currentVersion() == indexer.defaultVersion()
+        # the next version will be the starting version + 1
+        assert indexer.nextVersion() == VERSION_START + 1
 
         # add another entry -- now at the start
         entry = self.indexEntry(indexer.nextVersion())
+        expectedIndex[indexer.nextVersion()] = entry
         indexer.addIndexEntry(entry)
-        expectedIndex[VERSION_START] = entry
         assert indexer.index == expectedIndex
-        assert indexer.currentVersion() == VERSION_START
+        assert indexer.currentVersion() == VERSION_START + 1
+
         # the next version should be the starting version
         # until a record is written
-        assert indexer.nextVersion() == VERSION_START
-        # now write the record -- ensure it is written at the start
-        indexer.writeRecord(self.recordFromIndexEntry(entry))
+        assert indexer.nextVersion() == VERSION_START + 1
+        expectedIndex.pop(entry.version)
+        assert indexer.index == expectedIndex
+        # now write the record -- ensure it is written at the
+        record = self.recordFromIndexEntry(entry)
+        entry = self.indexEntryFromRecord(record)
+        indexer.writeNewRecord(record, entry)
         assert self.recordPath(VERSION_START).exists()
         # ensure current still here
-        assert indexer.currentVersion() == VERSION_START
+        assert indexer.currentVersion() == VERSION_START + 1
         # ensure next is after here
-        assert indexer.nextVersion() == VERSION_START + 1
+        assert indexer.nextVersion() == VERSION_START + 2
 
     def test_nextVersion_with_default_record_first(self):
         # check default behaves correctly if a record is written first
@@ -619,23 +625,15 @@ class TestIndexer(unittest.TestCase):
         assert indexer.nextVersion() == VERSION_START
 
         # add a record at the default version
-        record = self.record(VERSION_DEFAULT)
-        indexer.writeRecord(record)
-
-        # the current version is now the default version
-        assert indexer.currentVersion() == VERSION_DEFAULT
-        # the next version also should be the default version
-        # until an entry is written to disk
-        assert indexer.nextVersion() == VERSION_DEFAULT
-
-        # now write the index entry -- it should write to default
+        record = self.record(VersionState.DEFAULT)
         entry = self.indexEntryFromRecord(record)
-        indexer.addIndexEntry(entry)
+        assert indexer._flattenVersion(record.version) == VERSION_START
+        indexer.writeNewRecord(record, entry)
 
         # the current version is still the default version
-        assert indexer.currentVersion() == VERSION_DEFAULT
+        assert indexer.currentVersion() == VERSION_START
         # the next version will be one past the starting version
-        assert indexer.nextVersion() == VERSION_START
+        assert indexer.nextVersion() == VERSION_START + 1
 
     ### TESTS OF VERSION COMPARISON METHODS ###
 
@@ -689,9 +687,8 @@ class TestIndexer(unittest.TestCase):
             self.writeRecordVersion(version)
         indexer = self.initIndexer()
 
-        # if version path is unitialized, path points to version start
-        ans1 = indexer.versionPath(None)
-        assert ans1 == self.versionPath(VERSION_START)
+        with pytest.raises(ValueError, match=".*The indexer has encountered an invalid version*"):
+            indexer.versionPath(None)
 
         # if version is specified, return that one
         for i in versionList:
@@ -703,6 +700,7 @@ class TestIndexer(unittest.TestCase):
         versionList = [3, 4, 5]
         for version in versionList:
             self.writeRecordVersion(version)
+        self.prepareIndex(versionList)
         indexer = self.initIndexer()
         indexer.currentPath() == self.versionPath(max(versionList))
 
@@ -720,7 +718,7 @@ class TestIndexer(unittest.TestCase):
         indexer.index[version].appliesTo = f">={runNumber}"
         print(indexer.index)
         latest = indexer.latestApplicableVersion(runNumber)
-        assert indexer.latestApplicablePath(runNumber) == self.versionPath(latest)
+        assert indexer.getLatestApplicablePath(runNumber) == self.versionPath(latest)
 
     ### TEST INDEX MANIPULATION METHODS ###
 
@@ -765,19 +763,11 @@ class TestIndexer(unittest.TestCase):
             readIndex = parse_file_as(List[IndexEntry], indexer.indexPath())
             assert readIndex == list(indexer.index.values())
 
-    def test_addEntry_fails(self):
-        # adding an entry with a bad version will fail
-        indexer = self.initIndexer()
-        indexer.isValidVersion = lambda x: False  # now it will always return false
-        entry = self.indexEntry()
-        with pytest.raises(RuntimeError):
-            indexer.addIndexEntry(entry)
-
     def test_addEntry_default(self):
         indexer = self.initIndexer()
-        entry = self.indexEntry(VERSION_DEFAULT)
+        entry = self.indexEntry(indexer.defaultVersion())
         indexer.addIndexEntry(entry)
-        assert VERSION_DEFAULT in indexer.index
+        assert indexer.defaultVersion() in indexer.index
 
     def test_addEntry_advances(self):
         # adding an index entry advances the current version
@@ -831,7 +821,8 @@ class TestIndexer(unittest.TestCase):
         # make sure the record was saved at the next version
         # and the read / written records match
         record = self.record(nextVersion)
-        indexer.writeRecord(record)
+        entry = self.indexEntryFromRecord(record)
+        indexer.writeNewRecord(record, entry)
         res = indexer.readRecord(nextVersion)
         assert record.version == nextVersion
         assert res == record
@@ -840,11 +831,12 @@ class TestIndexer(unittest.TestCase):
         # write a record at some version number
         version = randint(10, 20)
         record = self.record(version)
+        entry = self.indexEntryFromRecord(record)
         indexer = self.initIndexer()
         # write then read the record
         # make sure the record version was updated
         # and the read / written records match
-        indexer.writeRecord(record)
+        indexer.writeNewRecord(record, entry)
         res = indexer.readRecord(version)
         assert record.version == version
         assert res == record
@@ -855,8 +847,8 @@ class TestIndexer(unittest.TestCase):
         version = randint(1, 11)
         indexer = self.initIndexer()
         assert not self.recordPath(version).exists()
-        res = indexer.readRecord(version)
-        assert res is None
+        with pytest.raises(FileNotFoundError, match=r".*No record found at*"):
+            indexer.readRecord(version)
 
     def test_readRecord(self):
         record = self.record(randint(1, 100))
@@ -870,25 +862,19 @@ class TestIndexer(unittest.TestCase):
         record = self.record(randint(1, 100))
         self.writeRecord(record)
         indexer = self.initIndexer()
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValueError, match=r".*The indexer has encountered an invalid version*"):
             indexer.readRecord("*")
 
     # write #
-
-    def test_writeRecord_fails(self):
-        record = self.record()
-        indexer = self.initIndexer()
-        indexer.isValidVersion = lambda x: False
-        with pytest.raises(RuntimeError):
-            indexer.writeRecord(record)
 
     def test_writeRecord_with_version(self):
         # this test ensures a record can be written to the indicated version
         # create a record and write it
         version = randint(2, 120)
         record = self.record(version)
+        entry = self.indexEntryFromRecord(record)
         indexer = self.initIndexer()
-        indexer.writeRecord(record)
+        indexer.writeNewRecord(record, entry)
         assert record.version == version
         assert self.recordPath(version).exists()
         # read it back in and ensure it is the same
@@ -909,7 +895,8 @@ class TestIndexer(unittest.TestCase):
         assert nextVersion != VERSION_START
         # now write the record
         record = self.record(nextVersion)
-        indexer.writeRecord(record)
+        entry = self.indexEntryFromRecord(record)
+        indexer.writeNewRecord(record, entry)
         assert record.version == nextVersion
         assert self.recordPath(nextVersion).exists()
         res = parse_file_as(Record, self.recordPath(nextVersion))
@@ -924,10 +911,11 @@ class TestIndexer(unittest.TestCase):
         # prepare the record
         record = DAOFactory.calibrationRecord()
         record.version = randint(2, 100)
+        entry = self.indexEntryFromRecord(record)
         # write then read in the record
         indexer = self.initIndexer(IndexerType.CALIBRATION)
-        indexer.writeRecord(record)
-        res = indexer.readRecord()
+        indexer.writeNewRecord(record, entry)
+        res = indexer.readRecord(record.version)
         assert type(res) is CalibrationRecord
         assert res == record
 
@@ -935,10 +923,11 @@ class TestIndexer(unittest.TestCase):
         # prepare the record
         record = DAOFactory.normalizationRecord()
         record.version = randint(2, 100)
+        entry = self.indexEntryFromRecord(record)
         # write then read in the record
         indexer = self.initIndexer(IndexerType.NORMALIZATION)
-        indexer.writeRecord(record)
-        res = indexer.readRecord()
+        indexer.writeNewRecord(record, entry)
+        res = indexer.readRecord(record.version)
         assert type(res) is NormalizationRecord
         assert res == record
 
@@ -949,13 +938,6 @@ class TestIndexer(unittest.TestCase):
         assert not indexer.parametersPath(1).exists()
         with pytest.raises(FileNotFoundError):
             indexer.readParameters(1)
-
-    def test_writeParameters_fails(self):
-        params = self.calculationParameters(randint(2, 10))
-        indexer = self.initIndexer()
-        indexer.isValidVersion = lambda x: False
-        with pytest.raises(RuntimeError):
-            indexer.writeParameters(params)
 
     def test_readWriteParameters(self):
         version = randint(1, 10)
@@ -990,7 +972,7 @@ class TestIndexer(unittest.TestCase):
         params = DAOFactory.calibrationParameters()
         indexer = self.initIndexer(IndexerType.CALIBRATION)
         indexer.writeParameters(params)
-        res = indexer.readParameters()
+        res = indexer.readParameters(params.version)
         assert type(res) is Calibration
         assert res == params
 
@@ -998,7 +980,7 @@ class TestIndexer(unittest.TestCase):
         params = DAOFactory.normalizationParameters()
         indexer = self.initIndexer(IndexerType.NORMALIZATION)
         indexer.writeParameters(params)
-        res = indexer.readParameters()
+        res = indexer.readParameters(params.version)
         assert type(res) is Normalization
         assert res == params
 
@@ -1006,10 +988,12 @@ class TestIndexer(unittest.TestCase):
         params = CalculationParameters(**DAOFactory.calibrationParameters().model_dump())
         indexer = self.initIndexer(IndexerType.REDUCTION)
         indexer.writeParameters(params)
-        res = indexer.readParameters()
+        res = indexer.readParameters(params.version)
         assert type(res) is CalculationParameters
         assert res == params
 
     def test__determineRecordType(self):
         indexer = self.initIndexer(IndexerType.CALIBRATION)
-        assert indexer._determineRecordType(VERSION_DEFAULT) == DEFAULT_RECORD_TYPE.get(IndexerType.CALIBRATION)
+        assert indexer._determineRecordType(indexer.defaultVersion()) == DEFAULT_RECORD_TYPE.get(
+            IndexerType.CALIBRATION
+        )

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -315,8 +315,11 @@ def test_readStateConfig_default():
         indexer = localDataService.calibrationIndexer("57514", True)
         parameters = DAOFactory.calibrationParameters("57514", True, indexer.defaultVersion())
         tmpRoot.saveObjectAt(groupingMap, localDataService._groupingMapPath(tmpRoot.stateId))
-        tmpRoot.saveObjectAt(parameters, indexer.parametersPath(VersionState.DEFAULT))
-        indexer.index = {VersionState.DEFAULT: mock.Mock()}  # NOTE manually update the Indexer
+        tmpRoot.saveObjectAt(parameters, indexer.parametersPath(indexer.defaultVersion()))
+
+        indexer.index = {
+            VersionState.DEFAULT: mock.MagicMock(appliesTo="57514", version=indexer.defaultVersion())
+        }  # NOTE manually update the Indexer
         actual = localDataService.readStateConfig("57514", True)
     assert actual is not None
     assert actual.stateId == DAOFactory.magical_state_id
@@ -332,7 +335,9 @@ def test_readStateConfig_previous():
         indexer = localDataService.calibrationIndexer("57514", True)
         tmpRoot.saveObjectAt(groupingMap, localDataService._groupingMapPath(tmpRoot.stateId))
         tmpRoot.saveObjectAt(parameters, indexer.parametersPath(version))
-        indexer.index = {version: mock.Mock()}  # NOTE manually update the Indexer
+        indexer.index = {
+            version: mock.MagicMock(appliesTo="57514", version=version)
+        }  # NOTE manually update the Indexer
         actual = localDataService.readStateConfig("57514", True)
     assert actual is not None
     assert actual.stateId == DAOFactory.magical_state_id
@@ -348,7 +353,9 @@ def test_readStateConfig_attaches_grouping_map():
         indexer = localDataService.calibrationIndexer("57514", True)
         tmpRoot.saveObjectAt(groupingMap, localDataService._groupingMapPath(tmpRoot.stateId))
         tmpRoot.saveObjectAt(parameters, indexer.parametersPath(version))
-        indexer.index = {version: mock.Mock()}  # NOTE manually update the Indexer
+        indexer.index = {
+            version: mock.MagicMock(appliesTo="57514", version=version)
+        }  # NOTE manually update the Indexer
         actual = localDataService.readStateConfig("57514", True)
     expectedMap = DAOFactory.groupingMap_SNAP()
     assert actual.groupingMap == expectedMap
@@ -365,7 +372,9 @@ def test_readStateConfig_invalid_grouping_map():
         indexer = localDataService.calibrationIndexer("57514", True)
         tmpRoot.saveObjectAt(groupingMap, localDataService._groupingMapPath(tmpRoot.stateId))
         tmpRoot.saveObjectAt(parameters, indexer.parametersPath(version))
-        indexer.index = {version: mock.Mock()}  # NOTE manually update the Indexer
+        indexer.index = {
+            version: mock.MagicMock(appliesTo="57514", version=version)
+        }  # NOTE manually update the Indexer
         # 'GroupingMap.defaultStateId' is _not_ a valid grouping-map 'stateId' for an existing `StateConfig`.
         with pytest.raises(  # noqa: PT012
             RuntimeError,
@@ -383,7 +392,9 @@ def test_readStateConfig_calls_prepareStateRoot():
     with state_root_redirect(localDataService, stateId=expected.instrumentState.id.hex) as tmpRoot:
         indexer = localDataService.calibrationIndexer("57514", True)
         tmpRoot.saveObjectAt(expected, indexer.parametersPath(version))
-        indexer.index = {version: mock.Mock()}  # NOTE manually update the Indexer
+        indexer.index = {
+            version: mock.MagicMock(appliesTo="57514", version=version)
+        }  # NOTE manually update the Indexer
         assert not localDataService._groupingMapPath(tmpRoot.stateId).exists()
         localDataService._prepareStateRoot = mock.Mock(
             side_effect=lambda x: tmpRoot.saveObjectAt(  # noqa ARG005
@@ -720,7 +731,8 @@ def test_write_model_pretty_StateConfig_excludes_grouping_map():
         # move the calculation parameters into correct folder
         indexer = localDataService.calibrationIndexer("57514", True)
         indexer.writeParameters(DAOFactory.calibrationParameters("57514", True, indexer.defaultVersion()))
-        indexer.index = {indexer.defaultVersion(): mock.Mock()}
+        indexer.index = {indexer.defaultVersion(): mock.MagicMock(appliesTo="57514", version=indexer.defaultVersion())}
+
         # move the grouping map into correct folder
         write_model_pretty(DAOFactory.groupingMap_SNAP(), localDataService._groupingMapPath(tmpRoot.stateId))
 
@@ -2120,7 +2132,7 @@ def test_readWriteNormalizationState():
 
     ans = localDataService.readNormalizationState(runNumber, True, VersionState.LATEST)
     assert ans == mockNormalizationIndexer.readParameters.return_value
-    mockNormalizationIndexer.readParameters.assert_called_once_with(VersionState.LATEST)
+    mockNormalizationIndexer.readParameters.assert_called_once_with(1)
 
 
 def test_readDetectorState():

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -45,7 +45,7 @@ from snapred.backend.dao import StateConfig
 from snapred.backend.dao.calibration.CalibrationRecord import CalibrationRecord
 from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.indexing.IndexEntry import IndexEntry
-from snapred.backend.dao.indexing.Versioning import VERSION_DEFAULT
+from snapred.backend.dao.indexing.Versioning import VERSION_START, VersionState
 from snapred.backend.dao.ingredients import ReductionIngredients
 from snapred.backend.dao.normalization.NormalizationRecord import NormalizationRecord
 from snapred.backend.dao.reduction.ReductionRecord import ReductionRecord
@@ -128,6 +128,18 @@ def _capture_logging(monkeypatch):
 
 
 fakeInstrumentFilePath = Resource.getPath("inputs/testInstrument/fakeSNAP_Definition.xml")
+
+
+def entryFromRecord(record):
+    return IndexEntry(
+        runNumber=record.runNumber,
+        useLiteMode=record.useLiteMode,
+        appliesTo=record.runNumber,
+        comments="test comment",
+        author="test author",
+        version=record.version,
+    )
+
 
 ### GENERALIZED METHODS FOR TESTING NORMALIZATION / CALIBRATION METHODS ###
 # Note: the REDUCTION workflow does not use the Indexer system except indirectly.
@@ -231,8 +243,13 @@ def do_test_read_state_no_version(workflow: Literal["Calibration", "Normalizatio
             expectedState = getattr(DAOFactory, f"{workflow.lower()}Parameters")()
             indexer = localDataService.indexer("xyz", useLiteMode, workflow)
             tmpRoot.saveObjectAt(expectedState, indexer.parametersPath(currentVersion))
-            indexer.index = {currentVersion: mock.Mock()}  # NOTE manually update indexer
-            actualState = getattr(localDataService, f"read{workflow}State")("xyz", useLiteMode)  # NOTE no version
+            indexer.index = {
+                currentVersion: mock.MagicMock(appliesTo="123", version=currentVersion)
+            }  # NOTE manually update indexer
+            indexer.dirVersions = [currentVersion]  # NOTE manually update indexer
+            actualState = getattr(localDataService, f"read{workflow}State")(
+                "123", useLiteMode, VersionState.LATEST
+            )  # NOTE no version
         assert actualState == expectedState
 
 
@@ -293,13 +310,13 @@ def getMockInstrumentConfig():
 def test_readStateConfig_default():
     # readstateConfig will load the default parameters file
     groupingMap = DAOFactory.groupingMap_SNAP()
-    parameters = DAOFactory.calibrationParameters("57514", True, VERSION_DEFAULT)
     localDataService = LocalDataService()
     with state_root_redirect(localDataService) as tmpRoot:
         indexer = localDataService.calibrationIndexer("57514", True)
+        parameters = DAOFactory.calibrationParameters("57514", True, indexer.defaultVersion())
         tmpRoot.saveObjectAt(groupingMap, localDataService._groupingMapPath(tmpRoot.stateId))
-        tmpRoot.saveObjectAt(parameters, indexer.parametersPath(VERSION_DEFAULT))
-        indexer.index = {VERSION_DEFAULT: mock.Mock()}  # NOTE manually update the Indexer
+        tmpRoot.saveObjectAt(parameters, indexer.parametersPath(VersionState.DEFAULT))
+        indexer.index = {VersionState.DEFAULT: mock.Mock()}  # NOTE manually update the Indexer
         actual = localDataService.readStateConfig("57514", True)
     assert actual is not None
     assert actual.stateId == DAOFactory.magical_state_id
@@ -702,8 +719,8 @@ def test_write_model_pretty_StateConfig_excludes_grouping_map():
     with state_root_redirect(localDataService) as tmpRoot:
         # move the calculation parameters into correct folder
         indexer = localDataService.calibrationIndexer("57514", True)
-        indexer.writeParameters(DAOFactory.calibrationParameters("57514", True, VERSION_DEFAULT))
-        indexer.index = {VERSION_DEFAULT: mock.Mock()}
+        indexer.writeParameters(DAOFactory.calibrationParameters("57514", True, indexer.defaultVersion()))
+        indexer.index = {indexer.defaultVersion(): mock.Mock()}
         # move the grouping map into correct folder
         write_model_pretty(DAOFactory.groupingMap_SNAP(), localDataService._groupingMapPath(tmpRoot.stateId))
 
@@ -1168,10 +1185,11 @@ def test_createCalibrationIndexEntry():
         assert ans.useLiteMode == request.useLiteMode
         assert ans.version == request.version
 
-        request.version = None
-        indexer = localDataService.calibrationIndexer(request.runNumber, request.useLiteMode)
+        request.version = VersionState.NEXT
+        localDataService.calibrationIndexer(request.runNumber, request.useLiteMode)
         ans = localDataService.createCalibrationIndexEntry(request)
-        assert ans.version == indexer.nextVersion()
+        # Set to next version, which on the first call should be the start version
+        assert ans.version == VERSION_START
 
 
 def test_createCalibrationRecord():
@@ -1185,10 +1203,11 @@ def test_createCalibrationRecord():
         assert ans.useLiteMode == request.useLiteMode
         assert ans.version == request.version
 
-        request.version = None
-        indexer = localDataService.calibrationIndexer(request.runNumber, request.useLiteMode)
+        request.version = VersionState.NEXT
+        localDataService.calibrationIndexer(request.runNumber, request.useLiteMode)
         ans = localDataService.createCalibrationRecord(request)
-        assert ans.version == indexer.nextVersion()
+        # Set to next version, which on the first call should be the start version
+        assert ans.version == VERSION_START
 
 
 def test_readCalibrationRecord_with_version():
@@ -1214,6 +1233,8 @@ def test_readWriteCalibrationRecord():
     for useLiteMode in [True, False]:
         record = DAOFactory.calibrationRecord("57514", useLiteMode, version=1)
         with state_root_redirect(localDataService):
+            entry = entryFromRecord(record)
+            localDataService.writeCalibrationIndexEntry(entry)
             localDataService.writeCalibrationRecord(record)
             actualRecord = localDataService.readCalibrationRecord("57514", useLiteMode)
         assert actualRecord.version == record.version
@@ -1311,9 +1332,10 @@ def test_createNormalizationIndexEntry():
         assert ans.version == request.version
 
         request.version = None
-        indexer = localDataService.normalizationIndexer(request.runNumber, request.useLiteMode)
+        localDataService.normalizationIndexer(request.runNumber, request.useLiteMode)
         ans = localDataService.createNormalizationIndexEntry(request)
-        assert ans.version == indexer.nextVersion()
+        # Set to next version, which on the first call should be the start version
+        assert ans.version == VERSION_START
 
 
 def test_createNormalizationRecord():
@@ -1327,10 +1349,9 @@ def test_createNormalizationRecord():
         assert ans.useLiteMode == request.useLiteMode
         assert ans.version == request.version
 
-        request.version = None
-        indexer = localDataService.normalizationIndexer(request.runNumber, request.useLiteMode)
+        request.version = VersionState.NEXT
         ans = localDataService.createNormalizationRecord(request)
-        assert ans.version == indexer.nextVersion()
+        assert ans.version == VERSION_START
 
 
 def test_readNormalizationRecord_with_version():
@@ -1355,11 +1376,18 @@ def test_readWriteNormalizationRecord():
     localDataService = LocalDataService()
     for useLiteMode in [True, False]:
         record.useLiteMode = useLiteMode
+        currentVersion = randint(VERSION_START, 120)
+        runNumber = record.runNumber
+        record.version = currentVersion
         # NOTE redirect nested so assertion occurs outside of redirect
         # failing assertions inside tempdirs can create unwanted files
         with state_root_redirect(localDataService):
-            localDataService.writeNormalizationRecord(record)
-            actualRecord = localDataService.readNormalizationRecord("57514", useLiteMode)
+            entry = entryFromRecord(record)
+            localDataService.writeNormalizationRecord(record, entry)
+            indexer = localDataService.normalizationIndexer(runNumber, useLiteMode)
+
+            indexer.index = {currentVersion: mock.MagicMock(appliesTo=runNumber, version=currentVersion)}
+            actualRecord = localDataService.readNormalizationRecord(runNumber, useLiteMode)
         assert actualRecord.version == record.version
         assert actualRecord.calculationParameters.version == record.calculationParameters.version
         assert actualRecord == record
@@ -1507,7 +1535,7 @@ def test_readWriteReductionRecord():
         localDataService.groceryService = mock.Mock()
         localDataService.writeReductionRecord(testRecord)
         actualRecord = localDataService.readReductionRecord(runNumber, testRecord.useLiteMode, testRecord.timestamp)
-    assert actualRecord == testRecord
+    assert actualRecord.dict() == testRecord.dict()
 
 
 @pytest.fixture
@@ -1833,7 +1861,9 @@ def test_readWriteReductionData(readSyntheticReductionRecord, createReductionWor
             cleanup_workspace_at_exit(_uniquePrefix + ws)
 
         actualRecord = localDataService.readReductionData(runNumber, useLiteMode, timestamp)
-        assert actualRecord == testRecord
+
+        assert actualRecord.normalization.calibrationVersionUsed == testRecord.normalization.calibrationVersionUsed
+        assert actualRecord.dict() == testRecord.dict()
 
         # workspaces should have been reloaded with their original names
         # Implementation note:
@@ -2017,16 +2047,17 @@ def test_readNormalizationState_no_version():
 
 
 def test_readWriteCalibrationState():
-    # NOTE this test is already covered by tests of the Indexer
-    # but it doesn't hurt to retain this test anyway
     runNumber = "123"
     localDataService = LocalDataService()
-    for useLiteMode in [True, False]:
-        calibration = DAOFactory.calibrationParameters(runNumber, useLiteMode)
-        with state_root_redirect(localDataService):
-            localDataService.writeCalibrationState(calibration)
-            ans = localDataService.readCalibrationState(runNumber, useLiteMode)
-        assert ans == calibration
+    mockCalibrationIndexer = mock.Mock()
+
+    localDataService.calibrationIndexer = mock.Mock(return_value=mockCalibrationIndexer)
+    localDataService.calibrationIndexer().latestApplicableVersion = mock.Mock(return_value=1)
+    mockCalibrationIndexer.nextVersion = mock.Mock(return_value=1)
+
+    ans = localDataService.readCalibrationState(runNumber, True, VersionState.LATEST)
+    assert ans == mockCalibrationIndexer.readParameters.return_value
+    mockCalibrationIndexer.readParameters.assert_called_once_with(1)
 
 
 def test_readWriteCalibrationState_noWritePermissions():
@@ -2055,7 +2086,7 @@ def test_readCalibrationState_hasWritePermissions():
 def test_writeDefaultDiffCalTable(fetchInstrumentDonor, createDiffCalTableWorkspaceName):
     # verify that the default diffcal table is being written to the default state directory
     runNumber = "default"
-    version = VERSION_DEFAULT
+    version = VERSION_START
     useLiteMode = True
     # mock the grocery service to return the fake instrument to use for geometry
     idfWS = mtd.unique_name(prefix="_idf_")
@@ -2081,12 +2112,15 @@ def test_readWriteNormalizationState():
     # but it doesn't hurt to retain this test anyway
     runNumber = "123"
     localDataService = LocalDataService()
-    for useLiteMode in [True, False]:
-        normalization = DAOFactory.normalizationParameters(runNumber, useLiteMode)
-        with state_root_redirect(localDataService):
-            localDataService.writeNormalizationState(normalization)
-            ans = localDataService.readNormalizationState(runNumber, useLiteMode)
-        assert ans == normalization
+    mockNormalizationIndexer = mock.Mock()
+
+    localDataService.normalizationIndexer = mock.Mock(return_value=mockNormalizationIndexer)
+    localDataService.normalizationIndexer().latestApplicableVersion = mock.Mock(return_value=1)
+    mockNormalizationIndexer.nextVersion = mock.Mock(return_value=1)
+
+    ans = localDataService.readNormalizationState(runNumber, True, VersionState.LATEST)
+    assert ans == mockNormalizationIndexer.readParameters.return_value
+    mockNormalizationIndexer.readParameters.assert_called_once_with(VersionState.LATEST)
 
 
 def test_readDetectorState():
@@ -2279,7 +2313,7 @@ def test_initializeState():
     testCalibrationData = DAOFactory.calibrationParameters(
         runNumber=runNumber,
         useLiteMode=useLiteMode,
-        version=VERSION_DEFAULT,
+        version=VERSION_START,
         instrumentState=DAOFactory.pv_instrument_state.copy(),
     )
 

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -10,6 +10,7 @@ from mantid.simpleapi import (
     mtd,
 )
 
+from snapred.backend.dao.indexing.Versioning import VersionState
 from snapred.backend.dao.request import CalibrationWritePermissionsRequest
 from snapred.backend.dao.response.NormalizationResponse import NormalizationResponse
 from snapred.backend.error.ContinueWarning import ContinueWarning
@@ -63,7 +64,7 @@ with mock.patch.dict(
         normalizationService.dataExportService.exportNormalizationIndexEntry = MagicMock()
         normalizationService.dataExportService.exportNormalizationIndexEntry.return_value = "expected"
         normalizationService.saveNormalizationToIndex(
-            IndexEntry(runNumber="1", useLiteMode=True, backgroundRunNumber="2")
+            IndexEntry(runNumber="1", useLiteMode=True, backgroundRunNumber="2", version=VersionState.NEXT)
         )
         assert normalizationService.dataExportService.exportNormalizationIndexEntry.called
         savedEntry = normalizationService.dataExportService.exportNormalizationIndexEntry.call_args.args[0]
@@ -210,7 +211,7 @@ class TestNormalizationService(unittest.TestCase):
         )
 
     def test_matchRuns(self):
-        self.instance.dataFactoryService.getThisOrLatestNormalizationVersion = mock.Mock(
+        self.instance.dataFactoryService.getLatestNormalizationVersion = mock.Mock(
             side_effect=[mock.sentinel.version1, mock.sentinel.version2],
         )
         request = mock.Mock(runNumbers=[mock.sentinel.run1, mock.sentinel.run2], useLiteMode=True)
@@ -276,7 +277,7 @@ class TestNormalizationService(unittest.TestCase):
         self.instance.sousChef = SculleryBoy()
         self.instance.groceryService = mockGroceryService
         self.instance.dataFactoryService.getCifFilePath = MagicMock(return_value="path/to/cif")
-        self.instance.dataFactoryService.getThisOrLatestCalibrationVersion = mock.Mock(return_value=1)
+        self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
         self.instance.dataExportService.getCalibrationStateRoot = mock.Mock(return_value="lah/dee/dah")
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
         self.instance.dataFactoryService.getCalibrationRecord = mock.Mock(return_value=mock.Mock(runNumber="12345"))
@@ -297,7 +298,7 @@ class TestNormalizationService(unittest.TestCase):
         # test `validateRequest` internal calls
         self.instance._sameStates = mock.Mock(return_value=True)
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
-        self.instance.dataFactoryService.getThisOrLatestCalibrationVersion = mock.Mock(return_value=1)
+        self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
         permissionsRequest = CalibrationWritePermissionsRequest(
             runNumber=self.request.runNumber, continueFlags=self.request.continueFlags
         )
@@ -309,7 +310,7 @@ class TestNormalizationService(unittest.TestCase):
     def test_validateDiffractionCalibrationExists_failure(self):
         request = mock.Mock(runNumber="12345", backgroundRunNumber="67890", continueFlags=ContinueWarning.Type.UNSET)
         self.instance.sousChef = SculleryBoy()
-        self.instance.dataFactoryService.getThisOrLatestCalibrationVersion = mock.Mock(return_value=-1)
+        self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=None)
 
         with pytest.raises(
             ContinueWarning,
@@ -324,7 +325,7 @@ class TestNormalizationService(unittest.TestCase):
             continueFlags=ContinueWarning.Type.DEFAULT_DIFFRACTION_CALIBRATION,
         )
         self.instance.sousChef = SculleryBoy()
-        self.instance.dataFactoryService.getThisOrLatestCalibrationVersion = mock.Mock(return_value=-1)
+        self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=None)
         self.instance._validateDiffractionCalibrationExists(request)
 
     def test_validateRequest_different_states(self):
@@ -370,7 +371,7 @@ class TestNormalizationService(unittest.TestCase):
         self.instance.dataFactoryService.getCifFilePath = mock.Mock(return_value="path/to/cif")
         self.instance.dataExportService.getCalibrationStateRoot = mock.Mock(return_value="lah/dee/dah")
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
-        self.instance.dataFactoryService.getThisOrLatestCalibrationVersion = mock.Mock(return_value=1)
+        self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
         self.instance.dataExportService.checkWritePermissions = mock.Mock(return_value=True)
         result = self.instance.normalization(self.request)
 

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -211,7 +211,7 @@ class TestNormalizationService(unittest.TestCase):
         )
 
     def test_matchRuns(self):
-        self.instance.dataFactoryService.getLatestNormalizationVersion = mock.Mock(
+        self.instance.dataFactoryService.getLatestApplicableNormalizationVersion = mock.Mock(
             side_effect=[mock.sentinel.version1, mock.sentinel.version2],
         )
         request = mock.Mock(runNumbers=[mock.sentinel.run1, mock.sentinel.run2], useLiteMode=True)

--- a/tests/unit/backend/service/test_ReductionService.py
+++ b/tests/unit/backend/service/test_ReductionService.py
@@ -125,8 +125,8 @@ class TestReductionService(unittest.TestCase):
         assert result == expected
 
     def test_fetchReductionGroceries(self):
-        self.instance.dataFactoryService.getThisOrLatestCalibrationVersion = mock.Mock(return_value=1)
-        self.instance.dataFactoryService.getThisOrLatestNormalizationVersion = mock.Mock(return_value=1)
+        self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
+        self.instance.dataFactoryService.getLatestNormalizationVersion = mock.Mock(return_value=1)
         self.instance._markWorkspaceMetadata = mock.Mock()
         self.request.continueFlags = ContinueWarning.Type.UNSET
         res = self.instance.fetchReductionGroceries(self.request)
@@ -142,10 +142,10 @@ class TestReductionService(unittest.TestCase):
             "outputs": ["one", "two", "three"],
         }
         mockReductionRecipe.return_value.cook = mock.Mock(return_value=mockResult)
-        self.instance.dataFactoryService.getThisOrLatestCalibrationVersion = mock.Mock(return_value=1)
+        self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
         self.instance.dataFactoryService.stateExists = mock.Mock(return_value=True)
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
-        self.instance.dataFactoryService.getThisOrLatestNormalizationVersion = mock.Mock(return_value=1)
+        self.instance.dataFactoryService.getLatestNormalizationVersion = mock.Mock(return_value=1)
         self.instance.dataFactoryService.normalizationExists = mock.Mock(return_value=True)
         self.instance._markWorkspaceMetadata = mock.Mock()
 
@@ -326,7 +326,7 @@ class TestReductionService(unittest.TestCase):
 
         # Verify the request is sorted by state id then normalization version
         mockDataFactory = mock.Mock()
-        mockDataFactory.getThisOrCurrentNormalizationVersion.side_effect = [0, 1]
+        mockDataFactory.getLatestApplicableNormalizationVersion.side_effect = [0, 1]
         mockDataFactory.constructStateId.return_value = ("state1", "_")
         self.instance.dataFactoryService = mockDataFactory
 
@@ -680,8 +680,8 @@ class TestReductionServiceMasks:
                 pixelMasks=[self.maskWS1, self.maskWS2, self.maskWS5],
                 focusGroups=[FocusGroup(name="apple", definition="path/to/grouping")],
             )
-            self.service.dataFactoryService.getThisOrLatestCalibrationVersion = mock.Mock(return_value=1)
-            self.service.dataFactoryService.getThisOrLatestNormalizationVersion = mock.Mock(return_value=2)
+            self.service.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
+            self.service.dataFactoryService.getLatestNormalizationVersion = mock.Mock(return_value=2)
             self.service._markWorkspaceMetadata = mock.Mock()
 
             groceryClerk = self.service.groceryClerk
@@ -741,8 +741,8 @@ class TestReductionServiceMasks:
                 pixelMasks=[self.maskWS1, self.maskWS2, self.maskWS5, not_a_mask],
                 focusGroups=[FocusGroup(name="apple", definition="path/to/grouping")],
             )
-            self.service.dataFactoryService.getThisOrLatestCalibrationVersion = mock.Mock(return_value=1)
-            self.service.dataFactoryService.getThisOrLatestNormalizationVersion = mock.Mock(return_value=2)
+            self.service.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
+            self.service.dataFactoryService.getLatestNormalizationVersion = mock.Mock(return_value=2)
             combinedMaskName = wng.reductionPixelMask().runNumber(request.runNumber).build()
             mockPrepCombinedMask.return_value = combinedMaskName
 

--- a/tests/unit/backend/service/test_ReductionService.py
+++ b/tests/unit/backend/service/test_ReductionService.py
@@ -126,7 +126,7 @@ class TestReductionService(unittest.TestCase):
 
     def test_fetchReductionGroceries(self):
         self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
-        self.instance.dataFactoryService.getLatestNormalizationVersion = mock.Mock(return_value=1)
+        self.instance.dataFactoryService.getLatestApplicableNormalizationVersion = mock.Mock(return_value=1)
         self.instance._markWorkspaceMetadata = mock.Mock()
         self.request.continueFlags = ContinueWarning.Type.UNSET
         res = self.instance.fetchReductionGroceries(self.request)
@@ -145,7 +145,7 @@ class TestReductionService(unittest.TestCase):
         self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
         self.instance.dataFactoryService.stateExists = mock.Mock(return_value=True)
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
-        self.instance.dataFactoryService.getLatestNormalizationVersion = mock.Mock(return_value=1)
+        self.instance.dataFactoryService.getLatestApplicableNormalizationVersion = mock.Mock(return_value=1)
         self.instance.dataFactoryService.normalizationExists = mock.Mock(return_value=True)
         self.instance._markWorkspaceMetadata = mock.Mock()
 
@@ -681,7 +681,7 @@ class TestReductionServiceMasks:
                 focusGroups=[FocusGroup(name="apple", definition="path/to/grouping")],
             )
             self.service.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
-            self.service.dataFactoryService.getLatestNormalizationVersion = mock.Mock(return_value=2)
+            self.service.dataFactoryService.getLatestApplicableNormalizationVersion = mock.Mock(return_value=2)
             self.service._markWorkspaceMetadata = mock.Mock()
 
             groceryClerk = self.service.groceryClerk
@@ -742,7 +742,7 @@ class TestReductionServiceMasks:
                 focusGroups=[FocusGroup(name="apple", definition="path/to/grouping")],
             )
             self.service.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
-            self.service.dataFactoryService.getLatestNormalizationVersion = mock.Mock(return_value=2)
+            self.service.dataFactoryService.getLatestApplicableNormalizationVersion = mock.Mock(return_value=2)
             combinedMaskName = wng.reductionPixelMask().runNumber(request.runNumber).build()
             mockPrepCombinedMask.return_value = combinedMaskName
 

--- a/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
+++ b/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
@@ -7,12 +7,11 @@ from pydantic import BaseModel, ConfigDict
 
 from snapred.meta.Config import Config
 from snapred.meta.mantid.WorkspaceNameGenerator import (
-    VERSION_DEFAULT,
-    VERSION_DEFAULT_NAME,
-    WorkspaceName,
+    ValueFormatter as wnvf,
 )
 from snapred.meta.mantid.WorkspaceNameGenerator import (
-    ValueFormatter as wnvf,
+    VersionState,
+    WorkspaceName,
 )
 from snapred.meta.mantid.WorkspaceNameGenerator import (
     WorkspaceNameGenerator as wng,
@@ -297,9 +296,9 @@ def test_pathVersion_none():
     assert ans == expected
 
 
-def test_pathVersion_default():
-    expected = f"v_{VERSION_DEFAULT_NAME}"
-    ans = wnvf.pathVersion(VERSION_DEFAULT)
+def test_pathversion_default():
+    expected = f"v_{VersionState.DEFAULT}"
+    ans = wnvf.pathVersion(VersionState.DEFAULT)
     assert ans == expected
 
 

--- a/tests/unit/meta/test_Decorators.py
+++ b/tests/unit/meta/test_Decorators.py
@@ -184,7 +184,7 @@ class BasicWidget(QWidget):
         self.text = text
 
 
-@pytest.mark.ui()
+@pytest.mark.ui
 def test_resettable(qtbot):
     parent = QWidget()
     qtbot.addWidget(parent)

--- a/tests/unit/meta/test_Decorators.py
+++ b/tests/unit/meta/test_Decorators.py
@@ -184,6 +184,7 @@ class BasicWidget(QWidget):
         self.text = text
 
 
+@pytest.mark.ui()
 def test_resettable(qtbot):
     parent = QWidget()
     qtbot.addWidget(parent)

--- a/tests/unit/ui/presenter/test_InitializeStatePresenter.py
+++ b/tests/unit/ui/presenter/test_InitializeStatePresenter.py
@@ -9,8 +9,6 @@ from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.ui.presenter.InitializeStatePresenter import InitializeStatePresenter
 from snapred.ui.widget.LoadingCursor import LoadingCursor
 
-app = QApplication(sys.argv)
-
 
 @not_a_test
 class TestableQWidget(QWidget):
@@ -26,11 +24,14 @@ class TestableQWidget(QWidget):
 
 @pytest.fixture
 def setup_view_and_workflow():
+    if QApplication.instance() is None:
+        QApplication(sys.argv)
     view = TestableQWidget()
     workflow = InitializeStatePresenter(view=view)
     return view, workflow
 
 
+@pytest.mark.ui()
 def test_handleButtonClicked_with_valid_input(setup_view_and_workflow):
     view, workflow = setup_view_and_workflow
     view.getRunNumber.return_value = "12345"
@@ -42,6 +43,7 @@ def test_handleButtonClicked_with_valid_input(setup_view_and_workflow):
         mock_initializeState.assert_called_once_with("12345", "Test State", True)
 
 
+@pytest.mark.ui()
 def test_handleButtonClicked_with_invalid_input(setup_view_and_workflow):
     view, workflow = setup_view_and_workflow
     view.getRunNumber.return_value = "invalid"
@@ -51,6 +53,7 @@ def test_handleButtonClicked_with_invalid_input(setup_view_and_workflow):
         mock_warning.assert_called_once()
 
 
+@pytest.mark.ui()
 def test__initializeState(setup_view_and_workflow):
     view, workflow = setup_view_and_workflow
     view.getRunNumber.return_value = "12345"
@@ -66,6 +69,7 @@ def test__initializeState(setup_view_and_workflow):
         mock_dialog_showSuccess.assert_called_once()
 
 
+@pytest.mark.ui()
 def test__handleResponse_error(setup_view_and_workflow):
     view, workflow = setup_view_and_workflow
     error_response = SNAPResponse(code=ResponseCode.ERROR, message="Error message")
@@ -78,6 +82,7 @@ def test__handleResponse_error(setup_view_and_workflow):
         mock_critical.assert_called_once()
 
 
+@pytest.mark.ui()
 def test__handleResponse_success(setup_view_and_workflow):
     view, workflow = setup_view_and_workflow
     success_response = SNAPResponse(code=ResponseCode.OK)

--- a/tests/unit/ui/presenter/test_InitializeStatePresenter.py
+++ b/tests/unit/ui/presenter/test_InitializeStatePresenter.py
@@ -31,7 +31,7 @@ def setup_view_and_workflow():
     return view, workflow
 
 
-@pytest.mark.ui()
+@pytest.mark.ui
 def test_handleButtonClicked_with_valid_input(setup_view_and_workflow):
     view, workflow = setup_view_and_workflow
     view.getRunNumber.return_value = "12345"
@@ -43,7 +43,7 @@ def test_handleButtonClicked_with_valid_input(setup_view_and_workflow):
         mock_initializeState.assert_called_once_with("12345", "Test State", True)
 
 
-@pytest.mark.ui()
+@pytest.mark.ui
 def test_handleButtonClicked_with_invalid_input(setup_view_and_workflow):
     view, workflow = setup_view_and_workflow
     view.getRunNumber.return_value = "invalid"
@@ -53,7 +53,7 @@ def test_handleButtonClicked_with_invalid_input(setup_view_and_workflow):
         mock_warning.assert_called_once()
 
 
-@pytest.mark.ui()
+@pytest.mark.ui
 def test__initializeState(setup_view_and_workflow):
     view, workflow = setup_view_and_workflow
     view.getRunNumber.return_value = "12345"
@@ -69,7 +69,7 @@ def test__initializeState(setup_view_and_workflow):
         mock_dialog_showSuccess.assert_called_once()
 
 
-@pytest.mark.ui()
+@pytest.mark.ui
 def test__handleResponse_error(setup_view_and_workflow):
     view, workflow = setup_view_and_workflow
     error_response = SNAPResponse(code=ResponseCode.ERROR, message="Error message")
@@ -82,7 +82,7 @@ def test__handleResponse_error(setup_view_and_workflow):
         mock_critical.assert_called_once()
 
 
-@pytest.mark.ui()
+@pytest.mark.ui
 def test__handleResponse_success(setup_view_and_workflow):
     view, workflow = setup_view_and_workflow
     success_response = SNAPResponse(code=ResponseCode.OK)

--- a/tests/unit/ui/view/test_CalibrationAssessmentView.py
+++ b/tests/unit/ui/view/test_CalibrationAssessmentView.py
@@ -1,9 +1,11 @@
 from unittest.mock import MagicMock
 
+import pytest
 from snapred.backend.dao.indexing.IndexEntry import IndexEntry
 from snapred.ui.view.DiffCalAssessmentView import DiffCalAssessmentView
 
 
+@pytest.mark.ui()
 def test_calibration_record_dropdown(qtbot):
     view = DiffCalAssessmentView()
     assert view.getCalibrationRecordCount() == 0
@@ -26,6 +28,7 @@ def test_calibration_record_dropdown(qtbot):
     assert view.getSelectedCalibrationRecordData() == (runNumber, useLiteMode, version)
 
 
+@pytest.mark.ui()
 def test_error_on_load_calibration_record(qtbot):
     view = DiffCalAssessmentView()
     qtbot.addWidget(view.loadButton)

--- a/tests/unit/ui/view/test_CalibrationAssessmentView.py
+++ b/tests/unit/ui/view/test_CalibrationAssessmentView.py
@@ -1,11 +1,12 @@
 from unittest.mock import MagicMock
 
 import pytest
+
 from snapred.backend.dao.indexing.IndexEntry import IndexEntry
 from snapred.ui.view.DiffCalAssessmentView import DiffCalAssessmentView
 
 
-@pytest.mark.ui()
+@pytest.mark.ui
 def test_calibration_record_dropdown(qtbot):
     view = DiffCalAssessmentView()
     assert view.getCalibrationRecordCount() == 0
@@ -28,7 +29,7 @@ def test_calibration_record_dropdown(qtbot):
     assert view.getSelectedCalibrationRecordData() == (runNumber, useLiteMode, version)
 
 
-@pytest.mark.ui()
+@pytest.mark.ui
 def test_error_on_load_calibration_record(qtbot):
     view = DiffCalAssessmentView()
     qtbot.addWidget(view.loadButton)

--- a/tests/unit/ui/view/test_InitializeStateCheckView.py
+++ b/tests/unit/ui/view/test_InitializeStateCheckView.py
@@ -1,6 +1,8 @@
+import pytest
 from snapred.ui.view.InitializeStateCheckView import InitializationMenu
 
 
+@pytest.mark.ui()
 def test_run_number_field(qtbot):
     menu = InitializationMenu(None)
     qtbot.addWidget(menu)

--- a/tests/unit/ui/view/test_InitializeStateCheckView.py
+++ b/tests/unit/ui/view/test_InitializeStateCheckView.py
@@ -1,8 +1,9 @@
 import pytest
+
 from snapred.ui.view.InitializeStateCheckView import InitializationMenu
 
 
-@pytest.mark.ui()
+@pytest.mark.ui
 def test_run_number_field(qtbot):
     menu = InitializationMenu(None)
     qtbot.addWidget(menu)

--- a/tests/unit/ui/widget/test_Workflow.py
+++ b/tests/unit/ui/widget/test_Workflow.py
@@ -40,7 +40,7 @@ def _generateWorkflow():
     return WorkflowBuilder().addNode(continueAction, view, "Test").build()
 
 
-@pytest.mark.ui()
+@pytest.mark.ui
 def test_workflowPresenterHandleContinueButtonClicked(qtbot):
     # Mock the worker pool
     mockWorkerPool = MagicMock()

--- a/tests/unit/ui/widget/test_Workflow.py
+++ b/tests/unit/ui/widget/test_Workflow.py
@@ -40,6 +40,7 @@ def _generateWorkflow():
     return WorkflowBuilder().addNode(continueAction, view, "Test").build()
 
 
+@pytest.mark.ui()
 def test_workflowPresenterHandleContinueButtonClicked(qtbot):
     # Mock the worker pool
     mockWorkerPool = MagicMock()

--- a/tests/unit/ui/workflow/test_DiffCalWorkflow.py
+++ b/tests/unit/ui/workflow/test_DiffCalWorkflow.py
@@ -14,6 +14,7 @@ from snapred.meta.pointer import create_pointer
 from snapred.ui.workflow.DiffCalWorkflow import DiffCalWorkflow
 
 
+@pytest.mark.ui()
 @patch("snapred.ui.workflow.DiffCalWorkflow.WorkflowImplementer.request")
 def test_purge_bad_peaks(workflowRequest, qtbot):  # noqa: ARG001
     """
@@ -65,6 +66,7 @@ def test_purge_bad_peaks(workflowRequest, qtbot):  # noqa: ARG001
     )
 
 
+@pytest.mark.ui()
 @patch("snapred.ui.workflow.DiffCalWorkflow.WorkflowImplementer.request")
 def test_purge_bad_peaks_two_wkspindex(workflowRequest, qtbot):  # noqa: ARG001
     """
@@ -126,6 +128,7 @@ def test_purge_bad_peaks_two_wkspindex(workflowRequest, qtbot):  # noqa: ARG001
     )
 
 
+@pytest.mark.ui()
 @patch("snapred.ui.workflow.DiffCalWorkflow.WorkflowImplementer.request")
 def test_purge_bad_peaks_too_few(workflowRequest, qtbot):  # noqa: ARG001
     """

--- a/tests/unit/ui/workflow/test_DiffCalWorkflow.py
+++ b/tests/unit/ui/workflow/test_DiffCalWorkflow.py
@@ -14,7 +14,7 @@ from snapred.meta.pointer import create_pointer
 from snapred.ui.workflow.DiffCalWorkflow import DiffCalWorkflow
 
 
-@pytest.mark.ui()
+@pytest.mark.ui
 @patch("snapred.ui.workflow.DiffCalWorkflow.WorkflowImplementer.request")
 def test_purge_bad_peaks(workflowRequest, qtbot):  # noqa: ARG001
     """
@@ -66,7 +66,7 @@ def test_purge_bad_peaks(workflowRequest, qtbot):  # noqa: ARG001
     )
 
 
-@pytest.mark.ui()
+@pytest.mark.ui
 @patch("snapred.ui.workflow.DiffCalWorkflow.WorkflowImplementer.request")
 def test_purge_bad_peaks_two_wkspindex(workflowRequest, qtbot):  # noqa: ARG001
     """
@@ -128,7 +128,7 @@ def test_purge_bad_peaks_two_wkspindex(workflowRequest, qtbot):  # noqa: ARG001
     )
 
 
-@pytest.mark.ui()
+@pytest.mark.ui
 @patch("snapred.ui.workflow.DiffCalWorkflow.WorkflowImplementer.request")
 def test_purge_bad_peaks_too_few(workflowRequest, qtbot):  # noqa: ARG001
     """

--- a/tests/unit/ui/workflow/test_WorkflowImplementer.py
+++ b/tests/unit/ui/workflow/test_WorkflowImplementer.py
@@ -7,7 +7,7 @@ from mantid.simpleapi import CreateSingleValuedWorkspace, GroupWorkspaces, mtd
 from snapred.ui.workflow.WorkflowImplementer import WorkflowImplementer
 
 
-@pytest.mark.ui()
+@pytest.mark.ui
 def test_rename_on_iterate_list(qtbot):  # noqa: ARG001
     """
     Test that on iteration, a list of workspaces will be renamed according to the iteration template.
@@ -26,7 +26,7 @@ def test_rename_on_iterate_list(qtbot):  # noqa: ARG001
     assert instance.collectedOutputs == newNames
 
 
-@pytest.mark.ui()
+@pytest.mark.ui
 def test_rename_on_iterate_group(qtbot):  # noqa: ARG001
     """
     Test that on iteration, a workspace group has all of its members renamed.

--- a/tests/unit/ui/workflow/test_WorkflowImplementer.py
+++ b/tests/unit/ui/workflow/test_WorkflowImplementer.py
@@ -1,11 +1,13 @@
 from random import randint
 from unittest.mock import MagicMock
 
+import pytest
 from mantid.simpleapi import CreateSingleValuedWorkspace, GroupWorkspaces, mtd
 
 from snapred.ui.workflow.WorkflowImplementer import WorkflowImplementer
 
 
+@pytest.mark.ui()
 def test_rename_on_iterate_list(qtbot):  # noqa: ARG001
     """
     Test that on iteration, a list of workspaces will be renamed according to the iteration template.
@@ -24,6 +26,7 @@ def test_rename_on_iterate_list(qtbot):  # noqa: ARG001
     assert instance.collectedOutputs == newNames
 
 
+@pytest.mark.ui()
 def test_rename_on_iterate_group(qtbot):  # noqa: ARG001
     """
     Test that on iteration, a workspace group has all of its members renamed.

--- a/tests/util_tests/test_state_helpers.py
+++ b/tests/util_tests/test_state_helpers.py
@@ -8,7 +8,7 @@ import pytest
 from util.dao import DAOFactory
 from util.state_helpers import reduction_root_redirect, state_root_override, state_root_redirect
 
-from snapred.backend.dao.indexing.Versioning import VERSION_DEFAULT
+from snapred.backend.dao.indexing.Versioning import VERSION_START
 from snapred.backend.data.LocalDataService import LocalDataService
 from snapred.meta.Config import Config
 from snapred.meta.mantid.WorkspaceNameGenerator import ValueFormatter as wnvf
@@ -68,7 +68,7 @@ def test_state_root_override_enter(
         assert Path(stateRootPath) == expectedStateRootPath
         assert Path(stateRootPath).exists()
         assert Path(stateRootPath).joinpath("groupingMap.json").exists()
-        versionString = wnvf.pathVersion(VERSION_DEFAULT)
+        versionString = wnvf.pathVersion(VERSION_START)
         assert (Path(stateRootPath) / "lite" / "diffraction" / versionString / "CalibrationParameters.json").exists()
 
 


### PR DESCRIPTION
## Description of work

Requires this data change to be merged to pass integration tests:
https://code.ornl.gov/sns-hfir-scse/infrastructure/test-data/snapred-data/-/merge_requests/1

## Explanation of work

It was found that the index was not appropriately failing when a version for a specified run was not found.
This was in part due to its subbing in the "current" version if it received `None` as an input, which it also happened to return when it couldnt find a version.  This then created a scenario in which not finding a record resulted in pulling the `current` version.

The `current` version being arbitrarily the last one done.

## To test

Run through the full range of workflows and see that they work.
Then mess with the calibration/normalization indexes and see how the reduction workflow responds.  Confirm that it matches up with what is expected.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#8253](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8253)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

to replicate:
1. Set calibration home = `/SNS/SNAP/shared/Calibration_next`
2. Reduce run 57482 (in lite mode)
3. Data are reduced, using version 2 of normcal in the folder `/SNS/SNAP/shared/Calibration_next/Powder/04bd2c53f6bf6754/lite/normalization/`

However, if the normalizationIndex.json is inspected its content should mean that there is no normcal available for run 57482:

```
[
    {
        "runNumber": "58809",
        "useLiteMode": true,
        "appliesTo": ">=58882",
        "comments": "test of v1.1.0rc1",
        "author": "mg",
        "timestamp": 1729258319.2569995,
        "version": 1
    },
    {
        "runNumber": "58809",
        "useLiteMode": true,
        "appliesTo": ">=58809",
        "comments": " 3mm V-Nb sample",
        "author": "Malcolm",
        "timestamp": 1730229952.2204628,
        "version": 2
    }
]
```
The normcal is only available for run numbers >=58809.

- [x] The expected behaviour would be that SNAPRed gives a warning that normcal does not exist for run 57482 and proceeds to manage that situation.
