### PR TITLE
fix write permission check

### DIFF
--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -3,6 +3,7 @@ import glob
 import json
 import os
 import re
+import tempfile
 import time
 from errno import ENOENT as NOT_FOUND
 from functools import lru_cache
@@ -175,10 +176,8 @@ class LocalDataService:
 
     @staticmethod
     def _hasWritePermissionstoPath(filePath: Path) -> bool:
-        import tempfile
-
         if not filePath.is_dir():
-            filePath = filePath.parent()
+            filePath = filePath.parent
         tempfile.tempdir = str(filePath)
         try:
             with tempfile.TemporaryFile() as fp:

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -3,7 +3,6 @@ import glob
 import json
 import os
 import re
-import stat
 import time
 from errno import ENOENT as NOT_FOUND
 from functools import lru_cache
@@ -176,35 +175,17 @@ class LocalDataService:
 
     @staticmethod
     def _hasWritePermissionstoPath(filePath: Path) -> bool:
-        # WARNING: `os.access` does not work correctly on the `/SNS` shared filesystem.
+        import tempfile
 
-        # formerly:
-        #   `return os.access(filePath, os.W_OK) if filePath.exists() else False`
-
-        # alternative implementation (LINUX specific):
-        hasPermissions = False
-        if filePath.exists():
-            stat_ = os.stat(filePath)
-
-            # Get the path's permissions mode bits.
-            mode = stat.S_IMODE(stat_.st_mode)
-
-            # Get the path owner's user-id, and group-id.
-            fuid = stat_.st_uid
-            fgid = stat_.st_gid
-
-            # Get the current user's user-id and group-ids
-            uid = os.getuid()
-            gids = os.getgroups()
-
-            # Check for any overlap with the write permission's mode bits:
-            #   checking the user-bits, if the current user is the owner;
-            #   then checking the group-bits, if the user belongs to the file-owner's group;
-            #   and finally checking the other-bits.
-            hasPermissions = (
-                (uid == fuid) and bool(mode & 0o200) or (fgid in gids) and bool(mode & 0o020) or bool(mode & 0o002)
-            )
-        return hasPermissions
+        if not filePath.is_dir():
+            filePath = filePath.parent()
+        tempfile.tempdir = str(filePath)
+        try:
+            with tempfile.TemporaryFile() as fp:
+                fp.write(b"Hello world!")
+        except Exception:  # noqa: BLE001
+            return False
+        return True
 
     @staticmethod
     def checkWritePermissions(path: Path) -> bool:

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -178,13 +178,16 @@ class LocalDataService:
     def _hasWritePermissionstoPath(filePath: Path) -> bool:
         if not filePath.is_dir():
             filePath = filePath.parent
+        result = True
+        preTempDir = tempfile.tempdir
         tempfile.tempdir = str(filePath)
         try:
             with tempfile.TemporaryFile() as fp:
                 fp.write(b"Hello world!")
         except Exception:  # noqa: BLE001
-            return False
-        return True
+            result = False
+        tempfile.tempdir = preTempDir
+        return result
 
     @staticmethod
     def checkWritePermissions(path: Path) -> bool:


### PR DESCRIPTION
## Description of work

The existing perms checks provide a false negative in some cases on the analysis cluster, this new check seems to work.

This solution was tested with Malcolm via a script.

## To test

This may not be easy for a dev to test because the perms issue had to do with not being allowed to write to a specific ipts despite having write perms.  But here is a comparison script.

```

import os
import stat
from pathlib import Path

def _hasWritePermissionstoPathOld(filePath: Path) -> bool:
        # WARNING: `os.access` does not work correctly on the `/SNS` shared filesystem.

        # formerly:
        #   `return os.access(filePath, os.W_OK) if filePath.exists() else False`

        # alternative implementation (LINUX specific):
        hasPermissions = False
        if filePath.exists():
            stat_ = os.stat(filePath)

            # Get the path's permissions mode bits.
            mode = stat.S_IMODE(stat_.st_mode)

            # Get the path owner's user-id, and group-id.
            fuid = stat_.st_uid
            fgid = stat_.st_gid

            # Get the current user's user-id and group-ids
            uid = os.getuid()
            gids = os.getgroups()

            # Check for any overlap with the write permission's mode bits:
            #   checking the user-bits, if the current user is the owner;
            #   then checking the group-bits, if the user belongs to the file-owner's group;
            #   and finally checking the other-bits.
            hasPermissions = (
                (uid == fuid) and bool(mode & 0o200) or (fgid in gids) and bool(mode & 0o020) or bool(mode & 0o002)
            )
        return hasPermissions
     
  
def _hasWritePermissionstoPathNew(filePath: Path) -> bool :
    import tempfile
    if not filePath.is_dir():
        filePath = filePath.parent()
    tempfile.tempdir = str(filePath)
    try:
        with tempfile.TemporaryFile() as fp:
            fp.write(b'Hello world!')
    except Exception as e:
        return False
    return True
  
assert _hasWritePermissionstoPathOld(Path("/SNS/SNAP/IPTS-28343/")) is True
assert _hasWritePermissionstoPathOld(Path("/SNS/users/wqp/SNAP/IPTS-28343/shared/")) is False

assert _hasWritePermissionstoPathNew(Path("/SNS/SNAP/IPTS-28343/")) is True
assert _hasWritePermissionstoPathNew(Path("/SNS/users/wqp/SNAP/IPTS-28343/shared/")) is False
```
NOTE: you will need to change the path in the asserts to not point to my home.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#8964](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8964)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] reduction should allow users who have write permissions to write the output of reduction.
