### PR TITLE
Oggles of Toggles

### DIFF
--- a/docs/source/api/snapred.ui.widget.rst
+++ b/docs/source/api/snapred.ui.widget.rst
@@ -98,6 +98,7 @@ snapred.ui.widget.Toggle module
 .. automodule:: snapred.ui.widget.Toggle
    :members:
    :undoc-members:
+   :exclude-members: stateChanged
    :show-inheritance:
 
 snapred.ui.widget.ToolBar module

--- a/src/snapred/ui/view/BackendRequestView.py
+++ b/src/snapred/ui/view/BackendRequestView.py
@@ -1,9 +1,10 @@
-from qtpy.QtWidgets import QGridLayout, QLineEdit, QWidget
+from qtpy.QtWidgets import QGridLayout, QWidget
 
 from snapred.backend.api.InterfaceController import InterfaceController
 from snapred.ui.threading.worker_pool import WorkerPool
 from snapred.ui.widget.LabeledCheckBox import LabeledCheckBox
 from snapred.ui.widget.LabeledField import LabeledField
+from snapred.ui.widget.LabeledToggle import LabeledToggle
 from snapred.ui.widget.MultiSelectDropDown import MultiSelectDropDown
 from snapred.ui.widget.SampleDropDown import SampleDropDown
 from snapred.ui.widget.TrueFalseDropDown import TrueFalseDropDown
@@ -22,11 +23,14 @@ class BackendRequestView(QWidget):
         self.layout = QGridLayout()
         self.setLayout(self.layout)
 
-    def _labeledField(self, label, field=None):
-        return LabeledField(label, field, self)
+    def _labeledField(self, label, field=None, text=None):
+        return LabeledField(label, field=field, text=text, parent=self)
 
     def _labeledLineEdit(self, label):
-        return LabeledField(label, QLineEdit(parent=self), self)
+        return LabeledField(label, field=None, text=None, parent=self)
+
+    def _labeledToggle(self, label, state):
+        return LabeledToggle(label, state, parent=self)
 
     def _labeledCheckBox(self, label):
         return LabeledCheckBox(label, self)

--- a/src/snapred/ui/view/DiffCalAssessmentView.py
+++ b/src/snapred/ui/view/DiffCalAssessmentView.py
@@ -1,17 +1,16 @@
 from typing import List
 
 from qtpy.QtCore import Signal, Slot
-from qtpy.QtWidgets import QComboBox, QGridLayout, QLabel, QMessageBox, QPushButton, QWidget
+from qtpy.QtWidgets import QComboBox, QLabel, QMessageBox, QPushButton
 
 from snapred.backend.dao.indexing.IndexEntry import IndexEntry
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.presenter.CalibrationAssessmentPresenter import CalibrationAssessmentPresenter
-from snapred.ui.widget.LabeledField import LabeledField
+from snapred.ui.view.BackendRequestView import BackendRequestView
 
 
-# TODO rebase on BackendRequestView
 @Resettable
-class DiffCalAssessmentView(QWidget):
+class DiffCalAssessmentView(BackendRequestView):
     """
 
     The DiffCalAssessmentView serves as a user interface within the SNAPRed application,
@@ -31,9 +30,6 @@ class DiffCalAssessmentView(QWidget):
 
         self.presenter = CalibrationAssessmentPresenter(self)
 
-        self.layout = QGridLayout()
-        self.setLayout(self.layout)
-
         self.interactionText = QLabel(
             "Calibration Complete! Please examine the calibration assessment workspaces. "
             "You can also load and examine previous calibration assessments for the same "
@@ -49,11 +45,12 @@ class DiffCalAssessmentView(QWidget):
         self.calibrationRecordDropdown.setEnabled(True)
         self.calibrationRecordDropdown.addItem("Select Calibration Record")
         self.calibrationRecordDropdown.model().item(0).setEnabled(False)
+        self.calibrationRecordField = self._labeledField("Calibration Record:", field=self.calibrationRecordDropdown)
 
         self.signalError.connect(self._displayError)
 
         self.layout.addWidget(self.interactionText, 0, 0)
-        self.layout.addWidget(LabeledField("Calibration Record:", self.calibrationRecordDropdown, self), 1, 0)
+        self.layout.addWidget(self.calibrationRecordField, 1, 0)
         self.layout.addWidget(self.loadButton, 1, 1)
         self.layout.addWidget(self.placeHolder)
 

--- a/src/snapred/ui/view/DiffCalRequestView.py
+++ b/src/snapred/ui/view/DiffCalRequestView.py
@@ -2,7 +2,6 @@ from snapred.meta.Config import Config
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
 from snapred.ui.view.BackendRequestView import BackendRequestView
-from snapred.ui.widget.Toggle import Toggle
 
 
 @Resettable
@@ -25,7 +24,7 @@ class DiffCalRequestView(BackendRequestView):
 
         # input fields
         self.runNumberField = self._labeledField("Run Number")
-        self.litemodeToggle = self._labeledField("Lite Mode", Toggle(parent=self, state=True))
+        self.litemodeToggle = self._labeledToggle("Lite Mode", True)
         self.fieldConvergenceThreshold = self._labeledField("Convergence Threshold")
         self.fieldNBinsAcrossPeakWidth = self._labeledField("Bins Across Peak Width")
 
@@ -36,7 +35,7 @@ class DiffCalRequestView(BackendRequestView):
 
         # checkbox for removing background
         # NOTE not enabled unless in CIS mode until remove event background is fixed -- then re-enable
-        self.removeBackgroundToggle = self._labeledField("RemoveBackground", Toggle(parent=self, state=False))
+        self.removeBackgroundToggle = self._labeledToggle("RemoveBackground", False)
         self.removeBackgroundToggle.setEnabled(Config["cis_mode"])
 
         # set field properties
@@ -44,7 +43,7 @@ class DiffCalRequestView(BackendRequestView):
         self.peakFunctionDropdown.setCurrentIndex(0)
 
         # skip pixel calibration toggle
-        self.skipPixelCalToggle = self._labeledField("Skip Pixel Calibration", Toggle(parent=self, state=False))
+        self.skipPixelCalToggle = self._labeledToggle("Skip Pixel Calibration", False)
 
         # add all widgets to layout
         self.layout.addWidget(self.runNumberField, 0, 0)
@@ -75,10 +74,10 @@ class DiffCalRequestView(BackendRequestView):
         return self.runNumberField.text()
 
     def getLiteMode(self):
-        return self.litemodeToggle.field.getState()
+        return self.litemodeToggle.getState()
 
     def getRemoveBackground(self):
-        return self.removeBackgroundToggle.field.getState()
+        return self.removeBackgroundToggle.getState()
 
     def getSkipPixelCalibration(self):
-        return self.skipPixelCalToggle.field.getState()
+        return self.skipPixelCalToggle.getState()

--- a/src/snapred/ui/view/DiffCalSaveView.py
+++ b/src/snapred/ui/view/DiffCalSaveView.py
@@ -1,13 +1,12 @@
 from qtpy.QtCore import Signal, Slot
-from qtpy.QtWidgets import QComboBox, QGridLayout, QLabel, QLineEdit, QWidget
+from qtpy.QtWidgets import QComboBox, QLabel
 
 from snapred.meta.decorators.Resettable import Resettable
-from snapred.ui.widget.LabeledField import LabeledField
+from snapred.ui.view.BackendRequestView import BackendRequestView
 
 
-# TODO rebase on BackendRequestView
 @Resettable
-class DiffCalSaveView(QWidget):
+class DiffCalSaveView(BackendRequestView):
     """
 
     The DiffCalSaveView is a Qt widget designed for the final step in the calibration process within
@@ -24,33 +23,31 @@ class DiffCalSaveView(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.currentIterationText = "Current"
-        self.layout = QGridLayout()
-        self.setLayout(self.layout)
 
         self.interactionText = QLabel("Assessment Complete! Would you like to save the calibration now?")
 
-        self.fieldRunNumber = LabeledField("Run Number :", QLineEdit(parent=self), self)
+        self.fieldRunNumber = self._labeledField("Run Number :")
         self.fieldRunNumber.setEnabled(False)
         self.signalRunNumberUpdate.connect(self._updateRunNumber)
 
-        self.fieldVersion = LabeledField("Version :", QLineEdit(parent=self), self)
+        self.fieldVersion = self._labeledField("Version :")
         # add tooltip to leave blank for new version
         self.fieldVersion.setToolTip("Leave blank for new version!")
 
-        self.fieldAppliesTo = LabeledField("Applies To :", QLineEdit(parent=self), self)
+        self.fieldAppliesTo = self._labeledField("Applies To :")
         self.fieldAppliesTo.setToolTip(
             "Determines which runs this calibration applies to. 'runNumber', '>runNumber', or \
                 '<runNumber', default is '>runNumber'."
         )
 
-        self.fieldComments = LabeledField("Comments :", QLineEdit(parent=self), self)
+        self.fieldComments = self._labeledField("Comments :")
         self.fieldComments.setToolTip("Comments about the calibration, documentation of important information.")
 
-        self.fieldAuthor = LabeledField("Author :", QLineEdit(parent=self), self)
+        self.fieldAuthor = self._labeledField("Author :")
         self.fieldAuthor.setToolTip("Author of the calibration.")
 
         self.iterationDropdown = QComboBox(parent=self)
-        self.iterationWidget = LabeledField("Iteration :", self.iterationDropdown, self)
+        self.iterationWidget = self._labeledField("Iteration :", field=self.iterationDropdown)
         self.iterationWidget.setVisible(False)
 
         self.layout.addWidget(self.interactionText)

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -7,7 +7,6 @@ from mantid.simpleapi import mtd
 from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import (
     QHBoxLayout,
-    QLineEdit,
     QMessageBox,
     QPushButton,
 )
@@ -22,7 +21,6 @@ from snapred.meta.decorators.Resettable import Resettable
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
 from snapred.meta.mantid.FitPeaksOutput import FitOutputEnum
 from snapred.ui.view.BackendRequestView import BackendRequestView
-from snapred.ui.widget.Toggle import Toggle
 
 
 @Resettable
@@ -57,8 +55,8 @@ class DiffCalTweakPeakView(BackendRequestView):
 
         # create the run number field and lite mode toggle
         self.runNumberField = self._labeledField("Run Number")
-        self.litemodeToggle = self._labeledField("Lite Mode", Toggle(parent=self, state=True))
-        self.maxChiSqField = self._labeledField("Max Chi Sq", QLineEdit(str(self.MAX_CHI_SQ)))
+        self.litemodeToggle = self._labeledToggle("Lite Mode", True)
+        self.maxChiSqField = self._labeledField("Max Chi Sq", text=str(self.MAX_CHI_SQ))
         self.signalRunNumberUpdate.connect(self._updateRunNumber)
         self.signalMaxChiSqUpdate.connect(self._updateMaxChiSq)
 
@@ -80,10 +78,10 @@ class DiffCalTweakPeakView(BackendRequestView):
             x.setEnabled(False)
 
         # create the peak adjustment controls
-        self.fieldXtalDMin = self._labeledField("xtal dMin", QLineEdit(str(self.XTAL_DMIN)))
-        self.fieldXtalDMax = self._labeledField("xtal dMax", QLineEdit(str(self.XTAL_DMAX)))
-        self.fieldFWHMleft = self._labeledField("FWHM left", QLineEdit(str(self.FWHM.left)))
-        self.fieldFWHMright = self._labeledField("FWHM right", QLineEdit(str(self.FWHM.right)))
+        self.fieldXtalDMin = self._labeledField("xtal dMin", text=str(self.XTAL_DMIN))
+        self.fieldXtalDMax = self._labeledField("xtal dMax", text=str(self.XTAL_DMAX))
+        self.fieldFWHMleft = self._labeledField("FWHM left", text=str(self.FWHM.left))
+        self.fieldFWHMright = self._labeledField("FWHM right", text=str(self.FWHM.right))
         peakControlLayout = QHBoxLayout()
         peakControlLayout.addWidget(self.fieldXtalDMin)
         peakControlLayout.addWidget(self.fieldXtalDMax)

--- a/src/snapred/ui/view/NormalizationRequestView.py
+++ b/src/snapred/ui/view/NormalizationRequestView.py
@@ -1,6 +1,5 @@
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.view.BackendRequestView import BackendRequestView
-from snapred.ui.widget.Toggle import Toggle
 
 
 @Resettable
@@ -21,7 +20,7 @@ class NormalizationRequestView(BackendRequestView):
 
         # input fields
         self.runNumberField = self._labeledLineEdit("Run Number:")
-        self.litemodeToggle = self._labeledField("Lite Mode", Toggle(parent=self, state=True))
+        self.litemodeToggle = self._labeledToggle("Lite Mode", True)
         self.backgroundRunNumberField = self._labeledLineEdit("Background Run Number:")
 
         # drop downs

--- a/src/snapred/ui/view/NormalizationTweakPeakView.py
+++ b/src/snapred/ui/view/NormalizationTweakPeakView.py
@@ -7,7 +7,6 @@ from mantid.simpleapi import mtd
 from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import (
     QHBoxLayout,
-    QLineEdit,
     QMessageBox,
     QPushButton,
 )
@@ -51,8 +50,8 @@ class NormalizationTweakPeakView(BackendRequestView):
         super().__init__(parent=parent)
 
         # create the run number fields
-        self.fieldRunNumber = self._labeledField("Run Number", QLineEdit(parent=self))
-        self.fieldBackgroundRunNumber = self._labeledField("Background Run Number", QLineEdit(parent=self))
+        self.fieldRunNumber = self._labeledField("Run Number")
+        self.fieldBackgroundRunNumber = self._labeledField("Background Run Number")
         # connect them to signals
         self.signalRunNumberUpdate.connect(self._updateRunNumber)
         self.signalBackgroundRunNumberUpdate.connect(self._updateBackgroundRunNumber)
@@ -72,8 +71,8 @@ class NormalizationTweakPeakView(BackendRequestView):
 
         # create the adjustment controls
         self.smoothingSlider = self._labeledField("Smoothing", SmoothingSlider())
-        self.fieldXtalDMin = self._labeledField("xtal dMin", QLineEdit(str(self.XTAL_DMIN)))
-        self.fieldXtalDMax = self._labeledField("xtal dMax", QLineEdit(str(self.XTAL_DMAX)))
+        self.fieldXtalDMin = self._labeledField("xtal dMin", text=str(self.XTAL_DMIN))
+        self.fieldXtalDMax = self._labeledField("xtal dMax", text=str(self.XTAL_DMAX))
         peakControlLayout = QHBoxLayout()
         peakControlLayout.addWidget(self.smoothingSlider, 2)
         peakControlLayout.addWidget(self.fieldXtalDMin)

--- a/src/snapred/ui/view/reduction/ReductionRequestView.py
+++ b/src/snapred/ui/view/reduction/ReductionRequestView.py
@@ -14,7 +14,6 @@ from snapred.backend.dao.state.RunNumber import RunNumber
 from snapred.backend.log.logger import snapredLogger
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.view.BackendRequestView import BackendRequestView
-from snapred.ui.widget.Toggle import Toggle
 
 logger = snapredLogger.getLogger(__name__)
 
@@ -52,7 +51,7 @@ class ReductionRequestView(BackendRequestView):
         self.runNumberDisplay.setSortingEnabled(False)
 
         # Lite mode toggle, pixel masks dropdown, and retain unfocused data checkbox
-        self.liteModeToggle = self._labeledField("Lite Mode", Toggle(parent=self, state=True))
+        self.liteModeToggle = self._labeledToggle("Lite Mode", True)
         self.retainUnfocusedDataCheckbox = self._labeledCheckBox("Retain Unfocused Data")
         self.convertUnitsDropdown = self._sampleDropDown(
             "Convert Units", ["TOF", "dSpacing", "Wavelength", "MomentumTransfer"]

--- a/src/snapred/ui/widget/LabeledField.py
+++ b/src/snapred/ui/widget/LabeledField.py
@@ -2,7 +2,7 @@ from qtpy.QtWidgets import QHBoxLayout, QLabel, QLineEdit, QWidget
 
 
 class LabeledField(QWidget):
-    def __init__(self, label, field=None, parent=None):
+    def __init__(self, label, field=None, text=None, parent=None):
         super(LabeledField, self).__init__(parent)
         self.setStyleSheet("background-color: #F5E9E2;")
         layout = QHBoxLayout()
@@ -13,6 +13,7 @@ class LabeledField(QWidget):
             self._field = field
         else:
             self._field = QLineEdit(parent=self)
+            self._field.setText(text)
 
         layout.addWidget(self._label)
         layout.addWidget(self._field)

--- a/src/snapred/ui/widget/LabeledToggle.py
+++ b/src/snapred/ui/widget/LabeledToggle.py
@@ -1,0 +1,30 @@
+from qtpy.QtCore import Signal
+from qtpy.QtWidgets import QHBoxLayout, QLabel, QWidget
+
+from snapred.ui.widget.Toggle import Toggle
+
+
+class LabeledToggle(QWidget):
+    stateChanged = Signal(bool)
+
+    def __init__(self, label, state, parent=None):
+        super(LabeledToggle, self).__init__(parent)
+        self.setStyleSheet("background-color: #F5E9E2;")
+
+        self._label = QLabel(label + ":", self)
+        self._toggle = Toggle(state=state, parent=self)
+
+        layout = QHBoxLayout()
+        layout.addWidget(self._label)
+        layout.addWidget(self._toggle)
+        layout.addStretch(1)
+        layout.setContentsMargins(5, 5, 5, 5)
+        self.setLayout(layout)
+
+        self._toggle.stateChanged.connect(self.stateChanged)
+
+    def getState(self):
+        return self._toggle.getState()
+
+    def setState(self, state):
+        self._toggle.setState(state)

--- a/src/snapred/ui/widget/Toggle.py
+++ b/src/snapred/ui/widget/Toggle.py
@@ -1,9 +1,11 @@
-from qtpy.QtCore import Property, QEasingCurve, QPropertyAnimation, Qt
+from qtpy.QtCore import Property, QEasingCurve, QPropertyAnimation, Qt, Signal, Slot
 from qtpy.QtGui import QLinearGradient, QPainter
 from qtpy.QtWidgets import QWidget
 
 
 class Toggle(QWidget):
+    stateChanged = Signal(bool)
+
     def __init__(self, parent=None, state=False):
         super().__init__(parent=parent)
         self._state = state
@@ -28,9 +30,12 @@ class Toggle(QWidget):
     def toggle(self):
         self.setState(not self._state)
 
+    @Slot(bool)
     def setState(self, state):
-        self._state = state
-        self.animateClick()
+        if self._state != state:
+            self._state = state
+            self.stateChanged.emit(state)
+            self.animateClick()
 
     def connectUpdate(self, update):  # noqa: ARG002
         self.toggleAnimation.finished.connect(update)

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -88,10 +88,14 @@ class DiffCalWorkflow(WorkflowImplementer):
         self._saveView = DiffCalSaveView(parent)
 
         # connect signal to populate the grouping dropdown after run is selected
-        self._requestView.litemodeToggle.field.connectUpdate(self._switchLiteNativeGroups)
+        self._requestView.litemodeToggle.stateChanged.connect(self._switchLiteNativeGroups)
         self._requestView.runNumberField.editingFinished.connect(self._populateGroupingDropdown)
         self._tweakPeakView.signalValueChanged.connect(self.onValueChange)
         self._tweakPeakView.signalPurgeBadPeaks.connect(self.purgeBadPeaks)
+
+        # connect the lite mode toggles across the views
+        self._requestView.litemodeToggle.stateChanged.connect(self._tweakPeakView.litemodeToggle.setState)
+        self._tweakPeakView.litemodeToggle.stateChanged.connect(self._requestView.litemodeToggle.setState)
 
         self.prevFWHM = DiffCalTweakPeakView.FWHM
         self.prevXtalDMin = DiffCalTweakPeakView.XTAL_DMIN
@@ -142,7 +146,7 @@ class DiffCalWorkflow(WorkflowImplementer):
     def _populateGroupingDropdown(self):
         # when the run number is updated, freeze the drop down to populate it
         runNumber = self._requestView.runNumberField.text()
-        useLiteMode = self._requestView.litemodeToggle.field.getState()
+        useLiteMode = self._requestView.litemodeToggle.getState()
 
         self.__setInteraction(False)
         self.workflow.presenter.handleAction(
@@ -172,13 +176,12 @@ class DiffCalWorkflow(WorkflowImplementer):
     @Slot()
     def _switchLiteNativeGroups(self):
         # determine resolution mode
-        useLiteMode = self._requestView.litemodeToggle.field.getState()
-        self._tweakPeakView.litemodeToggle.field.setState(useLiteMode)
+        useLiteMode = self._requestView.litemodeToggle.getState()
 
         # set default state for skipPixelCalToggle
         # in native mode, skip by default
         # in lite mode, do not skip by default
-        self._requestView.skipPixelCalToggle.field.setState(not useLiteMode)
+        self._requestView.skipPixelCalToggle.setState(not useLiteMode)
 
         self._requestView.groupingFileDropdown.setEnabled(False)
 
@@ -199,7 +202,7 @@ class DiffCalWorkflow(WorkflowImplementer):
 
         # fetch the data from the view
         self.runNumber = view.runNumberField.text()
-        self.useLiteMode = view.litemodeToggle.field.getState()
+        self.useLiteMode = view.litemodeToggle.getState()
         self.focusGroupPath = view.groupingFileDropdown.currentText()
         self.calibrantSamplePath = view.sampleDropdown.currentText()
         self.peakFunction = view.peakFunctionDropdown.currentText()

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -62,7 +62,7 @@ class NormalizationWorkflow(WorkflowImplementer):
         self._saveView = NormalizationSaveView(parent)
 
         # connect signal to populate the grouping dropdown after run is selected
-        self._requestView.litemodeToggle.field.connectUpdate(self._switchLiteNativeGroups)
+        self._requestView.litemodeToggle.stateChanged.connect(self._switchLiteNativeGroups)
         self._requestView.runNumberField.editingFinished.connect(self._populateGroupingDropdown)
         self._tweakPeakView.signalValueChanged.connect(self.onNormalizationValueChange)
 
@@ -93,7 +93,7 @@ class NormalizationWorkflow(WorkflowImplementer):
     def _populateGroupingDropdown(self):
         # when the run number is updated, grab the grouping map and populate grouping drop down
         runNumber = self._requestView.runNumberField.text()
-        self.useLiteMode = self._requestView.litemodeToggle.field.getState()
+        self.useLiteMode = self._requestView.litemodeToggle.getState()
 
         self.__setInteraction(False)
         self.workflow.presenter.handleAction(
@@ -124,7 +124,7 @@ class NormalizationWorkflow(WorkflowImplementer):
     @Slot()
     def _switchLiteNativeGroups(self):
         # when the run number is updated, freeze the drop down to populate it
-        useLiteMode = self._requestView.litemodeToggle.field.getState()
+        useLiteMode = self._requestView.litemodeToggle.getState()
 
         self._requestView.groupingFileDropdown.setEnabled(False)
 
@@ -146,7 +146,7 @@ class NormalizationWorkflow(WorkflowImplementer):
         # pull fields from view for normalization
 
         self.runNumber = view.runNumberField.field.text()
-        self.useLiteMode = view.litemodeToggle.field.getState()
+        self.useLiteMode = view.litemodeToggle.getState()
         self.backgroundRunNumber = view.backgroundRunNumberField.field.text()
         self.sampleIndex = view.sampleDropdown.currentIndex()
         self.prevGroupingIndex = view.groupingFileDropdown.currentIndex()

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -33,6 +33,7 @@ class ReductionWorkflow(WorkflowImplementer):
         )
         self._compatibleMasks: Dict[str, WorkspaceName] = {}
 
+        self._reductionRequestView.liteModeToggle.stateChanged.connect(lambda: self._populatePixelMaskDropdown())
         self._reductionRequestView.enterRunNumberButton.clicked.connect(lambda: self._populatePixelMaskDropdown())
         self._reductionRequestView.pixelMaskDropdown.dropDown.view().pressed.connect(self._onPixelMaskSelection)
 
@@ -98,6 +99,7 @@ class ReductionWorkflow(WorkflowImplementer):
 
     @ExceptionToErrLog
     def _populatePixelMaskDropdown(self):
+        self.useLiteMode = self._reductionRequestView.liteModeToggle.getState()  # noqa: F841
         runNumbers = self._reductionRequestView.getRunNumbers()
         if not runNumbers:
             self._reductionRequestView.pixelMaskDropdown.setItems([])
@@ -288,7 +290,7 @@ class ReductionWorkflow(WorkflowImplementer):
 
         request_ = ReductionRequest(
             runNumber=str(self._artificialNormalizationView.fieldRunNumber.text()),
-            useLiteMode=self._reductionRequestView.liteModeToggle.field.getState(),
+            useLiteMode=self._reductionRequestView.liteModeToggle.getState(),
             timestamp=timestamp,
             continueFlags=self.continueAnywayFlags,
             pixelMasks=pixelMasks,

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -105,7 +105,7 @@ class ReductionWorkflow(WorkflowImplementer):
             self._reductionRequestView.pixelMaskDropdown.setItems([])
             return []
 
-        self.useLiteMode = self._reductionRequestView.liteModeToggle.field.getState()  # noqa: F841
+        self.useLiteMode = self._reductionRequestView.liteModeToggle.getState()  # noqa: F841
 
         self.__setInteractive(False)
         self.workflow.presenter.handleAction(


### PR DESCRIPTION
## Description of work

This makes some improvements to the toggles and to adding UI elements to views.

In particular, it makes it easier to connect the toggles.

## Explanation of work

Added a `LabeledToggle` class which takes over the work of a `LabeledField` with a `Toggle` set as the field.  This just makes it easier to connect to a toggle.

Inside `BackendRequestView`, added the function to make a `LabeledToggle` analogously to other widgets.

Inside `LabeledField` added an argument for easier creation of labeled fields with a `QLineEdit` with text in them, since that was the most common use of `LabeledField`s.

Standardized use of `BackendRequestView`.

## To test

### Dev testing

This is all GUI work, so all testing is checking the GUI

#### Diffraction

In diffraction, make sure lite mode toggle and skip toggle work.  Input run 46680.  

Look at available groupings.  In most dev environments, they will have (lite) or (native) at the end (this can be setup if you don't).  Click the lite toggle and make sure this changes the groupings from lite to native.

Set the toggle to Lite, choose diamond, and pick a grouping.

Turn off skip pixel cal.  Try to continue.  You will get an error, confirming that pixel cal tried to run.  Turn of it off and continue.  You will not get the error, confirming it did not run.

At tweak peak view, observe state of lite mode toggle.  Go back to previous screen and flip the lite toggle.  Go forward, and make sure it has changed.

Check the name of the raw data workspace (tof_all_lite_raw_046680).  If you ran in Lite mode, it should be lite.  Check it has 18432 pixels.

Change FWHM right to 4 and recalculate.  Continue.  

At assess screen, verify everything looks the same.  Continue.

At save screen, verify the necessary fields are present and can take data.  You can do this by entering data in the fields, saving, then verifying in the CalibrationIndex for this state.

Run diffcal again in native mode.  Input 46680, skip pixel cal true, use lite mode false, diamond, any grouping.  At tweak peak stage, verify the name of the raw data workspace and check it has 1.2M pixels.

#### Normalization

In normalization, make sure the lite mode toggle works.  Input run 46680, background 46680.

Look at available groupings.  In most dev environments, they will have (lite) or (native) at the end (this can be setup if you don't)..  Click the lite toggle and make sure this changes the groupings from lite to native.

Set the toggle to Lite, choose diamond, and pick a grouping.  Continue.

At tweak peak field, make sure there are elements for run number, backgroun run number, dmin, dmax.  Continue.

At save screen, verify the necessary fields are present and can take data.  You can do this by entering data in the fields, saving, then verifying in the NormalizationIndex for this state.

Run normalization again in native mode.  Input 46680 as run and background, use lite mode false, diamond, any grouping.  At the tweak peak stage, verify the raw data workspace has 1.2M pixels.

#### Reduction

Remove or hide any saved normalizations for the state of 46680.

In reduction, try running with 46680 in lite mode.  You should see a popup about needing artificial normalization.  For the moment, say "No" (you do NOT want to do artificial normalization), then inspect the loaded raw workspace.  It should be lite (18432 pixels).  Now continue to artificial normalization.

Fiddle with buttons and create a normalization, and make sure reduction finishes.

Run again with 46680 in native mode.  When the popup comes up, click "No" (you do NOT want to do artificial normalization), then inspect the loaded raw workspace.  It should be native (1.2M pixels).  You can close the window now.

#### Additional check for Defect 8540

In Reduction with Lite mode toggle ON, enter 46680.

Toggle Lite mode OFF.

Run reduction.

When the data load, ensure it loaded the Native groupings and the Native resolution data file (~1.2M pixels).

### CIS testing

N/A

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

Not part of story, but arose during work on 

[EWM#7712](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7712)

Also fixes

[EWM#8540](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8540)

### Verification

N/A

### Acceptance Criteria

N/A