### PR TITLE
After completion of pixel calibration, show unfocused before and after 

### DIFF
--- a/src/snapred/backend/recipe/PixelDiffCalRecipe.py
+++ b/src/snapred/backend/recipe/PixelDiffCalRecipe.py
@@ -86,10 +86,10 @@ class PixelDiffCalRecipe(Recipe[Ingredients]):
         # the input data converted to d-spacing
         self.wsDSP = wng.diffCalInputDSP().runNumber(self.runNumber).build()
         self.convertUnitsAndRebin(self.wsTOF, self.wsDSP)
-        self.mantidSnapper.MakeDirtyDish(
+        self.mantidSnapper.CloneWorkspace(
             "Creating copy of initial d-spacing data",
             InputWorkspace=self.wsDSP,
-            OutputWorkspace=self.wsDSP + "_startOfPixelDiffCal",
+            OutputWorkspace=self.wsDSP + "_beforeCrossCor",
         )
 
         if self.removeBackground:
@@ -332,6 +332,10 @@ class PixelDiffCalRecipe(Recipe[Ingredients]):
             logger.info(f"... converging to answer; step {self._counts}, {self.medianOffsets[-1]} > {self.threshold}")
             self.queueAlgos()
         logger.info(f"Pixel calibration converged.  Offsets: {self.medianOffsets}")
+
+        # create for inspection
+        self.convertUnitsAndRebin(self.wsTOF, f"{self.wsDSP}_afterCrossCor")
+        self.mantidSnapper.executeQueue()
 
         return PixelDiffCalServing(
             result=True,


### PR DESCRIPTION
## Description of work

Some users of SNAP want to see unfocused before/after workspaces, to help assess the usefulness of pixel calibration.

## Explanation of work

One of the workspaces already existed, but was only retained in CIS mode.

Another of the workspaces is created at the end of `PixelDiffCalRecipe`.

## To test

### Dev testing

Run calibration with 46680.  It will fail, but not before creating the workspaces.

When it finishes, within the list of workspaces should be `dsp_046880_raw_beforeCrossCor` and `dsp_046680_raw_afterCrossCor`.  Check the following:
- both workspaces have 18432 spectra
- both workspaces are in d-Spacing
- both workspaces have the same binning
- both workspaces can be viewed in sliceviewer by right clicking in the ADS

Right click on the `tof_all_lite_raw_046680` workspace, and select to view the detectors.  This will open a table workspace with the column DIFC.  

Then right click on "before" workspace and select the same.  Verify the DIFC columns are identical between the original and the "before"

Right click on the "after" workspace and select the same.  Verify the DIFC columns differ between the original and "after"

### CIS testing

Run this with 58882 and Silicon (or your own choice).

Verify as above.

Also make sure, in slice viewer, that pixel calibration has done anything worthwhile.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#7712](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7712)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

**NOTE** this PR only applies to steps 1 and 2 described in the EWM item

- [x] After completion of pixel calibration and before group calibration, the user has access to before/after workspaces
- [x] The before/after workspaces are unfocused (18432 spectra in lite or 1.2M spectra in native)
- [x] The before/after workspaces functions of d-spacing
- [x] The before/after workspaces have the same binning 
- [x] The before/after workspaces differ in that one has been converted to d-spacing using the input difcal convertion and the second has been converted using the difcal that include the offsets determined via the pixel calibration process
- [x] The user is then able to visually inspect both workspaces using mantid workbench slice viewer

