### PR TITLE
added togglable lite compression, and override

### DIFF
--- a/src/snapred/backend/dao/WorkspaceMetadata.py
+++ b/src/snapred/backend/dao/WorkspaceMetadata.py
@@ -1,3 +1,5 @@
+from typing import Literal, Union
+
 from pydantic import BaseModel, ConfigDict
 
 from snapred.meta.Enum import StrEnum
@@ -30,5 +32,7 @@ class WorkspaceMetadata(BaseModel):
 
     diffcalState: DiffcalStateMetadata = UNSET
     normalizationState: NormalizationStateMetadata = UNSET
+    # NOTE: variables not allowed in type declarations
+    liteDataCompressionTolerance: Union[float, Literal["unset"]] = UNSET
 
     model_config = ConfigDict(extra="forbid", use_enum_values=True)

--- a/src/snapred/backend/service/LiteDataService.py
+++ b/src/snapred/backend/service/LiteDataService.py
@@ -52,7 +52,7 @@ class LiteDataService(Service):
             "Ingredients": ingredients.model_dump_json(),
         }
 
-        if Config["constants.LiteDataCreationAlgo.tolerance"] is not None:
+        if Config.exists("constants.LiteDataCreationAlgo.tolerance"):
             recipeKwargs["ToleranceOverride"] = Config["constants.LiteDataCreationAlgo.tolerance"]
 
         try:

--- a/src/snapred/backend/service/LiteDataService.py
+++ b/src/snapred/backend/service/LiteDataService.py
@@ -52,7 +52,10 @@ class LiteDataService(Service):
             "Ingredients": ingredients.model_dump_json(),
         }
 
-        if Config.exists("constants.LiteDataCreationAlgo.tolerance"):
+        if (
+            Config.exists("constants.LiteDataCreationAlgo.tolerance")
+            and Config["constants.LiteDataCreationAlgo.toggleCompressionTolerance"]
+        ):
             recipeKwargs["ToleranceOverride"] = Config["constants.LiteDataCreationAlgo.tolerance"]
 
         try:

--- a/src/snapred/backend/service/WorkspaceMetadataService.py
+++ b/src/snapred/backend/service/WorkspaceMetadataService.py
@@ -33,7 +33,10 @@ class WorkspaceMetadataService(Service):
         return ReadWorkspaceMetadata().cook({"workspace": workspace})
 
     def readMetadataTag(self, workspace: WorkspaceName, logname: str) -> str:
-        return self.readMetadataTags(workspace, [logname])[0]
+        tags = self.readMetadataTags(workspace, [logname])
+        if len(tags) == 0:
+            return UNSET
+        return tags[0]
 
     def readMetadataTags(self, workspace: WorkspaceName, lognames: List[str]) -> List[str]:
         metadata = self.readWorkspaceMetadata(workspace)

--- a/src/snapred/backend/service/WorkspaceMetadataService.py
+++ b/src/snapred/backend/service/WorkspaceMetadataService.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from snapred.backend.dao.WorkspaceMetadata import WorkspaceMetadata
+from snapred.backend.dao.WorkspaceMetadata import UNSET, WorkspaceMetadata
 from snapred.backend.recipe.ReadWorkspaceMetadata import ReadWorkspaceMetadata
 from snapred.backend.recipe.WriteWorkspaceMetadata import WriteWorkspaceMetadata
 from snapred.backend.service.Service import Service
@@ -37,4 +37,4 @@ class WorkspaceMetadataService(Service):
 
     def readMetadataTags(self, workspace: WorkspaceName, lognames: List[str]) -> List[str]:
         metadata = self.readWorkspaceMetadata(workspace)
-        return [getattr(metadata, logname) for logname in lognames]
+        return [getattr(metadata, logname) for logname in lognames if getattr(metadata, logname) is not UNSET]

--- a/src/snapred/meta/Config.py
+++ b/src/snapred/meta/Config.py
@@ -193,8 +193,11 @@ class _Config:
 
         return value
 
-    # period delimited key lookup
-    def __getitem__(self, key):
+    def exists(self, key: str) -> bool:
+        val = self._find(key)
+        return val is not None
+
+    def _find(self, key: str) -> Any:
         keys = key.split(".")
         val = self._config.get(keys[0])
         totalProcessed = 0
@@ -208,6 +211,13 @@ class _Config:
 
         if val is not None:
             val = self._replace(val, keys[1 + totalProcessed :])
+        return val
+
+    # period delimited key lookup
+    def __getitem__(self, key):
+        val = self._find(key)
+        if val is None:
+            raise KeyError(f"Key '{key}' not found in configuration")
         return val
 
 

--- a/src/snapred/meta/Config.py
+++ b/src/snapred/meta/Config.py
@@ -207,7 +207,7 @@ class _Config:
             if isinstance(val, str):
                 break
             totalProcessed += 1
-            val = val[k]
+            val = val.get(k)
 
         if val is not None:
             val = self._replace(val, keys[1 + totalProcessed :])

--- a/src/snapred/meta/Config.py
+++ b/src/snapred/meta/Config.py
@@ -196,7 +196,7 @@ class _Config:
     # period delimited key lookup
     def __getitem__(self, key):
         keys = key.split(".")
-        val = self._config[keys[0]]
+        val = self._config.get(keys[0])
         totalProcessed = 0
         for k in keys[1:]:
             if val is None:

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -208,36 +208,31 @@ constants:
   logsLocation: "entry/DASlogs"
   # logsLocation: "/mantid_workspace_1/logs"
 
-
-  CrystallographicInfo:
-    crystalDMin: 0.4
-    crystalDMax: 100.0
-
   ArtificialNormalization:
     peakWindowClippingSize: 10
-
   CalibrationReduction:
     tofMin: 2000
     tofMax: 14500
     rebinParams: [2000, -0.001, 14500]
-
-  DetectorPeakPredictor:
-    fwhm: 1.17741002252 # used to convert gaussian to fwhm (2 * log_e(2))
-
-  GroupDiffractionCalibration:
-    MaxChiSq: 100
-
-  ResampleX:
-    NumberBins: 1500
-
   CropFactors:
     lowWavelengthCrop: 0.05
     lowdSpacingCrop: 0.1
     highdSpacingCrop: 0.15
-
+  CrystallographicInfo:
+    crystalDMin: 0.4
+    crystalDMax: 100.0
+  DetectorPeakPredictor:
+    fwhm: 1.17741002252 # used to convert gaussian to fwhm (2 * log_e(2))
+  LiteDataCreationAlgo:
+    toggleCompressionTolerance: false  # false = no tolerance compression, true = tolerance compression
+    # tolerance: -0.004                 # tolerance override for calculated compression
+  GroupDiffractionCalibration:
+    MaxChiSq: 100
   RawVanadiumCorrection:
     numberOfSlices: 10
     numberOfAnnuli: 10
+  ResampleX:
+    NumberBins: 1500
 
 docs:
   user:

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -238,6 +238,10 @@ constants:
   GroupDiffractionCalibration:
     MaxChiSq: 100
 
+  LiteDataCreationAlgo:
+    toggleCompressionTolerance: false  # false = no tolerance compression, true = tolerance compression
+    # tolerance: -0.004                 # tolerance override for calculated compression
+
   ResampleX:
     NumberBins: 1500
 

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -240,7 +240,7 @@ constants:
 
   LiteDataCreationAlgo:
     toggleCompressionTolerance: false  # false = no tolerance compression, true = tolerance compression
-    # tolerance: -0.004                 # tolerance override for calculated compression
+    tolerance: -0.123                 # tolerance override for calculated compression
 
   ResampleX:
     NumberBins: 1500

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -28,6 +28,7 @@ from mantid.simpleapi import (
     mtd,
 )
 from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
+from util.Config_helpers import Config_override
 from util.helpers import createCompatibleDiffCalTable, createCompatibleMask
 from util.instrument_helpers import mapFromSampleLogs
 from util.kernel_helpers import tupleFromQuat, tupleFromV3D
@@ -1750,6 +1751,16 @@ class TestGroceryService(unittest.TestCase):
         # assert that the lite data service was created and called
         mockLiteDataService.assert_called_once()
         mockLiteDataService.return_value.reduceLiteData.assert_called_once_with(workspacename, workspacename)
+
+        with Config_override("constants.LiteDataCreationAlgo.toggleCompressionTolerance", True):
+            mockLiteDataService.reset_mock()
+            self.instance.writeWorkspaceMetadataAsTags = mock.Mock()
+
+            expected = WorkspaceMetadata(liteDataCompressionTolerance=0.004)
+
+            self.instance.convertToLiteMode(workspacename)
+
+            self.instance.writeWorkspaceMetadataAsTags.assert_called_once_with(workspacename, expected)
 
     def test_getCachedWorkspaces(self):
         rawWsName = self.instance._createRawNeutronWorkspaceName("556854", False)

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -737,10 +737,10 @@ class TestGroceryService(unittest.TestCase):
     def test_writeWorkspaceMetadataAsTags(self):
         self.instance.setWorkspaceTag = mock.Mock()
         wsName = "testWsName"
-        metadata = WorkspaceMetadata()
+        metadata = WorkspaceMetadata(diffcalState=DiffcalStateMetadata.ALTERNATE, liteDataCompressionTolerance=0.1)
         self.instance.writeWorkspaceMetadataAsTags(wsName, metadata)
-        assert self.instance.setWorkspaceTag.call_count == len(metadata.dict().keys())
-        self.instance.setWorkspaceTag.assert_called_with(wsName, "normalizationState", "unset")
+        assert self.instance.setWorkspaceTag.call_count == 2  # one for each metadata field set
+        self.instance.setWorkspaceTag.assert_called_with(wsName, "liteDataCompressionTolerance", 0.1)
 
     ## TEST CLEANUP METHODS
 
@@ -1737,6 +1737,12 @@ class TestGroceryService(unittest.TestCase):
         # The circular reference from `LiteDataService` back to `GroceryService.fetchLiteDataMap`
         #   (which should almost certainly be a service-to-service `InterfaceController` request)
         #   should be checked in `test_LiteDataService`, _not_ here.
+
+        mockLiteDataService().reduceLiteData = mock.Mock()
+        mockLiteDataService().reduceLiteData.return_value = ("ws", 0.004)
+
+        # reset calls
+        mockLiteDataService.reset_mock()
 
         workspacename = self.instance._createNeutronWorkspaceName(self.runNumber, False)
         self.instance.convertToLiteMode(workspacename)

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -720,7 +720,7 @@ class TestGroceryService(unittest.TestCase):
         assert f"Workspace {wsname} does not exist" in str(e1.value)
 
         with pytest.raises(RuntimeError) as e2:
-            self.instance.setWorkspaceTag(workspaceName=wsname, logname=logName, logvalue=tagValues[0])
+            self.instance.setWorkspaceTag(workspaceName=wsname, logname=logName, logvalue=tagValues[1])
         assert f"Workspace {wsname} does not exist" in str(e2.value)
 
         # Make sure default tag value is unset

--- a/tests/unit/backend/service/test_LiteDataService.py
+++ b/tests/unit/backend/service/test_LiteDataService.py
@@ -18,9 +18,12 @@ class TestLiteDataService(unittest.TestCase):
         executeRecipe,
     ):
         executeRecipe.return_value = {}
-        executeRecipe.side_effect = lambda **kwargs: CloneWorkspace(
-            InputWorkspace=kwargs["InputWorkspace"],
-            OutputWorkspace=kwargs["OutputWorkspace"],
+        executeRecipe.side_effect = lambda **kwargs: (
+            CloneWorkspace(
+                InputWorkspace=kwargs["InputWorkspace"],
+                OutputWorkspace=kwargs["OutputWorkspace"],
+            ),
+            0.04,
         )
 
         inputWorkspace = "_test_liteservice_555"

--- a/tests/unit/backend/service/test_LiteDataService.py
+++ b/tests/unit/backend/service/test_LiteDataService.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from mantid.simpleapi import CloneWorkspace, CreateSingleValuedWorkspace
+from util.Config_helpers import Config_override
 
 from snapred.backend.service.LiteDataService import LiteDataService
 from snapred.meta.Config import Resource
@@ -51,6 +52,18 @@ class TestLiteDataService(unittest.TestCase):
             LiteInstrumentDefinitionFile=None,
             Ingredients="{}",
         )
+
+        liteDataService.dataExportService = Mock()
+        with Config_override("constants.LiteDataCreationAlgo.toggleCompressionTolerance", True):
+            liteDataService.reduceLiteData(inputWorkspace, outputWorkspace)
+            executeRecipe.assert_called_with(
+                InputWorkspace=inputWorkspace,
+                OutputWorkspace=outputWorkspace,
+                LiteDataMapWorkspace="lite_map",
+                LiteInstrumentDefinitionFile=None,
+                Ingredients="{}",
+                ToleranceOverride=-0.123,
+            )
 
     @patch("snapred.backend.recipe.GenericRecipe.GenericRecipe.executeRecipe")
     def test_reduceLiteData_fails(self, mock_executeRecipe):


### PR DESCRIPTION
## Description of work

This exposes controls to the compression tolerance for the lite data creation algo and records new metadata on the workspace to track said tolerance value used.

## To test

I've mostly just been running normalization with `58810` and `58813` and then right clicking the given lite workspace generated to check its sample logs for the snapred metadata.  Toggle/change the application.yml, rerun and view the results.


## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#9030](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9030)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] Compression tolerance is togglable from the application yml (off by default)
- [x] Compression tolerance may be overwritten through the application.yml
- [x] if Compression tolerance is used, this is recorded as a metadata log
