### PR TITLE
pull correct peaks (reduction) from cif

### DIFF
--- a/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
@@ -151,8 +151,9 @@ class PurgeOverlappingPeaksAlgorithm(PythonAlgorithm):
         outputPeaks = self.filterPeaksOnDRange(outputPeaks)
         outputPeaks = self.filterNoPeakGroups(outputPeaks)
 
-        if len(outputPeaks) == 0:
-            raise RuntimeError("All Peaks were Purged!  Please adjust your parameters!\n\n\n")
+        # NOTE: Some samples have 0 peaks.
+        # if len(outputPeaks) == 0:
+        #     raise RuntimeError("All Peaks were Purged!  Please adjust your parameters!\n\n\n")
 
         self.setProperty("OutputPeakMap", list_to_raw(outputPeaks))
 

--- a/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
@@ -152,9 +152,6 @@ class PurgeOverlappingPeaksAlgorithm(PythonAlgorithm):
         outputPeaks = self.filterNoPeakGroups(outputPeaks)
 
         # NOTE: Some samples have 0 peaks.
-        # if len(outputPeaks) == 0:
-        #     raise RuntimeError("All Peaks were Purged!  Please adjust your parameters!\n\n\n")
-
         self.setProperty("OutputPeakMap", list_to_raw(outputPeaks))
 
         return outputPeaks

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -50,7 +50,6 @@ class SousChef(Service):
         self.dataFactoryService = DataFactoryService()
         self._pixelGroupCache: Dict[Tuple[str, bool, str], PixelGroup] = {}
         self._peaksCache: Dict[Tuple[str, bool, str, float, float, float], List[GroupPeakList]] = {}
-        self._xtalCache: Dict[Tuple[str, float, float], CrystallographicInfo] = {}
         return
 
     @staticmethod

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -144,18 +144,15 @@ class SousChef(Service):
             return Config["instrument.native.definition.file"]
 
     def prepCrystallographicInfo(self, ingredients: FarmFreshIngredients) -> CrystallographicInfo:
-        if not ingredients.cifPath:
-            samplePath = Path(ingredients.calibrantSamplePath).stem
-            ingredients.cifPath = self.dataFactoryService.getCifFilePath(samplePath)
+        samplePath = Path(ingredients.calibrantSamplePath).stem
+        ingredients.cifPath = self.dataFactoryService.getCifFilePath(samplePath)
         key = (
             ingredients.cifPath,
             ingredients.crystalDBounds.minimum,
             ingredients.crystalDBounds.maximum,
             ingredients.calibrantSamplePath,
         )
-        if key not in self._xtalCache:
-            self._xtalCache[key] = CrystallographicInfoService().ingest(*key)["crystalInfo"]
-        return deepcopy(self._xtalCache[key])
+        return CrystallographicInfoService().ingest(*key)["crystalInfo"]
 
     def prepPeakIngredients(self, ingredients: FarmFreshIngredients) -> PeakIngredients:
         return PeakIngredients(

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -259,11 +259,12 @@ class TestSousChef(unittest.TestCase):
 
         # mock out the data factory
         self.instance.dataFactoryService = mock.Mock()
-        self.instance.dataFactoryService.getCifFilePath.return_value = self.ingredients.cifPath
+        self.instance.dataFactoryService.getCifFilePath.return_value = mock.sentinel.cifPath
 
         self.instance.prepCrystallographicInfo(incompleteIngredients)
 
         assert XtalService.called
+        assert XtalService().ingest.call_args[0][0] == mock.sentinel.cifPath
         assert self.instance.dataFactoryService.getCifFilePath.called
 
     @mock.patch(thisService + "PeakIngredients")


### PR DESCRIPTION


## Description of work
This was an issue notice by Malcolm during testing, where despite souschef having the calibrant sample used during normalization, it was pulling crystal data from silicon (the calibrant sample from the diffcal used).

This pr ensures that the cif file associated with the normalization calibrant sample is actually used, and it doesnt refer to the disconnected cif_file living on the ffi.

## To test

This is most easily verified if you can output the detector peaks produced during reduction.
Observe that if you did a diffraction calibration with a silicon sample and a normalization with V-Nb_001, the last three peaks would be the following for `next`
```
DetectorPeak(position=LimitedValue[float](value=1.63769, minimum=1.6162073118442868, maximum=1.6783030113485202), peak=CrystallographicPeak(hkl=(3, 1, 1), dSpacing=1.6376860040951353, fSquared=550.8809859199997, multiplicity=24)), 
DetectorPeak(position=LimitedValue[float](value=1.92036, minimum=1.8951693152277678, maximum=1.967326707867764), peak=CrystallographicPeak(hkl=(2, 2, 0), dSpacing=1.9203570608125202, fSquared=1101.76197184, multiplicity=12)), 
DetectorPeak(position=LimitedValue[float](value=3.13593, minimum=3.094793784024488, maximum=3.2021956681772243), peak=CrystallographicPeak(hkl=(1, 1, 1), dSpacing=3.13592994862768, fSquared=550.88098592, multiplicity=8))]
```

These are silicon peaks, and are not what we want.
They should actually be completely empty as `V-Nb_001` should have NO peaks
```
"detectorPeaksMany":[[{"peaks":[],"groupID":1,"maxfwhm":0.0}],[{"peaks":[],"groupID":1,"maxfwhm":0.0},{"peaks":[],"groupID":2,"maxfwhm":0.0}],[{"peaks":[],"groupID":1,"maxfwhm":0.0},{"peaks":[],"groupID":2,"maxfwhm":0.0},{"peaks":[],"groupID":3,"maxfwhm":0.0},{"peaks":[],"groupID":4,"maxfwhm":0.0},{"peaks":[],"groupID":5,"maxfwhm":0.0},{"peaks":[],"groupID":6,"maxfwhm":0.0}],[{"peaks":[],"groupID":1,"maxfwhm":0.0},{"peaks":[],"groupID":2,"maxfwhm":0.0}]]
```

### CIS testing

<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

``` python
# replace with your test script below
```

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#9120](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9120)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] The detector peaks generated as part of reduction are the ones associated with the calibrant sample for Normalization and not Calibration.
