### PR TITLE
Remove unused test function

### DIFF
--- a/tests/util/helpers.py
+++ b/tests/util/helpers.py
@@ -12,7 +12,6 @@ import numpy as np
 from mantid.api import ITableWorkspace, MatrixWorkspace
 from mantid.dataobjects import GroupingWorkspace, MaskWorkspace
 from mantid.simpleapi import (
-    CompareWorkspaces,
     CreateEmptyTableWorkspace,
     CreateWorkspace,
     DeleteWorkspace,
@@ -209,29 +208,6 @@ def deleteWorkspaceNoThrow(wsName: str):
         DeleteWorkspace(wsName)
     except:  # noqa: E722
         pass
-
-
-def workspacesNotEqual(Workspace1: str, Workspace2: str, **other_options):
-    """
-    Meant to be called as
-    ``` python
-    assert workspacesNotEqual(ws1, ws2)
-    ```
-    Parameters:
-    - Workspace1: str -- one of the workspaces to compare
-    - Workspace2: str -- one of the workspaces to compare
-    - other_options: kwargs dict -- other options available to CompareWorkspaces
-    Returns: if the workspaces are NOT equal, will return True
-    If the workspaces ARE equal, will raise an assertion error
-    """
-    equal, _ = CompareWorkspaces(
-        Workspace1=Workspace1,
-        Workspace2=Workspace2,
-        **other_options,
-    )
-    if equal:
-        raise AssertionError(f"Workspaces {Workspace1} and {Workspace2} incorrectly evaluated as equal")
-    return not equal
 
 
 def nameOfRunningTestMethod(testCaseInstance: unittest.TestCase):


### PR DESCRIPTION
Everything has already moved to `mantid.testing.assert_not_equal()`. This is a maintenance task to remove the (now) unused function.

## To test

This is a maintenance that has no functional difference in the code. The builds should pass and nothing else will be affected.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#7338](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7338)

### Acceptance Criteria

`workspacesNotEqual()` should not appear anywhere in the snapred repository.
