### PR TITLE
Update the use of pointers within certain algorithms

### DIFF
--- a/src/snapred/backend/recipe/GenerateFocussedVanadiumRecipe.py
+++ b/src/snapred/backend/recipe/GenerateFocussedVanadiumRecipe.py
@@ -5,7 +5,6 @@ from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.RebinFocussedGroupDataRecipe import RebinFocussedGroupDataRecipe
 from snapred.backend.recipe.Recipe import Recipe
 from snapred.meta.decorators.Singleton import Singleton
-from snapred.meta.redantic import list_to_raw
 
 logger = snapredLogger.getLogger(__name__)
 
@@ -26,7 +25,7 @@ class GenerateFocussedVanadiumRecipe(Recipe[Ingredients]):
 
     def chopIngredients(self, ingredients: Ingredients):
         self.smoothingParameter = ingredients.smoothingParameter
-        self.detectorPeaks = list_to_raw(ingredients.detectorPeaks) if ingredients.detectorPeaks is not None else None
+        self.detectorPeaks = ingredients.detectorPeaks
         self.pixelGroup = ingredients.pixelGroup
 
         self.artificialNormalizationIngredients = ingredients.artificialNormalizationIngredients

--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -147,7 +147,7 @@ class MantidSnapper:
                 # for pointer property, set via its pointer
                 # allows for "pass-by-reference"-like behavior
                 # this is safe even if the memory address is directly passed
-                if isinstance(algorithm.getProperty(prop), PointerProperty):
+                if isinstance(algorithm.getProperty(prop), PointerProperty) and type(val) is not int:
                     val = create_pointer(val)
                 algorithm.setProperty(prop, val)
             if not algorithm.execute():

--- a/src/snapred/backend/recipe/algorithm/RemoveEventBackground.py
+++ b/src/snapred/backend/recipe/algorithm/RemoveEventBackground.py
@@ -9,7 +9,7 @@ from mantid.api import (
     PythonAlgorithm,
     WorkspaceUnitValidator,
 )
-from mantid.kernel import Direction
+from mantid.kernel import Direction, FloatBoundedValidator
 from mantid.kernel import ULongLongPropertyWithValue as PointerProperty
 from mantid.simpleapi import (
     ConvertToMatrixWorkspace,
@@ -58,6 +58,7 @@ class RemoveEventBackground(PythonAlgorithm):
             "SmoothingParameter",
             defaultValue=Config["calibration.diffraction.smoothingParameter"],
             direction=Direction.Input,
+            validator=FloatBoundedValidator(lower=0.0),
         )
         self.setRethrows(True)
 

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -45,6 +45,7 @@ from snapred.meta.mantid.WorkspaceNameGenerator import (
     WorkspaceName,
 )
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
+from snapred.meta.pointer import create_pointer
 from snapred.meta.redantic import parse_obj_as
 
 logger = snapredLogger.getLogger(__name__)
@@ -164,7 +165,7 @@ class NormalizationService(Service):
         # 3. smooth
         SmoothDataExcludingPeaksRecipe().executeRecipe(
             InputWorkspace=focusedVanadium,
-            DetectorPeaks=ingredients.detectorPeaks,
+            DetectorPeaks=create_pointer(ingredients.detectorPeaks),
             SmoothingParameter=request.smoothingParameter,
             OutputWorkspace=smoothedVanadium,
         )
@@ -369,7 +370,7 @@ class NormalizationService(Service):
         SmoothDataExcludingPeaksRecipe().executeRecipe(
             InputWorkspace=request.inputWorkspace,
             OutputWorkspace=request.outputWorkspace,
-            DetectorPeaks=peaks,
+            DetectorPeaks=create_pointer(peaks),
             SmoothingParameter=request.smoothingParameter,
         )
 

--- a/src/snapred/meta/pointer.py
+++ b/src/snapred/meta/pointer.py
@@ -15,8 +15,25 @@ def create_pointer(thing: Any) -> int:
     return id(thing)
 
 
-def access_pointer(pointer: int) -> Any:
-    thing = ctypes.cast(pointer, ctypes.py_object).value
+def inspect_pointer(pointer: int) -> Any:
+    """
+    Fetch an object referenced by the pointer, without removing it from the cache.
+    Useful for validateInputs with a pointer property.
+    @param the pointer to the object
+    @return the object pointed to
+    """
     if pointer in OBJCACHE:
-        del OBJCACHE[pointer]
+        return ctypes.cast(pointer, ctypes.py_object).value
+    else:
+        raise RuntimeError(f"No appropriate object held at address {hex(pointer)}")
+
+
+def access_pointer(pointer: int) -> Any:
+    """
+    Fetch an objected referenced by the pointer, and remove it from the cache.
+    @param the pointer to the object
+    @return the object pointed to
+    """
+    thing = inspect_pointer(pointer)
+    del OBJCACHE[pointer]
     return thing

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -143,6 +143,7 @@ class DiffCalWorkflow(WorkflowImplementer):
 
     def __setInteraction(self, state: bool):
         self._requestView.litemodeToggle.setEnabled(state)
+        self._requestView.skipPixelCalToggle.setEnabled(state)
         self._requestView.groupingFileDropdown.setEnabled(state)
 
     @ExceptionToErrLog
@@ -260,10 +261,6 @@ class DiffCalWorkflow(WorkflowImplementer):
         self._renewFocus(self.prevGroupingIndex)
         self._renewFitPeaks(self.peakFunction)
         response = self._calculateResidual()
-
-        # freeze these toggles, as they can no longer function
-        self._requestView.litemodeToggle.setEnabled(False)
-        self._requestView.skipPixelCalToggle.setEnabled(False)
 
         self._tweakPeakView.updateGraphs(
             self.focusedWorkspace,

--- a/tests/unit/backend/recipe/algorithm/test_RemoveEventBackground.py
+++ b/tests/unit/backend/recipe/algorithm/test_RemoveEventBackground.py
@@ -129,31 +129,22 @@ class TestRemoveEventBackground(unittest.TestCase):
             algo.execute()
 
     def test_smoothing_parameter_edge_cases(self):
-        peaks = self.create_test_peaks()
         ConvertToEventWorkspace(
             InputWorkspace=self.fakeData,
             OutputWorkspace=self.fakeData,
         )
         algo = Algo()
         algo.initialize()
-        algo.setProperty("InputWorkspace", self.fakeData)
-        algo.setProperty("GroupingWorkspace", self.fakeGroupingWorkspace)
-        algo.setProperty("DetectorPeaks", create_pointer(peaks))
-        algo.setProperty("SmoothingParameter", 0)
-        algo.setProperty("OutputWorkspace", "output_test_ws_no_smoothing")
 
-        assert algo.execute()
+        # negative values are excluded
+        with self.assertRaises(ValueError):  # noqa: PT027
+            algo.setProperty("SmoothingParameter", -1)
 
-        algo.setProperty("SmoothingParameter", -1)
-        algo.setProperty("OutputWorkspace", "output_test_ws_negative_smoothing")
-
-        with self.assertRaises(RuntimeError):  # noqa: PT027
-            algo.execute()
-
-        algo.setProperty("SmoothingParameter", 1000)
-        algo.setProperty("OutputWorkspace", "output_test_ws_large_smoothing")
-
-        assert algo.execute()
+        # zero is valid, large numbers valid, floats valid
+        valid_values = [0, 1000, 3.141592]
+        for value in valid_values:
+            algo.setProperty("SmoothingParameter", value)
+            assert value == algo.getProperty("SmoothingParameter").value
 
     def test_output_workspace_creation(self):
         peaks = self.create_test_peaks()

--- a/tests/unit/backend/recipe/algorithm/test_SmoothDataExcludingPeaksAlgo.py
+++ b/tests/unit/backend/recipe/algorithm/test_SmoothDataExcludingPeaksAlgo.py
@@ -12,7 +12,7 @@ from util.SculleryBoy import SculleryBoy
 from snapred.backend.dao.request import FarmFreshIngredients
 from snapred.backend.recipe.algorithm.SmoothDataExcludingPeaksAlgo import SmoothDataExcludingPeaksAlgo as Algo
 from snapred.meta.Config import Resource
-from snapred.meta.redantic import list_to_raw
+from snapred.meta.pointer import create_pointer
 
 
 class TestSmoothDataAlgo(unittest.TestCase):
@@ -39,16 +39,27 @@ class TestSmoothDataAlgo(unittest.TestCase):
     def test_execute_with_peaks(self):
         # input data
         testWS = CreateWorkspace(DataX=[0, 1, 2, 3, 4, 5, 6], DataY=[2, 2, 2, 2, 2, 2], UnitX="dSpacing")
-        jsonString = (
-            '[{"groupID": 1, "peaks": [{"position": {"value":1, "minimum":0, "maximum":2},'
-            ' "peak": {"hkl": [1, 1, 1], "dSpacing": 3.13592994862768,'
-            '"fSquared": 535.9619564273586, "multiplicity": 8}}]}]'
-        )
+        peaks = [
+            {
+                "groupID": 1,
+                "peaks": [
+                    {
+                        "position": {"value": 1, "minimum": 0, "maximum": 2},
+                        "peak": {
+                            "hkl": [1, 1, 1],
+                            "dSpacing": 3.13592994862768,
+                            "fSquared": 535.9619564273586,
+                            "multiplicity": 8,
+                        },
+                    }
+                ],
+            }
+        ]
         algo = Algo()
         algo.initialize()
         algo.setProperty("InputWorkspace", testWS)
         algo.setPropertyValue("OutputWorkspace", "test_out_ws")
-        algo.setProperty("DetectorPeaks", jsonString)
+        algo.setProperty("DetectorPeaks", create_pointer(peaks))
         algo.setProperty("SmoothingParameter", 0.0)
         assert algo.execute()
 
@@ -72,6 +83,6 @@ class TestSmoothDataAlgo(unittest.TestCase):
         smoothDataAlgo.initialize()
         smoothDataAlgo.setPropertyValue("InputWorkspace", test_ws_name)
         smoothDataAlgo.setPropertyValue("OutputWorkspace", "_output")
-        smoothDataAlgo.setPropertyValue("DetectorPeaks", list_to_raw(peaks))
-        smoothDataAlgo.setPropertyValue("SmoothingParameter", "0.9")
+        smoothDataAlgo.setProperty("DetectorPeaks", create_pointer(peaks))
+        smoothDataAlgo.setProperty("SmoothingParameter", 0.9)
         assert smoothDataAlgo.execute()

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -2,7 +2,7 @@
 import unittest
 import unittest.mock as mock
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from mantid.simpleapi import (
@@ -206,7 +206,7 @@ class TestNormalizationService(unittest.TestCase):
         mockRecipeInst.executeRecipe.assert_called_once_with(
             InputWorkspace=mockRequest.inputWorkspace,
             OutputWorkspace=mockRequest.outputWorkspace,
-            DetectorPeaks=self.instance.sousChef.prepDetectorPeaks(FarmFreshIngredients.return_value),
+            DetectorPeaks=ANY,  # NOTE it is impossible to see this pointer
             SmoothingParameter=mockRequest.smoothingParameter,
         )
 

--- a/tests/unit/meta/test_pointer.py
+++ b/tests/unit/meta/test_pointer.py
@@ -1,7 +1,9 @@
 import ctypes
 import gc
 
-from snapred.meta.pointer import access_pointer, create_pointer
+import pytest
+
+from snapred.meta.pointer import access_pointer, create_pointer, inspect_pointer
 
 
 def make_a():
@@ -42,3 +44,25 @@ def test_pointer_persistence():
     aa = access_pointer(pa)
     assert aa.__dir__() != {}
     assert aa == make_a()
+
+
+def test_inspect_pointer():
+    """Ensure pointers can be expected and still remain in the queue"""
+    a = make_a()
+    pa = create_pointer(a)
+    aa = inspect_pointer(pa)
+    aaa = access_pointer(pa)
+    assert a == aa
+    assert a == aaa
+
+
+def test_inspect_bad_pointer_error():
+    """Ensure accessing a bad pointer raises an error"""
+
+    # create a pointer then access it, which removes it from the cache
+    a = make_a()
+    pa = create_pointer(a)
+    access_pointer(pa)
+
+    with pytest.raises(RuntimeError):
+        inspect_pointer(pa)


### PR DESCRIPTION
## Description of work

In anticipation of the eventual [`PythonObjectionProperty`](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=7807), it is necessary to begin refactoring algorithms to rely more on pointer properties instead of passing large pydantic objects as strings.

It was also deemed necessary that algorithms relying heavily on direct manipulation of workspaces outside of algorithms, should not use `MantidSnapper` and instead call mantid functionality directly.

This updates two of the algorithms, `SmoothDataExcludingPeaksAlgo` and `DiffractionSpectrumWeightCalculator` to pass the peak lists through pointers instead of strings.  It also makes some needed change to enable that, like how pointer properties are handled between `GenericRecipe` and `MantidSnapper`.

## Explanation of work

Changed some string properties being used to pass a list of grouped detector peaks, to instead by pointer properties passing the same lists by their pointer.

Added a new method to inspect pointers that does not remove them from the cache, to use in `validateInputs` methods.

Fixed `MantidSnapper` to not cast pointers into pointers; that is, if a pointer property's value is already a pointer, just pass that pointer and don't make another layer of pointers.

## To test

### Dev testing

Run in CIS mode so that the toggle to remove background can be flipped.

Run both diffraction and normalization and ensure nothing changed.

### CIS testing

N/A

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#8086](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8086)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

**NOTE** the other work in EWM 8086 is handled in PR #505.  This only handles the updates to `SmoothDataExcludingPeaksAlgo` called for in EWM 8086.

- [x]  update and refactor SmoothDataExcludingPeaksAlgo to make use of pointers, validators, and other improvements
