### PR TITLE
Historical SNAPInstPrm

### DIFF
--- a/src/snapred/backend/dao/InstrumentConfig.py
+++ b/src/snapred/backend/dao/InstrumentConfig.py
@@ -1,12 +1,10 @@
-from pydantic import BaseModel
-
+from snapred.backend.dao.indexing.Versioning import VersionedObject
 from snapred.meta.Config import Config
 
 
-class InstrumentConfig(BaseModel):
+class InstrumentConfig(VersionedObject):
     """Class to hold the instrument parameters."""
 
-    version: str
     facility: str
     name: str
     nexusFileExtension: str

--- a/src/snapred/backend/dao/indexing/Versioning.py
+++ b/src/snapred/backend/dao/indexing/Versioning.py
@@ -12,6 +12,8 @@ class VersionState(StrEnum):
     DEFAULT = Config["version.friendlyName.default"]
     LATEST = "latest"
     NEXT = "next"
+    # NOTE: This is only so we may read old saved IntrumentConfigs
+    LEGACY_INST_PRM = "1.4"
 
 
 # I'm not sure why ci is failing without this, it doesn't seem to be used anywhere

--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -49,7 +49,7 @@ class DataFactoryService:
         return self.lookupService.readRunConfig(runId)
 
     def getInstrumentConfig(self, runId: str) -> InstrumentConfig:  # noqa: ARG002
-        return self.lookupService.getInstrumentConfig()
+        return self.lookupService.readInstrumentConfig(runId)
 
     def getStateConfig(self, runId: str, useLiteMode: bool) -> StateConfig:  # noqa: ARG002
         return self.lookupService.readStateConfig(runId, useLiteMode)

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -806,7 +806,7 @@ class GroceryService:
 
                 case (True, _, True, _):
                     # lite mode and lite-mode exists on disk
-                    data = self.grocer.executeRecipe(str(liteModeFilePath), workspaceName, loader)
+                    data = self.grocer.executeRecipe(str(liteModeFilePath), workspaceName, loader, runNumber=runNumber)
                     success = True
 
                 case (True, True, _, _):
@@ -821,13 +821,13 @@ class GroceryService:
 
                 case (True, _, _, True):
                     # lite mode and native exists on disk
-                    data = self.grocer.executeRecipe(str(nativeModeFilePath), workspaceName, loader)
+                    data = self.grocer.executeRecipe(str(nativeModeFilePath), workspaceName, loader, runNumber=runNumber)
                     convertToLiteMode = True
                     success = True
 
                 case (False, _, _, True):
                     # native mode and native exists on disk
-                    data = self.grocer.executeRecipe(str(nativeModeFilePath), workspaceName, loader)
+                    data = self.grocer.executeRecipe(str(nativeModeFilePath), workspaceName, loader, runNumber=runNumber)
                     success = True
 
                 case _:
@@ -850,7 +850,7 @@ class GroceryService:
                     "StartTime": startTime,
                 }
                 data = self.grocer.executeRecipe(
-                    workspace=workspaceName, loader="LoadLiveData", loaderArgs=json.dumps(loaderArgs)
+                    workspace=workspaceName, loader="LoadLiveData", loaderArgs=json.dumps(loaderArgs), runNumber=runNumber
                 )
                 if data["result"]:
                     logs = self.mantidSnapper.mtd[workspaceName].getRun()
@@ -928,7 +928,7 @@ class GroceryService:
 
                 case (True, _, True, _):
                     # lite mode and lite-mode exists on disk
-                    data = self.grocer.executeRecipe(str(liteModeFilePath), rawWorkspaceName, loader)
+                    data = self.grocer.executeRecipe(str(liteModeFilePath), rawWorkspaceName, loader, runNumber=runNumber)
                     self._loadedRuns[key] = 0
                     success = True
 
@@ -941,14 +941,14 @@ class GroceryService:
                 case (True, _, _, True):
                     # lite mode and native exists on disk
                     goingNative = self._key(runNumber, False)
-                    data = self.grocer.executeRecipe(str(nativeModeFilePath), nativeRawWorkspaceName, loader="")
+                    data = self.grocer.executeRecipe(str(nativeModeFilePath), nativeRawWorkspaceName, loader="", runNumber=runNumber)
                     self._loadedRuns[self._key(*goingNative)] = 0
                     convertToLiteMode = True
                     success = True
 
                 case (False, _, _, True):
                     # native mode and native exists on disk
-                    data = self.grocer.executeRecipe(str(nativeModeFilePath), nativeRawWorkspaceName, loader)
+                    data = self.grocer.executeRecipe(str(nativeModeFilePath), nativeRawWorkspaceName, loader, runNumber=runNumber)
                     self._loadedRuns[key] = 0
                     success = True
 
@@ -973,7 +973,7 @@ class GroceryService:
                     "StartTime": startTime,
                 }
                 data = self.grocer.executeRecipe(
-                    workspace=nativeRawWorkspaceName, loader="LoadLiveData", loaderArgs=json.dumps(loaderArgs)
+                    workspace=nativeRawWorkspaceName, loader="LoadLiveData", loaderArgs=json.dumps(loaderArgs), runNumber=runNumber
                 )
                 if data["result"]:
                     logs = self.mantidSnapper.mtd[nativeRawWorkspaceName].getRun()

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -821,13 +821,17 @@ class GroceryService:
 
                 case (True, _, _, True):
                     # lite mode and native exists on disk
-                    data = self.grocer.executeRecipe(str(nativeModeFilePath), workspaceName, loader, runNumber=runNumber)
+                    data = self.grocer.executeRecipe(
+                        str(nativeModeFilePath), workspaceName, loader, runNumber=runNumber
+                    )
                     convertToLiteMode = True
                     success = True
 
                 case (False, _, _, True):
                     # native mode and native exists on disk
-                    data = self.grocer.executeRecipe(str(nativeModeFilePath), workspaceName, loader, runNumber=runNumber)
+                    data = self.grocer.executeRecipe(
+                        str(nativeModeFilePath), workspaceName, loader, runNumber=runNumber
+                    )
                     success = True
 
                 case _:
@@ -850,7 +854,10 @@ class GroceryService:
                     "StartTime": startTime,
                 }
                 data = self.grocer.executeRecipe(
-                    workspace=workspaceName, loader="LoadLiveData", loaderArgs=json.dumps(loaderArgs), runNumber=runNumber
+                    workspace=workspaceName,
+                    loader="LoadLiveData",
+                    loaderArgs=json.dumps(loaderArgs),
+                    runNumber=runNumber,
                 )
                 if data["result"]:
                     logs = self.mantidSnapper.mtd[workspaceName].getRun()
@@ -928,7 +935,9 @@ class GroceryService:
 
                 case (True, _, True, _):
                     # lite mode and lite-mode exists on disk
-                    data = self.grocer.executeRecipe(str(liteModeFilePath), rawWorkspaceName, loader, runNumber=runNumber)
+                    data = self.grocer.executeRecipe(
+                        str(liteModeFilePath), rawWorkspaceName, loader, runNumber=runNumber
+                    )
                     self._loadedRuns[key] = 0
                     success = True
 
@@ -941,14 +950,18 @@ class GroceryService:
                 case (True, _, _, True):
                     # lite mode and native exists on disk
                     goingNative = self._key(runNumber, False)
-                    data = self.grocer.executeRecipe(str(nativeModeFilePath), nativeRawWorkspaceName, loader="", runNumber=runNumber)
+                    data = self.grocer.executeRecipe(
+                        str(nativeModeFilePath), nativeRawWorkspaceName, loader="", runNumber=runNumber
+                    )
                     self._loadedRuns[self._key(*goingNative)] = 0
                     convertToLiteMode = True
                     success = True
 
                 case (False, _, _, True):
                     # native mode and native exists on disk
-                    data = self.grocer.executeRecipe(str(nativeModeFilePath), nativeRawWorkspaceName, loader, runNumber=runNumber)
+                    data = self.grocer.executeRecipe(
+                        str(nativeModeFilePath), nativeRawWorkspaceName, loader, runNumber=runNumber
+                    )
                     self._loadedRuns[key] = 0
                     success = True
 
@@ -973,7 +986,10 @@ class GroceryService:
                     "StartTime": startTime,
                 }
                 data = self.grocer.executeRecipe(
-                    workspace=nativeRawWorkspaceName, loader="LoadLiveData", loaderArgs=json.dumps(loaderArgs), runNumber=runNumber
+                    workspace=nativeRawWorkspaceName,
+                    loader="LoadLiveData",
+                    loaderArgs=json.dumps(loaderArgs),
+                    runNumber=runNumber,
                 )
                 if data["result"]:
                     logs = self.mantidSnapper.mtd[nativeRawWorkspaceName].getRun()

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -98,9 +98,6 @@ class LocalDataService:
 
     ##### MISCELLANEOUS METHODS #####
 
-    def getInstrumentConfig(self):
-        return self._instrumentConfig
-
     def fileExists(self, path):
         return os.path.isfile(path)
 

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -18,7 +18,7 @@ from mantid.api import Run
 from mantid.dataobjects import MaskWorkspace
 from mantid.kernel import ConfigService, PhysicalConstants
 from mantid.simpleapi import GetIPTS, mtd
-from pydantic import ValidationError, validate_call
+from pydantic import ValidationError
 
 from snapred.backend.dao import (
     GSASParameters,
@@ -71,7 +71,7 @@ from snapred.meta.mantid.WorkspaceNameGenerator import (
 from snapred.meta.mantid.WorkspaceNameGenerator import (
     WorkspaceType as wngt,
 )
-from snapred.meta.redantic import parse_file_as, write_model_pretty
+from snapred.meta.redantic import parse_file_as, validate_call, write_model_pretty
 
 logger = snapredLogger.getLogger(__name__)
 

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -93,8 +93,7 @@ class LocalDataService:
     CONVERSION_FACTOR = Config["constants.m2cm"] * PhysicalConstants.h / PhysicalConstants.NeutronMass
 
     def __init__(self) -> None:
-        self._verifyPaths = Config["localdataservice.config.verifypaths"]
-        self._instrumentConfig = self._readInstrumentConfig()
+        self.verifyPaths = Config["localdataservice.config.verifypaths"]
         self.mantidSnapper = MantidSnapper(None, "Utensils")
 
     ##### MISCELLANEOUS METHODS #####
@@ -105,47 +104,13 @@ class LocalDataService:
     def fileExists(self, path):
         return os.path.isfile(path)
 
-    def _determineInstrConfigPaths(self) -> None:
-        """This method locates the instrument configuration path and
-        sets the instance variable ``_instrumentConfigPath``."""
-        # verify parent directory exists
-        self._instrumentHomePath = Path(Config["instrument.home"])
-        if self._verifyPaths and not self._instrumentHomePath.exists():
-            raise _createFileNotFoundError(Config["instrument.home"], self._instrumentHomePath)
-
-        # look for the config file and verify it exists
-        self._instrumentConfigPath = Config["instrument.config"]
-        if self._verifyPaths and not Path(self._instrumentConfigPath).exists():
-            raise _createFileNotFoundError("Missing Instrument Config", Config["instrument.config"])
-
-    def _readInstrumentConfig(self) -> InstrumentConfig:
-        self._determineInstrConfigPaths()
-
-        instrumentParameterMap = self._readInstrumentParameters()
-        try:
-            instrumentParameterMap["bandwidth"] = instrumentParameterMap.pop("neutronBandwidth")
-            instrumentParameterMap["maxBandwidth"] = instrumentParameterMap.pop("extendedNeutronBandwidth")
-            instrumentParameterMap["delTOverT"] = instrumentParameterMap.pop("delToT")
-            instrumentParameterMap["delLOverL"] = instrumentParameterMap.pop("delLoL")
-            instrumentParameterMap["version"] = str(instrumentParameterMap["version"])
-            instrumentConfig = InstrumentConfig(**instrumentParameterMap)
-        except KeyError as e:
-            raise KeyError(f"{e}: while reading instrument configuration '{self._instrumentConfigPath}'") from e
-        if self._instrumentHomePath:
-            instrumentConfig.calibrationDirectory = Path(Config["instrument.calibration.home"])
-            if self._verifyPaths and not instrumentConfig.calibrationDirectory.exists():
-                raise _createFileNotFoundError("[calibration directory]", instrumentConfig.calibrationDirectory)
+    def readInstrumentConfig(self, runNumber: str) -> InstrumentConfig:
+        instrumentConfig = self.readInstrumentParameters(runNumber)
+        instrumentConfig.calibrationDirectory = Config["instrument.calibration.home"]
+        if self.verifyPaths and not Path(instrumentConfig.calibrationDirectory).exists():
+            raise _createFileNotFoundError("[calibration directory]", instrumentConfig.calibrationDirectory)
 
         return instrumentConfig
-
-    def _readInstrumentParameters(self) -> Dict[str, Any]:
-        instrumentParameterMap: Dict[str, Any] = {}
-        try:
-            with open(self._instrumentConfigPath, "r") as json_file:
-                instrumentParameterMap = json.load(json_file)
-            return instrumentParameterMap
-        except FileNotFoundError as e:
-            raise _createFileNotFoundError("Instrument configuration file", self._instrumentConfigPath) from e
 
     def readStateConfig(self, runId: str, useLiteMode: bool) -> StateConfig:
         indexer = self.calibrationIndexer(runId, useLiteMode)
@@ -268,22 +233,23 @@ class LocalDataService:
     def _readRunConfig(self, runId: str) -> RunConfig:
         # lookup path for IPTS number
         iptsPath = self.getIPTS(runId)
-
+        instrumentConfig = self.readInstrumentConfig(runId)
         return RunConfig(
             IPTS=iptsPath,
             runNumber=runId,
             maskFileName="",
-            maskFileDirectory=iptsPath + self._instrumentConfig.sharedDirectory,
-            gsasFileDirectory=iptsPath + self._instrumentConfig.reducedDataDirectory,
+            maskFileDirectory=iptsPath + instrumentConfig.sharedDirectory,
+            gsasFileDirectory=iptsPath + instrumentConfig.reducedDataDirectory,
             calibrationState=None,
         )  # TODO: where to find case? "before" "after"
 
     def _constructPVFilePath(self, runId: str) -> Path:
         runConfig = self._readRunConfig(runId)
+        instrumentConfig = self.readInstrumentConfig(runId)
         return Path(
             runConfig.IPTS,
-            self._instrumentConfig.nexusDirectory,
-            f"SNAP_{str(runConfig.runNumber)}{self._instrumentConfig.nexusFileExtension}",
+            instrumentConfig.nexusDirectory,
+            f"SNAP_{str(runConfig.runNumber)}{instrumentConfig.nexusFileExtension}",
         )
 
     def _readPVFile(self, runId: str):
@@ -476,6 +442,11 @@ class LocalDataService:
     def normalizationIndexer(self, runId: str, useLiteMode: bool):
         return self.indexer(runId, useLiteMode, IndexerType.NORMALIZATION)
 
+    def instrumentParameterIndexer(self):
+        return Indexer(
+            indexerType=IndexerType.INSTRUMENT_PARAMETER, directory=Path(Config["instrument.parameters.home"])
+        )
+
     def writeCalibrationIndexEntry(self, entry: IndexEntry):
         """
         The entry must have correct version.
@@ -487,6 +458,31 @@ class LocalDataService:
         The entry must have correct version.
         """
         self.normalizationIndexer(entry.runNumber, entry.useLiteMode).addIndexEntry(entry)
+
+    ##### Instrument Parameter Methods #####
+
+    # 1. write new instrumen param file 2. read appropriate instrument param file
+    def writeInstrumentParameters(self, instrumentParameters: InstrumentConfig, appliesTo: str, author: str):
+        """
+        Writes the instrument parameters to disk.
+        """
+        indexer = self.instrumentParameterIndexer()
+        newEntry = indexer.createIndexEntry(
+            runNumber=ReservedRunNumber.NATIVE,
+            useLiteMode=False,
+            # The above two fields are irrelevant for instrument parameters, but required by the IndexEntry model.
+            version=VersionState.NEXT,
+            appliesTo=appliesTo,
+            author=author,
+        )
+        indexer.writeNewVersionedObject(instrumentParameters, newEntry)
+
+    def readInstrumentParameters(self, runNumber: str):
+        indexer = self.instrumentParameterIndexer()
+        version = indexer.latestApplicableVersion(runNumber)
+        if version is None:
+            raise FileNotFoundError(f"No instrument parameters found for run {runNumber}")
+        return indexer.readVersionedObject(InstrumentConfig, version)
 
     ##### NORMALIZATION METHODS #####
 
@@ -930,7 +926,9 @@ class LocalDataService:
         #   and generate the stateID SHA.
         stateId, detectorState = self.generateStateId(runId)
 
-        # Pull static values from resources
+        # then read data from the common calibration state parameters stored at root of calibration directory
+        instrumentConfig = self.readInstrumentConfig(runId)
+        # then pull static values specified by Malcolm from resources
         defaultGroupSliceValue = Config["calibration.parameters.default.groupSliceValue"]
         fwhmMultipliers = Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
         peakTailCoefficient = Config["calibration.parameters.default.peakTailCoefficient"]
@@ -941,11 +939,11 @@ class LocalDataService:
         # Calculate the derived values
         lambdaLimit = Limit(
             minimum=detectorState.wav
-            - (self._instrumentConfig.bandwidth / 2)
-            + self._instrumentConfig.lowWavelengthCrop,
-            maximum=detectorState.wav + (self._instrumentConfig.bandwidth / 2),
+            - (instrumentConfig.bandwidth / 2)
+            + instrumentConfig.lowWavelengthCrop,
+            maximum=detectorState.wav + (instrumentConfig.bandwidth / 2),
         )
-        L = self._instrumentConfig.L1 + self._instrumentConfig.L2
+        L = instrumentConfig.L1 + instrumentConfig.L2
         tofLimit = Limit(
             minimum=lambdaLimit.minimum * L / self.CONVERSION_FACTOR,
             maximum=lambdaLimit.maximum * L / self.CONVERSION_FACTOR,
@@ -954,7 +952,7 @@ class LocalDataService:
 
         return InstrumentState(
             id=stateId,
-            instrumentConfig=self._instrumentConfig,
+            instrumentConfig=instrumentConfig,
             detectorState=detectorState,
             gsasParameters=gsasParameters,
             particleBounds=particleBounds,

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -938,9 +938,7 @@ class LocalDataService:
 
         # Calculate the derived values
         lambdaLimit = Limit(
-            minimum=detectorState.wav
-            - (instrumentConfig.bandwidth / 2)
-            + instrumentConfig.lowWavelengthCrop,
+            minimum=detectorState.wav - (instrumentConfig.bandwidth / 2) + instrumentConfig.lowWavelengthCrop,
             maximum=detectorState.wav + (instrumentConfig.bandwidth / 2),
         )
         L = instrumentConfig.L1 + instrumentConfig.L2

--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -16,6 +16,7 @@ class FetchGroceriesRecipe:
         utensils = Utensils()
         utensils.PyInit()
         self.mantidSnapper = utensils.mantidSnapper
+        self.dataService = LocalDataService()
 
     def executeRecipe(
         self,
@@ -26,6 +27,7 @@ class FetchGroceriesRecipe:
         instrumentSource="",
         *,
         loaderArgs: str = "",
+        runNumber: int = None,
     ) -> Dict[str, Any]:
         """
         Wraps the fetch groceries algorithm
@@ -66,7 +68,9 @@ class FetchGroceriesRecipe:
 
             if data["loader"] in ("LoadEventNexus", "LoadLiveData"):
                 self.dataService = LocalDataService()
-                config = self.dataService.getInstrumentConfig()
+                if runNumber is None:
+                    raise RuntimeError("Code Err: Run number is required for event nexus files so we can remove the prompt pulse")
+                config = self.dataService.readInstrumentConfig(runNumber)
                 width = config.width
                 frequency = config.frequency
                 self.mantidSnapper.RemovePromptPulse(

--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -69,7 +69,9 @@ class FetchGroceriesRecipe:
             if data["loader"] in ("LoadEventNexus", "LoadLiveData"):
                 self.dataService = LocalDataService()
                 if runNumber is None:
-                    raise RuntimeError("Code Err: Run number is required for event nexus files so we can remove the prompt pulse")
+                    raise RuntimeError(
+                        "Code Err: Run number is required for event nexus files so we can remove the prompt pulse"
+                    )
                 config = self.dataService.readInstrumentConfig(runNumber)
                 width = config.width
                 frequency = config.frequency

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -61,6 +61,9 @@ class SousChef(Service):
 
     def prepCalibration(self, ingredients: FarmFreshIngredients) -> Calibration:
         calibration = self.dataFactoryService.getCalibrationState(ingredients.runNumber, ingredients.useLiteMode)
+        # NOTE: This generates a new instrument state based on the appropriate SNAPInstPrm, as opposed to
+        #       passing the previous instrument state forward.
+        calibration.instrumentState = self.dataFactoryService.getDefaultInstrumentState(ingredients.runNumber)
         calibration.calibrantSamplePath = ingredients.calibrantSamplePath
         calibration.peakIntensityThreshold = self._getThresholdFromCalibrantSample(ingredients.calibrantSamplePath)
         calibration.instrumentState.fwhmMultipliers = ingredients.fwhmMultipliers

--- a/src/snapred/meta/decorators/ExceptionHandler.py
+++ b/src/snapred/meta/decorators/ExceptionHandler.py
@@ -15,6 +15,8 @@ def extractTrueStacktrace() -> str:
         tb = traceback.extract_tb(exc_info[2])
         full_tb = stack[:-1] + tb
         exc_line = traceback.format_exception_only(*exc_info[:2])
+        # filter for lines in SNAPREd/tests or SNAPREd/src
+        full_tb = [line for line in full_tb if "SNAPRed/tests" in line.filename or "SNAPRed/src" in line.filename]
         stacktraceStr = "\n".join(["".join(traceback.format_list(full_tb)), "".join(exc_line)])
         return stacktraceStr
     return "no exception has occurred"

--- a/src/snapred/meta/decorators/Singleton.py
+++ b/src/snapred/meta/decorators/Singleton.py
@@ -4,6 +4,10 @@ from typing import List
 _Singleton_instances: List[type] = []
 
 
+# NOTE: January, 31, 2025 - There may be a race condition between inherited classes of a signleton class
+#       There was some Weirdness observed involving the testfile InstaEats.py where the inheriter of
+#       LocalDataService was just a LocalDataService object and not a WhateversInTheFridge object.
+#       Instantiating the WhateversInTheFridge earlier may have fixed the issue for now.
 def Singleton(orig_cls):
     orig_new = orig_cls.__new__
     orig_init = orig_cls.__init__

--- a/src/snapred/meta/redantic.py
+++ b/src/snapred/meta/redantic.py
@@ -1,10 +1,18 @@
+import functools
 import json
 from pathlib import Path
 from typing import Any, List, Type, TypeVar, Union
 
 from pydantic import BaseModel, TypeAdapter
+from pydantic import validate_call as pydantic_validate_call
 
 T = TypeVar("T")
+
+
+def validate_call(func: callable):
+    # wraps lets us get a stack trace that makes sense instead of 50 lines of pydantic internals
+    wrapped = pydantic_validate_call(func)
+    return functools.update_wrapper(wrapped, func)
 
 
 def parse_obj_as(type_: Type[T], obj: Any) -> T:

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -34,6 +34,8 @@ instrument:
 
   # Swap the commented out fields when using ultralite data
   config: ${instrument.calibration.home}/SNAPInstPrm.json
+  parameters:
+    home: ${instrument.calibration.home}/SNAPInstPrm
   native:
     pixelResolution: 1179648
     # pixelResolution: 72

--- a/src/snapred/resources/default/request/fitMultiplePeaks/fitMultiplePeaks/payload.json
+++ b/src/snapred/resources/default/request/fitMultiplePeaks/fitMultiplePeaks/payload.json
@@ -2,7 +2,7 @@
   "instrumentState": {
     "id": "0a1b2c3d0a1b2c3d",
     "instrumentConfig": {
-      "version": "1.4",
+      "version": 1,
       "facility": "SNS",
       "name": "SNAP",
       "nexusFileExtension": ".nxs.h5",

--- a/src/snapred/resources/default/request/vanadiumReduction/vanadiumReduction/payload.json
+++ b/src/snapred/resources/default/request/vanadiumReduction/vanadiumReduction/payload.json
@@ -6,7 +6,7 @@
         "instrumentState": {
         "id": "0a1b2c3d0a1b2c3d",
             "instrumentConfig": {
-                "version": "1.4",
+                "version": 1,
                 "facility": "SNS",
                 "name": "SNAP",
                 "nexusFileExtension": ".nxs.h5",

--- a/src/snapred/resources/input_parameters.json
+++ b/src/snapred/resources/input_parameters.json
@@ -2,7 +2,7 @@
     "instrumentState": {
       "id": "0a1b2c3d0a1b2c3d",
       "instrumentConfig": {
-        "version": "1.4",
+        "version": 1,
         "facility": "SNS",
         "name": "SNAP",
         "nexusFileExtension": ".nxs.h5",

--- a/tests/cis_tests/create_SNAPInstPrm_historical.py
+++ b/tests/cis_tests/create_SNAPInstPrm_historical.py
@@ -1,0 +1,56 @@
+
+
+from snapred.backend.dao.InstrumentConfig import InstrumentConfig
+from snapred.backend.dao.indexing.Versioning import VersionState
+from snapred.backend.data.LocalDataService import LocalDataService
+
+
+instrumentConfigJson = {
+  "version": 1.4,
+  "facility": "SNS",
+  "name": "SNAP",
+  "nexusFileExtension": ".nxs.h5",
+  "nexusFilePrefix": "SNAP_",
+  "calibrationDirectory": "/SNS/SNAP/shared/Calibration/Powder/",
+  "calibrationFilePrefix": "SNAPcalibLog",
+  "calibrationFileExtension": "json",
+  "pixelGroupingDirectory":"PixelGroupingDefinitions/",
+  "sharedDirectory": "shared/",
+  "nexusDirectory": "nexus/",
+  "reducedDataDirectory": "shared/manualReduced/",
+  "reductionRecordDirectory": "shared/manualReduced/reductionRecord/",
+  "GSAS-IIDirectory": "GSAS-II/",
+  "GSAS-IIExtension": ".gsa",
+  "neutronBandwidth": 3.2,
+  "extendedNeutronBandwidth": 3.2,
+  "L1": 15.0,
+  "L2": 0.5,
+  "delToT": 0.002,
+  "delLoL": 3.226e-3,
+  "delThNoGuide": 2.00e-3,
+  "delThWithGuide": 6.40e-3,
+  "alpha": 0.1,
+  "beta_0": 0.02,
+  "beta_1": 0.05,
+  "width": 1600.0,
+  "frequency": 60.4
+}
+
+del instrumentConfigJson["version"]
+instrumentConfigJson["bandwidth"] = instrumentConfigJson.pop("neutronBandwidth")
+instrumentConfigJson["maxBandwidth"] = instrumentConfigJson.pop("extendedNeutronBandwidth")
+instrumentConfigJson["delTOverT"] = instrumentConfigJson.pop("delToT")
+instrumentConfigJson["delLOverL"] = instrumentConfigJson.pop("delLoL")
+
+
+instrumentConfig = InstrumentConfig(
+    version=VersionState.NEXT,
+    **instrumentConfigJson
+)
+
+
+localDataService = LocalDataService()
+localDataService.writeInstrumentParameters(instrumentConfig, ">=46342,<=63976", "author: snap test script")
+
+savedInstrumentConfig = localDataService.readInstrumentParameters(46342)
+print(savedInstrumentConfig.model_dump_json())

--- a/tests/integration/test_versions_in_order.py
+++ b/tests/integration/test_versions_in_order.py
@@ -92,6 +92,12 @@ class ImitationDataService(LocalDataService):
         if self._outputPath.exists():
             shutil.rmtree(self._outputPath)
 
+    def readInstrumentParameters(self, runNumber):  # noqa: ARG002
+        return DAOFactory.default_instrument_config
+
+    def readInstrumentConfig(self, runNumber):  # noqa: ARG002
+        return DAOFactory.default_instrument_config
+
     def readCifFilePath(self, sampleId: str):
         return Resource.getPath("inputs/crystalInfo/example.cif")
 

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -37,6 +37,8 @@ instrument:
     home: ${instrument.home}/{IPTS}/shared/SNAPRed
 
   config: ${instrument.calibration.home}/SNAPInstPrm.json
+  parameters:
+    home: ${instrument.calibration.home}/SNAPInstPrm
   native:
     pixelResolution: 1179648
     # "instrument.native.definition" is overridden in "test.yml":

--- a/tests/resources/inputs/reduction/ReductionRecord_20240614T130420.json
+++ b/tests/resources/inputs/reduction/ReductionRecord_20240614T130420.json
@@ -395,7 +395,7 @@
                     "decodedKey": null
                 },
                 "instrumentConfig": {
-                    "version": "1.4",
+                    "version": 1,
                     "facility": "SNS",
                     "name": "SNAP",
                     "nexusFileExtension": ".nxs.h5",
@@ -688,7 +688,7 @@
                     "decodedKey": null
                 },
                 "instrumentConfig": {
-                    "version": "1.4",
+                    "version": 1,
                     "facility": "SNS",
                     "name": "SNAP",
                     "nexusFileExtension": ".nxs.h5",
@@ -772,7 +772,7 @@
                 "decodedKey": null
             },
             "instrumentConfig": {
-                "version": "1.4",
+                "version": 1,
                 "facility": "SNS",
                 "name": "SNAP",
                 "nexusFileExtension": ".nxs.h5",

--- a/tests/unit/backend/dao/test_IndexEntry.py
+++ b/tests/unit/backend/dao/test_IndexEntry.py
@@ -35,6 +35,18 @@ def test_appliesTo():
         assert symbol in entry.appliesTo
 
 
+def test_appliesToMultiple():
+    """
+    Test that the appliesTo property is correctly parsed.
+    """
+    # Arrange
+    testDataSymbol = testData.copy()
+    testDataSymbol["appliesTo"] = ">=1234,<=4321"
+    entry = IndexEntry(**testDataSymbol)
+    assert "1234" in entry.appliesTo
+    assert "4321" in entry.appliesTo
+
+
 def test_appliesToFailsValidation():
     """
     Test that the appliesTo property fails validation when the input is incorrect.
@@ -42,6 +54,18 @@ def test_appliesToFailsValidation():
     # Arrange
     testDataSymbol = testData.copy()
     testDataSymbol["appliesTo"] = "1234a"
+
+    with pytest.raises(ValueError, match="appliesTo must be in the format of"):
+        IndexEntry(**testDataSymbol)
+
+
+def test_appliesToMultipleFailsValidation():
+    """
+    Test that the appliesTo property fails validation when the input is incorrect.
+    """
+    # Arrange
+    testDataSymbol = testData.copy()
+    testDataSymbol["appliesTo"] = ">=1234,<=4321,1234a"
 
     with pytest.raises(ValueError, match="appliesTo must be in the format of"):
         IndexEntry(**testDataSymbol)

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -39,7 +39,7 @@ class TestDataFactoryService(unittest.TestCase):
             if callable(getattr(LocalDataService, func)) and not func.startswith("__")
         ]
         # these are treated specially for specific returns
-        exceptions = ["readStateConfig", "readRunConfig"]
+        exceptions = ["readInstrumentConfig", "readStateConfig", "readRunConfig"]
         needIndexer = ["calibrationIndexer", "normalizationIndexer"]
         method_list = [method for method in method_list if method not in exceptions and method not in needIndexer]
         for x in method_list:
@@ -50,7 +50,7 @@ class TestDataFactoryService(unittest.TestCase):
         mockCalibration = Calibration.model_construct(instrumentState=mockInstrumentState)
 
         # these are treated specially as returning specific object types
-        cls.mockLookupService.readInstrumentConfig = mock.Mock(return_value=InstrumentConfig.model_construct({}))
+        cls.mockLookupService.readInstrumentConfig.return_value = InstrumentConfig.model_construct({})
         #
         # ... allow the `StateConfig` to actually complete validation:
         #   this is required because `getReductionState` is declared in the wrong place... :(

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -51,6 +51,7 @@ class TestDataFactoryService(unittest.TestCase):
 
         # these are treated specially as returning specific object types
         cls.mockLookupService.getInstrumentConfig.return_value = InstrumentConfig.model_construct({})
+        cls.mockLookupService.readInstrumentConfig = mock.Mock(return_value=InstrumentConfig.model_construct({}))
         #
         # ... allow the `StateConfig` to actually complete validation:
         #   this is required because `getReductionState` is declared in the wrong place... :(

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -39,7 +39,7 @@ class TestDataFactoryService(unittest.TestCase):
             if callable(getattr(LocalDataService, func)) and not func.startswith("__")
         ]
         # these are treated specially for specific returns
-        exceptions = ["getInstrumentConfig", "readStateConfig", "readRunConfig"]
+        exceptions = ["readStateConfig", "readRunConfig"]
         needIndexer = ["calibrationIndexer", "normalizationIndexer"]
         method_list = [method for method in method_list if method not in exceptions and method not in needIndexer]
         for x in method_list:
@@ -50,7 +50,6 @@ class TestDataFactoryService(unittest.TestCase):
         mockCalibration = Calibration.model_construct(instrumentState=mockInstrumentState)
 
         # these are treated specially as returning specific object types
-        cls.mockLookupService.getInstrumentConfig.return_value = InstrumentConfig.model_construct({})
         cls.mockLookupService.readInstrumentConfig = mock.Mock(return_value=InstrumentConfig.model_construct({}))
         #
         # ... allow the `StateConfig` to actually complete validation:

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -1177,7 +1177,7 @@ class TestGroceryService(unittest.TestCase):
                         # lite mode and lite-mode exists on disk
                         assert result == mockFetchGroceriesRecipe.executeRecipe.return_value
                         mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                            str(liteModeFilePath), workspaceName, item.loader
+                            str(liteModeFilePath), workspaceName, item.loader, runNumber=runNumber
                         )
                         mockConvertToLiteMode.assert_not_called()
 
@@ -1193,7 +1193,7 @@ class TestGroceryService(unittest.TestCase):
                         # lite mode and native exists on disk
                         assert result == mockFetchGroceriesRecipe.executeRecipe.return_value
                         mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                            str(nativeModeFilePath), workspaceName, item.loader
+                            str(nativeModeFilePath), workspaceName, item.loader, runNumber=runNumber
                         )
                         mockConvertToLiteMode.assert_called_once_with(workspaceName, export=False)
 
@@ -1201,7 +1201,7 @@ class TestGroceryService(unittest.TestCase):
                         # native mode and native exists on disk
                         assert result == mockFetchGroceriesRecipe.executeRecipe.return_value
                         mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                            str(nativeModeFilePath), workspaceName, item.loader
+                            str(nativeModeFilePath), workspaceName, item.loader, runNumber=runNumber
                         )
                         mockConvertToLiteMode.assert_not_called()
 
@@ -1332,7 +1332,10 @@ class TestGroceryService(unittest.TestCase):
                 mockUpdateNeutronCache.assert_called_once_with(runNumber, useLiteMode)
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                    workspace=workspaceName, loader="LoadLiveData", loaderArgs=json.dumps(expectedLoaderArgs)
+                    workspace=workspaceName,
+                    loader="LoadLiveData",
+                    loaderArgs=json.dumps(expectedLoaderArgs),
+                    runNumber=runNumber,
                 )
                 if useLiteMode:
                     mockConvertToLiteMode.assert_called_once_with(workspaceName, export=False)
@@ -1456,7 +1459,10 @@ class TestGroceryService(unittest.TestCase):
                 mockUpdateNeutronCache.assert_called_once_with(runNumber, useLiteMode)
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                    workspace=workspaceName, loader="LoadLiveData", loaderArgs=json.dumps(expectedLoaderArgs)
+                    workspace=workspaceName,
+                    loader="LoadLiveData",
+                    loaderArgs=json.dumps(expectedLoaderArgs),
+                    runNumber=runNumber,
                 )
                 mockConvertToLiteMode.assert_not_called()
                 mockDeleteWorkspace.assert_called_once_with(workspaceName)
@@ -1562,7 +1568,10 @@ class TestGroceryService(unittest.TestCase):
                 mockUpdateNeutronCache.assert_called_once_with(runNumber, useLiteMode)
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                    workspace=workspaceName, loader="LoadLiveData", loaderArgs=json.dumps(expectedLoaderArgs)
+                    workspace=workspaceName,
+                    loader="LoadLiveData",
+                    loaderArgs=json.dumps(expectedLoaderArgs),
+                    runNumber=runNumber,
                 )
                 if useLiteMode:
                     mockConvertToLiteMode.assert_called_once_with(workspaceName, export=False)
@@ -1675,7 +1684,10 @@ class TestGroceryService(unittest.TestCase):
                 mockUpdateNeutronCache.assert_called_once_with(runNumber, useLiteMode)
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                    workspace=workspaceName, loader="LoadLiveData", loaderArgs=json.dumps(expectedLoaderArgs)
+                    workspace=workspaceName,
+                    loader="LoadLiveData",
+                    loaderArgs=json.dumps(expectedLoaderArgs),
+                    runNumber=runNumber,
                 )
                 mockConvertToLiteMode.assert_not_called()
                 mockDeleteWorkspace.assert_called_once_with(workspaceName)
@@ -1779,7 +1791,7 @@ class TestGroceryService(unittest.TestCase):
                         assert result == mockFetchGroceriesRecipe.executeRecipe.return_value
                         assert instance._loadedRuns[(runNumber, useLiteMode)] == 1
                         mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                            str(liteModeFilePath), liteRawWorkspaceName, item.loader
+                            str(liteModeFilePath), liteRawWorkspaceName, item.loader, runNumber=runNumber
                         )
                         mockConvertToLiteMode.assert_not_called()
 
@@ -1797,7 +1809,7 @@ class TestGroceryService(unittest.TestCase):
                         assert instance._loadedRuns[(runNumber, False)] == 0
                         assert instance._loadedRuns[(runNumber, useLiteMode)] == 1
                         mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                            str(nativeModeFilePath), nativeRawWorkspaceName, loader=item.loader
+                            str(nativeModeFilePath), nativeRawWorkspaceName, loader=item.loader, runNumber=runNumber
                         )
                         mockConvertToLiteMode.assert_called_once_with(liteRawWorkspaceName, export=True)
 
@@ -1806,7 +1818,7 @@ class TestGroceryService(unittest.TestCase):
                         assert result == mockFetchGroceriesRecipe.executeRecipe.return_value
                         assert instance._loadedRuns[(runNumber, useLiteMode)] == (1 if not useLiteMode else 0)
                         mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                            str(nativeModeFilePath), nativeRawWorkspaceName, item.loader
+                            str(nativeModeFilePath), nativeRawWorkspaceName, item.loader, runNumber=runNumber
                         )
                         mockConvertToLiteMode.assert_not_called()
 
@@ -1942,7 +1954,10 @@ class TestGroceryService(unittest.TestCase):
                 mockUpdateNeutronCache.assert_called_once_with(runNumber, useLiteMode)
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                    workspace=nativeRawWorkspaceName, loader="LoadLiveData", loaderArgs=json.dumps(expectedLoaderArgs)
+                    workspace=nativeRawWorkspaceName,
+                    loader="LoadLiveData",
+                    loaderArgs=json.dumps(expectedLoaderArgs),
+                    runNumber=runNumber,
                 )
                 if useLiteMode:
                     assert instance._loadedRuns[(runNumber, False)] == 0
@@ -2069,7 +2084,10 @@ class TestGroceryService(unittest.TestCase):
                 mockUpdateNeutronCache.assert_called_once_with(runNumber, useLiteMode)
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                    workspace=nativeRawWorkspaceName, loader="LoadLiveData", loaderArgs=json.dumps(expectedLoaderArgs)
+                    workspace=nativeRawWorkspaceName,
+                    loader="LoadLiveData",
+                    loaderArgs=json.dumps(expectedLoaderArgs),
+                    runNumber=runNumber,
                 )
                 mockConvertToLiteMode.assert_not_called()
                 mockDeleteWorkspace.assert_called_once_with(nativeRawWorkspaceName)
@@ -2181,7 +2199,10 @@ class TestGroceryService(unittest.TestCase):
                 mockUpdateNeutronCache.assert_called_once_with(runNumber, useLiteMode)
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                    workspace=nativeRawWorkspaceName, loader="LoadLiveData", loaderArgs=json.dumps(expectedLoaderArgs)
+                    workspace=nativeRawWorkspaceName,
+                    loader="LoadLiveData",
+                    loaderArgs=json.dumps(expectedLoaderArgs),
+                    runNumber=runNumber,
                 )
                 if useLiteMode:
                     assert instance._loadedRuns[(runNumber, False)] == 0
@@ -2297,7 +2318,10 @@ class TestGroceryService(unittest.TestCase):
                 mockUpdateNeutronCache.assert_called_once_with(runNumber, useLiteMode)
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                    workspace=nativeRawWorkspaceName, loader="LoadLiveData", loaderArgs=json.dumps(expectedLoaderArgs)
+                    workspace=nativeRawWorkspaceName,
+                    loader="LoadLiveData",
+                    loaderArgs=json.dumps(expectedLoaderArgs),
+                    runNumber=runNumber,
                 )
                 mockConvertToLiteMode.assert_not_called()
                 mockDeleteWorkspace.assert_called_once_with(nativeRawWorkspaceName)

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -2261,8 +2261,9 @@ def test_readDetectorState(monkeypatch):
 def test_readDetectorState_no_PVFile():
     runNumber = "123"
     instance = LocalDataService()
-    instance._readPVFile = mock.Mock(side_effect=FileNotFoundError(""))
-    instance.readLiveMetadata = mock.Mock(return_value=mock.MagicMock(runNumber=0))
+    instance._readPVFile = mock.Mock(side_effect=FileNotFoundError("..."))
+    instance.readLiveMetadata = mock.Mock(return_value=mock.MagicMock(runNumber=-1))
+    instance.hasLiveDataConnection = mock.Mock(return_value=True)
     with pytest.raises(RuntimeError, match="No PVFile exists for run"):
         instance.readDetectorState(runNumber)
 

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -2261,8 +2261,9 @@ def test_readDetectorState(monkeypatch):
 def test_readDetectorState_no_PVFile():
     runNumber = "123"
     instance = LocalDataService()
-    instance._readPVFile = mock.Mock(side_effect=FileNotFoundError("lah dee dah"))
-    with pytest.raises(FileNotFoundError, match="lah dee dah"):
+    instance._readPVFile = mock.Mock(side_effect=FileNotFoundError(""))
+    instance.readLiveMetadata = mock.Mock(return_value=mock.MagicMock(runNumber=0))
+    with pytest.raises(RuntimeError, match="No PVFile exists for run"):
         instance.readDetectorState(runNumber)
 
 
@@ -2617,6 +2618,9 @@ def test_initializeState():
     localDataService._instrumentConfig = testCalibrationData.instrumentState.instrumentConfig
     localDataService.writeCalibrationState = mock.Mock()
     localDataService._prepareStateRoot = mock.Mock()
+    localDataService.readInstrumentConfig = mock.MagicMock(
+        return_value=testCalibrationData.instrumentState.instrumentConfig
+    )
 
     with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tmpDir:
         stateId = testCalibrationData.instrumentState.id.hex  # "ab8704b0bc2a2342"
@@ -2648,7 +2652,7 @@ def test_initializeState_calls_prepareStateRoot():
     localDataService._instrumentConfig = testCalibrationData.instrumentState.instrumentConfig
     localDataService.writeCalibrationState = mock.Mock()
     localDataService._readDefaultGroupingMap = mock.Mock(return_value=mock.Mock(isDirty=False))
-
+    localDataService.generateInstrumentState = mock.MagicMock(return_value=testCalibrationData.instrumentState)
     with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tmpDir:
         stateId = ENDURING_STATE_ID
         stateRootPath = Path(tmpDir) / stateId

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -869,11 +869,7 @@ def test__readRunConfig():
     # Test of private `_readRunConfig` method
     localDataService = LocalDataService()
     localDataService.getIPTS = mock.Mock(return_value="IPTS-123")
-<<<<<<< HEAD
-    localDataService._instrumentConfig = getMockInstrumentConfig()
-=======
     localDataService.readInstrumentConfig = mock.Mock(return_value=getMockInstrumentConfig())
->>>>>>> 1679dc74 (refactor indexer to rounte saves and loads through a generic VersionedObject form of each method)
     actual = localDataService._readRunConfig("57514")
     assert actual is not None
     assert actual.runNumber == "57514"

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -128,12 +128,16 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         self.rx.mantidSnapper.RemovePromptPulse = mock.MagicMock()
 
         self.clearoutWorkspaces()
-        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadEventNexus")
+        self.rx.dataService.readInstrumentConfig = mock.MagicMock()
+        res = self.rx.executeRecipe(self.filepath, self.fetchedWSname, "LoadEventNexus", runNumber=555)
         assert len(res) > 0
         assert res["result"]
         assert res["loader"] == "LoadEventNexus"
         assert res["workspace"] == self.fetchedWSname
         assert self.rx.mantidSnapper.RemovePromptPulse.called
+        
+        with pytest.raises(RuntimeError, match="Run number is required for event nexus files"):
+            self.rx.executeRecipe(self.filepath, self.fetchedWSname, "LoadEventNexus")
 
     @mock.patch("snapred.backend.recipe.FetchGroceriesRecipe.logger")
     @mock.patch("snapred.backend.recipe.FetchGroceriesRecipe.FetchGroceriesAlgorithm")

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -129,7 +129,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
 
         self.clearoutWorkspaces()
         self.rx.dataService.readInstrumentConfig = mock.MagicMock()
-        res = self.rx.executeRecipe(self.filepath, self.fetchedWSname, "LoadEventNexus", runNumber=555)
+        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadEventNexus", runNumber=555)
         assert len(res) > 0
         assert res["result"]
         assert res["loader"] == "LoadEventNexus"
@@ -137,7 +137,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         assert self.rx.mantidSnapper.RemovePromptPulse.called
 
         with pytest.raises(RuntimeError, match="Run number is required for event nexus files"):
-            self.rx.executeRecipe(self.filepath, self.fetchedWSname, "LoadEventNexus")
+            self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadEventNexus")
 
     @mock.patch("snapred.backend.recipe.FetchGroceriesRecipe.logger")
     @mock.patch("snapred.backend.recipe.FetchGroceriesRecipe.FetchGroceriesAlgorithm")
@@ -149,8 +149,8 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         self.rx.mantidSnapper.RemovePromptPulse = mock.MagicMock()
 
         self.clearoutWorkspaces()
-
-        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadEventNexus")
+        self.rx.dataService.readInstrumentConfig = mock.MagicMock()
+        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadEventNexus", runNumber=555)
         mockLogger.info.assert_called_with(f"Fetching data from {self.filePath} into {res['workspace']}")
         mockLogger.debug.assert_called_with(f"Finished fetching {res['workspace']} from {self.filePath}")
 
@@ -164,8 +164,8 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         self.rx.mantidSnapper.RemovePromptPulse = mock.MagicMock()
 
         self.clearoutWorkspaces()
-
-        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadLiveData")
+        self.rx.dataService.readInstrumentConfig = mock.MagicMock()
+        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadLiveData", runNumber=555)
         mockLogger.info.assert_called_with(f"Fetching live data into {res['workspace']}")
         mockLogger.debug.assert_called_with(f"Finished fetching {res['workspace']} from live-data listener")
 
@@ -178,7 +178,8 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         self.rx.mantidSnapper.RemovePromptPulse = mock.Mock()
 
         self.clearoutWorkspaces()
-        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadLiveData")
+        self.rx.dataService.readInstrumentConfig = mock.MagicMock()
+        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadLiveData", runNumber=555)
         assert len(res) > 0
         assert res["result"]
         assert res["loader"] == "LoadLiveData"

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -135,7 +135,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         assert res["loader"] == "LoadEventNexus"
         assert res["workspace"] == self.fetchedWSname
         assert self.rx.mantidSnapper.RemovePromptPulse.called
-        
+
         with pytest.raises(RuntimeError, match="Run number is required for event nexus files"):
             self.rx.executeRecipe(self.filepath, self.fetchedWSname, "LoadEventNexus")
 

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -92,6 +92,7 @@ class TestSousChef(unittest.TestCase):
     def test_prepCalibration(self):
         mockCalibration = mock.Mock()
         self.instance.dataFactoryService.getCalibrationState = mock.Mock(return_value=mockCalibration)
+        self.instance.dataFactoryService.getDefaultInstrumentState = mock.Mock(return_value=mock.Mock())
         self.instance.prepCalibrantSample = mock.Mock()
         self.instance._getThresholdFromCalibrantSample = mock.Mock(return_value=0.5)
 
@@ -107,6 +108,7 @@ class TestSousChef(unittest.TestCase):
     def test_prepCalibration_userFWHM(self):
         mockCalibration = mock.Mock()
         self.instance.dataFactoryService.getCalibrationState = mock.Mock(return_value=mockCalibration)
+        self.instance.dataFactoryService.getDefaultInstrumentState = mock.Mock(return_value=mock.Mock())
         self.instance._getThresholdFromCalibrantSample = mock.Mock(return_value=0.5)
         fakeLeft = 116
         fakeRight = 17

--- a/tests/util/Config_helpers.py
+++ b/tests/util/Config_helpers.py
@@ -38,15 +38,17 @@ def Config_override(key: str, value: Any):
         return Node(val, ks[-1])
 
     # __enter__
-    _savedNode: Tuple[Dict[str, Any], str] = lookupNode(Config._config, key)
-    _savedValue: Any = _savedNode.dict[_savedNode.key]
-    _savedNode.dict[_savedNode.key] = value
-    yield Config
-
-    # __exit__
-    del _savedNode.dict[_savedNode.key]
-    if _savedValue is not None:
-        _savedNode.dict[_savedNode.key] = _savedValue
+    # test failing with exepction will pollute other tests with this config change if not caught up the stack
+    try:
+        _savedNode: Tuple[Dict[str, Any], str] = lookupNode(Config._config, key)
+        _savedValue: Any = _savedNode.dict[_savedNode.key]
+        _savedNode.dict[_savedNode.key] = value
+        yield Config
+    finally:
+        # __exit__
+        del _savedNode.dict[_savedNode.key]
+        if _savedValue is not None:
+            _savedNode.dict[_savedNode.key] = _savedValue
 
 
 @pytest.fixture

--- a/tests/util/InstaEats.py
+++ b/tests/util/InstaEats.py
@@ -45,6 +45,8 @@ class InstaEats(GroceryService):
 
     def __init__(self):
         super().__init__(dataService=WhateversInTheFridge())
+        self.dataService = WhateversInTheFridge()
+        assert isinstance(self.dataService, WhateversInTheFridge)
         self.groupingMap = self.dataService._readDefaultGroupingMap()
         self.testInstrumentFile = Resource.getPath("inputs/testInstrument/fakeSNAP_Definition.xml")
         self.instrumentDonorWorkspace = mtd.unique_name(prefix="_instrument_donor")

--- a/tests/util/WhateversInTheFridge.py
+++ b/tests/util/WhateversInTheFridge.py
@@ -48,8 +48,7 @@ class WhateversInTheFridge(LocalDataService):
     iptsCache: Dict[Tuple[str, str], Any] = {}
 
     def __init__(self) -> None:
-        self._verifyPaths = False
-        self._instrumentConfig = self._readInstrumentConfig()
+        self.verifyPaths = False
         self.mantidSnapper = MantidSnapper(None, "Utensils")
         self.latestVersion = Config["version.start"]
 

--- a/tests/util/dao.py
+++ b/tests/util/dao.py
@@ -71,7 +71,7 @@ class DAOFactory:
     ## INSTRUMENT CONFIG
 
     instrument_config_boilerplate = {
-        "version": "1.4",
+        "version": 0,
         "facility": "SNS",
         "name": "SNAP",
         "nexusFileExtension": ".nxs.h5",

--- a/tests/util_tests/test_state_helpers.py
+++ b/tests/util_tests/test_state_helpers.py
@@ -70,7 +70,7 @@ def mockPVFile(detectorState: DetectorState) -> mock.Mock:
 @mock.patch.object(LocalDataService, "_writeDefaultDiffCalTable")
 @mock.patch.object(LocalDataService, "generateStateId")
 @mock.patch.object(LocalDataService, "_readDefaultGroupingMap")
-@mock.patch.object(LocalDataService, "getInstrumentConfig")
+@mock.patch.object(LocalDataService, "readInstrumentConfig")
 @mock.patch.object(LocalDataService, "_readPVFile")
 def test_state_root_override_enter(
     mockReadPVFile,
@@ -105,7 +105,7 @@ def test_state_root_override_enter(
 
 @mock.patch.object(LocalDataService, "_writeDefaultDiffCalTable")
 @mock.patch.object(LocalDataService, "_readDefaultGroupingMap")
-@mock.patch.object(LocalDataService, "getInstrumentConfig")
+@mock.patch.object(LocalDataService, "readInstrumentConfig")
 @mock.patch.object(LocalDataService, "_readPVFile")
 def test_state_root_override_exit(
     mockReadPVFile,
@@ -134,7 +134,7 @@ def test_state_root_override_exit(
 
 @mock.patch.object(LocalDataService, "_writeDefaultDiffCalTable")
 @mock.patch.object(LocalDataService, "_readDefaultGroupingMap")
-@mock.patch.object(LocalDataService, "getInstrumentConfig")
+@mock.patch.object(LocalDataService, "readInstrumentConfig")
 @mock.patch.object(LocalDataService, "_readPVFile")
 def test_state_root_override_exit_no_delete(
     mockReadPVFile,


### PR DESCRIPTION
This PR also requires changes to snapred-data: https://code.ornl.gov/sns-hfir-scse/infrastructure/test-data/snapred-data/-/merge_requests/4


## Description of work

This pr enables snapred to track and refer to historical/indexed SNAPInstPrm's by a run number conditional.
It also comes with a cis_test script for initializing said index.
**NOTE:** I recommend using said script to add the index to your local Calibration directory. 

## Explanation of work

- UPDATED InstrumentConfig a VersionedObject so it can be indexed
- UPDATED applies to logic to now support comma separated conditionals for multiple bounds.
- UPDATED run number is now required when using EventNexus loaders in GroceryService/FetchGroceries due to the necessity of instrumentState values to removePromptPulse
- UPDATED Indexer to funnel all saves and loads of indexed files to a shared set of central methods operating on `VersionedObjects`
- UPDATED SousChef to always pull a new InstrumentState based on the the instrumentConfig in the new index, as per request of Malcolm
- UPDATED test data to utilize new index

## To test

Create a new SNAPInstPrm index using the cis_test script
Run all workflows to completion.

Ensure No Regression.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#3408](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3408)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] 1. We need a naming scheme that allows for multiple instances of the SNAPInstPrm.json e.g. SNAPInstPrm_00.json, SNAPInstPrm_01.json etc.
- [x] 2. We need to add parameters: `minimumApplicableRunNumber` and `maximumApplicableRunNumber` (or similar range definition) such that there is an unambiguous indexing of input sample or calibrant run numbers with the resultant json files.
- [x] 3. SNAPRed must be able to acquire the correct InstPrm file on the basis of input run number
- [x] 4. The correct instPrm file will be applied for any of SNAPRed's workflows: difcal, normcal or reduction.
- [x] 5. Although we are currently envisaging only two InstPrm files to be needed. The design should allow for future InstPrm files to be created (although not more than a handful of these are expected)
