### PR TITLE
Ewm8373 rebin normalization and reduction output correctly

### DIFF
--- a/src/snapred/backend/dao/ingredients/GenerateFocussedVanadiumIngredients.py
+++ b/src/snapred/backend/dao/ingredients/GenerateFocussedVanadiumIngredients.py
@@ -3,6 +3,7 @@ from typing import Optional
 from pydantic import BaseModel
 
 from snapred.backend.dao.GroupPeakList import GroupPeakList
+from snapred.backend.dao.ingredients.ArtificialNormalizationIngredients import ArtificialNormalizationIngredients
 from snapred.backend.dao.state.PixelGroup import PixelGroup
 from snapred.meta.Config import Config
 
@@ -14,3 +15,4 @@ class GenerateFocussedVanadiumIngredients(BaseModel):
     pixelGroup: PixelGroup
     # This can be None if we lack a calibration
     detectorPeaks: Optional[list[GroupPeakList]] = None
+    artificialNormalizationIngredients: Optional[ArtificialNormalizationIngredients] = None

--- a/src/snapred/backend/dao/ingredients/RebinFocussedGroupDataIngredients.py
+++ b/src/snapred/backend/dao/ingredients/RebinFocussedGroupDataIngredients.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+from snapred.backend.dao.state.PixelGroup import PixelGroup
+
+
+class RebinFocussedGroupDataIngredients(BaseModel):
+    pixelGroup: PixelGroup
+    preserveEvents: bool = False

--- a/src/snapred/backend/dao/ingredients/ReductionIngredients.py
+++ b/src/snapred/backend/dao/ingredients/ReductionIngredients.py
@@ -58,6 +58,7 @@ class ReductionIngredients(BaseModel):
             smoothingParameter=self.smoothingParameter,
             pixelGroup=self.pixelGroups[groupingIndex],
             detectorPeaks=self.getDetectorPeaks(groupingIndex),
+            artificialNormalizationIngredients=self.artificialNormalizationIngredients,
         )
 
     def applyNormalization(self, groupingIndex: int) -> ApplyNormalizationIngredients:

--- a/src/snapred/backend/dao/request/CreateArtificialNormalizationRequest.py
+++ b/src/snapred/backend/dao/request/CreateArtificialNormalizationRequest.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel
 
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
@@ -11,13 +11,7 @@ class CreateArtificialNormalizationRequest(BaseModel):
     decreaseParameter: bool = True
     lss: bool = True
     diffractionWorkspace: WorkspaceName
-    outputWorkspace: WorkspaceName = None
-
-    @root_validator(pre=True)
-    def set_output_workspace(cls, values):
-        if values.get("diffractionWorkspace") and not values.get("outputWorkspace"):
-            values["outputWorkspace"] = WorkspaceName(f"{values['diffractionWorkspace']}_artificialNorm")
-        return values
+    outputWorkspace: WorkspaceName
 
     class Config:
         arbitrary_types_allowed = True  # Allow arbitrary types like WorkspaceName

--- a/src/snapred/backend/recipe/RebinFocussedGroupDataRecipe.py
+++ b/src/snapred/backend/recipe/RebinFocussedGroupDataRecipe.py
@@ -1,0 +1,82 @@
+from typing import Any, Dict, Tuple
+
+from snapred.backend.dao.ingredients import RebinFocussedGroupDataIngredients as Ingredients
+from snapred.backend.log.logger import snapredLogger
+from snapred.backend.recipe.Recipe import Recipe
+from snapred.meta.Config import Config
+from snapred.meta.decorators.Singleton import Singleton
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
+
+logger = snapredLogger.getLogger(__name__)
+
+Pallet = Tuple[Ingredients, Dict[str, str]]
+
+
+@Singleton
+class RebinFocussedGroupDataRecipe(Recipe[Ingredients]):
+    NUM_BINS = Config["constants.ResampleX.NumberBins"]
+    LOG_BINNING = True
+
+    def mandatoryInputWorkspaces(self):
+        return {"inputWorkspace"}
+
+    def chopIngredients(self, ingredients: Ingredients):
+        """
+        Chops off the needed elements of the ingredients.
+        We are mostly concerned about the drange for a ResampleX operation.
+        """
+        self.pixelGroup = ingredients.pixelGroup
+        # The adjustment below is a temp fix, will be permanently fixed in EWM 6262
+        lowdSpacingCrop = Config["constants.CropFactors.lowdSpacingCrop"]
+        if lowdSpacingCrop < 0:
+            raise ValueError("Low d-spacing crop factor must be positive")
+
+        highdSpacingCrop = Config["constants.CropFactors.highdSpacingCrop"]
+        if highdSpacingCrop < 0:
+            raise ValueError("High d-spacing crop factor must be positive")
+
+        dMin = [x + lowdSpacingCrop for x in self.pixelGroup.dMin()]
+        dMax = [x - highdSpacingCrop for x in self.pixelGroup.dMax()]
+
+        if not dMax > dMin:
+            raise ValueError("d-spacing crop factors are too large -- resultant dMax must be > resultant dMin")
+        self.dMin = dMin
+        self.dMax = dMax
+        self.dBin = self.pixelGroup.dBin()
+
+        self.preserveEvents = ingredients.preserveEvents
+
+    def unbagGroceries(self, groceries: Dict[str, WorkspaceName]):
+        """
+        Unpacks the workspace data from the groceries.
+        The input sample data workpsace, inputworkspace, is required, in dspacing
+        The normalization workspace, normalizationWorkspace, is optional, in dspacing.
+        The background workspace, backgroundWorkspace, is optional, not implemented, in dspacing.
+        """
+        self.sampleWs = groceries["inputWorkspace"]
+
+    def queueAlgos(self):
+        """
+        Queues up the procesing algorithms for the recipe.
+        Requires: unbagged groceries and chopped ingredients.
+        """
+        self.mantidSnapper.RebinRagged(
+            "Rebinning workspace for group...",
+            InputWorkspace=self.sampleWs,
+            XMin=self.dMin,
+            XMax=self.dMax,
+            Delta=self.dBin,
+            OutputWorkspace=self.sampleWs,
+            PreserveEvents=self.preserveEvents,
+        )
+
+    # NOTE: Metaphorically, would ingredients better have been called Spices?
+    # Considering they are mostly never the meat of a recipe.
+    def cook(self, ingredients: Ingredients, groceries: Dict[str, str]) -> Dict[str, Any]:
+        """
+        Main interface method for the recipe.
+        Given the ingredients and groceries, it prepares, executes and returns the final workspace.
+        """
+        self.prep(ingredients, groceries)
+        self.execute()
+        return self.sampleWs

--- a/src/snapred/backend/recipe/Recipe.py
+++ b/src/snapred/backend/recipe/Recipe.py
@@ -22,10 +22,11 @@ class Recipe(ABC, Generic[Ingredients]):
         Sets up the recipe with the necessary utensils.
         """
         # NOTE: workaround, we just add an empty host algorithm.
-        if utensils is None:
-            utensils = Utensils()
-            utensils.PyInit()
-        self.mantidSnapper = utensils.mantidSnapper
+        self.utensils = utensils
+        if self.utensils is None:
+            self.utensils = Utensils()
+            self.utensils.PyInit()
+        self.mantidSnapper = self.utensils.mantidSnapper
 
     def __init_subclass__(cls) -> None:
         cls._Ingredients = get_args(cls.__orig_bases__[0])[0]  # type: ignore

--- a/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
+++ b/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
@@ -32,13 +32,13 @@ class ReductionGroupProcessingRecipe(Recipe[Ingredients]):
             "Converting to TOF...",
             InputWorkspace=self.rawInput,
             Target="TOF",
-            OutputWorkspace=self.rawInput,
+            OutputWorkspace=self.outputWS,
         )
 
         self.mantidSnapper.FocusSpectraAlgorithm(
             "Focusing Spectra...",
-            InputWorkspace=self.rawInput,
-            OutputWorkspace=self.rawInput,
+            InputWorkspace=self.outputWS,
+            OutputWorkspace=self.outputWS,
             GroupingWorkspace=self.groupingWS,
             Ingredients=self.pixelGroup.json(),
             RebinOutput=False,
@@ -46,10 +46,9 @@ class ReductionGroupProcessingRecipe(Recipe[Ingredients]):
 
         self.mantidSnapper.NormalizeByCurrentButTheCorrectWay(
             "Normalizing Current ... but the correct way!",
-            InputWorkspace=self.rawInput,
-            OutputWorkspace=self.rawInput,
+            InputWorkspace=self.outputWS,
+            OutputWorkspace=self.outputWS,
         )
-        self.outputWS = self.rawInput
 
     def mandatoryInputWorkspaces(self) -> Set[WorkspaceName]:
         return {"inputWorkspace", "groupingWorkspace"}

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -69,6 +69,7 @@ class WorkspaceType(str, Enum):
     RAW_VANADIUM = "rawVanadium"
     FOCUSED_RAW_VANADIUM = "focusedRawVanadium"
     SMOOTHED_FOCUSED_RAW_VANADIUM = "smoothedFocusedRawVanadium"
+    ARTIFICIAL_NORMALIZATION_PREVIEW = "artificialNormalizationPreview"
 
     # <reduction tag>_<runNumber>_<timestamp>
     REDUCTION_OUTPUT = "reductionOutput"
@@ -293,6 +294,10 @@ class _WorkspaceNameGenerator:
         TRUE = "lite"
         FALSE = ""
 
+    class ArtificialNormWorkspaceType:
+        PREVIEW = "preview"
+        SOURCE = "source"
+
     # TODO: Return abstract WorkspaceName type to help facilitate control over workspace names
     #       and discourage non-standard names.
     def run(self):
@@ -410,6 +415,16 @@ class _WorkspaceNameGenerator:
             self._delimiter,
             unit=self.Units.DSP,
             version=None,
+        )
+
+    def artificialNormalizationPreview(self):
+        return NameBuilder(
+            WorkspaceType.ARTIFICIAL_NORMALIZATION_PREVIEW,
+            self._normCalArtificialNormalizationPreviewTemplate,
+            self._normCalArtificialNormalizationPreviewTemplateKeys,
+            self._delimiter,
+            unit=self.Units.DSP,
+            type=self.ArtificialNormWorkspaceType.PREVIEW,
         )
 
     def reductionOutput(self):

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -126,6 +126,7 @@ mantid:
           rawVanadium: "{unit},{group},{runNumber},raw_van_corr,{version}"
           focusedRawVanadium: "{unit},{group},{runNumber},raw_van_corr,{version}"
           smoothedFocusedRawVanadium: "{unit},{group},{runNumber},fitted_van_corr,{version}"
+          artificialNormalizationPreview: "artificial_norm,{unit},{group},{runNumber},{type}"
         reduction:
           output: "reduced,{unit},{group},{runNumber},{timestamp}"
           outputGroup: "reduced,{runNumber},{timestamp}"

--- a/src/snapred/ui/view/reduction/ArtificialNormalizationView.py
+++ b/src/snapred/ui/view/reduction/ArtificialNormalizationView.py
@@ -105,8 +105,8 @@ class ArtificialNormalizationView(BackendRequestView):
         # verify the fields before recalculation
         try:
             smoothingValue = float(self.smoothingSlider.field.text())
-            lss = self.lssDropdown.currentIndex() == "True"
-            decreaseParameter = self.decreaseParameterDropdown.currentIndex == "True"
+            lss = self.lssDropdown.getValue()
+            decreaseParameter = self.decreaseParameterDropdown.getValue()
             peakWindowClippingSize = int(self.peakWindowClippingSize.field.text())
         except ValueError as e:
             QMessageBox.warning(
@@ -199,7 +199,7 @@ class ArtificialNormalizationView(BackendRequestView):
         return float(self.smoothingSlider.field.text())
 
     def getLSS(self):
-        return self.lssDropdown.currentIndex() == 1
+        return self.lssDropdown.getValue()
 
     def getDecreaseParameter(self):
-        return self.decreaseParameterDropdown.currentIndex() == 1
+        return self.decreaseParameterDropdown.getValue()

--- a/src/snapred/ui/widget/TrueFalseDropDown.py
+++ b/src/snapred/ui/widget/TrueFalseDropDown.py
@@ -29,3 +29,6 @@ class TrueFalseDropDown(QWidget):
 
     def currentText(self):
         return self.dropDown.currentText()
+
+    def getValue(self):
+        return self.currentText() == "True"

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -127,6 +127,7 @@ mantid:
             rawVanadium: "_{unit},{group},raw_van_corr,{runNumber},{version}"
             focusedRawVanadium: "_{unit},{group},raw_van_corr,{runNumber},{version}"
             smoothedFocusedRawVanadium: "_{unit},{group},fitted_van_corr,{runNumber},{version}"
+            artificialNormalizationPreview: "artificial_norm,{unit},{group},{runNumber},{type}"
           reduction:
             output: "_reduced,{unit},{group},{runNumber},{timestamp}"
             outputGroup: "_reduced,{runNumber},{timestamp}"

--- a/tests/unit/backend/recipe/algorithm/test_CreateArtificialNormalizationAlgo.py
+++ b/tests/unit/backend/recipe/algorithm/test_CreateArtificialNormalizationAlgo.py
@@ -42,7 +42,10 @@ class TestCreateArtificialNormalizationAlgo(unittest.TestCase):
         algo = Algo()
         algo.initialize()
         algo.setProperty("InputWorkspace", self.fakeRawData)
-        algo.setProperty("Ingredients", self.fakeIngredients.json())
+        algo.setProperty("decreaseParameter", self.fakeIngredients.decreaseParameter)
+        algo.setProperty("lss", self.fakeIngredients.lss)
+        algo.setProperty("peakWindowClippingSize", self.fakeIngredients.peakWindowClippingSize)
+        algo.setProperty("smoothingParameter", self.fakeIngredients.smoothingParameter)
         algo.setProperty("OutputWorkspace", "test_output_ws")
         originalData = []
         inputWs = mtd[self.fakeRawData]
@@ -70,7 +73,10 @@ class TestCreateArtificialNormalizationAlgo(unittest.TestCase):
         algo = Algo()
         algo.initialize()
         algo.setProperty("InputWorkspace", self.fakeRawData)
-        algo.setProperty("Ingredients", self.fakeIngredients.json())
+        algo.setProperty("decreaseParameter", self.fakeIngredients.decreaseParameter)
+        algo.setProperty("lss", self.fakeIngredients.lss)
+        algo.setProperty("peakWindowClippingSize", self.fakeIngredients.peakWindowClippingSize)
+        algo.setProperty("smoothingParameter", self.fakeIngredients.smoothingParameter)
         algo.setProperty("OutputWorkspace", "test_output_ws")
         assert algo.execute()
 
@@ -84,7 +90,10 @@ class TestCreateArtificialNormalizationAlgo(unittest.TestCase):
         algo = Algo()
         algo.initialize()
         algo.setProperty("InputWorkspace", self.fakeRawData)
-        algo.setProperty("Ingredients", self.fakeIngredients.json())
+        algo.setProperty("decreaseParameter", self.fakeIngredients.decreaseParameter)
+        algo.setProperty("lss", self.fakeIngredients.lss)
+        algo.setProperty("peakWindowClippingSize", self.fakeIngredients.peakWindowClippingSize)
+        algo.setProperty("smoothingParameter", self.fakeIngredients.smoothingParameter)
         algo.setProperty("OutputWorkspace", "test_output_ws")
         algo.execute()
         output_ws = mtd["test_output_ws"]

--- a/tests/unit/backend/recipe/test_RebinFocussedGroupDataRecipe.py
+++ b/tests/unit/backend/recipe/test_RebinFocussedGroupDataRecipe.py
@@ -1,0 +1,74 @@
+import unittest
+
+import pytest
+from mantid.api import MatrixWorkspace
+from mantid.simpleapi import (
+    CreateSampleWorkspace,
+    DeleteWorkspaces,
+    GroupDetectors,
+    mtd,
+)
+from util.Config_helpers import Config_override
+from util.dao import DAOFactory
+from util.SculleryBoy import SculleryBoy
+
+from snapred.backend.recipe.RebinFocussedGroupDataRecipe import RebinFocussedGroupDataRecipe as Recipe
+
+ThisRecipe: str = "snapred.backend.recipe.RebinFocussedGroupDataRecipe"
+
+
+class TestRebinFocussedGroupDataRecipe(unittest.TestCase):
+    sculleryBoy = SculleryBoy()
+
+    def setUp(self):
+        testCalibration = DAOFactory.calibrationRecord("57514", True, 1)
+        self.pixelGroup = testCalibration.pixelGroups[0]
+        self.pixelGroup
+        self.ingredients = Recipe.Ingredients(pixelGroup=self.pixelGroup, preserveEvents=True)
+
+        self.sampleWorkspace = "sampleWorkspace"
+        CreateSampleWorkspace(
+            OutputWorkspace=self.sampleWorkspace,
+            BankPixelWidth=3,
+        )
+        GroupDetectors(
+            InputWorkspace=self.sampleWorkspace,
+            OutputWorkspace=self.sampleWorkspace,
+            GroupingPattern="0-3,4-5,6-8,9-17",
+        )
+
+    def tearDown(self) -> None:
+        DeleteWorkspaces(self.sampleWorkspace)
+        return super().tearDown()
+
+    def test_recipe(self):
+        inputWs = mtd[self.sampleWorkspace]
+        assert not inputWs.isRaggedWorkspace()
+        recipe = Recipe()
+        recipe.cook(self.ingredients, {"inputWorkspace": self.sampleWorkspace})
+
+        outputWs = mtd[self.sampleWorkspace]
+        assert isinstance(outputWs, MatrixWorkspace)
+        assert outputWs.isRaggedWorkspace()
+
+    def test_badChopIngredients(self):
+        ingredients = Recipe.Ingredients(pixelGroup=self.sculleryBoy.prepPixelGroup())
+        recipe = Recipe()
+        with (
+            Config_override("constants.CropFactors.lowdSpacingCrop", 500.0),
+            Config_override("constants.CropFactors.highdSpacingCrop", 1000.0),
+            pytest.raises(ValueError, match="d-spacing crop factors are too large"),
+        ):
+            recipe.chopIngredients(ingredients)
+        #
+        with (
+            Config_override("constants.CropFactors.lowdSpacingCrop", -10.0),
+            pytest.raises(ValueError, match="Low d-spacing crop factor must be positive"),
+        ):
+            recipe.chopIngredients(ingredients)
+        #
+        with (
+            Config_override("constants.CropFactors.highdSpacingCrop", -10.0),
+            pytest.raises(ValueError, match="High d-spacing crop factor must be positive"),
+        ):
+            recipe.chopIngredients(ingredients)

--- a/tests/unit/backend/recipe/test_ReductionGroupProcessingRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionGroupProcessingRecipe.py
@@ -85,9 +85,9 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
         output = recipe.cook(self.mockIngredients(), groceries)
 
         assert recipe.rawInput == groceries["inputWorkspace"]
-        assert recipe.outputWS == groceries["inputWorkspace"]
+        assert recipe.outputWS == groceries["outputWorkspace"]
         assert recipe.groupingWS == groceries["groupingWorkspace"]
-        assert output == groceries["inputWorkspace"]
+        assert output == groceries["outputWorkspace"]
 
         assert mockSnapper.executeQueue.called
         assert mockSnapper.FocusSpectraAlgorithm.called
@@ -110,9 +110,9 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
         output = recipe.cater([(self.mockIngredients(), groceries)])
 
         assert recipe.rawInput == groceries["inputWorkspace"]
-        assert recipe.outputWS == groceries["inputWorkspace"]
+        assert recipe.outputWS == groceries["outputWorkspace"]
         assert recipe.groupingWS == groceries["groupingWorkspace"]
-        assert output[0] == groceries["inputWorkspace"]
+        assert output[0] == groceries["outputWorkspace"]
 
         assert mockSnapper.executeQueue.called
         assert mockSnapper.FocusSpectraAlgorithm.called

--- a/tests/unit/backend/recipe/test_ReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionRecipe.py
@@ -384,8 +384,8 @@ class ReductionRecipeTest(TestCase):
         recipe = ReductionRecipe()
         recipe.mantidSnapper = mockMantidSnapper
         recipe.mantidSnapper.mtd = mockMtd
-        recipe._prepareArtificialNormalization = mock.Mock()
-        recipe._prepareArtificialNormalization.return_value = "norm_grouped"
+        recipe._getNormalizationWorkspaceName = mock.Mock()
+        recipe._getNormalizationWorkspaceName.return_value = "norm_grouped"
 
         # Set up ingredients and other variables for the recipe
         recipe.groceries = {}
@@ -447,12 +447,14 @@ class ReductionRecipeTest(TestCase):
         recipe._applyRecipe.assert_any_call(
             GenerateFocussedVanadiumRecipe,
             recipe.ingredients.generateFocussedVanadium(0),
-            inputWorkspace="norm_grouped",
+            inputWorkspace="sample_grouped",
+            outputWorkspace=recipe._getNormalizationWorkspaceName.return_value,
         )
         recipe._applyRecipe.assert_any_call(
             GenerateFocussedVanadiumRecipe,
             recipe.ingredients.generateFocussedVanadium(1),
-            inputWorkspace="norm_grouped",
+            inputWorkspace="sample_grouped",
+            outputWorkspace=recipe._getNormalizationWorkspaceName.return_value,
         )
 
         recipe._applyRecipe.assert_any_call(
@@ -468,9 +470,9 @@ class ReductionRecipeTest(TestCase):
             normalizationWorkspace="norm_grouped",
         )
 
-        recipe._prepareArtificialNormalization.call_count == 2
-        recipe._prepareArtificialNormalization.assert_any_call("sample_grouped", 0)
-        recipe._prepareArtificialNormalization.assert_any_call("sample_grouped", 1)
+        recipe._getNormalizationWorkspaceName.call_count == 2
+        recipe._getNormalizationWorkspaceName.assert_any_call(0)
+        recipe._getNormalizationWorkspaceName.assert_any_call(1)
 
         recipe.ingredients.effectiveInstrument.assert_not_called()
 
@@ -497,8 +499,8 @@ class ReductionRecipeTest(TestCase):
             recipe = ReductionRecipe()
             recipe.mantidSnapper = mockMantidSnapper
             recipe.mantidSnapper.mtd = mockMtd
-            recipe._prepareArtificialNormalization = mock.Mock()
-            recipe._prepareArtificialNormalization.return_value = "norm_grouped"
+            recipe._getNormalizationWorkspaceName = mock.Mock()
+            recipe._getNormalizationWorkspaceName.return_value = "norm_grouped"
 
             # Set up ingredients and other variables for the recipe
             recipe.groceries = {}
@@ -560,12 +562,14 @@ class ReductionRecipeTest(TestCase):
             recipe._applyRecipe.assert_any_call(
                 GenerateFocussedVanadiumRecipe,
                 recipe.ingredients.generateFocussedVanadium(0),
-                inputWorkspace="norm_grouped",
+                inputWorkspace="sample_grouped",
+                outputWorkspace=recipe._getNormalizationWorkspaceName.return_value,
             )
             recipe._applyRecipe.assert_any_call(
                 GenerateFocussedVanadiumRecipe,
                 recipe.ingredients.generateFocussedVanadium(1),
-                inputWorkspace="norm_grouped",
+                inputWorkspace="sample_grouped",
+                outputWorkspace=recipe._getNormalizationWorkspaceName.return_value,
             )
 
             recipe._applyRecipe.assert_any_call(
@@ -581,9 +585,9 @@ class ReductionRecipeTest(TestCase):
                 normalizationWorkspace="norm_grouped",
             )
 
-            recipe._prepareArtificialNormalization.call_count == 2
-            recipe._prepareArtificialNormalization.assert_any_call("sample_grouped", 0)
-            recipe._prepareArtificialNormalization.assert_any_call("sample_grouped", 1)
+            recipe._getNormalizationWorkspaceName.call_count == 2
+            recipe._getNormalizationWorkspaceName.assert_any_call(0)
+            recipe._getNormalizationWorkspaceName.assert_any_call(1)
 
             recipe._applyRecipe.assert_any_call(
                 EffectiveInstrumentRecipe,

--- a/tests/util/SculleryBoy.py
+++ b/tests/util/SculleryBoy.py
@@ -6,6 +6,7 @@ from util.dao import DAOFactory
 
 from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.ingredients import (
+    ArtificialNormalizationIngredients,
     DiffractionCalibrationIngredients,
     NormalizationIngredients,
     ReductionIngredients,
@@ -105,6 +106,9 @@ class SculleryBoy:
             calibrantSample=self.prepCalibrantSample("123"),
             detectorPeaks=self.prepDetectorPeaks(ingredients),
         )
+
+    def prepArtificialNormalizationIngredients(self):
+        return ArtificialNormalizationIngredients(smoothingParameter=0.1)
 
     def verifyCalibrationExists(self, runNumber: str, useLiteMode: bool) -> bool:  # noqa ARG002
         return True


### PR DESCRIPTION
## Description of work

This pr adds appropriate binning for both the artificial normalization subflow of Reduction as well as the Reduction outputs proper.

This is important because the Divide operation along with several others are sensitive to the current binning of an EventWorkspaces, even before we drop events and make it a Histogram(solidifying the resolution/bins).

It also sets the outputs of reduction to distributions, as that is what a user will expect of their output data.

## Explanation of work

- I refactored the way we bin group focussed data into a standardized Recipe, `RebinFocussedGroupDataRecipe`
- Moved the Artificial Normalization code into `GenerateFocussedVanadiumRecipe` as that was originally where we wanted to put it.  It helps keeping like with like.
- `ArtificialNormalizationRequest` should not be arbitrarily generating the output workspace name
- `ApplyNormalizationRecipe` now uses the centralized rebinning, as well as rebinning before a Divide and dropping events after the Divide
- Added `RebinFocussedGroupDataRecipe` to house binning for Reduction/Normalization rebin operations.
- Updated `Recipe` to be able to `adopt` host algorithm (Still needs further investigation for proper use as it seems to not share a mantidsnapper instance, but should be fine to include)
- `ReductionGroupProcessingRecipe` now respects the outputworkspace property
- `ReductionRecipe` updated to account for new way of generating an Artificial Normalization
- `CreateArtificialNormalizationAlgo` input properties refactored to use Mantid primatives instead of ingredients (i.e. `int`),  only clone if outputworkspace is different than input, convert units before we drop events.
- `ReductionService` changed to rebin as part of the artificial norm preview
- `WorkspaceNameGenerator` added new name for art norm preview
 
## To test

This is heavily dependent on your ability to diagnose the data and confirm binning.
So we will rely on Malcolm to confirm whether or not this data output is correct.

As a dev, do the best you can to confirm that the new operation completed successfully.

Freshly init state folder for desired run, I have been using `59039`
Perform reduction on `59039`

### On `Next`

Plot the artificial norm workspace, observe the results.
Reduce your data.
Plot the output `column` workspace.
Observe the data.
Observe that it is not a distribution (i.e. the min y value is 0 and not 1)
Observe any other artifact.

### On `This Branch`

Plot the Artificial Norm workspace, observe the different results.
![image](https://github.com/user-attachments/assets/bc9e62b8-e182-4c60-bdad-b755d76ded7e)
If you double the smoothing and peak window values you should get something much smoother
![image](https://github.com/user-attachments/assets/f09e1a4d-83b8-4c10-9722-6423ab5416af)

Observe the Logs, confirm that the log "Rebinning workspace for group..." now appears where on next it doesnt.
Reduce your data.
Plot the output `column` workspace.
Observe the data.
Observe that it is a distribution (i.e. the min y value is 1)
Observe a relatively flat output.
![image](https://github.com/user-attachments/assets/9ec94b47-a541-49dc-978d-a115cb524a3d)

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#8373](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8373)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] the input datasets for peakClip must be rebinned following the pixelGroupingParameters dMin, dMax and dBin which SNAPRed determines for each individual pixel group before calculating the normalization function in peakClip.
- [x] The outcome is that the Divide output workspace flag `isDistribution` is set equal to False, when it should be True.
