### PR TITLE
fix inputs for Artificial Norm

### DIFF
--- a/src/snapred/ui/view/reduction/ArtificialNormalizationView.py
+++ b/src/snapred/ui/view/reduction/ArtificialNormalizationView.py
@@ -104,8 +104,8 @@ class ArtificialNormalizationView(BackendRequestView):
         # verify the fields before recalculation
         try:
             smoothingValue = float(self.smoothingSlider.field.text())
-            lss = self.lssDropdown.currentIndex() == "True"
-            decreaseParameter = self.decreaseParameterDropdown.currentIndex == "True"
+            lss = self.lssDropdown.getValue()
+            decreaseParameter = self.decreaseParameterDropdown.getValue()
             peakWindowClippingSize = int(self.peakWindowClippingSize.field.text())
         except ValueError as e:
             QMessageBox.warning(
@@ -193,7 +193,7 @@ class ArtificialNormalizationView(BackendRequestView):
         return float(self.smoothingSlider.field.text())
 
     def getLSS(self):
-        return self.lssDropdown.currentIndex() == 1
+        return self.lssDropdown.getValue()
 
     def getDecreaseParameter(self):
-        return self.decreaseParameterDropdown.currentIndex() == 1
+        return self.decreaseParameterDropdown.getValue()

--- a/src/snapred/ui/widget/TrueFalseDropDown.py
+++ b/src/snapred/ui/widget/TrueFalseDropDown.py
@@ -29,3 +29,6 @@ class TrueFalseDropDown(QWidget):
 
     def currentText(self):
         return self.dropDown.currentText()
+
+    def getValue(self):
+        return self.currentText() == "True"

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -232,7 +232,9 @@ class ReductionWorkflow(WorkflowImplementer):
         # SPECIAL FOR THE REDUCTION WORKFLOW: clear everything _except_ the output workspaces
         #   _before_ transitioning to the "save" panel.
         # TODO: make '_clearWorkspaces' a public method (i.e make this combination a special `cleanup` method).
-        self._clearWorkspaces(exclude=self.outputs, clearCachedWorkspaces=True)
+
+        # NOTE: should this not occur in the 'finalizeReduction' method?
+        # self._clearWorkspaces(exclude=self.outputs, clearCachedWorkspaces=True)
         return self.responses[-1]
 
     def _artificialNormalization(self, workflowPresenter, responseData, runNumber):
@@ -243,8 +245,8 @@ class ReductionWorkflow(WorkflowImplementer):
             useLiteMode=self.useLiteMode,
             peakWindowClippingSize=int(self._artificialNormalizationView.peakWindowClippingSize.field.text()),
             smoothingParameter=self._artificialNormalizationView.getSmoothingParameter(),
-            decreaseParameter=self._artificialNormalizationView.decreaseParameterDropdown.currentIndex() == 1,
-            lss=self._artificialNormalizationView.lssDropdown.currentIndex() == 1,
+            decreaseParameter=self._artificialNormalizationView.decreaseParameterDropdown.getValue(),
+            lss=self._artificialNormalizationView.lssDropdown.getValue(),
             diffractionWorkspace=responseData,
         )
         response = self.request(path="reduction/artificialNormalization", payload=request_)


### PR DESCRIPTION
## Description of work

Standardized the way we read bools from the true/false dropdowns, they were being read incorrectly
This might also inadvertantly located where we were going wrong for this retain workspaces bug. 


## To test

Initialize a state, run reduction on `59039` with art norm, confirm that in the preview window the art norm is updated when changing the flags from true to false.
Check the outputs with and without flags and confirm they are different.


## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#8374](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8374)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] This defect is to ensure the values specified in the UI match those that are applied (and the defaults should remain as they are: both true)

