### PR TITLE
Updates required to run SNAPRed

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,11 +3,12 @@ channels:
 - conda-forge
 - default
 - mantid-ornl/label/rc
+- mantid/label/nightly
 dependencies:
 - python=3.10
 - pip
 - pydantic>=2.7.3,<3
-- mantidworkbench=6.10.0.2rc1
+- mantidworkbench>=6.11.20241203
 - qtpy
 - pre-commit
 - pytest


### PR DESCRIPTION
SNAPRed seems to require a later build of mantidworkbench to run, otherwise I get an exception:

```
  File ".../SNAPRed/src/snapred/backend/recipe/algorithm/RemoveEventBackground.py", line 14, in <module>
    from mantid.simpleapi import (
ImportError: cannot import name 'GroupedDetectorIDs' from 'mantid.simpleapi' (.../anaconda3/envs/SNAPRed/lib/python3.10/site-packages/mantid/simpleapi.py)

```