### PR TITLE
Fix workflow presenter to run things from threads

### DIFF
--- a/src/snapred/ui/presenter/WorkflowPresenter.py
+++ b/src/snapred/ui/presenter/WorkflowPresenter.py
@@ -1,4 +1,4 @@
-from typing import Callable, List
+from typing import Any, Callable, List, Tuple
 
 from qtpy.QtCore import QObject, Signal, Slot
 from qtpy.QtWidgets import QMainWindow, QMessageBox
@@ -167,7 +167,18 @@ class WorkflowPresenter(QObject):
         continueOnSuccess = lambda success: self.advanceWorkflow() if success else None  # noqa E731
         self.handleAction(verifyAndContinue, None, continueOnSuccess)
 
-    def handleAction(self, action, args, onSuccess):
+    def handleAction(
+        self,
+        action: Callable[[Any], Any],
+        args: Tuple[Any, ...] | Any | None,
+        onSuccess: Callable[[None], None],
+    ):
+        """
+        Send front-end task to a separate worker to complete.
+        @param action : a Callable to be called on worker
+        @param args : the argument action is to be called with
+        @param onSuccess : another Callable, called on completion, must take no parameters
+        """
         # do action
         self.worker = self.worker_pool.createWorker(target=action, args=args)
         self.worker.finished.connect(lambda: self._enableButtons(True))  # re-enable panel buttons on finish

--- a/src/snapred/ui/threading/worker_pool.py
+++ b/src/snapred/ui/threading/worker_pool.py
@@ -26,7 +26,7 @@ class Worker(QObject):
         """Long-running task."""
         try:
             if self.args is not None:
-                results = self.target(self.args)
+                results = self.target(*self.args)
             else:
                 results = self.target()
             # results.code = 200 # set to 200 for testing

--- a/src/snapred/ui/threading/worker_pool.py
+++ b/src/snapred/ui/threading/worker_pool.py
@@ -25,8 +25,10 @@ class Worker(QObject):
     def run(self):
         """Long-running task."""
         try:
-            if self.args is not None:
+            if isinstance(self.args, tuple):
                 results = self.target(*self.args)
+            elif self.args is not None:
+                results = self.target(self.args)
             else:
                 results = self.target()
             # results.code = 200 # set to 200 for testing

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -1,8 +1,5 @@
 from mantid.simpleapi import mtd
 from qtpy.QtCore import Slot
-from qtpy.QtWidgets import (
-    QMessageBox,
-)
 
 from snapred.backend.dao import RunConfig
 from snapred.backend.dao.indexing.IndexEntry import IndexEntry
@@ -21,7 +18,7 @@ from snapred.backend.dao.request import (
     HasStateRequest,
     SimpleDiffCalRequest,
 )
-from snapred.backend.dao.SNAPResponse import SNAPResponse
+from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.FitMultiplePeaksAlgorithm import FitOutputEnum
@@ -136,6 +133,10 @@ class DiffCalWorkflow(WorkflowImplementer):
         self._continueAnywayHandler(continueInfo)
         self._tweakPeakView.updateContinueAnyway(True)
 
+    def __setInteraction(self, state: bool):
+        self._requestView.litemodeToggle.setEnabled(state)
+        self._requestView.groupingFileDropdown.setEnabled(state)
+
     @ExceptionToErrLog
     @Slot()
     def _populateGroupingDropdown(self):
@@ -143,34 +144,34 @@ class DiffCalWorkflow(WorkflowImplementer):
         runNumber = self._requestView.runNumberField.text()
         useLiteMode = self._requestView.litemodeToggle.field.getState()
 
-        self._requestView.groupingFileDropdown.setEnabled(False)
-        self._requestView.litemodeToggle.setEnabled(False)
-        # TODO: Use threads, account for fail cases
-        try:
-            # check if the state exists -- if so load its grouping map
-            payload = HasStateRequest(
-                runId=runNumber,
-                useLiteMode=useLiteMode,
-            )
-            hasState = self.request(path="calibration/hasState", payload=payload.json()).data
-            if hasState:
-                self.groupingMap = self.request(path="config/groupingMap", payload=runNumber).data
-            else:
-                self.groupingMap = self.defaultGroupingMap
-            self.focusGroups = self.groupingMap.getMap(useLiteMode)
+        self.__setInteraction(False)
+        self.workflow.presenter.handleAction(
+            self.handleDropdown,
+            args=(runNumber, useLiteMode),
+            onSuccess=lambda: self.__setInteraction(True),
+        )
 
-            # populate and re-enable the drop down
-            self._requestView.populateGroupingDropdown(list(self.focusGroups.keys()))
-        except Exception as e:  # noqa BLE001
-            print(e)
+    def handleDropdown(self, runNumber, useLiteMode):
+        # check if the state exists -- if so load its grouping map
+        payload = HasStateRequest(
+            runId=runNumber,
+            useLiteMode=useLiteMode,
+        )
+        hasState = self.request(path="calibration/hasState", payload=payload.json()).data
+        if hasState:
+            self.groupingMap = self.request(path="config/groupingMap", payload=runNumber).data
+        else:
+            self.groupingMap = self.defaultGroupingMap
+        self.focusGroups = self.groupingMap.getMap(useLiteMode)
 
-        self._requestView.groupingFileDropdown.setEnabled(True)
-        self._requestView.litemodeToggle.setEnabled(True)
+        # populate and re-enable the drop down
+        self._requestView.populateGroupingDropdown(list(self.focusGroups.keys()))
+        return SNAPResponse(code=ResponseCode.OK)
 
     @ExceptionToErrLog
     @Slot()
     def _switchLiteNativeGroups(self):
-        # when the run number is updated, freeze the drop down to populate it
+        # determine resolution mode
         useLiteMode = self._requestView.litemodeToggle.field.getState()
         self._tweakPeakView.litemodeToggle.field.setState(useLiteMode)
 
@@ -180,14 +181,17 @@ class DiffCalWorkflow(WorkflowImplementer):
         self._requestView.skipPixelCalToggle.field.setState(not useLiteMode)
 
         self._requestView.groupingFileDropdown.setEnabled(False)
-        # TODO: Use threads, account for fail cases
-        try:
-            self.focusGroups = self.groupingMap.getMap(useLiteMode)
-            self._requestView.populateGroupingDropdown(list(self.focusGroups.keys()))
-        except Exception as e:  # noqa BLE001
-            print(e)
 
-        self._requestView.groupingFileDropdown.setEnabled(True)
+        self.workflow.presenter.handleAction(
+            self.handleSwitchLiteNative,
+            args=(useLiteMode,),
+            onSuccess=lambda: self._requestView.groupingFileDropdown.setEnabled(True),
+        )
+
+    def handleSwitchLiteNative(self, useLiteMode):
+        self.focusGroups = self.groupingMap.getMap(useLiteMode)
+        self._requestView.populateGroupingDropdown(list(self.focusGroups.keys()))
+        return SNAPResponse(code=ResponseCode.OK)
 
     @Slot(WorkflowPresenter, result=SNAPResponse)
     def _specifyRun(self, workflowPresenter):
@@ -260,59 +264,61 @@ class DiffCalWorkflow(WorkflowImplementer):
 
     @ExceptionToErrLog
     @Slot(int, float, float, SymmetricPeakEnum, Pair, float)
-    def onValueChange(self, groupingIndex, xtalDMin, xtalDMax, peakFunction, fwhm, maxChiSq):
+    def onValueChange(self, *args):
         self._tweakPeakView.disableRecalculateButton()
-        # TODO: This is a temporary solution,
-        # this should have never been setup to all run on the same thread.
-        # It assumed an exception would never be tossed and thus
-        # would never enable the recalc button again if one did
-        try:
-            self.focusGroupPath = list(self.focusGroups.items())[groupingIndex][0]
+        self.workflow.presenter.handleAction(
+            self.renewWhenRecalculate,
+            args=args,
+            onSuccess=self._tweakPeakView.enableRecalculateButton,
+        )
 
-            # if peaks will change, redo only the smoothing
-            if (
-                xtalDMin != self.prevXtalDMin
-                or xtalDMax != self.prevXtalDMax
-                or peakFunction != self.peakFunction
-                or fwhm != self.prevFWHM
-                or maxChiSq != self.maxChiSq
-                or self.peaksWerePurged
-            ):
-                self._renewIngredients(xtalDMin, xtalDMax, peakFunction, fwhm, maxChiSq)
-                self._renewFitPeaks(peakFunction)
-                self._calculateResidual()
-                self.peaksWerePurged = False
+    def renewWhenRecalculate(self, groupingIndex, xtalDMin, xtalDMax, peakFunction, fwhm, maxChiSq):
+        self._tweakPeakView.disableRecalculateButton()
 
-            # if the grouping file changes, load new grouping and refocus
-            if groupingIndex != self.prevGroupingIndex:
-                self._renewIngredients(xtalDMin, xtalDMax, peakFunction, fwhm, maxChiSq)
-                self._renewFocus(groupingIndex)
-                self._renewFitPeaks(peakFunction)
-                self._calculateResidual()
+        self.focusGroupPath = list(self.focusGroups.items())[groupingIndex][0]
 
-            # NOTE it was determined pixel calibration NOT need to be re-calculated when peak params change.
-            # However, if this requirement changes, the if at L282 should be combined with the if at 269,
-            # and the order should be _renewIngredients --> _renewPixelCal --> _renewFocus --> _renewFitPeaks
+        # if peaks will change, redo only the smoothing
+        if (
+            xtalDMin != self.prevXtalDMin
+            or xtalDMax != self.prevXtalDMax
+            or peakFunction != self.peakFunction
+            or fwhm != self.prevFWHM
+            or maxChiSq != self.maxChiSq
+            or self.peaksWerePurged
+        ):
+            self._renewIngredients(xtalDMin, xtalDMax, peakFunction, fwhm, maxChiSq)
+            self._renewFitPeaks(peakFunction)
+            self._calculateResidual()
 
-            self._tweakPeakView.updateGraphs(
-                self.focusedWorkspace,
-                self.ingredients.groupedPeakLists,
-                self.fitPeaksDiagnostic,
-                self.residualWorkspace,
-            )
+        # if the grouping file changes, load new grouping and refocus
+        if groupingIndex != self.prevGroupingIndex:
+            self._renewIngredients(xtalDMin, xtalDMax, peakFunction, fwhm, maxChiSq)
+            self._renewFocus(groupingIndex)
+            self._renewFitPeaks(peakFunction)
+            self._calculateResidual()
 
-            # update the values for next call to this method
-            self.prevXtalDMin = xtalDMin
-            self.prevXtalDMax = xtalDMax
-            self.prevFWHM = fwhm
-            self.peakFunction = peakFunction
-            self.prevGroupingIndex = groupingIndex
-            self.maxChiSq = maxChiSq
-        except Exception as e:  # noqa BLE001
-            print(e)
+        self.peaksWerePurged = False
 
-        # renable button when graph is updated
-        self._tweakPeakView.enableRecalculateButton()
+        # NOTE it was determined pixel calibration NOT need to be re-calculated when peak params change.
+        # However, if this requirement changes, the if at L282 should be combined with the if at 269,
+        # and the order should be _renewIngredients --> _renewPixelCal --> _renewFocus --> _renewFitPeaks
+
+        self._tweakPeakView.updateGraphs(
+            self.focusedWorkspace,
+            self.ingredients.groupedPeakLists,
+            self.fitPeaksDiagnostic,
+            self.residualWorkspace,
+        )
+
+        # update the values for next call to this method
+        self.prevXtalDMin = xtalDMin
+        self.prevXtalDMax = xtalDMax
+        self.prevFWHM = fwhm
+        self.peakFunction = peakFunction
+        self.prevGroupingIndex = groupingIndex
+        self.maxChiSq = maxChiSq
+
+        return SNAPResponse(code=ResponseCode.OK)
 
     def _createDiffCalRequest(self, xtalDMin, xtalDMax, peakFunction, fwhm, maxChiSq) -> DiffractionCalibrationRequest:
         """
@@ -389,49 +395,49 @@ class DiffCalWorkflow(WorkflowImplementer):
     @Slot(float)
     def purgeBadPeaks(self, maxChiSq):
         self._tweakPeakView.disableRecalculateButton()
-        try:
-            # update the max chi sq
-            self.maxChiSq = maxChiSq
-            allPeaks = self.ingredients.groupedPeakLists
-            param_table = mtd[self.fitPeaksDiagnostic].getItem(FitOutputEnum.Parameters.value).toDict()
-            index = param_table["wsindex"]
-            allChi2 = param_table["chi2"]
-            goodPeaks = []
-            for wkspIndex, groupPeaks in enumerate(allPeaks):
-                peaks = groupPeaks.peaks
-                # collect the fit chi-sq parameters for this spectrum, and the fits
-                chi2 = [x2 for i, x2 in zip(index, allChi2) if i == wkspIndex]
-                goodPeaks.append([peak for x2, peak in zip(chi2, peaks) if x2 < maxChiSq])
-            too_fews = [goodPeak for goodPeak in goodPeaks if len(goodPeak) < 2]
-            if too_fews != []:
-                QMessageBox.critical(
-                    self._tweakPeakView,
-                    "Too Few Peaks",
-                    "Purging would result in fewer than the required 2 peaks for calibration.  "
-                    "The current set of peaks will be retained.",
-                    QMessageBox.Ok,
-                )
-            else:
-                for wkspIndex, groupPeaks in enumerate(allPeaks):
-                    groupPeaks.peaks = goodPeaks[wkspIndex]
-                self.peaksWerePurged = True
+        self.workflow.presenter.handleAction(
+            self._purgeBadPeaks,
+            args=(maxChiSq,),
+            onSuccess=self._tweakPeakView.enableRecalculateButton,
+        )
 
-            # renew the fits to the peaks
-            self._renewFitPeaks(self.peakFunction)
+    def _purgeBadPeaks(self, maxChiSq):
+        # update the max chi sq
+        self.maxChiSq = maxChiSq
+        allPeaks = self.ingredients.groupedPeakLists
+        param_table = mtd[self.fitPeaksDiagnostic].getItem(FitOutputEnum.Parameters.value).toDict()
+        index = param_table["wsindex"]
+        allChi2 = param_table["chi2"]
+        goodPeaks = []
+        for wkspIndex, groupPeaks in enumerate(allPeaks):
+            peaks = groupPeaks.peaks
+            # collect the fit chi-sq parameters for this spectrum, and the fits
+            chi2 = [x2 for i, x2 in zip(index, allChi2) if i == wkspIndex]
+            goodPeaks.append([peak for x2, peak in zip(chi2, peaks) if x2 < maxChiSq])
+        too_fews = [goodPeak for goodPeak in goodPeaks if len(goodPeak) < 2]
+        if too_fews != []:
+            msg = """
+            Too Few Peaks
+            Purging would result in fewer than the required 2 peaks for calibration.
+            The current set of peaks will be retained.,
+            """
+            raise RuntimeError(msg)
+        else:
+            for wkspIndex, originalGroupPeaks in enumerate(allPeaks):
+                originalGroupPeaks.peaks = goodPeaks[wkspIndex]
+            self.ingredients.groupedPeakLists = allPeaks
+            self.peaksWerePurged = True
 
-            # update graph with reduced peak list
-            self._tweakPeakView.updateGraphs(
-                self.focusedWorkspace,
-                self.ingredients.groupedPeakLists,
-                self.fitPeaksDiagnostic,
-            )
+        # renew the fits to the peaks
+        self._renewFitPeaks(self.peakFunction)
 
-        except Exception as e:  # noqa BLE001
-            # NOTE this has the same issue as onValueChange
-            print(e)
-
-        # renable button when graph is updated
-        self._tweakPeakView.enableRecalculateButton()
+        # update graph with reduced peak list
+        self._tweakPeakView.updateGraphs(
+            self.focusedWorkspace,
+            self.ingredients.groupedPeakLists,
+            self.fitPeaksDiagnostic,
+        )
+        return SNAPResponse(code=ResponseCode.OK)
 
     @Slot(WorkflowPresenter, result=SNAPResponse)
     def _triggerDiffractionCalibration(self, workflowPresenter):

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -419,7 +419,7 @@ class DiffCalWorkflow(WorkflowImplementer):
             msg = """
             Too Few Peaks
             Purging would result in fewer than the required 2 peaks for calibration.
-            The current set of peaks will be retained.,
+            The current set of peaks will be retained.
             """
             raise RuntimeError(msg)
         else:
@@ -436,6 +436,7 @@ class DiffCalWorkflow(WorkflowImplementer):
             self.focusedWorkspace,
             self.ingredients.groupedPeakLists,
             self.fitPeaksDiagnostic,
+            self.residualWorkspace,
         )
         return SNAPResponse(code=ResponseCode.OK)
 
@@ -474,7 +475,7 @@ class DiffCalWorkflow(WorkflowImplementer):
             maxChiSq=self.maxChiSq,
         )
 
-        response = self.request(path="calibration/assessment", payload=payload.json())
+        response = self.request(path="calibration/assessment", payload=payload)
         assessmentResponse = response.data
         self.calibrationRecord = assessmentResponse.record
 

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -83,6 +83,10 @@ class NormalizationWorkflow(WorkflowImplementer):
             .build()
         )
 
+    def __setInteraction(self, state: bool):
+        self._requestView.litemodeToggle.setEnabled(state)
+        self._requestView.groupingFileDropdown.setEnabled(state)
+
     @EntryExitLogger(logger=logger)
     @ExceptionToErrLog
     @Slot()
@@ -91,28 +95,28 @@ class NormalizationWorkflow(WorkflowImplementer):
         runNumber = self._requestView.runNumberField.text()
         self.useLiteMode = self._requestView.litemodeToggle.field.getState()
 
-        self._requestView.litemodeToggle.setEnabled(False)
-        self._requestView.groupingFileDropdown.setEnabled(False)
-        # TODO: Use threads, account for fail cases
-        try:
-            # check if the state exists -- if so load its grouping map
-            payload = HasStateRequest(
-                runId=runNumber,
-                useLiteMode=self.useLiteMode,
-            )
-            hasState = self.request(path="calibration/hasState", payload=payload.json()).data
-            if hasState:
-                self.groupingMap = self.request(path="config/groupingMap", payload=runNumber).data
-            else:
-                self.groupingMap = self.defaultGroupingMap
-            self.focusGroups = self.groupingMap.getMap(self.useLiteMode)
+        self.__setInteraction(False)
+        self.workflow.presenter.handleAction(
+            self.handleDropdown,
+            args=(runNumber, self.useLiteMode),
+            onSuccess=lambda: self.__setInteraction(True),
+        )
 
-            # populate and reenable the drop down
-            self._requestView.populateGroupingDropdown(list(self.focusGroups.keys()))
-        except Exception as e:  # noqa BLE001
-            print(e)
-        self._requestView.litemodeToggle.setEnabled(True)
-        self._requestView.groupingFileDropdown.setEnabled(True)
+    def handleDropdown(self, runNumber, useLiteMode):
+        # check if the state exists -- if so load its grouping map
+        payload = HasStateRequest(
+            runId=runNumber,
+            useLiteMode=useLiteMode,
+        )
+        hasState = self.request(path="calibration/hasState", payload=payload.json()).data
+        if hasState:
+            self.groupingMap = self.request(path="config/groupingMap", payload=runNumber).data
+        else:
+            self.groupingMap = self.defaultGroupingMap
+        self.focusGroups = self.groupingMap.getMap(useLiteMode)
+
+        # populate and reenable the drop down
+        self._requestView.populateGroupingDropdown(list(self.focusGroups.keys()))
 
     @EntryExitLogger(logger=logger)
     @ExceptionToErrLog
@@ -122,14 +126,16 @@ class NormalizationWorkflow(WorkflowImplementer):
         useLiteMode = self._requestView.litemodeToggle.field.getState()
 
         self._requestView.groupingFileDropdown.setEnabled(False)
-        # TODO: Use threads, account for fail cases
-        try:
-            self.focusGroups = self.groupingMap.getMap(useLiteMode)
-            self._requestView.populateGroupingDropdown(list(self.focusGroups.keys()))
-        except Exception as e:  # noqa BLE001
-            print(e)
 
-        self._requestView.groupingFileDropdown.setEnabled(True)
+        self.workflow.presenter.handleAction(
+            self.handleSwitchLiteNative,
+            args=(useLiteMode,),
+            onSuccess=lambda: self._requestView.groupingFileDropdown.setEnabled(True),
+        )
+
+    def handleSwitchLiteNative(self, useLiteMode):
+        self.focusGroups = self.groupingMap.getMap(useLiteMode)
+        self._requestView.populateGroupingDropdown(list(self.focusGroups.keys()))
 
     @EntryExitLogger(logger=logger)
     @Slot(WorkflowPresenter, result=SNAPResponse)
@@ -292,45 +298,42 @@ class NormalizationWorkflow(WorkflowImplementer):
     @EntryExitLogger(logger=logger)
     @ExceptionToErrLog
     @Slot(int, float, float, float)
-    def onNormalizationValueChange(self, index, smoothingValue, xtalDMin, xtalDMax):  # noqa: ARG002
+    def onNormalizationValueChange(self, *args):  # noqa: ARG002
         if not self.initializationComplete:
             return
         # disable recalculate button
         self._tweakPeakView.disableRecalculateButton()
-        # TODO: This is a temporary solution,
-        # this should have never been setup to all run on the same thread.
-        # It assumed an exception would never be tossed and thus
-        # would never enable the recalc button again if one did
-        try:
-            # if the grouping file change, redo whole calculation
-            groupingFileChanged = index != self.prevGroupingIndex
-            # if peaks will change, redo only the smoothing
-            smoothingValueChanged = self.prevSmoothingParameter != smoothingValue
-            xtalDMinValueChanged = xtalDMin != self.prevXtalDMin
-            xtalDMaxValueChanged = xtalDMax != self.prevXtalDMax
-            peakListWillChange = smoothingValueChanged or xtalDMinValueChanged or xtalDMaxValueChanged
+        self.workflow.presenter.handleAction(
+            self.renewWhenRecalculate,
+            args=args,
+            onSuccess=self._tweakPeakView.enableRecalculateButton,
+        )
 
-            # check the case, apply correct update
-            if groupingFileChanged:
-                self.callNormalization(index, smoothingValue, xtalDMin, xtalDMax)
-            elif peakListWillChange:
-                self.applySmoothingUpdate(index, smoothingValue, xtalDMin, xtalDMax)
-            elif "focusedVanadium" in self.responses[-1].data and "smoothedVanadium" in self.responses[-1].data:
-                # if nothing changed but this function was called anyway... just replot stuff with old values
-                focusWorkspace = self.responses[-1].data["focusedVanadium"]
-                smoothWorkspace = self.responses[-1].data["smoothedVanadium"]
-                peaks = self.responses[-1].data["detectorPeaks"]
-                self._tweakPeakView.updateWorkspaces(focusWorkspace, smoothWorkspace, peaks)
-            else:
-                raise Exception("Expected data not found in the last response")
+    def renewWhenRecalculate(self, index, smoothingValue, xtalDMin, xtalDMax):
+        # if the grouping file change, redo whole calculation
+        groupingFileChanged = index != self.prevGroupingIndex
+        # if peaks will change, redo only the smoothing
+        smoothingValueChanged = self.prevSmoothingParameter != smoothingValue
+        xtalDMinValueChanged = xtalDMin != self.prevXtalDMin
+        xtalDMaxValueChanged = xtalDMax != self.prevXtalDMax
+        peakListWillChange = smoothingValueChanged or xtalDMinValueChanged or xtalDMaxValueChanged
 
-            # update the values for next call to this method
-            self.prevGroupingIndex = index
-            self.prevSmoothingParameter = smoothingValue
-            self.prevXtalDMin = xtalDMin
-            self.prevXtalDMax = xtalDMax
-        except Exception as e:  # noqa BLE001
-            print(e)
+        # check the case, apply correct update
+        if groupingFileChanged:
+            self.callNormalization(index, smoothingValue, xtalDMin, xtalDMax)
+        elif peakListWillChange:
+            self.applySmoothingUpdate(index, smoothingValue, xtalDMin, xtalDMax)
+        elif "focusedVanadium" in self.responses[-1].data and "smoothedVanadium" in self.responses[-1].data:
+            # if nothing changed but this function was called anyway... just replot stuff with old values
+            focusWorkspace = self.responses[-1].data["focusedVanadium"]
+            smoothWorkspace = self.responses[-1].data["smoothedVanadium"]
+            peaks = self.responses[-1].data["detectorPeaks"]
+            self._tweakPeakView.updateWorkspaces(focusWorkspace, smoothWorkspace, peaks)
+        else:
+            raise Exception("Expected data not found in the last response")
 
-        # renable button when graph is updated
-        self._tweakPeakView.enableRecalculateButton()
+        # update the values for next call to this method
+        self.prevGroupingIndex = index
+        self.prevSmoothingParameter = smoothingValue
+        self.prevXtalDMin = xtalDMin
+        self.prevXtalDMax = xtalDMax

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -11,7 +11,7 @@ from snapred.backend.dao.request import (
     NormalizationRequest,
 )
 from snapred.backend.dao.request.SmoothDataExcludingPeaksRequest import SmoothDataExcludingPeaksRequest
-from snapred.backend.dao.SNAPResponse import SNAPResponse
+from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.backend.log.logger import snapredLogger
 from snapred.meta.decorators.EntryExitLogger import EntryExitLogger
 from snapred.meta.decorators.ExceptionToErrLog import ExceptionToErrLog
@@ -117,6 +117,7 @@ class NormalizationWorkflow(WorkflowImplementer):
 
         # populate and reenable the drop down
         self._requestView.populateGroupingDropdown(list(self.focusGroups.keys()))
+        return SNAPResponse(code=ResponseCode.OK)
 
     @EntryExitLogger(logger=logger)
     @ExceptionToErrLog
@@ -136,6 +137,7 @@ class NormalizationWorkflow(WorkflowImplementer):
     def handleSwitchLiteNative(self, useLiteMode):
         self.focusGroups = self.groupingMap.getMap(useLiteMode)
         self._requestView.populateGroupingDropdown(list(self.focusGroups.keys()))
+        return SNAPResponse(code=ResponseCode.OK)
 
     @EntryExitLogger(logger=logger)
     @Slot(WorkflowPresenter, result=SNAPResponse)
@@ -337,3 +339,5 @@ class NormalizationWorkflow(WorkflowImplementer):
         self.prevSmoothingParameter = smoothingValue
         self.prevXtalDMin = xtalDMin
         self.prevXtalDMax = xtalDMax
+
+        return SNAPResponse(code=ResponseCode.OK)

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -129,6 +129,7 @@ class ReductionWorkflow(WorkflowImplementer):
 
         # Populate the dropdown with the mask names.
         self._reductionRequestView.pixelMaskDropdown.setItems(list(self._compatibleMasks.keys()))
+        return SNAPResponse(code=ResponseCode.OK)
 
     def _validateRunNumbers(self, runNumbers: List[str]):
         # For now, all run numbers in a reduction batch must be from the same instrument state.

--- a/tests/unit/ui/workflow/test_DiffCalWorkflow.py
+++ b/tests/unit/ui/workflow/test_DiffCalWorkflow.py
@@ -8,9 +8,7 @@ from mantid.simpleapi import (
     GroupWorkspaces,
     mtd,
 )
-
 from qtpy.QtWidgets import QMessageBox
-
 
 from snapred.meta.mantid.FitPeaksOutput import FIT_PEAK_DIAG_SUFFIX, FitOutputEnum
 from snapred.meta.pointer import create_pointer

--- a/tests/unit/ui/workflow/test_DiffCalWorkflow.py
+++ b/tests/unit/ui/workflow/test_DiffCalWorkflow.py
@@ -49,12 +49,21 @@ def test_purge_bad_peaks(workflowRequest, qtbot):  # noqa: ARG001
     )
     diffcalWorkflow.fitPeaksDiagnostic = diagWS
     diffcalWorkflow.peakFunction = "gaussian"
+    diffcalWorkflow.residualWorkspace = ws1
     diffcalWorkflow.focusedWorkspace = ws1
     diffcalWorkflow._renewFitPeaks = MagicMock()
     diffcalWorkflow._tweakPeakView.updateGraphs = MagicMock()
 
     diffcalWorkflow._purgeBadPeaks(maxChiSq)
     assert diffcalWorkflow.ingredients.groupedPeakLists[0].peaks == good_peaks
+
+    diffcalWorkflow._renewFitPeaks.assert_called_once_with(diffcalWorkflow.peakFunction)
+    diffcalWorkflow._tweakPeakView.updateGraphs.assert_called_once_with(
+        diffcalWorkflow.focusedWorkspace,
+        diffcalWorkflow.ingredients.groupedPeakLists,
+        diffcalWorkflow.fitPeaksDiagnostic,
+        diffcalWorkflow.residualWorkspace,
+    )
 
 
 @patch("snapred.ui.workflow.DiffCalWorkflow.WorkflowImplementer.request")
@@ -100,6 +109,7 @@ def test_purge_bad_peaks_two_wkspindex(workflowRequest, qtbot):  # noqa: ARG001
     )
     diffcalWorkflow.fitPeaksDiagnostic = diagWS
     diffcalWorkflow.peakFunction = "gaussian"
+    diffcalWorkflow.residualWorkspace = ws1
     diffcalWorkflow.focusedWorkspace = ws1
     diffcalWorkflow._renewFitPeaks = MagicMock()
     diffcalWorkflow._tweakPeakView.updateGraphs = MagicMock()
@@ -113,6 +123,7 @@ def test_purge_bad_peaks_two_wkspindex(workflowRequest, qtbot):  # noqa: ARG001
         diffcalWorkflow.focusedWorkspace,
         diffcalWorkflow.ingredients.groupedPeakLists,
         diffcalWorkflow.fitPeaksDiagnostic,
+        diffcalWorkflow.residualWorkspace,
     )
 
 


### PR DESCRIPTION
## Description of work

There are some processes which take place inside workflows.  It is important these be able to return errors.   Many of these methods were not sent to separate threads, which meant errors could not be handled through the universal error handling point.

This fixes that, providing a method for all workflows to call to easily send methods to  new thread.

## Explanation of work

Inside `WorkflowPresenter`, split off the functionality that handles actions on continue to handle any kind of action.

Updated the workflows to make use of this functionality, instead of their prior `try-catch` blocks that only logged errors to the output.

## To test

### Dev testing

This impacts the following parts of the UI:
 - groupings populated in the drop down
 - recalculation on peak-tweak parameters
 - purging peaks from diffcal workflow

Make sure these parts of the workflow are still completely correctly.

### CIS testing

N/A

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

There is no ticket for this work , but it supports other work in 

[EWM#7712](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7712)

### Verification

N/A

### Acceptance Criteria

N/A
