### PR TITLE
Allow user to skip pixelcal after pixelcal

### DIFF
--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -60,6 +60,9 @@ class DiffCalTweakPeakView(BackendRequestView):
         self.signalRunNumberUpdate.connect(self._updateRunNumber)
         self.signalMaxChiSqUpdate.connect(self._updateMaxChiSq)
 
+        # skip pixel calibration toggle
+        self.skipPixelCalToggle = self._labeledToggle("Skip Pixel Calibration", False)
+
         self.continueAnyway = False
         self.signalContinueAnyway.connect(self._updateContinueAnyway)
 
@@ -99,7 +102,8 @@ class DiffCalTweakPeakView(BackendRequestView):
 
         # add all elements to the grid layout
         self.layout.addWidget(self.runNumberField, 0, 0)
-        self.layout.addWidget(self.litemodeToggle, 0, 1)
+        self.layout.addWidget(self.litemodeToggle, 0, 1, 1, 2)
+        self.layout.addWidget(self.skipPixelCalToggle, 0, 2)
         self.layout.addWidget(self.navigationBar, 1, 0)
         self.layout.addWidget(self.canvas, 2, 0, 1, -1)
         self.layout.addLayout(peakControlLayout, 3, 0, 1, 2)
@@ -318,3 +322,6 @@ class DiffCalTweakPeakView(BackendRequestView):
             self._testContinueAnywayStates()
 
         return True
+
+    def getSkipPixelCalibration(self):
+        return self.skipPixelCalToggle.field.getState()


### PR DESCRIPTION
## Description of work

If the user performs pixel calibration, but sees that it did not do anything positive, allow the user from the tweak peak stage to elect to skip pixel calibration and recalculate.

## Explanation of work

After all the other changes, this was very trivial.

Add a new button to tweak peak view for skipping pixel calibration, and add a check if the user changes their initial selection.

If the initial selection changes, recalculate with/without pixel calibration.

## To test

### Dev testing

Run diffraction with 46680, skip pixel toggle set to False.

It should fail.  In the workspace list, open the two table workspaces, `diffract_consts_default_v0` and `diffract_const_046680`.  Compare, and ensure these are not equal workspaces.

Right-click on `diffract_const_046680` and rename it to something obvious so that it is not overwritten.

Set Skip Pixel Cal toggle to True and continue.  There may be a warning about a workspace already loaded.

Set Skip Pixel Cal toggle to False and press Recalculate.  The same warning will come up.  Close it.

Compare the new `diffract_const_046680` to the original.  They should be identical. This proves the workflow is being re-run without skipping pixel calibration.

Change the grouping and recalculate.  Make sure it works.

Change the grouping **and** a dMin and recalculate.  Make sure it works.

Change **only** a dMin and recalculate.  Make sure it works.

Continue to save.  You'll have to set Skip Pixel Cal to True and change the FWHM to 4 and Recalculate to continue.


### CIS testing

As above, but I suggest 58882.  Make sure to inspect the before/after files in slice viewer.  Make sure you can find them and they make sense.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#7712](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7712)

### Verification

- [X] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

**NOTE** Following conversation with Malcolm, the behavior of iterating pixelcal is not necessary as there are no parameters to adjust.

- [X] ~~after pixel calibration, user has available two d-spacing unfocussed workspaces reflecting separately the input calibration and the output calibration (i.e. application of the pixel-calibration-generated DIFC values).~~ **already met in PR #511**
- [X] ~~The user can continue to next stage of workflow if desired~~ **already met**
- [ ] Or, the user can repeat pixel calibration, opting to completey reset DIFCs to their original values
- [ ] The user has access to a UI element to select from the above options
- [ ] The user can repeat pixel calibration an arbitrary number of times (note: they can, but it doesn't do much)
- [ ] Conducting N iterations, where N>2 should not cause further increase in RAM usage
