### PR TITLE
added the residual to the normalization workflow

### DIFF
--- a/src/snapred/backend/dao/request/CalculateNormalizationResidualRequest.py
+++ b/src/snapred/backend/dao/request/CalculateNormalizationResidualRequest.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, ConfigDict
+
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
+
+
+class CalculateNormalizationResidualRequest(BaseModel):
+    runNumber: int
+    dataWorkspace: WorkspaceName
+    calculationWorkspace: WorkspaceName
+
+    model_config = ConfigDict(
+        # required in order to use 'WorkspaceName'
+        arbitrary_types_allowed=True,
+    )

--- a/src/snapred/backend/recipe/GenericRecipe.py
+++ b/src/snapred/backend/recipe/GenericRecipe.py
@@ -1,7 +1,7 @@
 import json
 from typing import Generic, TypeVar, get_args
 
-from mantid.simpleapi import ConvertTableToMatrixWorkspace
+from mantid.simpleapi import ConvertTableToMatrixWorkspace, Minus
 from pydantic import BaseModel
 
 from snapred.backend.log.logger import snapredLogger
@@ -108,4 +108,8 @@ class BufferMissingColumnsRecipe(GenericRecipe[BufferMissingColumnsAlgo]):
 
 
 class ArtificialNormalizationRecipe(GenericRecipe[CreateArtificialNormalizationAlgo]):
+    pass
+
+
+class MinusRecipe(GenericRecipe[Minus]):
     pass

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -11,6 +11,7 @@ from snapred.backend.dao.normalization import (
     Normalization,
 )
 from snapred.backend.dao.request import (
+    CalculateNormalizationResidualRequest,
     CalibrationWritePermissionsRequest,
     CreateNormalizationRecordRequest,
     FarmFreshIngredients,
@@ -30,6 +31,7 @@ from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.GenericRecipe import (
     FocusSpectraRecipe,
+    MinusRecipe,
     RawVanadiumCorrectionRecipe,
     SmoothDataExcludingPeaksRecipe,
 )
@@ -407,3 +409,13 @@ class NormalizationService(Service):
                     request.useLiteMode
                 ).add()
         return set(self.groceryService.fetchGroceryList(self.groceryClerk.buildList())), normalizations
+
+    @Register("calculateResidual")
+    def calculateResidual(self, request: CalculateNormalizationResidualRequest):
+        outputWorkspace = wng.normCalResidual().runNumber(request.runNumber).unit(wng.Units.DSP).build()
+        MinusRecipe().executeRecipe(
+            LHSWorkspace=request.dataWorkspace,
+            RHSWorkspace=request.calculationWorkspace,
+            OutputWorkspace=outputWorkspace,
+        )
+        return outputWorkspace

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -71,6 +71,8 @@ class WorkspaceType(str, Enum):
     SMOOTHED_FOCUSED_RAW_VANADIUM = "smoothedFocusedRawVanadium"
     ARTIFICIAL_NORMALIZATION_PREVIEW = "artificialNormalizationPreview"
 
+    RESIDUAL = "normCalResidual"
+
     # <reduction tag>_<runNumber>_<timestamp>
     REDUCTION_OUTPUT = "reductionOutput"
     # <reduction tag>_<stateSHA>_<timestamp>
@@ -425,6 +427,16 @@ class _WorkspaceNameGenerator:
             self._delimiter,
             unit=self.Units.DSP,
             type=self.ArtificialNormWorkspaceType.PREVIEW,
+        )
+
+    def normCalResidual(self):
+        return NameBuilder(
+            WorkspaceType.RESIDUAL,
+            self._normCalResidualTemplate,
+            self._normCalResidualTemplateKeys,
+            self._delimiter,
+            unit=self.Units.DSP,
+            version=None,
         )
 
     def reductionOutput(self):

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -127,6 +127,7 @@ mantid:
           focusedRawVanadium: "{unit},{group},{runNumber},raw_van_corr,{version}"
           smoothedFocusedRawVanadium: "{unit},{group},{runNumber},fitted_van_corr,{version}"
           artificialNormalizationPreview: "artificial_norm,{unit},{group},{runNumber},{type}"
+          residual: "{unit},{runNumber},residual"
         reduction:
           output: "reduced,{unit},{group},{runNumber},{timestamp}"
           outputGroup: "reduced,{runNumber},{timestamp}"

--- a/src/snapred/ui/view/NormalizationTweakPeakView.py
+++ b/src/snapred/ui/view/NormalizationTweakPeakView.py
@@ -161,9 +161,10 @@ class NormalizationTweakPeakView(BackendRequestView):
             return
         self.signalValueChanged.emit(index, smoothingValue, xtalDMin, xtalDMax)
 
-    def updateWorkspaces(self, focusWorkspace, smoothedWorkspace, peaks):
+    def updateWorkspaces(self, focusWorkspace, smoothedWorkspace, peaks, residualWorkspace):
         self.focusWorkspace = focusWorkspace
         self.smoothedWorkspace = smoothedWorkspace
+        self.residualWorkspace = residualWorkspace
         self.groupingSchema = self.groupingFileDropdown.currentText()
         self._updateGraphs(peaks)
 
@@ -171,6 +172,7 @@ class NormalizationTweakPeakView(BackendRequestView):
         # get the updated workspaces and optimal graph grid
         focusedWorkspace = mtd[self.focusWorkspace]
         smoothedWorkspace = mtd[self.smoothedWorkspace]
+        residualWorkspace = mtd[self.residualWorkspace]
         peaks = pydantic.TypeAdapter(List[GroupPeakList]).validate_python(peaks)
         numGraphs = focusedWorkspace.getNumberHistograms()
         nrows, ncols = self._optimizeRowsAndCols(numGraphs)
@@ -186,6 +188,8 @@ class NormalizationTweakPeakView(BackendRequestView):
 
             ax.plot(focusedWorkspace, wkspIndex=i, label="Focused Data", normalize_by_bin_width=True)
             ax.plot(smoothedWorkspace, wkspIndex=i, label="Smoothed Data", normalize_by_bin_width=True, linestyle="--")
+            ax.plot(residualWorkspace, wkspIndex=i, label="Residual Data", normalize_by_bin_width=True, linestyle=":")
+
             ax.legend()
             ax.tick_params(direction="in")
             ax.set_title(f"Group ID: {i + 1}")

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -253,6 +253,8 @@ class DiffCalWorkflow(WorkflowImplementer):
         self.prevXtalDMax = payload.crystalDMax  # NOTE set in __init__ to defaults
         self.prevFWHM = payload.fwhmMultipliers  # NOTE set in __init__ to defaults
         self.prevGroupingIndex = view.groupingFileDropdown.currentIndex()
+
+        # TODO: These need to be moved to the workspace name generator
         self.fitPeaksDiagnostic = f"fit_peak_diag_{self.runNumber}_{self.prevGroupingIndex}_pre"
 
         self.residualWorkspace = f"diffcal_residual_{self.runNumber}"

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -128,6 +128,7 @@ mantid:
             focusedRawVanadium: "_{unit},{group},raw_van_corr,{runNumber},{version}"
             smoothedFocusedRawVanadium: "_{unit},{group},fitted_van_corr,{runNumber},{version}"
             artificialNormalizationPreview: "artificial_norm,{unit},{group},{runNumber},{type}"
+            residual: "{unit},{runNumber},residual"
           reduction:
             output: "_reduced,{unit},{group},{runNumber},{timestamp}"
             outputGroup: "_reduced,{runNumber},{timestamp}"


### PR DESCRIPTION
## Description of work

This adds an additional workspace to the normalization tweak peak view to help visualize the residual data post subtraction of the smoothed data.

## Explanation of work

pretty straight forward, mostly just added an endpoint that allows the normalization workflow to Minus these workspaces and produce the residual.

## To test

Run the normalization workflow to completion, with plenty of recalcs
I used the following 
runnumbers:
58810
58813
Sample: Silcon
Group: Column

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#7783](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7783)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] The residual is available and updates according to the tweak peak view
