### PR TITLE
Simple fix to Defect 8554

### DIFF
--- a/src/snapred/backend/dao/state/DetectorState.py
+++ b/src/snapred/backend/dao/state/DetectorState.py
@@ -1,6 +1,6 @@
 from enum import IntEnum
 from numbers import Number
-from typing import Literal, Tuple
+from typing import Dict, Literal, Tuple
 
 from pydantic import BaseModel, field_validator
 
@@ -26,3 +26,24 @@ class DetectorState(BaseModel):
             #   e.g. hdf5 returns `int64`
             v = int(v)
         return v
+
+    @classmethod
+    def constructFromLogValues(cls, logValues):
+        return DetectorState(
+            arc=(float(logValues["det_arc1"]), float(logValues["det_arc2"])),
+            lin=(float(logValues["det_lin1"]), float(logValues["det_lin2"])),
+            wav=float(logValues["BL3:Chop:Skf1:WavelengthUserReq"]),
+            freq=float(logValues["BL3:Det:TH:BL:Frequency"]),
+            guideStat=int(logValues["BL3:Mot:OpticsPos:Pos"]),
+        )
+
+    def getLogValues(self) -> Dict[str, str]:
+        return {
+            "det_lin1": str(self.lin[0]),
+            "det_lin2": str(self.lin[1]),
+            "det_arc1": str(self.arc[0]),
+            "det_arc2": str(self.arc[1]),
+            "BL3:Chop:Skf1:WavelengthUserReq": str(self.wav),
+            "BL3:Det:TH:BL:Frequency": str(self.freq),
+            "BL3:Mot:OpticsPos:Pos": str(self.guideStat),
+        }

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -517,11 +517,12 @@ class GroceryService:
         """
         Check if a pixel mask is valid.
         :param pixelMask: the name of the MaskWorkspace to check
-        :type pixelMasl: Workspacename
-        :return: True if pixelMask is a non-empty MaskWorkspace in the ADS.  False otherwise.
+        :type pixelMask: Workspacename
+        :return: True if pixelMask is a non-trivial MaskWorkspace in the ADS.  False otherwise.
         :rtype: bool
         """
-
+        # A non-trivial mask is a mask that has a non-zero number of masked pixels.
+        
         if not self.mantidSnapper.mtd.doesExist(pixelMask):
             return False
         else:

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -513,6 +513,26 @@ class GroceryService:
         else:
             raise RuntimeError(f"Workspace {workspaceName} does not exist")
 
+    def checkPixelMask(self, pixelMask: WorkspaceName) -> bool:
+        """
+        Check if a pixel mask is valid.
+        :param pixelMask: the name of the MaskWorkspace to check
+        :type pixelMasl: Workspacename
+        :return: True if pixelMask is a non-empty MaskWorkspace in the ADS.  False otherwise.
+        :rtype: bool
+        """
+
+        if not self.mantidSnapper.mtd.doesExist(pixelMask):
+            return False
+        else:
+            mask = self.mantidSnapper.mtd[pixelMask]
+            if mask.id() != "MaskWorkspace":
+                return False
+            elif mask.getNumberMasked() == 0:
+                return False
+            else:
+                return True
+
     ## FETCH METHODS
     """
     The fetch methods orchestrate finding data files, loading them into workspaces,

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -522,7 +522,7 @@ class GroceryService:
         :rtype: bool
         """
         # A non-trivial mask is a mask that has a non-zero number of masked pixels.
-        
+
         if not self.mantidSnapper.mtd.doesExist(pixelMask):
             return False
         else:

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -526,7 +526,7 @@ class GroceryService:
             return False
         else:
             mask = self.mantidSnapper.mtd[pixelMask]
-            if mask.id() != "MaskWorkspace":
+            if not isinstance(mask, MaskWorkspace):
                 return False
             elif mask.getNumberMasked() == 0:
                 return False

--- a/src/snapred/backend/recipe/ReductionRecipe.py
+++ b/src/snapred/backend/recipe/ReductionRecipe.py
@@ -63,7 +63,7 @@ class ReductionRecipe(Recipe[Ingredients]):
         self.groceries = groceries.copy()
         self.sampleWs = groceries["inputWorkspace"]
         self.normalizationWs = groceries.get("normalizationWorkspace", "")
-        self.maskWs = groceries.get("combinedMask", "")
+        self.maskWs = groceries.get("combinedPixelMask", "")
         self.groupingWorkspaces = groceries["groupingWorkspaces"]
 
     def _cloneWorkspace(self, inputWorkspace: str, outputWorkspace: str) -> str:

--- a/src/snapred/backend/recipe/algorithm/FocusSpectraAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FocusSpectraAlgorithm.py
@@ -7,6 +7,7 @@ from mantid.api import (
     PythonAlgorithm,
     WorkspaceUnitValidator,
 )
+from mantid.dataobjects import GroupingWorkspace
 from mantid.kernel import Direction, StringMandatoryValidator
 
 from snapred.backend.dao.state.PixelGroup import PixelGroup as Ingredients
@@ -78,7 +79,7 @@ class FocusSpectraAlgorithm(PythonAlgorithm):
         # make sure the input workspace can be reduced by this grouping workspace
         inWS = self.mantidSnapper.mtd[self.getPropertyValue("InputWorkspace")]
         groupWS = self.mantidSnapper.mtd[self.getPropertyValue("GroupingWorkspace")]
-        if "Grouping" not in groupWS.id():
+        if not isinstance(groupWS, GroupingWorkspace):
             errors["GroupingWorkspace"] = "Grouping workspace must be an actual GroupingWorkspace"
         elif inWS.getNumberHistograms() == len(groupWS.getGroupIDs()):
             msg = "The data appears to have already been diffraction focused"

--- a/src/snapred/backend/recipe/algorithm/GroupedDetectorIDs.py
+++ b/src/snapred/backend/recipe/algorithm/GroupedDetectorIDs.py
@@ -7,6 +7,7 @@ from mantid.api import (
     PythonAlgorithm,
     mtd,
 )
+from mantid.dataobjects import GroupingWorkspace
 from mantid.kernel import Direction, ULongLongPropertyWithValue
 
 from snapred.meta.pointer import create_pointer
@@ -24,7 +25,7 @@ class GroupedDetectorIDs(PythonAlgorithm):
     def validateInputs(self) -> Dict[str, str]:
         err = {}
         focusWS = mtd[self.getPropertyValue("GroupingWorkspace")]
-        if focusWS.id() != "GroupingWorkspace":
+        if not isinstance(focusWS, GroupingWorkspace):
             err["GroupingWorkspace"] = "The workspace must be a GroupingWorkspace"
         return err
 

--- a/src/snapred/backend/recipe/algorithm/RemoveSmoothedBackground.py
+++ b/src/snapred/backend/recipe/algorithm/RemoveSmoothedBackground.py
@@ -1,6 +1,7 @@
 from typing import Dict, List
 
 from mantid.api import (
+    IEventWorkspace,
     IEventWorkspaceProperty,
     MatrixWorkspaceProperty,
     PropertyMode,
@@ -94,7 +95,7 @@ class RemoveSmoothedBackground(PythonAlgorithm):
         self.inputWorkspaceName = self.getPropertyValue("InputWorkspace")
         self.outputWorkspaceName = self.getPropertyValue("OutputWorkspace")
         self.focusWorkspace = self.getPropertyValue("GroupingWorkspace")
-        self.isEventWs = mtd[self.inputWorkspaceName].id() == "EventWorkspace"
+        self.isEventWs = isinstance(mtd[self.inputWorkspaceName], IEventWorkspace)
 
     def PyExec(self):
         """

--- a/src/snapred/backend/service/ReductionService.py
+++ b/src/snapred/backend/service/ReductionService.py
@@ -305,8 +305,8 @@ class ReductionService(Service):
         for mask in request.pixelMasks:
             match mask.tokens("workspaceType"):
                 case wngt.REDUCTION_PIXEL_MASK:
-                    runNumber, time = mask.tokens("runNumber", "timestamp")
-                    self.groceryClerk.name(mask).reduction_pixel_mask(runNumber, time).useLiteMode(useLiteMode).add()
+                    runNumber, temp_ts = mask.tokens("runNumber", "timestamp")
+                    self.groceryClerk.name(mask).reduction_pixel_mask(runNumber, temp_ts).useLiteMode(useLiteMode).add()
                 case wngt.REDUCTION_USER_PIXEL_MASK:
                     numberTag = mask.tokens("numberTag")
                     residentMasks[mask] = wng.reductionUserPixelMask().numberTag(numberTag).build()

--- a/tests/unit/backend/dao/test_DetectorState.py
+++ b/tests/unit/backend/dao/test_DetectorState.py
@@ -1,0 +1,26 @@
+# note: this runs the same checks as the calibrant_samples_script CIS test
+import unittest
+
+from snapred.backend.dao.state.DetectorState import DetectorState
+
+
+class TestDetectorstate(unittest.TestCase):
+    def test_getLogValues(self):
+        exp = {
+            "det_lin1": "1.0",
+            "det_lin2": "1.1",
+            "det_arc1": "2.2",
+            "det_arc2": "2.3",
+            "BL3:Chop:Skf1:WavelengthUserReq": "3.4",
+            "BL3:Det:TH:BL:Frequency": "4.5",
+            "BL3:Mot:OpticsPos:Pos": "2",
+        }
+        detectorState = DetectorState.constructFromLogValues(exp)
+        assert detectorState.arc[0] == float(exp["det_arc1"])
+        assert detectorState.arc[1] == float(exp["det_arc2"])
+        assert detectorState.lin[0] == float(exp["det_lin1"])
+        assert detectorState.lin[1] == float(exp["det_lin2"])
+        assert detectorState.wav == float(exp["BL3:Chop:Skf1:WavelengthUserReq"])
+        assert detectorState.freq == float(exp["BL3:Det:TH:BL:Frequency"])
+        assert detectorState.guideStat == float(exp["BL3:Mot:OpticsPos:Pos"])
+        assert exp == detectorState.getLogValues()

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -1904,7 +1904,7 @@ class TestGroceryService(unittest.TestCase):
         assert not mtd.doesExist(nonexistent)
         assert not self.instance.checkPixelMask(nonexistent)
 
-        # raises an error if workspace not a mask workspace
+        # raises an error if the workspace is not a MaskWorkspace
         notamask = mtd.unique_name(prefix="_mask_check_")
         CreateSampleWorkspace(
             OutputWorkspace=notamask,

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -1912,13 +1912,13 @@ class TestGroceryService(unittest.TestCase):
             BankPixelWidth=1,
         )
         assert mtd.doesExist(notamask)
-        assert mtd[notamask].id() != "MaskWorkspace"
+        assert not isinstance(mtd[notamask], MaskWorkspace)
         assert not self.instance.checkPixelMask(notamask)
 
         # return False if nothing is masked
         emptymask = mtd.unique_name(prefix="_mask_check_")
         ExtractMask(InputWorkspace=notamask, OutputWorkspace=emptymask)
-        assert mtd[emptymask].id() == "MaskWorkspace"
+        assert isinstance(mtd[emptymask], MaskWorkspace)
         assert mtd[emptymask].getNumberMasked() == 0
         assert not self.instance.checkPixelMask(emptymask)
 
@@ -1926,6 +1926,6 @@ class TestGroceryService(unittest.TestCase):
         nonemptymask = mtd.unique_name(prefix="_mask_check_")
         MaskDetectors(Workspace=notamask, WorkspaceIndexList=[0])
         ExtractMask(InputWorkspace=notamask, OutputWorkspace=nonemptymask)
-        assert mtd[nonemptymask].id() == "MaskWorkspace"
+        assert isinstance(mtd[nonemptymask], MaskWorkspace)
         assert mtd[nonemptymask].getNumberMasked() != 0
         assert self.instance.checkPixelMask(nonemptymask)

--- a/tests/unit/backend/service/test_ReductionService.py
+++ b/tests/unit/backend/service/test_ReductionService.py
@@ -778,7 +778,7 @@ class TestReductionServiceMasks:
         """
 
         def mock_compatible_mask(wsname, runNumber, useLiteMode):  # noqa ARG001
-            return maskFromArray(wsname, [0, 0, 0, 0, 0])
+            return maskFromArray([0, 0, 0, 0, 0], wsname)
 
         def mock_fetch_grocery_list(groceryList):
             import hashlib
@@ -792,7 +792,7 @@ class TestReductionServiceMasks:
                 hasher.update(json.dumps(item.__dict__).encode("utf-8"))
                 x = int.from_bytes(hasher.digest(1), "big")
                 mask = [int(x) for x in list("{0:0b}".format(x))]
-                workspaceName = maskFromArray(workspaceName, mask)
+                workspaceName = maskFromArray(mask, workspaceName)
                 groceries.append(workspaceName)
             return groceries
 

--- a/tests/unit/backend/service/test_ReductionService.py
+++ b/tests/unit/backend/service/test_ReductionService.py
@@ -699,7 +699,7 @@ class TestReductionServiceMasks:
         request = ReductionRequest(
             runNumber=self.runNumber1,
             useLiteMode=self.useLiteMode,
-            timestamp=timestamp + 1,
+            timestamp=timestamp,
             pixelMasks=masks,
         )
 

--- a/tests/util/helpers.py
+++ b/tests/util/helpers.py
@@ -90,7 +90,7 @@ def createNPixelWorkspace(wsname, numberOfPixels, detectorState: DetectorState =
             freq=60.0,
             guideStat=1,
         )
-        logs = detectorState.getLogValues()
+    logs = detectorState.getLogValues()
     lognames = list(logs.keys())
     logvalues = list(logs.values())
     logtypes = ["Number Series"] * len(lognames)

--- a/tests/util/helpers.py
+++ b/tests/util/helpers.py
@@ -9,7 +9,7 @@ from typing import Any, List, Tuple
 
 import numpy
 import numpy as np
-from mantid.api import ITableWorkspace, MatrixWorkspace
+from mantid.api import IEventWorkspace, ITableWorkspace, MatrixWorkspace
 from mantid.dataobjects import GroupingWorkspace, MaskWorkspace
 from mantid.simpleapi import (
     AddSampleLog,
@@ -232,7 +232,7 @@ def initializeRandomMask(maskWSName: str, fraction: float) -> MaskWorkspace:
 
 def setSpectraToZero(inputWS: MatrixWorkspace, nss: Sequence[int]):
     # Zero out all spectra in the list of spectra
-    if "EventWorkspace" not in inputWS.id():
+    if not isinstance(inputWS, IEventWorkspace):
         for ns in nss:
             # allow "ragged" case
             zs = np.zeros_like(inputWS.readY(ns))
@@ -255,7 +255,7 @@ def setGroupSpectraToZero(ws: MatrixWorkspace, groupingWS: GroupingWorkspace, gi
     detInfo = ws.detectorInfo()
     for gid in gids:
         dets = groupingWS.getDetectorIDsOfGroup(gid)
-        if "EventWorkspace" not in ws.id():
+        if not isinstance(ws, IEventWorkspace):
             for det in dets:
                 ns = detInfo.indexOf(int(det))
                 # allow "ragged" case


### PR DESCRIPTION
## Description of work

Within the Reduction workflow, if a calibration table is present and has a mask, that mask should be applied.

However, it wasn't, unless the user specified a pixel mask.

There were two issues:
1. mismatch of the name of the mask between the service and recipe
2. a spurious `if` in the service which ended up not loading the diffcal mask unless the user had specified another one to load.

## Explanation of work

Inside `ReductionRecipe`, just changed the name to match.

Inside `ReductionService`, had to fix the logic around which pixel masks are loaded.  This all takes place inside the `prepCombinedMask` function, making things a bit cleaner.  This will *always* load the diffcal mask, if there is one, and then load all user-specified pixel masks, and combine all of the loaded masks at the end.  The "combined" mask might be a combination of just one mask, and might have no masked pixels.

`ReductionService` will only pass this mask if it has masked pixels.  This requires a method to check the mask workspace.  This was added to `GroceryService`, as this seems the most obvious place for it.

Additional tests ensure:
- the mask workspace created in the service correctly sets the mask workspace inside the recipe (preventing the original issue)
- even if no pixel masks are sent, the diffcal mask is still loaded (preventing the original issue)
- prepCombinedMask pulls in all the masks it should and properly combines them
- fetchReductionGroceries only passes the combined mask workspace when it is non-empty
- the check on if a mask workspace is empty works correctly

## To test

### Dev testing

The added unit tests should ensure the defect behavior is fixed.

### CIS testing

Run reduction for a run with a diffcal mask and some available pixel masks.  Make sure they are properly combined.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#8554](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8554)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] in Reduction workflow, if there is a diffcal mask present, it is loaded and applied to the workspace, even if the user does not specify pixel masks.
