### PR TITLE
Remove check on matching bins

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - python=3.10
 - pip
 - pydantic>=2.7.3,<3
-- mantidworkbench>=6.11.20241203
+- mantidworkbench>=6.11.20250101
 - qtpy
 - pre-commit
 - pytest

--- a/src/snapred/backend/recipe/CalculateDiffCalResidualRecipe.py
+++ b/src/snapred/backend/recipe/CalculateDiffCalResidualRecipe.py
@@ -109,7 +109,10 @@ class CalculateDiffCalResidualRecipe(Recipe[Ingredients]):
         combinedWorkspace = processedSpectra[0]
         for spectrum in processedSpectra[1:]:
             self.mantidSnapper.ConjoinWorkspaces(
-                f"Combining spectrum {spectrum}...", InputWorkspace1=combinedWorkspace, InputWorkspace2=spectrum
+                f"Combining spectrum {spectrum}...",
+                InputWorkspace1=combinedWorkspace,
+                InputWorkspace2=spectrum,
+                CheckMatchingBins=False,
             )
 
         # Step 4: Calculate the residual difference between the combined workspace and input workspace

--- a/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
+++ b/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
@@ -128,6 +128,7 @@ class ConjoinDiagnosticWorkspaces(PythonAlgorithm):
             InputWorkspace1=outws,
             InputWorkspace2=tmpws,
             CheckOverlapping=False,
+            CheckMatchingBins=False,
         )
         if self.autoDelete and inws in mtd:
             DeleteWorkspace(inws)

--- a/tests/unit/backend/recipe/algorithm/test_ConjoinDiagnosticWorkspaces.py
+++ b/tests/unit/backend/recipe/algorithm/test_ConjoinDiagnosticWorkspaces.py
@@ -157,6 +157,7 @@ class TestConjoinDiagnosticWorkspaces(unittest.TestCase):
         name1 = mtd.unique_name(prefix="group1_")
         group1 = WorkspaceGroup()
         wksp1 = CreateWorkspace(
+            OutputWorkspace=f"{name1}_dspacing",
             DataX=[0, 1, 2, 3],
             DataY=[2, 2, 2],
             NSpec=1,
@@ -169,9 +170,9 @@ class TestConjoinDiagnosticWorkspaces(unittest.TestCase):
         group2 = WorkspaceGroup()
         wksp2 = CreateWorkspace(
             OutputWorkspace=f"{name2}_dspacing",
-            DataX=[0, 1, 2],
-            DataY=[3, 3],
-            NSpec=1,
+            DataX=[0, 0, 0, 0, 1, 2],
+            DataY=[1000, 1000, 3, 3],
+            NSpec=2,
         )
         group2.addWorkspace(wksp2)
         mtd.add(name2, group2)


### PR DESCRIPTION
## Description of work

Mantid [PR #38478](https://github.com/mantidproject/mantid/pull/38478) introduced a new flag to check if bins match.  However, the new flag was set with default value of `True`, meaning the default behavior is not consistent with the old behavior.

This broke any behavior around `FitPeaks`, `PDCalibration`, and `ConjoinDiagnosticWorkspaces` inside of SNAPRed.

This PR sets the flag to `False`, which should fix this issue.

## Explanation of work

Inside `CoinjoinWorkspace` inside `ConjoinDiagnsoticWorkspace`, set the `CheckMatchingBins` flag to `False`.

## To test

Make sure unit tests are able to complete.

## Link to EWM item

N/A

### Verification

N/A

### Acceptance Criteria

- [ ] unit tests can pass again
