### PR TITLE
reduction: live-data: complete

### DIFF
--- a/docs/source/api/snapred.ui.handler.rst
+++ b/docs/source/api/snapred.ui.handler.rst
@@ -10,7 +10,7 @@ snapred.ui.handler.SNAPResponseHandler module
 .. automodule:: snapred.ui.handler.SNAPResponseHandler
    :members:
    :undoc-members:
-   :exclude-members: continueAnyway, signal, signalWarning
+   :exclude-members: continueAnyway, liveDataStateTransition, resetWorkflow, signal, signalWarning, userCancellation
    :show-inheritance:
 
 Module contents

--- a/docs/source/api/snapred.ui.presenter.rst
+++ b/docs/source/api/snapred.ui.presenter.rst
@@ -67,7 +67,7 @@ snapred.ui.presenter.WorkflowPresenter module
 .. automodule:: snapred.ui.presenter.WorkflowPresenter
    :members:
    :undoc-members:
-   :exclude-members: actionCompleted, disableOtherWorkflows, enableAllWorkflows
+   :exclude-members: actionCompleted, cancellationRequest, disableOtherWorkflows, enableAllWorkflows, resetCompleted, workflowInProgressChange
    :show-inheritance:
 
 Module contents

--- a/docs/source/api/snapred.ui.view.rst
+++ b/docs/source/api/snapred.ui.view.rst
@@ -138,7 +138,7 @@ snapred.ui.view.reduction.ReductionRequestView module
 .. automodule:: snapred.ui.view.reduction.ReductionRequestView
    :members:
    :undoc-members:
-   :exclude-members: signalRemoveRunNumber
+   :exclude-members: signalRemoveRunNumber, liveDataModeChange
    :show-inheritance:
 
 snapred.ui.view.TestPanelView module

--- a/docs/source/api/snapred.ui.widget.rst
+++ b/docs/source/api/snapred.ui.widget.rst
@@ -44,6 +44,15 @@ snapred.ui.widget.LabeledField module
    :undoc-members:
    :show-inheritance:
 
+snapred.ui.widget.LEDIndicator module
+-------------------------------------
+
+.. automodule:: snapred.ui.widget.LEDIndicator
+   :members:
+   :undoc-members:
+   :exclude-members: bezelColor, color, setColor, setFlashSequence
+   :show-inheritance:
+
 snapred.ui.widget.LogTable module
 ---------------------------------
 
@@ -98,7 +107,7 @@ snapred.ui.widget.Toggle module
 .. automodule:: snapred.ui.widget.Toggle
    :members:
    :undoc-members:
-   :exclude-members: stateChanged
+   :exclude-members: backgroundColor, ellipsePosition, gradEndColor, gradStartColor, stateChanged
    :show-inheritance:
 
 snapred.ui.widget.ToolBar module

--- a/environment.yml
+++ b/environment.yml
@@ -2,13 +2,14 @@ name: SNAPRed
 channels:
 - conda-forge
 - default
-- mantid-ornl
 - mantid/label/nightly
+- mantid-ornl
+- mantid-ornl/label/rc
 dependencies:
 - python=3.10
 - pip
 - pydantic>=2.7.3,<3
-- mantidworkbench=6.11.0.3
+- mantidworkbench=6.11.0.4rc1
 - qtpy
 - pre-commit
 - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "A desktop application for Lifecycle Managment of data collected f
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "mantidworkbench >= 6.11.0.3",
+    "mantidworkbench >= 6.11.0.4rc1",
     "pyoncat ~= 1.6"
 ]
 readme = "README.md"

--- a/src/snapred/backend/dao/GSASParameters.py
+++ b/src/snapred/backend/dao/GSASParameters.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 
 class GSASParameters(BaseModel):
-    """Class to GSAS parameters"""
+    """Class for various GSAS parameters"""
 
     alpha: float
     beta: Tuple[float, float]

--- a/src/snapred/backend/dao/LiveMetadata.py
+++ b/src/snapred/backend/dao/LiveMetadata.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from typing import ClassVar
+
+from pydantic import BaseModel
+
+from snapred.backend.dao.state import DetectorState
+
+
+class LiveMetadata(BaseModel):
+    """Metadata about any in-progress data acquisition."""
+
+    # Implementation notes:
+    #
+    #   * If there's no run currently active, the `runNumber` will be `INACTIVE_RUN`.
+    #
+    #   * Metadata may change at any time.  For example, the run may terminate and become inactive.
+    #     For this reason, in most cases this DAO should never be cached.
+    #
+
+    INACTIVE_RUN: ClassVar[int] = 0
+
+    runNumber: str
+
+    startTime: datetime
+    endTime: datetime
+
+    detectorState: DetectorState
+
+    protonCharge: float
+
+    def hasActiveRun(self):
+        return int(self.runNumber) != LiveMetadata.INACTIVE_RUN
+
+    def beamState(self):
+        return self.protonCharge > 0.0

--- a/src/snapred/backend/dao/SNAPResponse.py
+++ b/src/snapred/backend/dao/SNAPResponse.py
@@ -17,6 +17,8 @@ class ResponseCode(IntEnum):
     OK = 200
     MAX_OK = 300
     CONTINUE_WARNING = 301
+    USER_CANCELLATION = 326
+    LIVE_DATA_STATE = 351
     RECOVERABLE = 400
     ERROR = 500
 

--- a/src/snapred/backend/dao/calibration/CalibrationDefaultRecord.py
+++ b/src/snapred/backend/dao/calibration/CalibrationDefaultRecord.py
@@ -1,4 +1,6 @@
-from typing import Dict, List
+from typing import Annotated, Dict, List
+
+from pydantic import Field
 
 from snapred.backend.dao.calibration.Calibration import Calibration
 from snapred.backend.dao.indexing.Record import Record
@@ -23,4 +25,4 @@ class CalibrationDefaultRecord(Record, extra="ignore"):
     calculationParameters: Calibration
 
     # specific to calibration records
-    workspaces: Dict[WorkspaceType, List[WorkspaceName]]
+    workspaces: Dict[Annotated[WorkspaceType, Field(use_enum_values=True)], List[WorkspaceName]]

--- a/src/snapred/backend/dao/indexing/CalculationParameters.py
+++ b/src/snapred/backend/dao/indexing/CalculationParameters.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
-from pydantic import field_validator
+import numpy
+from pydantic import ConfigDict, field_validator
 
 from snapred.backend.dao.indexing.Versioning import VersionedObject
 from snapred.backend.dao.state.InstrumentState import InstrumentState
@@ -29,8 +30,8 @@ class CalculationParameters(VersionedObject, extra="allow"):
 
     instrumentState: InstrumentState
     seedRun: str
-    useLiteMode: bool
-    creationDate: datetime
+    useLiteMode: bool | numpy.bool_
+    creationDate: datetime | str
     name: str
 
     @field_validator("seedRun", mode="before")
@@ -39,3 +40,24 @@ class CalculationParameters(VersionedObject, extra="allow"):
         if isinstance(v, int):
             v = str(v)
         return v
+
+    @field_validator("creationDate", mode="before")
+    @classmethod
+    def validate_creationDate(cls, v):
+        if isinstance(v, str):
+            v = datetime.fromisoformat(v)
+        return v
+
+    @field_validator("useLiteMode", mode="before")
+    @classmethod
+    def validate_useLiteMode(cls, v):
+        # this allows the use of 'strict' mode
+        if isinstance(v, numpy.bool_):
+            # Conversion from HDF5 metadata.
+            v = bool(v)
+        return v
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,  # numpy.bool_
+        strict=True,
+    )

--- a/src/snapred/backend/dao/indexing/Record.py
+++ b/src/snapred/backend/dao/indexing/Record.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import numpy
 from pydantic import ConfigDict, field_validator
 
 from snapred.backend.dao.indexing.CalculationParameters import CalculationParameters
@@ -36,7 +37,16 @@ class Record(VersionedObject, extra="allow"):
             v = str(v)
         return v
 
+    @field_validator("useLiteMode", mode="before")
+    @classmethod
+    def validate_useLiteMode(cls, v):
+        # this allows the use of 'strict' mode
+        if isinstance(v, numpy.bool_):
+            # Conversion from HDF5 metadata.
+            v = bool(v)
+        return v
+
     model_config = ConfigDict(
         # required in order to use 'WorkspaceName'
-        arbitrary_types_allowed=True,
+        arbitrary_types_allowed=True
     )

--- a/src/snapred/backend/dao/ingredients/ReductionIngredients.py
+++ b/src/snapred/backend/dao/ingredients/ReductionIngredients.py
@@ -69,6 +69,4 @@ class ReductionIngredients(BaseModel):
     def effectiveInstrument(self, groupingIndex: int) -> EffectiveInstrumentIngredients:
         return EffectiveInstrumentIngredients(unmaskedPixelGroup=self.unmaskedPixelGroups[groupingIndex])
 
-    model_config = ConfigDict(
-        extra="forbid",
-    )
+    model_config = ConfigDict(extra="forbid", strict=True)

--- a/src/snapred/backend/dao/reduction/ReductionRecord.py
+++ b/src/snapred/backend/dao/reduction/ReductionRecord.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+import numpy
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from snapred.backend.dao.calibration import CalibrationDefaultRecord
 from snapred.backend.dao.calibration.CalibrationRecord import CalibrationRecord
@@ -21,7 +22,7 @@ class ReductionRecord(BaseModel):
     #   for this reason, this class is not derived from 'Record',
     #   and does not include a 'CalculationParameters' instance.
     runNumber: str
-    useLiteMode: bool
+    useLiteMode: bool | numpy.bool_
     timestamp: float = Field(frozen=True, default=None)
 
     # specific to reduction records
@@ -30,11 +31,6 @@ class ReductionRecord(BaseModel):
     pixelGroupingParameters: Dict[str, List[PixelGroupingParameters]]
 
     workspaceNames: List[WorkspaceName]
-
-    model_config = ConfigDict(
-        # required in order to use 'WorkspaceName'
-        arbitrary_types_allowed=True,
-    )
 
     """
     *Other details to include above*:
@@ -55,3 +51,16 @@ class ReductionRecord(BaseModel):
     dSAppliedData: (dS == down sampling)
     dSAppliedParameters: (rebinning parameters)
     """
+
+    @field_validator("useLiteMode", mode="before")
+    @classmethod
+    def validate_useLiteMode(cls, v):
+        # this allows the use of 'strict' mode
+        if isinstance(v, numpy.bool_):
+            v = bool(v)
+        return v
+
+    model_config = ConfigDict(
+        # required in order to use 'WorkspaceName'
+        arbitrary_types_allowed=True,
+    )

--- a/src/snapred/backend/dao/request/CreateArtificialNormalizationRequest.py
+++ b/src/snapred/backend/dao/request/CreateArtificialNormalizationRequest.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
@@ -13,7 +13,8 @@ class CreateArtificialNormalizationRequest(BaseModel):
     diffractionWorkspace: WorkspaceName
     outputWorkspace: WorkspaceName
 
-    class Config:
-        arbitrary_types_allowed = True  # Allow arbitrary types like WorkspaceName
-        extra = "forbid"  # Forbid extra fields
-        validate_assignment = True  # Enable dynamic validation
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,  # Allow arbitrary types like WorkspaceName
+        extra="forbid",  # Forbid extra fields
+        validate_assignment=True,  # Enable dynamic validation
+    )

--- a/src/snapred/backend/dao/request/CreateCalibrationRecordRequest.py
+++ b/src/snapred/backend/dao/request/CreateCalibrationRecordRequest.py
@@ -1,6 +1,6 @@
-from typing import Dict, List, Optional
+from typing import Annotated, Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from snapred.backend.dao.calibration.Calibration import Calibration
 from snapred.backend.dao.calibration.FocusGroupMetric import FocusGroupMetric
@@ -24,9 +24,9 @@ class CreateCalibrationRecordRequest(BaseModel, extra="forbid"):
     crystalInfo: CrystallographicInfo
     pixelGroups: Optional[List[PixelGroup]] = None
     focusGroupCalibrationMetrics: FocusGroupMetric
-    workspaces: Dict[WorkspaceType, List[WorkspaceName]]
+    workspaces: Dict[Annotated[WorkspaceType, Field(use_enum_values=True)], List[WorkspaceName]]
 
     model_config = ConfigDict(
         # required in order to use 'WorkspaceName'
-        arbitrary_types_allowed=True,
+        arbitrary_types_allowed=True
     )

--- a/src/snapred/backend/dao/request/ReductionRequest.py
+++ b/src/snapred/backend/dao/request/ReductionRequest.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import List, NamedTuple, Optional, Tuple
 
 from pydantic import BaseModel, ConfigDict, field_validator
@@ -15,6 +16,8 @@ Versions = NamedTuple("Versions", [("calibration", Version), ("normalization", V
 class ReductionRequest(BaseModel):
     runNumber: str
     useLiteMode: bool
+    liveDataMode: Optional[bool] = False
+    liveDataDuration: Optional[datetime.timedelta] = None
     timestamp: Optional[float] = None
     focusGroups: List[FocusGroup] = []
 

--- a/src/snapred/backend/dao/response/ReductionResponse.py
+++ b/src/snapred/backend/dao/response/ReductionResponse.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from typing import Optional
 
 from pydantic import BaseModel, ConfigDict
@@ -9,6 +10,9 @@ from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 class ReductionResponse(BaseModel):
     record: ReductionRecord
     unfocusedData: Optional[WorkspaceName] = None
+
+    # wallclock execution time: used by the live-data workflow cycle
+    executionTime: timedelta
 
     model_config = ConfigDict(
         extra="forbid",

--- a/src/snapred/backend/dao/state/DetectorState.py
+++ b/src/snapred/backend/dao/state/DetectorState.py
@@ -28,22 +28,26 @@ class DetectorState(BaseModel):
         return v
 
     @classmethod
-    def constructFromLogValues(cls, logValues):
+    def fromLogs(cls, logs: Dict[str, Number]):
+        # NeXus/HDF5 and `mantid.api.Run` logs are time-series =>
+        #   here we take only the first entry in each series.
         return DetectorState(
-            arc=(float(logValues["det_arc1"]), float(logValues["det_arc2"])),
-            lin=(float(logValues["det_lin1"]), float(logValues["det_lin2"])),
-            wav=float(logValues["BL3:Chop:Skf1:WavelengthUserReq"]),
-            freq=float(logValues["BL3:Det:TH:BL:Frequency"]),
-            guideStat=int(logValues["BL3:Mot:OpticsPos:Pos"]),
+            arc=(logs["det_arc1"][0], logs["det_arc2"][0]),
+            lin=(logs["det_lin1"][0], logs["det_lin2"][0]),
+            wav=logs.get("BL3:Chop:Skf1:WavelengthUserReq", logs.get("BL3:Chop:Gbl:WavelengthReq"))[0],
+            freq=logs["BL3:Det:TH:BL:Frequency"][0],
+            guideStat=int(logs["BL3:Mot:OpticsPos:Pos"][0]),
         )
 
-    def getLogValues(self) -> Dict[str, str]:
+    def toLogs(self) -> Dict[str, Number]:
+        # NeXus/HDF5 and `mantid.api.Run` logs are time-series =>
+        #   here we return each entry as a tuple.
         return {
-            "det_lin1": str(self.lin[0]),
-            "det_lin2": str(self.lin[1]),
-            "det_arc1": str(self.arc[0]),
-            "det_arc2": str(self.arc[1]),
-            "BL3:Chop:Skf1:WavelengthUserReq": str(self.wav),
-            "BL3:Det:TH:BL:Frequency": str(self.freq),
-            "BL3:Mot:OpticsPos:Pos": str(self.guideStat),
+            "det_lin1": (self.lin[0],),
+            "det_lin2": (self.lin[1],),
+            "det_arc1": (self.arc[0],),
+            "det_arc2": (self.arc[1],),
+            "BL3:Chop:Skf1:WavelengthUserReq": (self.wav,),
+            "BL3:Det:TH:BL:Frequency": (self.freq,),
+            "BL3:Mot:OpticsPos:Pos": (self.guideStat,),
         }

--- a/src/snapred/backend/dao/state/DiffractionCalibrant.py
+++ b/src/snapred/backend/dao/state/DiffractionCalibrant.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from snapred.backend.dao.CrystallographicInfo import CrystallographicInfo
 
@@ -14,3 +14,5 @@ class DiffractionCalibrant(BaseModel):
     reference: Optional[str] = None
     crystallographicInfo: Optional[CrystallographicInfo] = None
     fSquaredThreshold: Optional[float] = None
+
+    model_config = ConfigDict(strict=True)

--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from pydantic import validate_call
 
@@ -8,12 +8,14 @@ from snapred.backend.dao.calibration.CalibrationRecord import CalibrationRecord
 from snapred.backend.dao.indexing.IndexEntry import IndexEntry
 from snapred.backend.dao.indexing.Versioning import Version, VersionState
 from snapred.backend.dao.InstrumentConfig import InstrumentConfig
+from snapred.backend.dao.LiveMetadata import LiveMetadata
 from snapred.backend.dao.normalization.NormalizationRecord import NormalizationRecord
 from snapred.backend.dao.reduction import ReductionRecord
 from snapred.backend.dao.ReductionState import ReductionState
 from snapred.backend.dao.request.CalibrationExportRequest import CalibrationExportRequest
 from snapred.backend.dao.request.NormalizationExportRequest import NormalizationExportRequest
 from snapred.backend.dao.RunConfig import RunConfig
+from snapred.backend.dao.state.DetectorState import DetectorState
 from snapred.backend.dao.StateConfig import StateConfig
 from snapred.backend.data.GroceryService import GroceryService
 from snapred.backend.data.LocalDataService import LocalDataService
@@ -47,12 +49,12 @@ class DataFactoryService:
         return self.lookupService.readRunConfig(runId)
 
     def getInstrumentConfig(self, runId: str) -> InstrumentConfig:  # noqa: ARG002
-        return self.lookupService.readInstrumentConfig()
+        return self.lookupService.getInstrumentConfig()
 
     def getStateConfig(self, runId: str, useLiteMode: bool) -> StateConfig:  # noqa: ARG002
         return self.lookupService.readStateConfig(runId, useLiteMode)
 
-    def constructStateId(self, runId: str):
+    def constructStateId(self, runId: str) -> Tuple[str, DetectorState]:
         return self.lookupService.generateStateId(runId)
 
     def stateExists(self, runId: str):
@@ -74,7 +76,7 @@ class DataFactoryService:
         return self.lookupService.readDefaultGroupingMap()
 
     def getDefaultInstrumentState(self, runId: str):
-        return self.lookupService.generateInstrumentStateFromRoot(runId)
+        return self.lookupService.generateInstrumentState(runId)
 
     ##### CALIBRATION METHODS #####
 
@@ -219,3 +221,12 @@ class DataFactoryService:
 
     def deleteWorkspaceUnconditional(self, name):
         return self.groceryService.deleteWorkspaceUnconditional(name)
+
+    ##### LIVE-DATA SUPPORT METHODS #####
+
+    def hasLiveDataConnection(self) -> bool:
+        """For 'live data' methods: test if there is a listener connection to the instrument."""
+        return self.lookupService.hasLiveDataConnection()
+
+    def getLiveMetadata(self) -> LiveMetadata:
+        return self.lookupService.readLiveMetadata()

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -3,22 +3,27 @@ import glob
 import json
 import os
 import re
+import socket
 import tempfile
 import time
+from collections.abc import Mapping
 from errno import ENOENT as NOT_FOUND
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
+from urllib.parse import urlparse
 
 import h5py
+from mantid.api import Run
 from mantid.dataobjects import MaskWorkspace
-from mantid.kernel import PhysicalConstants
+from mantid.kernel import ConfigService, PhysicalConstants
 from mantid.simpleapi import GetIPTS, mtd
-from pydantic import validate_call
+from pydantic import ValidationError, validate_call
 
 from snapred.backend.dao import (
     GSASParameters,
     InstrumentConfig,
+    LiveMetadata,
     ObjectSHA,
     ParticleBounds,
     RunConfig,
@@ -44,6 +49,7 @@ from snapred.backend.dao.state import (
 from snapred.backend.dao.state.CalibrantSample import CalibrantSample
 from snapred.backend.data.Indexer import Indexer, IndexerType
 from snapred.backend.data.NexusHDF5Metadata import NexusHDF5Metadata as n5m
+from snapred.backend.data.util.PV_logs_util import datetimeFromLogTime, mappingFromNeXusLogs, mappingFromRun
 from snapred.backend.error.RecoverableException import RecoverableException
 from snapred.backend.error.StateValidationException import StateValidationException
 from snapred.backend.log.logger import snapredLogger
@@ -82,37 +88,37 @@ def _createFileNotFoundError(msg, filename):
 
 @Singleton
 class LocalDataService:
-    instrumentConfig: "InstrumentConfig"
-    verifyPaths: bool = True
-
     # conversion factor from microsecond/Angstrom to meters
     # (TODO: FIX THIS COMMENT! Obviously `m2cm` doesn't convert from 1.0 / Angstrom to 1.0 / meters.)
     CONVERSION_FACTOR = Config["constants.m2cm"] * PhysicalConstants.h / PhysicalConstants.NeutronMass
 
     def __init__(self) -> None:
-        self.verifyPaths = Config["localdataservice.config.verifypaths"]
-        self.instrumentConfig = self.readInstrumentConfig()
+        self._verifyPaths = Config["localdataservice.config.verifypaths"]
+        self._instrumentConfig = self._readInstrumentConfig()
         self.mantidSnapper = MantidSnapper(None, "Utensils")
 
     ##### MISCELLANEOUS METHODS #####
+
+    def getInstrumentConfig(self):
+        return self._instrumentConfig
 
     def fileExists(self, path):
         return os.path.isfile(path)
 
     def _determineInstrConfigPaths(self) -> None:
         """This method locates the instrument configuration path and
-        sets the instance variable ``instrumentConfigPath``."""
+        sets the instance variable ``_instrumentConfigPath``."""
         # verify parent directory exists
-        self.dataPath = Path(Config["instrument.home"])
-        if self.verifyPaths and not self.dataPath.exists():
-            raise _createFileNotFoundError(Config["instrument.home"], self.dataPath)
+        self._instrumentHomePath = Path(Config["instrument.home"])
+        if self._verifyPaths and not self._instrumentHomePath.exists():
+            raise _createFileNotFoundError(Config["instrument.home"], self._instrumentHomePath)
 
         # look for the config file and verify it exists
-        self.instrumentConfigPath = Config["instrument.config"]
-        if self.verifyPaths and not Path(self.instrumentConfigPath).exists():
+        self._instrumentConfigPath = Config["instrument.config"]
+        if self._verifyPaths and not Path(self._instrumentConfigPath).exists():
             raise _createFileNotFoundError("Missing Instrument Config", Config["instrument.config"])
 
-    def readInstrumentConfig(self) -> InstrumentConfig:
+    def _readInstrumentConfig(self) -> InstrumentConfig:
         self._determineInstrConfigPaths()
 
         instrumentParameterMap = self._readInstrumentParameters()
@@ -124,10 +130,10 @@ class LocalDataService:
             instrumentParameterMap["version"] = str(instrumentParameterMap["version"])
             instrumentConfig = InstrumentConfig(**instrumentParameterMap)
         except KeyError as e:
-            raise KeyError(f"{e}: while reading instrument configuration '{self.instrumentConfigPath}'") from e
-        if self.dataPath:
+            raise KeyError(f"{e}: while reading instrument configuration '{self._instrumentConfigPath}'") from e
+        if self._instrumentHomePath:
             instrumentConfig.calibrationDirectory = Path(Config["instrument.calibration.home"])
-            if self.verifyPaths and not instrumentConfig.calibrationDirectory.exists():
+            if self._verifyPaths and not instrumentConfig.calibrationDirectory.exists():
                 raise _createFileNotFoundError("[calibration directory]", instrumentConfig.calibrationDirectory)
 
         return instrumentConfig
@@ -135,11 +141,11 @@ class LocalDataService:
     def _readInstrumentParameters(self) -> Dict[str, Any]:
         instrumentParameterMap: Dict[str, Any] = {}
         try:
-            with open(self.instrumentConfigPath, "r") as json_file:
+            with open(self._instrumentConfigPath, "r") as json_file:
                 instrumentParameterMap = json.load(json_file)
             return instrumentParameterMap
         except FileNotFoundError as e:
-            raise _createFileNotFoundError("Instrument configuration file", self.instrumentConfigPath) from e
+            raise _createFileNotFoundError("Instrument configuration file", self._instrumentConfigPath) from e
 
     def readStateConfig(self, runId: str, useLiteMode: bool) -> StateConfig:
         indexer = self.calibrationIndexer(runId, useLiteMode)
@@ -222,8 +228,27 @@ class LocalDataService:
 
     @lru_cache
     def getIPTS(self, runNumber: str, instrumentName: str = Config["instrument.name"]) -> str:
-        ipts = GetIPTS(RunNumber=runNumber, Instrument=instrumentName)
-        return str(ipts)
+        IPTS = GetIPTS(RunNumber=runNumber, Instrument=instrumentName)
+
+        # WARNING:
+        #   When successful, `GetIPTS` returns the _likely_ user-data directory for this run number.
+        # It does _not_ actually check whether any input-data file for this run number exists.
+        # For example, in live-data mode, the IPTS directory will probably exist,
+        # but the input file will not yet exist.
+
+        return str(IPTS)
+
+    def createNeutronFilePath(self, runNumber: str, useLiteMode: bool) -> Path:
+        # TODO: normalize with `GroceryService` version!
+
+        # TODO: fully normalize this to pathlib.Path:
+        #   -- problems (among others): `GetIPTS` returns with an '/' at the end?
+
+        IPTS = self.getIPTS(runNumber)
+        instr = "nexus.lite" if useLiteMode else "nexus.native"
+        pre = instr + ".prefix"
+        ext = instr + ".extension"
+        return Path(IPTS + Config[pre] + str(runNumber) + Config[ext])
 
     def stateExists(self, runId: str) -> bool:
         stateId, _ = self.generateStateId(runId)
@@ -248,8 +273,8 @@ class LocalDataService:
             IPTS=iptsPath,
             runNumber=runId,
             maskFileName="",
-            maskFileDirectory=iptsPath + self.instrumentConfig.sharedDirectory,
-            gsasFileDirectory=iptsPath + self.instrumentConfig.reducedDataDirectory,
+            maskFileDirectory=iptsPath + self._instrumentConfig.sharedDirectory,
+            gsasFileDirectory=iptsPath + self._instrumentConfig.reducedDataDirectory,
             calibrationState=None,
         )  # TODO: where to find case? "before" "after"
 
@@ -257,8 +282,8 @@ class LocalDataService:
         runConfig = self._readRunConfig(runId)
         return Path(
             runConfig.IPTS,
-            self.instrumentConfig.nexusDirectory,
-            f"SNAP_{str(runConfig.runNumber)}{self.instrumentConfig.nexusFileExtension}",
+            self._instrumentConfig.nexusDirectory,
+            f"SNAP_{str(runConfig.runNumber)}{self._instrumentConfig.nexusFileExtension}",
         )
 
     def _readPVFile(self, runId: str):
@@ -273,13 +298,14 @@ class LocalDataService:
     # NOTE `lru_cache` decorator needs to be on the outside
     @lru_cache
     @ExceptionHandler(StateValidationException)
-    def generateStateId(self, runId: str) -> Tuple[str, str]:
+    def generateStateId(self, runId: str) -> Tuple[str, DetectorState | None]:
+        detectorState = None
         if runId in ReservedRunNumber.values():
             SHA = ObjectSHA(hex=ReservedStateId.forRun(runId))
         else:
             detectorState = self.readDetectorState(runId)
             SHA = self._stateIdFromDetectorState(detectorState)
-        return SHA.hex, SHA.decodedKey
+        return SHA.hex, detectorState
 
     def _stateIdFromDetectorState(self, detectorState: DetectorState) -> ObjectSHA:
         stateID = StateId(
@@ -295,10 +321,10 @@ class LocalDataService:
         )
         return ObjectSHA.fromObject(stateID)
 
-    def stateIdFromWorkspace(self, wsName: WorkspaceName) -> Tuple[str, str]:
+    def stateIdFromWorkspace(self, wsName: WorkspaceName) -> Tuple[str, DetectorState]:
         detectorState = self.detectorStateFromWorkspace(wsName)
         SHA = self._stateIdFromDetectorState(detectorState)
-        return SHA.hex, SHA.decodedKey
+        return SHA.hex, detectorState
 
     def _findMatchingFileList(self, pattern, throws=True) -> List[str]:
         """
@@ -491,9 +517,9 @@ class LocalDataService:
             version = indexer.latestApplicableVersion(runId)
         record = None
         if version is not None:
+            logger.info(f"loading normalization version: {version} for runId: {runId}")
             record = indexer.readRecord(version)
-        logger.info(indexer.index)
-        logger.info(f"latest applicable version: {version} for runId: {runId} ")
+
         return record
 
     def writeNormalizationRecord(self, record: NormalizationRecord, entry: Optional[IndexEntry] = None):
@@ -553,6 +579,7 @@ class LocalDataService:
             version = indexer.latestApplicableVersion(runId)
         record = None
         if version is not None:
+            logger.info(f"loading calibration version: {version} for runId: {runId}")
             record = indexer.readRecord(version)
 
         return record
@@ -853,60 +880,33 @@ class LocalDataService:
         indexer = self.normalizationIndexer(normalization.seedRun, normalization.useLiteMode)
         indexer.writeParameters(normalization)
 
-    def readDetectorState(self, runId: str) -> DetectorState:
+    def _detectorStateFromMapping(self, logs: Mapping) -> DetectorState:
         detectorState = None
-        pvFile = self._readPVFile(runId)
-        wav_value = None
-        logsLocation = Config["constants.logsLocation"]
-        wav_key_1 = f"{logsLocation}/BL3:Chop:Gbl:WavelengthReq/value"
-        wav_key_2 = f"{logsLocation}/BL3:Chop:Skf1:WavelengthUserReq/value"
-
-        if wav_key_1 in pvFile:
-            wav_value = pvFile.get(wav_key_1)[0]
-        elif wav_key_2 in pvFile:
-            wav_value = pvFile.get(wav_key_2)[0]
-        else:
-            raise ValueError(f"Could not find wavelength logs in file '{self._constructPVFilePath(runId)}'")
-
         try:
-            detectorState = DetectorState(
-                arc=[pvFile.get(f"{logsLocation}/det_arc1/value")[0], pvFile.get(f"{logsLocation}/det_arc2/value")[0]],
-                wav=wav_value,
-                freq=pvFile.get(f"{logsLocation}/BL3:Det:TH:BL:Frequency/value")[0],
-                guideStat=pvFile.get(f"{logsLocation}/BL3:Mot:OpticsPos:Pos/value")[0],
-                lin=[pvFile.get(f"{logsLocation}/det_lin1/value")[0], pvFile.get(f"{logsLocation}/det_lin2/value")[0]],
-            )
-        except (TypeError, KeyError) as e:
-            raise ValueError(f"Could not find all required logs in file '{self._constructPVFilePath(runId)}': {e}")
+            try:
+                detectorState = DetectorState.fromLogs(logs)
+            except (KeyError, TypeError) as e:
+                raise RuntimeError("Some required logs are not present. Cannot assemble a DetectorState") from e
+        except ValidationError as e:
+            raise RuntimeError("Logs have an unexpected format.  Cannot assemble a DetectorState.") from e
+        return detectorState
+
+    def readDetectorState(self, runNumber: str) -> DetectorState:
+        detectorState = None
+        try:
+            detectorState = self._detectorStateFromMapping(mappingFromNeXusLogs(self._readPVFile(runNumber)))
+        except FileNotFoundError:
+            if not self.hasLiveDataConnection():
+                raise  # the existing exception is sufficient
+            metadata = self.readLiveMetadata()
+            if metadata.runNumber == runNumber:
+                detectorState = metadata.detectorState
+            else:
+                raise RuntimeError(f"No PVFile exists for run {runNumber}, and it isn't a live run.")
         return detectorState
 
     def detectorStateFromWorkspace(self, wsName: WorkspaceName) -> DetectorState:
-        detectorState = None
-        try:
-            logs = mtd[wsName].getRun()
-
-            # Check for the wavelength logs
-            wav_value = None
-            if logs.hasProperty("BL3:Chop:Gbl:WavelengthReq"):
-                wav_value = logs.getProperty("BL3:Chop:Gbl:WavelengthReq").value[0]
-            elif logs.hasProperty("BL3:Chop:Skf1:WavelengthUserReq"):
-                wav_value = logs.getProperty("BL3:Chop:Skf1:WavelengthUserReq").value[0]
-            else:
-                raise ValueError(f"Workspace '{wsName}' does not have the required wavelength logs")
-
-            # Assemble DetectorState using the logs
-            detectorState = DetectorState(
-                arc=[logs.getProperty("det_arc1").value[0], logs.getProperty("det_arc2").value[0]],
-                wav=wav_value,
-                freq=logs.getProperty("BL3:Det:TH:BL:Frequency").value[0],
-                guideStat=logs.getProperty("BL3:Mot:OpticsPos:Pos").value[0],
-                lin=[logs.getProperty("det_lin1").value[0], logs.getProperty("det_lin2").value[0]],
-            )
-        except Exception as e:  # noqa: E722
-            raise RuntimeError(
-                f"Workspace '{wsName}' does not have all required logs to assemble a DetectorState"
-            ) from e
-        return detectorState
+        return self._detectorStateFromMapping(mappingFromRun(mtd[wsName].getRun()))
 
     @validate_call
     def _writeDefaultDiffCalTable(self, runNumber: str, useLiteMode: bool):
@@ -925,27 +925,27 @@ class LocalDataService:
         #   and delete its workspaces after completion.
         grocer.deleteWorkspaceUnconditional(outWS)
 
-    def generateInstrumentStateFromRoot(self, runId: str):
-        stateId, _ = self.generateStateId(runId)
+    def generateInstrumentState(self, runId: str):
+        # Read the detector state from the PV data file,
+        #   and generate the stateID SHA.
+        stateId, detectorState = self.generateStateId(runId)
 
-        # Read the detector state from the pv data file
-        detectorState = self.readDetectorState(runId)
-
-        # then read data from the common calibration state parameters stored at root of calibration directory
-        instrumentConfig = self.readInstrumentConfig()
-        # then pull static values specified by Malcolm from resources
+        # Pull static values from resources
         defaultGroupSliceValue = Config["calibration.parameters.default.groupSliceValue"]
         fwhmMultipliers = Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
         peakTailCoefficient = Config["calibration.parameters.default.peakTailCoefficient"]
         gsasParameters = GSASParameters(
             alpha=Config["calibration.parameters.default.alpha"], beta=Config["calibration.parameters.default.beta"]
         )
-        # then calculate the derived values
+
+        # Calculate the derived values
         lambdaLimit = Limit(
-            minimum=detectorState.wav - (instrumentConfig.bandwidth / 2) + instrumentConfig.lowWavelengthCrop,
-            maximum=detectorState.wav + (instrumentConfig.bandwidth / 2),
+            minimum=detectorState.wav
+            - (self._instrumentConfig.bandwidth / 2)
+            + self._instrumentConfig.lowWavelengthCrop,
+            maximum=detectorState.wav + (self._instrumentConfig.bandwidth / 2),
         )
-        L = instrumentConfig.L1 + instrumentConfig.L2
+        L = self._instrumentConfig.L1 + self._instrumentConfig.L2
         tofLimit = Limit(
             minimum=lambdaLimit.minimum * L / self.CONVERSION_FACTOR,
             maximum=lambdaLimit.maximum * L / self.CONVERSION_FACTOR,
@@ -954,7 +954,7 @@ class LocalDataService:
 
         return InstrumentState(
             id=stateId,
-            instrumentConfig=instrumentConfig,
+            instrumentConfig=self._instrumentConfig,
             detectorState=detectorState,
             gsasParameters=gsasParameters,
             particleBounds=particleBounds,
@@ -970,9 +970,8 @@ class LocalDataService:
         from snapred.backend.data.GroceryService import GroceryService
 
         grocer = GroceryService()
-        stateId, _ = self.generateStateId(runId)
-
-        instrumentState = self.generateInstrumentStateFromRoot(runId)
+        instrumentState = self.generateInstrumentState(runId)
+        stateId = instrumentState.id
 
         calibrationReturnValue = None
 
@@ -1045,6 +1044,8 @@ class LocalDataService:
         self._writeGroupingMap(stateId, groupingMap)
 
     def checkCalibrationFileExists(self, runId: str):
+        # TODO: run number format validation does not belong here!
+
         # first perform some basic validation of the run ID
         # - it must be a string of only digits
         # - it must be greater than some minimal run number
@@ -1052,15 +1053,14 @@ class LocalDataService:
             return False
         # then make sure the run number has a valid IPTS
         try:
-            self.getIPTS(runId)
-        # if no IPTS found, return false
-        except RuntimeError:
-            return False
-        # if found, try to construct the path and test if the path exists
-        else:
+            # The existence of a calibration state root does not necessarily have anything to do with
+            #   whether or not the run has an existing IPTS directory.
+
             stateID, _ = self.generateStateId(runId)
             calibrationStatePath: Path = self.constructCalibrationStateRoot(stateID)
             return calibrationStatePath.exists()
+        except (FileNotFoundError, RuntimeError):
+            return False
 
     ##### GROUPING MAP METHODS #####
 
@@ -1258,3 +1258,100 @@ class LocalDataService:
         # At present, this method is just a wrapper for 'writeDiffCalWorkspaces':
         #   its existence allows for the separation of pixel-mask I/O from diffraction-calibration workspace I/O.
         self.writeDiffCalWorkspaces(path, filename, maskWorkspaceName=maskWorkspaceName)
+
+    ## LIVE-DATA SUPPORT METHODS
+
+    @lru_cache
+    def hasLiveDataConnection(self) -> bool:
+        """For 'live data' methods: test if there is a listener connection to the instrument."""
+
+        # NOTE: adding `lru_cache` to this method bypasses a possible race condition in
+        #   `ConfigService.getFacility(...)`.  (And yes, that should be a `const` method.  :( )
+
+        # In addition to 'analysis.sns.gov', other nodes on the subnet should be OK as well.
+        #   So this check should also return True on those nodes.
+        # If this method returns True, then the `SNSLiveEventDataListener` should be able to function.
+
+        # Normalize to an actual "URL" and then strip off the protocol (not actually "http") and port:
+        #   `liveDataAddress` returns a string similar to "bl3-daq1.sns.gov:31415".
+
+        facility, instrument = Config["liveData.facility.name"], Config["liveData.instrument.name"]
+        hostname = urlparse(
+            "http://" + ConfigService.getFacility(facility).instrument(instrument).liveDataAddress()
+        ).hostname
+        status = True
+        try:
+            socket.gethostbyaddr(hostname)
+        except Exception as e:  # noqa: BLE001
+            # specifically:
+            #   we're expecting a `socket.gaierror`, but any exception will indicate that there's no connection
+            logger.debug(f"`hasLiveDataConnection` returns `False`: exception: {e}")
+            status = False
+        return status
+
+    def _liveMetadataFromRun(self, run: Run) -> LiveMetadata:
+        """Construct a 'LiveMetadata' instance from a 'mantid.api.Run' instance."""
+
+        logs = mappingFromRun(run)
+        metadata = None
+        try:
+            run_number: str = str(logs["run_number"])
+
+            # See comments at `snapred.backend.data.util.PV_logs_util.datetimeFromLogTime` about this conversion.
+            start_time: datetime.datetime = datetimeFromLogTime(logs["start_time"])
+
+            end_time: datetime.datetime = datetimeFromLogTime(logs["end_time"])
+
+            # Many required log values will not be present if a run is inactive.
+            detector_state = (
+                self._detectorStateFromMapping(logs) if run_number != str(LiveMetadata.INACTIVE_RUN) else None
+            )
+
+            proton_charge = logs["proton_charge"]
+
+            metadata = LiveMetadata(
+                runNumber=run_number,
+                startTime=start_time,
+                endTime=end_time,
+                detectorState=detector_state,
+                protonCharge=proton_charge,
+            )
+        except (KeyError, RuntimeError, ValidationError) as e:
+            raise RuntimeError("unable to extract LiveMetadata from Run") from e
+        return metadata
+
+    def _readLiveData(self, ws: WorkspaceName, duration: int):
+        # 'StartTime=""' => read all of the available data
+
+        # Initialize `startTime` to indicate that we want `duration` seconds of data prior to the current time.
+        startTime = (
+            (datetime.datetime.utcnow() + datetime.timedelta(seconds=-duration)).isoformat() if duration != 0 else ""
+        )
+
+        # TODO: this call is partially duplicated at `FetchGroceriesAlgorithm`.
+        #   However, this separate method is required in order to specify a "fast load" for metadata purposes.
+        self.mantidSnapper.LoadLiveData(
+            "load live-data chunk",
+            OutputWorkspace=ws,
+            Instrument=Config["liveData.instrument.name"],
+            AccumulationMethod=Config["liveData.accumulationMethod"],
+            StartTime=startTime,
+        )
+        self.mantidSnapper.executeQueue()
+
+        return ws
+
+    def readLiveMetadata(self) -> LiveMetadata:
+        ws = self.mantidSnapper.mtd.unique_hidden_name()
+
+        # Retrieve the smallest possible data increment, in order to read the logs:
+        ws = self._readLiveData(ws, duration=1)
+        metadata = self._liveMetadataFromRun(self.mantidSnapper.mtd[ws].getRun())
+
+        self.mantidSnapper.DeleteWorkspace("delete temporary workspace", Workspace=ws)
+        self.mantidSnapper.executeQueue()
+        return metadata
+
+    def readLiveData(self, ws: WorkspaceName, duration: int) -> WorkspaceName:
+        # A duration of zero => read all of the available data.
+        return self._readLiveData(ws, duration)

--- a/src/snapred/backend/data/util/PV_logs_util.py
+++ b/src/snapred/backend/data/util/PV_logs_util.py
@@ -1,0 +1,140 @@
+"""
+Python `Mapping`-interface adapters and utility-methods relating to Mantid workspace logs (i.e. `Run`)
+  and process-variable(PV) logs.
+"""
+
+import datetime
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+import h5py
+import numpy as np
+from mantid.api import Run
+from mantid.simpleapi import AddSampleLog, mtd
+
+from snapred.meta.Config import Config
+
+
+def transferInstrumentPVLogs(dest: Run, src: Run, keys: Iterable[str]):
+    # Transfer instrument-specific PV-log values, between the `Run` attributes
+    #   of source and destination workspaces.
+
+    # Placed here for use by various `FetchGroceriesAlgorithm` loaders.
+    for key in keys:
+        if src.hasProperty(key):
+            # WARNING: known Mantid defect: `addPropery` 'name' arg will not be used.
+            #   'name' of new property will be taken from the source property.
+            dest.addProperty(key, src.getProperty(key), True)
+    # REMINDER: the instrument-parameter update still needs to be explicitly triggered!
+
+
+def populateInstrumentParameters(wsName: str):
+    # This utility function is a "stand in" until Mantid PR #38684 can be merged.
+    # (see https://github.com/mantidproject/mantid/pull/38684)
+    # After that, `mtd[wsName].populateInstrumentParameters()` should be used instead.
+
+    # Any PV-log key will do, so long as it is one that always exists in the logs.
+    pvLogKey = "run_title"
+    pvLogValue = mtd[wsName].run().getProperty(pvLogKey).value
+
+    AddSampleLog(
+        Workspace=wsName,
+        LogName=pvLogKey,
+        logText=pvLogValue,
+        logType="String",
+        UpdateInstrumentParameters=True,
+    )
+
+
+def datetimeFromLogTime(logTime: np.datetime64) -> datetime.datetime:
+    # Convert from PV-log time with nanoseconds resolution
+    #   to `datetime` with microseconds resolution.
+
+    # PV-log time values are of type `numpy.datetime64` with nanosecond resolution.
+    # From the documentation, they are measured with respect to the "utc" timezone.
+    # WARNING: without converting to the  "us" datetime64 representation first,
+    #   the `astype(datetime.datetime)` will fallback to returning an <int64>.
+    return datetime.datetime.replace(
+        np.datetime64(logTime, "us").astype(datetime.datetime), tzinfo=datetime.timezone.utc
+    )
+
+
+def mappingFromRun(run: Run) -> Mapping:
+    # Normalize `mantid.api.run` to a standard Python Mapping.
+
+    class _Mapping(Mapping):
+        def __init__(self, run: Run):
+            self._run = run
+
+        def __getitem__(self, key: str) -> Any:
+            # Deal with PV-logs special cases:
+            #   map getter methods to keys.
+            value = None
+            match key:
+                # These time values are of type `numpy.datetime64` with nanosecond resolution.
+                # To convert to `datetime.datetime`, which only supports microseconds:
+                #   see the `datetimeFromLogTime` method above.
+
+                case "end_time":
+                    value = self._run.endTime().to_datetime64()
+
+                case "start_time":
+                    value = self._run.startTime().to_datetime64()
+
+                case "proton_charge":
+                    value = self._run.getProtonCharge()
+
+                case "run_number":
+                    value = self._run.getProperty("run_number").value if self._run.hasProperty("run_number") else 0
+
+                case _:
+                    try:
+                        value = self._run.getProperty(key).value
+                    except RuntimeError as e:
+                        if "Unknown property search object" in str(e):
+                            raise KeyError(key) from e
+                        raise
+            return value
+
+        def __iter__(self):
+            return self._run.keys().__iter__()
+
+        def __len__(
+            self,
+        ):
+            return len(self._run.keys())
+
+        def __contains__(self, key: str):
+            return self._run.hasProperty(key)
+
+        def keys(self):
+            return self._run.keys()
+
+    return _Mapping(run)
+
+
+def mappingFromNeXusLogs(h5: h5py.File) -> Mapping:
+    # Normalize NeXus hdf5 logs to a standard Python Mapping.
+
+    class _Mapping(Mapping):
+        def __init__(self, h5: h5py.File):
+            self._logs = h5[Config["instrument.PVLogs.rootGroup"]]
+
+        def __getitem__(self, key: str) -> Any:
+            return self._logs[key + "/value"]
+
+        def __iter__(self):
+            return self.keys().__iter__()
+
+        def __len__(
+            self,
+        ):
+            return len(self._logs.keys())
+
+        def __contains__(self, key: str):
+            return self._logs.__contains__(key + "/value")
+
+        def keys(self):
+            return [k[0 : k.rfind("/value")] for k in self._logs.keys()]
+
+    return _Mapping(h5)

--- a/src/snapred/backend/error/LiveDataState.py
+++ b/src/snapred/backend/error/LiveDataState.py
@@ -1,0 +1,87 @@
+from enum import Enum, auto
+
+from pydantic import BaseModel, model_validator
+
+from snapred.backend.log.logger import snapredLogger
+
+logger = snapredLogger.getLogger(__name__)
+
+
+class LiveDataState(Exception):
+    """
+    Raised when a live-data run changes state.
+    """
+
+    class Type(Enum):
+        UNSET = 0
+
+        # <run number> > 0 <- <run number> == 0
+        RUN_START = auto()
+
+        # <run number> == 0 <- <run number> > 0
+        RUN_END = auto()
+
+        # <run number>` != <run number>  <- <run number> > 0
+        RUN_GAP = auto()
+
+    class Model(BaseModel):
+        message: str
+        transition: "LiveDataState.Type"
+
+        endRunNumber: str
+        startRunNumber: str
+
+        @model_validator(mode="after")
+        def _validate_LiveDataState(self):
+            if self.endRunNumber == self.startRunNumber or (
+                (int(self.endRunNumber) > 0 and int(self.startRunNumber) > 0)
+                and int(self.endRunNumber) < int(self.startRunNumber)
+            ):
+                raise ValueError(f"not a run-state transition: {self.endRunNumber} <- {self.startRunNumber}")
+            return self
+
+    def __init__(self, message: str, transition: "Type", endRunNumber: str, startRunNumber: str):
+        LiveDataState.Model.model_rebuild(force=True)
+        self.model = LiveDataState.Model(
+            message=message, transition=transition, endRunNumber=endRunNumber, startRunNumber=startRunNumber
+        )
+        super().__init__(message)
+
+    @property
+    def message(self):
+        return self.model.message
+
+    @property
+    def transition(self):
+        return self.model.transition
+
+    @property
+    def endRunNumber(self):
+        return self.model.endRunNumber
+
+    @property
+    def startRunNumber(self):
+        return self.model.startRunNumber
+
+    @staticmethod
+    def parse_raw(raw) -> "LiveDataState":
+        raw = LiveDataState.Model.model_validate_json(raw)
+        return LiveDataState(**raw.dict())
+
+    @staticmethod
+    def runStateTransition(endRunNumber: str, startRunNumber: str) -> "LiveDataState":
+        transition = LiveDataState.Type.UNSET
+        message = "unknown state transition"
+        if int(endRunNumber) > 0 and int(startRunNumber) == 0:
+            transition = LiveDataState.Type.RUN_START
+            message = f"start of run {endRunNumber}"
+        elif int(endRunNumber) == 0 and int(startRunNumber) > 0:
+            transition = LiveDataState.Type.RUN_END
+            message = f"end of run {startRunNumber}"
+        elif int(endRunNumber) > 0 and int(startRunNumber) > 0:
+            transition = LiveDataState.Type.RUN_GAP
+            message = f"run-number gap: {endRunNumber} <- {startRunNumber}"
+        else:
+            raise ValueError(f"unexpected run-state transition: {endRunNumber} <- {startRunNumber}")
+
+        return LiveDataState(message, transition=transition, endRunNumber=endRunNumber, startRunNumber=startRunNumber)

--- a/src/snapred/backend/error/RecoverableException.py
+++ b/src/snapred/backend/error/RecoverableException.py
@@ -1,3 +1,4 @@
+import logging
 from enum import Flag, auto
 from typing import Any, Optional
 
@@ -39,13 +40,17 @@ class RecoverableException(Exception):
     def __init__(self, message: str, flags: "Type" = 0, data: Optional[Any] = None):
         RecoverableException.Model.model_rebuild(force=True)  # replaces: `update_forward_refs` method
         self.model = RecoverableException.Model(message=message, flags=flags, data=data)
-        logger.error(f"{extractTrueStacktrace()}")
+        if logger.isEnabledFor(logging.DEBUG):
+            # This is a `RecoverableException`, which is barely even an error, so we do NOT spam the logs!
+            logger.error(f"{extractTrueStacktrace()}")
         super().__init__(message)
 
+    @staticmethod
     def parse_raw(raw):
         raw = RecoverableException.Model.model_validate_json(raw)
         return RecoverableException(**raw.dict())
 
+    @staticmethod
     def stateUninitialized(runNumber: str, useLiteMode: bool):
         return RecoverableException(
             "State uninitialized",

--- a/src/snapred/backend/error/StateValidationException.py
+++ b/src/snapred/backend/error/StateValidationException.py
@@ -1,8 +1,3 @@
-import os
-import traceback
-from pathlib import Path
-from typing import Tuple
-
 from snapred.backend.log.logger import snapredLogger
 
 logger = snapredLogger.getLogger(__name__)
@@ -11,39 +6,27 @@ logger = snapredLogger.getLogger(__name__)
 class StateValidationException(Exception):
     "Raised when an Instrument State is invalid"
 
+    """
+    Implementation note:
+        The previous implementation of this class actually checked the write permissions for the filename
+    from the exception's stack trace.  WHY would any end user be interested in whether or not they could write
+    to the file of the <python filename> where the exception was raised?!
+        In changing this, I realize we _could_ meaningfully check write permissions to
+    `Config['instrument.calibration.powder.home']`.  However, the problem is that a `StateValidationException`
+    is more general than just this diffraction-calibration or normalization-calibration workflow case.
+    For this reason I ended up only checking the exception types.  If nothing else, this gives us an interim solution.
+    Further, I'll note that the permissions are now checked during the verification step at the start of each workflow,
+    and if there are issues, a messagebox pops up indicating that.  For this reason, any check here, or any associated
+    exception message should be redundant.
+    """
+
     def __init__(self, exception: Exception):
         exceptionStr = str(exception)
-        tb = exception.__traceback__
 
-        if tb is not None:
-            tb_info = traceback.extract_tb(tb)
-            if tb_info:
-                filePath = tb_info[-1].filename
-                lineNumber = tb_info[-1].lineno
-                functionName = tb_info[-1].name
-            else:
-                filePath, lineNumber, functionName = None, lineNumber, functionName
+        if isinstance(exception, (FileNotFoundError, PermissionError)):
+            self.message = f"The following error occurred: {exceptionStr}\n\n" + "Please contact your IS or CIS."
         else:
-            filePath, lineNumber, functionName = None, None, None
-
-        doesFileExist, hasWritePermission = self._checkFileAndPermissions(filePath)
-
-        if filePath and doesFileExist and hasWritePermission:
-            self.message = f"The following error occurred:{exceptionStr}\n\n" "Please contact your IS or CIS."
-        elif filePath and doesFileExist:
-            self.message = f"You do not have write permissions: {filePath}"
-        elif filePath:
-            self.message = f"The file does not exist: {filePath}"
-        else:
-            self.message = "Instrument State for given Run Number is invalid! (see logs for details.)"
+            self.message = "Instrument State for given Run Number is invalid! (See logs for details.)"
 
         logger.error(exceptionStr)
         super().__init__(self.message)
-
-    @staticmethod
-    def _checkFileAndPermissions(filePath) -> Tuple[bool, bool]:
-        if filePath is None:
-            return False, False
-        fileExists = Path(filePath).exists()
-        writePermission = os.access(filePath, os.W_OK) if fileExists else False
-        return fileExists, writePermission

--- a/src/snapred/backend/error/UserCancellation.py
+++ b/src/snapred/backend/error/UserCancellation.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel
+
+from snapred.backend.log.logger import snapredLogger
+
+logger = snapredLogger.getLogger(__name__)
+
+
+class UserCancellation(Exception):
+    """Raised when cancellation has been requested by the user."""
+
+    class Model(BaseModel):
+        message: str
+
+    def __init__(self, message: str):
+        UserCancellation.Model.model_rebuild(force=True)
+        self.model = UserCancellation.Model(message=message)
+        super().__init__(message)
+
+    @property
+    def message(self):
+        return self.model.message
+
+    @staticmethod
+    def parse_raw(raw) -> "UserCancellation":
+        model = UserCancellation.Model.model_validate_json(raw)
+        return UserCancellation(**model.model_dump())

--- a/src/snapred/backend/recipe/CalculateDiffCalResidualRecipe.py
+++ b/src/snapred/backend/recipe/CalculateDiffCalResidualRecipe.py
@@ -112,7 +112,7 @@ class CalculateDiffCalResidualRecipe(Recipe[None]):
                 f"Combining spectrum {spectrum}...",
                 InputWorkspace1=combinedWorkspace,
                 InputWorkspace2=spectrum,
-                # CheckMatchingBins=False, # not available in 6.11.0.3rc2
+                CheckMatchingBins=False, # not available in 6.11.0.3rc2
             )
 
         # Step 4: Calculate the residual difference between the combined workspace and input workspace

--- a/src/snapred/backend/recipe/CalculateDiffCalResidualRecipe.py
+++ b/src/snapred/backend/recipe/CalculateDiffCalResidualRecipe.py
@@ -112,7 +112,7 @@ class CalculateDiffCalResidualRecipe(Recipe[None]):
                 f"Combining spectrum {spectrum}...",
                 InputWorkspace1=combinedWorkspace,
                 InputWorkspace2=spectrum,
-                CheckMatchingBins=False, # not available in 6.11.0.3rc2
+                CheckMatchingBins=False,  # not available in 6.11.0.3rc2
             )
 
         # Step 4: Calculate the residual difference between the combined workspace and input workspace

--- a/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
+++ b/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
@@ -128,7 +128,7 @@ class ConjoinDiagnosticWorkspaces(PythonAlgorithm):
             InputWorkspace1=outws,
             InputWorkspace2=tmpws,
             CheckOverlapping=False,
-            CheckMatchingBins=False # Not available in 6.11.0.3rc2
+            CheckMatchingBins=False,  # Not available in 6.11.0.3rc2
         )
         if self.autoDelete and inws in mtd:
             DeleteWorkspace(inws)

--- a/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
+++ b/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
@@ -128,7 +128,7 @@ class ConjoinDiagnosticWorkspaces(PythonAlgorithm):
             InputWorkspace1=outws,
             InputWorkspace2=tmpws,
             CheckOverlapping=False,
-            # CheckMatchingBins=False, # Not available in 6.11.0.3rc2
+            CheckMatchingBins=False # Not available in 6.11.0.3rc2
         )
         if self.autoDelete and inws in mtd:
             DeleteWorkspace(inws)

--- a/src/snapred/backend/recipe/algorithm/LoadCalibrationWorkspaces.py
+++ b/src/snapred/backend/recipe/algorithm/LoadCalibrationWorkspaces.py
@@ -14,8 +14,10 @@ from mantid.api import (
 from mantid.dataobjects import MaskWorkspaceProperty
 from mantid.kernel import Direction
 
+from snapred.backend.data.util.PV_logs_util import populateInstrumentParameters, transferInstrumentPVLogs
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
+from snapred.meta.Config import Config
 
 logger = snapredLogger.getLogger(__name__)
 
@@ -30,7 +32,7 @@ class LoadCalibrationWorkspaces(PythonAlgorithm):
         InstrumentDonor: str -- name of the instrument donor workspace
         CalibrationTable: str -- name of the output table workspace
         MaskWorkspace: str -- name of the output mask workspace
-        GroupingWorkspace: str -- name of the output mask workspace
+        GroupingWorkspace: str -- name of the output grouping workspace
     """
 
     def category(self):
@@ -65,7 +67,7 @@ class LoadCalibrationWorkspaces(PythonAlgorithm):
         )
         self.declareProperty(
             MatrixWorkspaceProperty("GroupingWorkspace", "", Direction.Output, PropertyMode.Optional),
-            doc="Name of the output mask workspace",
+            doc="Name of the output grouping workspace",
         )
 
         self.setRethrows(True)
@@ -134,6 +136,22 @@ class LoadCalibrationWorkspaces(PythonAlgorithm):
                 OutputWorkspace=self.groupingWorkspace,
             )
         self.mantidSnapper.executeQueue()
+
+        # Transfer the instrument PV-logs -- not done yet by `LoadDiffCal`.
+        if self.maskWorkspace:
+            transferInstrumentPVLogs(
+                self.mantidSnapper.mtd[self.maskWorkspace].mutableRun(),
+                self.mantidSnapper.mtd[self.getPropertyValue("InstrumentDonor")].run(),
+                Config["instrument.PVLogs.instrumentKeys"],
+            )
+            populateInstrumentParameters(self.maskWorkspace)
+        if self.groupingWorkspace:
+            transferInstrumentPVLogs(
+                self.mantidSnapper.mtd[self.groupingWorkspace].mutableRun(),
+                self.mantidSnapper.mtd[self.getPropertyValue("InstrumentDonor")].run(),
+                Config["instrument.PVLogs.instrumentKeys"],
+            )
+            populateInstrumentParameters(self.groupingWorkspace)
 
         if self.calibrationTable:
             # NOTE ConvertDiffCal has issues ifthe "tofmin" column is present,

--- a/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
+++ b/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
@@ -21,10 +21,10 @@ class MakeDirtyDish(PythonAlgorithm):
         self._CISmode: bool = Config["cis_mode"]
 
     def PyExec(self) -> None:
-        inWS = self.getProperty("InputWorkspace").value
-        outWS = self.getProperty("OutputWorkspace").value
-        self.log().notice(f"Dirtying up dish {inWS} --> {outWS}")
         if self._CISmode:
+            inWS = self.getProperty("InputWorkspace").value
+            outWS = self.getProperty("OutputWorkspace").value
+            self.log().debug(f"Dirtying up dish {inWS} --> {outWS}")
             CloneWorkspace(
                 InputWorkspace=inWS,
                 OutputWorkspace=outWS,

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -317,7 +317,9 @@ class CalibrationService(Service):
 
         # Rebuild the workspace names to strip any "iteration" number:
         savedWorkspaces = {}
-        for key, wsNames in record.workspaces.items():
+        for key_, wsNames in record.workspaces.items():
+            key = wngt(key_)  # TODO: fix usage of `@FromString`. Probably get rid of it!
+
             savedWorkspaces[key] = []
             match key:
                 case wngt.DIFFCAL_OUTPUT:
@@ -392,12 +394,17 @@ class CalibrationService(Service):
     @FromString
     def fetchMatchingCalibrations(self, request: MatchRunsRequest):
         calibrations = self.matchRunsToCalibrationVersions(request)
+        masks = set()
         for runNumber in request.runNumbers:
             if runNumber in calibrations:
                 self.groceryClerk.diffcal_table(runNumber, calibrations[runNumber]).useLiteMode(
                     request.useLiteMode
                 ).add()
-        return set(self.groceryService.fetchGroceryList(self.groceryClerk.buildList())), calibrations
+                # Calibration masks are also required, and are automatically loaded at the same time.
+                masks.add(wng.diffCalMask().runNumber(runNumber).version(calibrations[runNumber]).build())
+        workspaces = set(self.groceryService.fetchGroceryList(self.groceryClerk.buildList()))
+        workspaces.update(masks)
+        return workspaces, calibrations
 
     @FromString
     def saveCalibrationToIndex(self, entry: IndexEntry):

--- a/src/snapred/backend/service/Service.py
+++ b/src/snapred/backend/service/Service.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, List
 from snapred.backend.dao.SNAPRequest import SNAPRequest
 from snapred.meta.Config import Config
 
-# Type define which is a callable function with a List of SNAPRequests as input,
+# Type definition which is a callable function with a List of SNAPRequests as input,
 # and a Dict of str keys and List of SNAPRequests values as expected output.
 GroupingLambda = Callable[[List[SNAPRequest]], Dict[str, List[SNAPRequest]]]
 

--- a/src/snapred/meta/Enum.py
+++ b/src/snapred/meta/Enum.py
@@ -2,6 +2,10 @@ import enum
 
 
 class StrEnum(str, enum.Enum):
+    def __str__(self):
+        # Match behavior of Python `StrEnum` (>= 3.11)
+        return self.value
+
     @classmethod
     def values(cls):
         return [e.value for e in cls]

--- a/src/snapred/meta/decorators/ExceptionHandler.py
+++ b/src/snapred/meta/decorators/ExceptionHandler.py
@@ -10,12 +10,14 @@ logger = snapredLogger.getLogger(__name__)
 
 def extractTrueStacktrace() -> str:
     exc_info = sys.exc_info()
-    stack = traceback.extract_stack()
-    tb = traceback.extract_tb(exc_info[2])
-    full_tb = stack[:-1] + tb
-    exc_line = traceback.format_exception_only(*exc_info[:2])
-    stacktraceStr = "\n".join(["".join(traceback.format_list(full_tb)), "".join(exc_line)])
-    return stacktraceStr
+    if exc_info[1] is not None:
+        stack = traceback.extract_stack()
+        tb = traceback.extract_tb(exc_info[2])
+        full_tb = stack[:-1] + tb
+        exc_line = traceback.format_exception_only(*exc_info[:2])
+        stacktraceStr = "\n".join(["".join(traceback.format_list(full_tb)), "".join(exc_line)])
+        return stacktraceStr
+    return "no exception has occurred"
 
 
 def ExceptionHandler(exceptionType: Type[Exception]):

--- a/src/snapred/meta/decorators/Resettable.py
+++ b/src/snapred/meta/decorators/Resettable.py
@@ -16,21 +16,24 @@ def Resettable(orig_cls):
             self._args = args
             self._kwargs = kwargs
             orig_cls.__new__ = orig_new
-            self.layout = QHBoxLayout()
-            self.layout.addWidget(orig_cls(*args, **kwargs))
+
+            # IMPORTANT: do not hide the "layout" method!
+            layout_ = QHBoxLayout()
+            layout_.addWidget(orig_cls(*args, **kwargs))
+
             orig_cls.__new__ = __new__
-            self.setLayout(self.layout)
+            self.setLayout(layout_)
 
         def reset(self):
-            widget = self.layout.itemAt(0).widget()
-            self.layout.removeWidget(widget)
+            widget = self.layout().itemAt(0).widget()
+            self.layout().removeWidget(widget)
             widget.deleteLater()
             orig_cls.__new__ = orig_new
-            self.layout.addWidget(orig_cls(*self._args, **self._kwargs))
+            self.layout().addWidget(orig_cls(*self._args, **self._kwargs))
             orig_cls.__new__ = __new__
 
         def __getattr__(self, name):
-            return getattr(self.layout.itemAt(0).widget(), name)
+            return getattr(self.layout().itemAt(0).widget(), name)
 
     orig_cls.__new__ = __new__
     return orig_cls

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -8,6 +8,9 @@ orchestration:
   path:
     delimiter: /
 
+facility:
+  name: SNS
+
 instrument:
   name: SNAP
   home: ${IPTS.root}/SNAP
@@ -46,9 +49,50 @@ instrument:
     map:
       file: ${instrument.calibration.home}/Powder/LiteGroupMap.hdf
       # file: ${module.root}/resources/ultralite/CRACKLELiteDataMap.xml
+
+  PVLogs:
+    # Swap these when running with ultralite data
+    rootGroup: "entry/DASlogs"
+    # rootGroup: "mantid_workspace_1/logs"
+
+    # PV-log keys relating to instrument settings:
+    instrumentKeys:
+    - "BL3:Chop:Gbl:WavelengthReq"
+    - "BL3:Chop:Skf1:WavelengthUserReq"
+    - "det_arc1"
+    - "det_arc2"
+    - "BL3:Det:TH:BL:Frequency"
+    - "BL3:Mot:OpticsPos:Pos"
+    - "det_lin1"
+    - "det_lin2"
+
   startingRunNumber: 10000
   minimumRunNumber: 46342
   maxNumberOfRuns: 10
+
+liveData:
+  # Override 'liveData.facility' and 'liveData.instrument'
+  #   in order to use the mock listener for testing
+  #   without overriding the real instrument.
+  facility:
+    name: ${facility.name}
+    # name: TEST_LIVE
+  instrument:
+    name: ${instrument.name}
+    # name: ADARA_FileReader
+  accumulationMethod: Replace
+  testInput:
+    inputFilename: SNAP_46680.nxs.h5
+    # WARNING: "chunks" seems a bit glitchy:
+    #   event workspaces are not loaded uniformly with respect to
+    #   event _pixel_ assignment.
+    # For thorough testing "1" might actually be the best value!
+    chunks: 1 # 50
+
+  # Update-interval slider limits and position in seconds.
+  updateIntervalMinimum: 60
+  updateIntervalDefault: 120
+  updateIntervalMaximum: 900
 
 nexus:
   lite:
@@ -114,6 +158,7 @@ mantid:
       delimiter: "_"
       template:
         run: "{unit},{group},{lite},{auxiliary},{runNumber}"
+        liteDataMap: "lite_grouping_map"
         diffCal:
           input: "{unit},{runNumber},raw"
           table: "diffract_consts,{runNumber},{version}"
@@ -204,9 +249,6 @@ constants:
   PeakIntensityFractionThreshold: 0.05
   m2cm: 10000.0 # conversion factor for m^2 to cm^2
   maskedPixelThreshold: 0.15
-  # Swap these when running with ultralite data
-  logsLocation: "entry/DASlogs"
-  # logsLocation: "/mantid_workspace_1/logs"
 
   ArtificialNormalization:
     peakWindowClippingSize: 10

--- a/src/snapred/resources/style.qss
+++ b/src/snapred/resources/style.qss
@@ -68,3 +68,30 @@ QWidget#header {
     color: #0B0014;
     border-radius: 10px;
 }
+
+.Toggle {
+    /* fixed height and width */
+    min-height: 30px; max-height: 30px;
+    min-width: 60px; max-width: 60px;
+
+    /* Toggle-switch background */
+    qproperty-backgroundColor: rgb(0, 128, 0); /* Qt.darkGreen */
+
+    /* Toggle-switch bar: vertical gradient */
+    qproperty-gradStartColor: rgb(0, 255, 0);
+    qproperty-gradEndColor: rgb(0, 128, 128); /* Qt.darkCyan */
+}
+
+/* WARNING: "liteModeToggle" is the name of the `LabeledField.field`, not the `LabeledField` itself! */
+Toggle#liteModeToggle {
+    /* `liteModeToggle` uses only default values */
+}
+
+Toggle#liveDataToggle {
+    /* Toggle-switch background */
+    qproperty-backgroundColor: rgb(0, 0, 128); /* Qt.darkBlue */
+
+    /* Toggle-switch bar: vertical gradient */
+    qproperty-gradStartColor: rgb(0, 0, 255);
+    qproperty-gradEndColor: rgb(0, 128, 128); /* Qt.darkCyan */
+}

--- a/src/snapred/resources/workbench_style.qss
+++ b/src/snapred/resources/workbench_style.qss
@@ -1,0 +1,30 @@
+/*
+ * ANYTHING ADDED here must NOT interfere with the global mantid-workbench stylesheet settings.
+ */
+
+.Toggle {
+    /* fixed height and width */
+    min-height: 30px; max-height: 30px;
+    min-width: 60px; max-width: 60px;
+
+    /* Toggle-switch background */
+    qproperty-backgroundColor: rgb(0, 128, 0); /* Qt.darkGreen */
+
+    /* Toggle-switch bar: vertical gradient */
+    qproperty-gradStartColor: rgb(0, 255, 0);
+    qproperty-gradEndColor: rgb(0, 128, 128); /* Qt.darkCyan */
+}
+
+/* WARNING: "liteModeToggle" is the name of the `LabeledField.field`, not the `LabeledField` itself! */
+Toggle#liteModeToggle {
+    /* `liteModeToggle` uses only default values */
+}
+
+Toggle#liveDataToggle {
+    /* Toggle-switch background */
+    qproperty-backgroundColor: rgb(0, 0, 128); /* Qt.darkBlue */
+
+    /* Toggle-switch bar: vertical gradient */
+    qproperty-gradStartColor: rgb(0, 0, 255);
+    qproperty-gradEndColor: rgb(0, 128, 128); /* Qt.darkCyan */
+}

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -36,6 +36,9 @@ except ImportError:
 LOGGERCLASSKEY = "logging.channels.consoleChannel.class"
 LOGGERLEVELKEY = "logging.loggers.root.level"
 DATASEARCH_DIR_KEY = "datasearch.directories"
+DEFAULT_FACILITY_KEY = "default.facility"
+FILEEVENTDATALISTENER_FILENAME_KEY = "fileeventdatalistener.filename"
+FILEEVENTDATALISTENER_CHUNKS_KEY = "fileeventdatalistener.chunks"
 
 
 # This method is also used by tests, so it's declared outside of the `SNAPRedGUI` class
@@ -70,6 +73,9 @@ class SNAPRedGUI(QMainWindow):
 
         # Redirect the IPTS search directories
         self._redirectIPTSSearchDirectories()
+
+        # Add any required live-data config values
+        self._addLiveDataMantidConfigEntries()
 
         # make sure mantid console logging is disabled
         self._redirectMantidConsoleLog()
@@ -138,6 +144,7 @@ class SNAPRedGUI(QMainWindow):
     def closeEvent(self, event):
         self._restartMantidConsoleLog()
         self._restoreIPTSSearchDirectories()
+        self._restoreLiveDataMantidConfigEntries()
         event.accept()
 
     def changeEvent(self, event):
@@ -156,6 +163,39 @@ class SNAPRedGUI(QMainWindow):
 
     def _restoreIPTSSearchDirectories(self):
         self._mantidConfig.setString(DATASEARCH_DIR_KEY, self._savedMantidConfigEntries[DATASEARCH_DIR_KEY])
+
+    def _addLiveDataMantidConfigEntries(self):
+        # Save any current default-facility setting:
+        self._savedMantidConfigEntries[DEFAULT_FACILITY_KEY] = self._mantidConfig[DEFAULT_FACILITY_KEY]
+
+        # Add the required default-facility value:
+        self._mantidConfig.setString(DEFAULT_FACILITY_KEY, Config["liveData.facility.name"])
+
+        if Config["liveData.facility.name"] == "TEST_LIVE":
+            # Save any current values from the file-listener keys:
+            self._savedMantidConfigEntries[FILEEVENTDATALISTENER_FILENAME_KEY] = self._mantidConfig[
+                FILEEVENTDATALISTENER_FILENAME_KEY
+            ]
+            self._savedMantidConfigEntries[FILEEVENTDATALISTENER_CHUNKS_KEY] = self._mantidConfig[
+                FILEEVENTDATALISTENER_CHUNKS_KEY
+            ]
+
+            # Add the required 'ADARA_FileReader' values:
+            self._mantidConfig.setString(FILEEVENTDATALISTENER_FILENAME_KEY, Config["liveData.testInput.inputFilename"])
+            self._mantidConfig.setString(FILEEVENTDATALISTENER_CHUNKS_KEY, str(Config["liveData.testInput.chunks"]))
+
+    def _restoreLiveDataMantidConfigEntries(self):
+        # Restore any previous default-facility setting:
+        self._mantidConfig.setString(DEFAULT_FACILITY_KEY, self._savedMantidConfigEntries[DEFAULT_FACILITY_KEY])
+
+        if Config["liveData.facility.name"] == "TEST_LIVE":
+            # Restore any previous values to the file-listener keys:
+            self._mantidConfig.setString(
+                FILEEVENTDATALISTENER_FILENAME_KEY, self._savedMantidConfigEntries[FILEEVENTDATALISTENER_FILENAME_KEY]
+            )
+            self._mantidConfig.setString(
+                FILEEVENTDATALISTENER_CHUNKS_KEY, self._savedMantidConfigEntries[FILEEVENTDATALISTENER_CHUNKS_KEY]
+            )
 
     def _redirectMantidConsoleLog(self):
         # Save the current Mantid logging configuration
@@ -194,7 +234,8 @@ class SNAPRedGUI(QMainWindow):
         logger.handlers.clear()
 
 
-def qapp():
+# Be careful here: the _key_ pytest-qt fixture is named `qapp`!
+def _qapp():
     if QApplication.instance():
         _app = QApplication.instance()
     else:
@@ -205,7 +246,7 @@ def qapp():
 def start(options=None):
     logger = snapredLogger.getLogger(__name__)
 
-    app = qapp()
+    app = _qapp()
     with Resource.open("style.qss", "r") as styleSheet:
         app.setStyleSheet(styleSheet.read())
 

--- a/src/snapred/ui/presenter/WorkflowPresenter.py
+++ b/src/snapred/ui/presenter/WorkflowPresenter.py
@@ -1,11 +1,14 @@
-from typing import Any, Callable, List, Tuple
+from typing import Any, Callable, List, Optional, Tuple
 
 from qtpy.QtCore import QObject, Signal, Slot
 from qtpy.QtWidgets import QMainWindow, QMessageBox
 
 from snapred.backend.api.InterfaceController import InterfaceController
 from snapred.backend.error.ContinueWarning import ContinueWarning
+from snapred.backend.error.LiveDataState import LiveDataState
+from snapred.backend.error.UserCancellation import UserCancellation
 from snapred.backend.log.logger import snapredLogger
+from snapred.meta.Config import Config
 from snapred.ui.handler.SNAPResponseHandler import SNAPResponseHandler
 from snapred.ui.model.WorkflowNodeModel import WorkflowNodeModel
 from snapred.ui.threading.worker_pool import WorkerPool
@@ -16,11 +19,18 @@ logger = snapredLogger.getLogger(__name__)
 
 
 class WorkflowPresenter(QObject):
+    workflowInProgressChange = Signal(bool)
+    cancellationRequest = Signal()
     enableAllWorkflows = Signal()
     disableOtherWorkflows = Signal()
 
-    # Allow an observer (e.g. `qtbot`) to monitor action completion.
+    # Allow an observer (e.g. `qtbot` or the `reductionWorkflow` itself) to monitor action completion.
     actionCompleted = Signal()
+
+    # Sent at the _end_ of the reset method
+    # -- this is necessary to allow the parent workflow to override reset specifics.
+    # (This is less than ideal, but the workflow's <reset hooks> are called at the _start_ of the reset method.)
+    resetCompleted = Signal()
 
     def __init__(
         self,
@@ -29,7 +39,7 @@ class WorkflowPresenter(QObject):
         iterateLambda=None,
         resetLambda=None,
         cancelLambda=None,
-        completionMessageLambda=None,
+        completeWorkflowLambda=None,
         parent=None,
     ):
         super().__init__()
@@ -37,13 +47,25 @@ class WorkflowPresenter(QObject):
         # 'WorkerPool' is a singleton:
         #    declaring it as an instance attribute, rather than a class attribute,
         #    allows singleton reset during testing.
-        self.completionMessageLambda = completionMessageLambda
 
+        self.worker = None
+        # No worker thread is actively engaged in running a workflow task.
+        self._setWorkflowIsRunning(False)
         self.worker_pool = WorkerPool()
+
+        # The first workflow node (i.e. tab) has not yet been started.
+        self._setWorkflowInProgress(False)
 
         self.view = WorkflowView(model, parent)
         self._iteration = 1
         self.model = model
+
+        # Normal operating mode for any workflow is _manual_ mode:
+        #   e.g., in this mode the user clicks the `continue` button to start or to continue the workflow.
+        # Alternatively, when manual mode is False, the workflow continues automatically, based on
+        #   timing considerations.  Reduction of live data uses this mode.
+        #   In this operating mode, the user clicks the `cancel` button to exit this automatic workflow loop.
+        self._manualMode = True
 
         # All workflow "hook" methods must be initialized, either to a bound method
         #   or to an equivalent lambda function taking arguments as specified.
@@ -51,8 +73,15 @@ class WorkflowPresenter(QObject):
         self._iterateLambda: Callable[[WorkflowPresenter], None] = (
             iterateLambda if iterateLambda is not None else self._NOP
         )
-        self._resetLambda: Callable[[], None] = resetLambda if resetLambda is not None else self.reset
+
+        # WARNING: `reset` calls `self._resetLambda` -- don't make it circular!
+        self._resetLambda: Callable[[], None] = resetLambda if resetLambda is not None else self._NOP
+
         self._cancelLambda: Callable[[], None] = cancelLambda if cancelLambda is not None else self.resetWithPermission
+
+        self._completeWorkflowLambda: Callable[[], None] = (
+            completeWorkflowLambda if completeWorkflowLambda is not None else self.completeWorkflow
+        )
 
         self.externalWorkspaces: List[str] = []
         # Retain list of ADS-resident workspaces at start of workflow
@@ -60,8 +89,13 @@ class WorkflowPresenter(QObject):
         self.interfaceController = InterfaceController()
 
         self._hookupSignals()
+        self.cancellationRequest.connect(self.requestCancellation)
+
         self.responseHandler = SNAPResponseHandler(self.view)
         self.responseHandler.continueAnyway.connect(self.continueAnyway)
+        self.responseHandler.resetWorkflow.connect(self.reset)
+        self.responseHandler.userCancellation.connect(self.userCancellation)
+        self.responseHandler.liveDataStateTransition.connect(self.liveDataStateTransition)
 
         if self.view.parent() is not None:
             self.enableAllWorkflows.connect(self.view.parent().enableAllWorkflows)
@@ -84,26 +118,50 @@ class WorkflowPresenter(QObject):
         self.window.setCentralWidget(self.view)
         self.window.show()
 
-    def resetSoft(self):
-        self.widget.reset(hard=False)
+    def resetSoft(self, manualOverride: bool = False):
+        self.widget.reset(hard=False, manualMode=self.manualMode or manualOverride)
 
     def resetHard(self):
         self.widget.reset(hard=True)
 
     def reset(self):
         self._resetLambda()
-        self.resetSoft()
+        self.resetSoft(manualOverride=True)
         self._iteration = 1
+        self._setWorkflowInProgress(False)
+
+        # The following are required for live-data mode:
+        #   but should be redundant for other modes.
+        self.enableButtons(True)
+        self.setInteractive(True)
 
         # Workflow is complete: enable the other workflow tabs.
         self.enableAllWorkflows.emit()
 
-    def resetWithPermission(self):
+        # Signal that the reset sequence is complete.
+        self.resetCompleted.emit()
+
+    def safeShutdown(self):
+        # Request any executing worker thread to shut down.
+        if self.workflowIsRunning:
+            self.cancellationRequest.emit()
+        else:
+            self.reset()
+
+    def resetWithPermission(self, *, shutdownLambda: Optional[Callable[[], None]] = None):
+        # TODO: tracking a known defect:
+        #   "`shutdownLambda` assigned to `bool`".
+
+        shutdown = self.safeShutdown if shutdownLambda is None else shutdownLambda
         ActionPrompt.prompt(
             "Are you sure?",
-            "Are you sure you want to cancel the workflow? This will clear all workspaces.",
-            self.reset,
-            self.view,
+            "Are you sure you want to cancel the workflow?\n" + "This will clear any partially-calculated results.",
+            shutdown,
+            parent=self.view,
+            # Previously this used "Continue" / "Cancel" and was really confusing!
+            # For a workflow cancellation request specifically,
+            # please use "Yes" or "No", _not_ "Continue" or "Cancel"!
+            buttonNames=("Yes", "No"),
         )
 
     def iterate(self):
@@ -114,6 +172,15 @@ class WorkflowPresenter(QObject):
     @property
     def iteration(self):
         return self._iteration
+
+    @property
+    def manualMode(self) -> bool:
+        return self._manualMode
+
+    def setManualMode(self, flag: bool):
+        # Manual mode is a _dynamic_ property, to be set by the workflow itself when it enters or leaves this mode.
+        # (Alternatively, this could be a `@property.setter`, but that's not consistent with `qtpy` usage.)
+        self._manualMode = flag
 
     def _hookupSignals(self):
         for i, model in enumerate(self.model):
@@ -133,27 +200,36 @@ class WorkflowPresenter(QObject):
             widget.onContinueButtonClicked(self.handleContinueButtonClicked)
             widget.onCancelButtonClicked(self._cancelLambda)
 
+    @Slot()
     def handleIterateButtonClicked(self):
         self.iterate()
 
+    @Slot()
     def handleSkipButtonClicked(self):
         self.advanceWorkflow()
 
+    @Slot()
     def advanceWorkflow(self):
         if self.view.currentTab >= self.view.totalNodes - 1:
-            self.completeWorkflow()
+            self._completeWorkflowLambda()
         else:
             self.view.advanceWorkflow()
 
+    @Slot(object)
     def handleContinueButtonClicked(self, model):
+        # The associated signal is of type ``Signal(WorkflowNodeModel) as Signal(object)``
         if self.view.currentTab == 0:
             self._startLambda()
 
             # disable other workflow-tabs during workflow execution
             self.disableOtherWorkflows.emit()
 
+            # indicate that the first workflow node (i.e. tab) has been started
+            self._setWorkflowInProgress(True)
+
         # disable navigation buttons during run
-        self._enableButtons(False)
+        self.enableButtons(False)
+        self.setInteractive(False)
 
         # scoped action to verify before running
         def verifyAndContinue():
@@ -164,14 +240,16 @@ class WorkflowPresenter(QObject):
             return model.continueAction(self)
 
         # do action
-        continueOnSuccess = lambda success: self.advanceWorkflow() if success else None  # noqa E731
-        self.handleAction(verifyAndContinue, None, continueOnSuccess)
+        self.handleAction(verifyAndContinue, None, self.continueOnSuccess)
 
     def handleAction(
         self,
         action: Callable[[Any], Any],
         args: Tuple[Any, ...] | Any | None,
-        onSuccess: Callable[[None], None],
+        onSuccess: Callable[[bool], None],
+        # Allow this thread pool to also be used for non-workflow actions,
+        #   such as the really slow live-metadata update :( .
+        isWorkflow=True,
     ):
         """
         Send front-end task to a separate worker to complete.
@@ -181,18 +259,73 @@ class WorkflowPresenter(QObject):
         """
         # do action
         self.worker = self.worker_pool.createWorker(target=action, args=args)
-        self.worker.finished.connect(lambda: self._enableButtons(True))  # re-enable panel buttons on finish
+
+        # Re-enable the panel buttons on finish:
+        #   note that the reduction workflow in live-data mode doesn't do this,
+        #   because its loop is only exited by clicking the cancel button.
+        if self.manualMode:
+            self.worker.finished.connect(lambda: self.enableButtons(True))
+
+        self.worker.finished.connect(self.actionCompleted)
         self.worker.result.connect(self._handleComplications)
         self.worker.success.connect(onSuccess)
+
+        if isWorkflow:
+            self.worker.finished.connect(lambda: self._setWorkflowIsRunning(False))
+            self._setWorkflowIsRunning(True)
+
         self.worker_pool.submitWorker(self.worker)
-        self.actionCompleted.emit()
 
     @Slot(bool)
-    def _enableButtons(self, enable):
+    def continueOnSuccess(self, success: bool):
+        if success:
+            self.advanceWorkflow()
+
+    @Slot(bool)
+    def _setWorkflowIsRunning(self, flag: bool):
+        # `workflowIsRunning` property:
+        #   a worker thread is actively engaged in processing a workflow-related task.
+
+        self._workflowIsRunning = flag
+        if not flag:
+            # Transfer ownership to `worker_pool` for final deletion.
+            self.worker = None
+        return self._workflowIsRunning
+
+    @property
+    def workflowIsRunning(self):
+        return self._workflowIsRunning
+
+    @Slot(bool)
+    def _setWorkflowInProgress(self, flag: bool):
+        # `workflowInProgress` property:
+        #   the workflow has started its first node(i.e. tab).
+
+        self._workflowInProgress = flag
+        self.workflowInProgressChange.emit(flag)
+        return self._workflowInProgress
+
+    @property
+    def workflowInProgress(self):
+        return self._workflowInProgress
+
+    @Slot(bool)
+    def enableButtons(self, enable):
         # This slot is necessary in order for the buttons to actually be updated from the worker.
-        buttons = [self.view.continueButton, self.view.cancelButton, self.view.skipButton]
+
+        # A user-cancellation request is now supported in all views,
+        #   so the `self.cancelButton` should never be disabled.
+        #   (And should always be re-enabled after its use.)
+        self.view.cancelButton.setEnabled(True)
+
+        buttons = [self.view.continueButton, self.view.skipButton]
         for button in buttons:
             button.setEnabled(enable)
+
+    @Slot(bool)
+    def setInteractive(self, flag: bool):
+        # Enable or disable all other controls (except the workflow-node buttons, see `enableButtons`).
+        self.view.tabView.setInteractive(flag)
 
     @Slot(object)
     def _handleComplications(self, result):
@@ -208,11 +341,39 @@ class WorkflowPresenter(QObject):
             raise NotImplementedError(f"Continue anyway handler not implemented: {self.view.tabModel}")
         self.handleContinueButtonClicked(self.view.tabModel)
 
-    def completeWorkflow(self):
+    @Slot(object)
+    def liveDataStateTransition(self, liveDataInfo: LiveDataState.Model):
+        # The associated signal is of type ``Signal(SNAPResponseHandler.liveDataStateTransition) as Signal(object)``
+        QMessageBox.information(self.view, "Live Data:", liveDataInfo.message)
+        # Any live-data transition resets the workflow:
+        #   at which point the live-data part of the request view should display the new live-data status.
+        self.reset()
+
+    @Slot()
+    def requestCancellation(self):
+        if self.worker:
+            # This supports coarse-grained cancellation:
+            #   possible only after each service request completes.
+
+            # Disabling the button here gives the user feedback that their action
+            #   has actually had any effect.
+            self.view.cancelButton.setEnabled(False)
+
+            # This needs to be executed _off_ the worker's thread.
+            # Otherwise it wouldn't happen until after the entire task
+            #   is completed.
+            self.worker.requestCancellation()
+
+    @Slot(object)
+    def userCancellation(self, userCancellationInfo: UserCancellation.Model):  # noqa: ARG002
+        # We've already asked for permission.
+        self.reset()
+
+    def completeWorkflow(self, message: str = Config["ui.default.workflow.completionMessage"]):
         # Directly show the completion message and reset the workflow
         QMessageBox.information(
             self.view,
             "‧₊Workflow Complete‧₊",
-            self.completionMessageLambda(),
+            message,
         )
         self.reset()

--- a/src/snapred/ui/view/ActionPromptView.py
+++ b/src/snapred/ui/view/ActionPromptView.py
@@ -3,7 +3,7 @@ from qtpy.QtWidgets import QDesktopWidget, QGridLayout, QLabel, QMainWindow, QPu
 
 
 class ActionPromptView(QMainWindow):
-    def __init__(self, title, message, parent=None):
+    def __init__(self, title, message, parent=None, buttonNames=("Continue", "Cancel")):
         super(ActionPromptView, self).__init__(parent)
         self.title = title
         self.message = message
@@ -20,8 +20,8 @@ class ActionPromptView(QMainWindow):
         self.messageLabel = QLabel(self.message)
         self.grid.addWidget(self.messageLabel)
 
-        self.continueButton = QPushButton("Continue")
-        self.cancelButton = QPushButton("Cancel")
+        self.continueButton = QPushButton(buttonNames[0])
+        self.cancelButton = QPushButton(buttonNames[1])
         self.buttonLayout = QGridLayout()
         self.buttonLayout.addWidget(self.continueButton, 0, 0)
         self.buttonLayout.addWidget(self.cancelButton, 0, 1)

--- a/src/snapred/ui/view/BackendRequestView.py
+++ b/src/snapred/ui/view/BackendRequestView.py
@@ -1,3 +1,6 @@
+from abc import ABC, abstractmethod
+
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QGridLayout, QWidget
 
 from snapred.backend.api.InterfaceController import InterfaceController
@@ -10,7 +13,11 @@ from snapred.ui.widget.SampleDropDown import SampleDropDown
 from snapred.ui.widget.TrueFalseDropDown import TrueFalseDropDown
 
 
-class BackendRequestView(QWidget):
+class _Meta(type(ABC), type(QWidget)):
+    pass
+
+
+class BackendRequestView(ABC, QWidget, metaclass=_Meta):
     def __init__(self, parent=None):
         super(BackendRequestView, self).__init__(parent)
 
@@ -20,11 +27,12 @@ class BackendRequestView(QWidget):
         self.interfaceController = InterfaceController()
         self.worker_pool = WorkerPool()
 
-        self.layout = QGridLayout()
-        self.setLayout(self.layout)
+        # IMPORTANT: do not hide the "layout" method!
+        _layout = QGridLayout()
+        self.setLayout(_layout)
 
-    def _labeledField(self, label, field=None, text=None):
-        return LabeledField(label, field=field, text=text, parent=self)
+    def _labeledField(self, label, field=None, text=None, orientation=Qt.Horizontal):
+        return LabeledField(label, field=field, text=text, parent=self, orientation=orientation)
 
     def _labeledLineEdit(self, label):
         return LabeledField(label, field=None, text=None, parent=self)
@@ -44,5 +52,11 @@ class BackendRequestView(QWidget):
     def _multiSelectDropDown(self, label, items=[]):
         return MultiSelectDropDown(label, items, self)
 
+    @abstractmethod
     def verify(self):
-        raise NotImplementedError("The verification for this step was not completed.")
+        pass
+
+    @abstractmethod
+    def setInteractive(flag: bool):
+        # Enable or disable all controls _except_ for the workflow-node buttons (i.e. Continue, Cancel, and etc.).
+        pass

--- a/src/snapred/ui/view/DiffCalAssessmentView.py
+++ b/src/snapred/ui/view/DiffCalAssessmentView.py
@@ -49,10 +49,12 @@ class DiffCalAssessmentView(BackendRequestView):
 
         self.signalError.connect(self._displayError)
 
-        self.layout.addWidget(self.interactionText, 0, 0)
-        self.layout.addWidget(self.calibrationRecordField, 1, 0)
-        self.layout.addWidget(self.loadButton, 1, 1)
-        self.layout.addWidget(self.placeHolder)
+        # IMPORTANT: do not hide the "layout" method!
+        _layout = self.layout()
+        _layout.addWidget(self.interactionText, 0, 0)
+        _layout.addWidget(self.calibrationRecordField, 1, 0)
+        _layout.addWidget(self.loadButton, 1, 1)
+        _layout.addWidget(self.placeHolder)
 
         self.signalRunNumberUpdate.connect(self.presenter.loadCalibrationIndex)
 
@@ -95,3 +97,7 @@ class DiffCalAssessmentView(BackendRequestView):
     def verify(self):
         # TODO: what fields need to be verified?
         return True
+
+    def setInteractive(self, flag: bool):
+        # TODO: put widgets here to allow them to be enabled or disabled by the presenter.
+        pass

--- a/src/snapred/ui/view/DiffCalRequestView.py
+++ b/src/snapred/ui/view/DiffCalRequestView.py
@@ -23,7 +23,7 @@ class DiffCalRequestView(BackendRequestView):
 
         # input fields
         self.runNumberField = self._labeledField("Run Number")
-        self.litemodeToggle = self._labeledToggle("Lite Mode", True)
+        self.liteModeToggle = self._labeledToggle("Lite Mode", True)
         self.fieldConvergenceThreshold = self._labeledField("Convergence Threshold")
         self.fieldNBinsAcrossPeakWidth = self._labeledField("Bins Across Peak Width")
 
@@ -37,22 +37,23 @@ class DiffCalRequestView(BackendRequestView):
         self.removeBackgroundToggle.setEnabled(True)
 
         # set field properties
-        self.litemodeToggle.setEnabled(True)
+        self.liteModeToggle.setEnabled(True)
         self.peakFunctionDropdown.setCurrentIndex(0)
 
         # skip pixel calibration toggle
         self.skipPixelCalToggle = self._labeledToggle("Skip Pixel Calibration", False)
 
         # add all widgets to layout
-        self.layout.addWidget(self.runNumberField, 0, 0)
-        self.layout.addWidget(self.litemodeToggle, 0, 1)
-        self.layout.addWidget(self.skipPixelCalToggle, 0, 2)
-        self.layout.addWidget(self.fieldConvergenceThreshold, 1, 0)
-        self.layout.addWidget(self.fieldNBinsAcrossPeakWidth, 1, 1)
-        self.layout.addWidget(self.removeBackgroundToggle, 1, 2)
-        self.layout.addWidget(self.sampleDropdown, 2, 0)
-        self.layout.addWidget(self.groupingFileDropdown, 2, 1)
-        self.layout.addWidget(self.peakFunctionDropdown, 2, 2)
+        layout_ = self.layout()
+        layout_.addWidget(self.runNumberField, 0, 0)
+        layout_.addWidget(self.liteModeToggle, 0, 1)
+        layout_.addWidget(self.skipPixelCalToggle, 0, 2)
+        layout_.addWidget(self.fieldConvergenceThreshold, 1, 0)
+        layout_.addWidget(self.fieldNBinsAcrossPeakWidth, 1, 1)
+        layout_.addWidget(self.removeBackgroundToggle, 1, 2)
+        layout_.addWidget(self.sampleDropdown, 2, 0)
+        layout_.addWidget(self.groupingFileDropdown, 2, 1)
+        layout_.addWidget(self.peakFunctionDropdown, 2, 2)
 
     def populateGroupingDropdown(self, groups):
         self.groupingFileDropdown.setItems(groups)
@@ -68,11 +69,24 @@ class DiffCalRequestView(BackendRequestView):
             raise ValueError("Please select a peak function")
         return True
 
+    def setInteractive(self, flag: bool):
+        # TODO: put widgets here to allow them to be enabled or disabled by the presenter.
+        self.runNumberField.setEnabled(flag)
+        self.fieldConvergenceThreshold.setEnabled(flag)
+        self.fieldNBinsAcrossPeakWidth.setEnabled(flag)
+        self.sampleDropdown.setEnabled(flag)
+        self.groupingFileDropdown.setEnabled(flag)
+        self.peakFunctionDropdown.setEnabled(flag)
+
+        self.liteModeToggle.setEnabled(flag)
+        self.removeBackgroundToggle.setEnabled(flag)
+        self.skipPixelCalToggle.setEnabled(flag)
+
     def getRunNumber(self):
         return self.runNumberField.text()
 
     def getLiteMode(self):
-        return self.litemodeToggle.getState()
+        return self.liteModeToggle.getState()
 
     def getRemoveBackground(self):
         return self.removeBackgroundToggle.getState()

--- a/src/snapred/ui/view/DiffCalSaveView.py
+++ b/src/snapred/ui/view/DiffCalSaveView.py
@@ -50,12 +50,13 @@ class DiffCalSaveView(BackendRequestView):
         self.iterationWidget = self._labeledField("Iteration :", field=self.iterationDropdown)
         self.iterationWidget.setVisible(False)
 
-        self.layout.addWidget(self.interactionText)
-        self.layout.addWidget(self.fieldRunNumber)
-        self.layout.addWidget(self.fieldVersion)
-        self.layout.addWidget(self.fieldAppliesTo)
-        self.layout.addWidget(self.fieldComments)
-        self.layout.addWidget(self.fieldAuthor)
+        _layout = self.layout()
+        _layout.addWidget(self.interactionText)
+        _layout.addWidget(self.fieldRunNumber)
+        _layout.addWidget(self.fieldVersion)
+        _layout.addWidget(self.fieldAppliesTo)
+        _layout.addWidget(self.fieldComments)
+        _layout.addWidget(self.fieldAuthor)
 
     # This signal boilerplate mumbo jumbo is necessary because worker threads cant update the gui directly
     # So we have to send a signal to the main thread to update the gui, else we get an unhelpful segfault
@@ -68,7 +69,7 @@ class DiffCalSaveView(BackendRequestView):
 
     def enableIterationDropdown(self):
         self.iterationWidget.setVisible(True)
-        self.layout.addWidget(self.iterationWidget)
+        self.layout().addWidget(self.iterationWidget)
 
     def setIterationDropdown(self, iterations):
         self.resetIterationDropdown()
@@ -81,6 +82,10 @@ class DiffCalSaveView(BackendRequestView):
         if self.fieldComments.text() == "":
             raise ValueError("You must add comments")
         return True
+
+    def setInteractive(self, flag: bool):
+        # TODO: put widgets here to allow them to be enabled or disabled by the presenter.
+        pass
 
     def hideIterationDropdown(self):
         self.iterationWidget.setVisible(False)

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -58,7 +58,7 @@ class DiffCalTweakPeakView(BackendRequestView):
 
         # create the run number field and lite mode toggle
         self.runNumberField = self._labeledField("Run Number")
-        self.litemodeToggle = self._labeledToggle("Lite Mode", True)
+        self.liteModeToggle = self._labeledToggle("Lite Mode", True)
         self.maxChiSqField = self._labeledField("Max Chi Sq", text=str(self.MAX_CHI_SQ))
         self.signalRunNumberUpdate.connect(self._updateRunNumber)
         self.signalMaxChiSqUpdate.connect(self._updateMaxChiSq)
@@ -82,7 +82,7 @@ class DiffCalTweakPeakView(BackendRequestView):
         self.peakFunctionDropdown = self._sampleDropDown("Peak Function", [p.value for p in SymmetricPeakEnum])
 
         # disable run number, lite mode, sample, peak function -- cannot be changed now
-        for x in [self.runNumberField, self.litemodeToggle, self.sampleDropdown]:
+        for x in [self.runNumberField, self.liteModeToggle, self.sampleDropdown]:
             x.setEnabled(False)
 
         # create the peak adjustment controls
@@ -106,19 +106,20 @@ class DiffCalTweakPeakView(BackendRequestView):
         self.purgePeaksButton.clicked.connect(self.emitPurge)
 
         # add all elements to the grid layout
-        self.layout.addWidget(self.runNumberField, 0, 0)
-        self.layout.addWidget(self.litemodeToggle, 0, 1, 1, 2)
-        self.layout.addWidget(self.skipPixelCalToggle, 0, 2)
-        self.layout.addWidget(self.navigationBar, 1, 0)
-        self.layout.addWidget(self.canvas, 2, 0, 1, -1)
-        self.layout.addLayout(peakControlLayout, 3, 0, 1, 2)
-        self.layout.addWidget(self.sampleDropdown, 4, 0)
-        self.layout.addWidget(self.groupingFileDropdown, 4, 1)
-        self.layout.addWidget(self.peakFunctionDropdown, 4, 2)
-        self.layout.addWidget(self.purgePeaksButton, 4, 3)
-        self.layout.addWidget(self.recalculationButton, 5, 0, 1, 4)
+        layout_ = self.layout()
+        layout_.addWidget(self.runNumberField, 0, 0)
+        layout_.addWidget(self.liteModeToggle, 0, 1, 1, 2)
+        layout_.addWidget(self.skipPixelCalToggle, 0, 2)
+        layout_.addWidget(self.navigationBar, 1, 0)
+        layout_.addWidget(self.canvas, 2, 0, 1, -1)
+        layout_.addLayout(peakControlLayout, 3, 0, 1, 2)
+        layout_.addWidget(self.sampleDropdown, 4, 0)
+        layout_.addWidget(self.groupingFileDropdown, 4, 1)
+        layout_.addWidget(self.peakFunctionDropdown, 4, 2)
+        layout_.addWidget(self.purgePeaksButton, 4, 3)
+        layout_.addWidget(self.recalculationButton, 5, 0, 1, 4)
 
-        self.layout.setRowStretch(2, 10)
+        layout_.setRowStretch(2, 10)
 
         # store the initial layout without graphs
         self.initialLayoutHeight = self.size().height()
@@ -333,6 +334,10 @@ class DiffCalTweakPeakView(BackendRequestView):
             self._testContinueAnywayStates()
 
         return True
+
+    def setInteractive(self, flag: bool):
+        # TODO: put widgets here to allow them to be enabled or disabled by the presenter.
+        pass
 
     def getSkipPixelCalibration(self):
         return self.skipPixelCalToggle.field.getState()

--- a/src/snapred/ui/view/NormalizationRequestView.py
+++ b/src/snapred/ui/view/NormalizationRequestView.py
@@ -20,7 +20,7 @@ class NormalizationRequestView(BackendRequestView):
 
         # input fields
         self.runNumberField = self._labeledLineEdit("Run Number:")
-        self.litemodeToggle = self._labeledToggle("Lite Mode", True)
+        self.liteModeToggle = self._labeledToggle("Lite Mode", True)
         self.backgroundRunNumberField = self._labeledLineEdit("Background Run Number:")
 
         # drop downs
@@ -28,14 +28,15 @@ class NormalizationRequestView(BackendRequestView):
         self.groupingFileDropdown = self._sampleDropDown("Select Grouping File", groups)
 
         # set field properties
-        self.litemodeToggle.setEnabled(False)
+        self.liteModeToggle.setEnabled(False)
 
         # add all widgets to layout
-        self.layout.addWidget(self.runNumberField, 0, 0)
-        self.layout.addWidget(self.litemodeToggle, 0, 1)
-        self.layout.addWidget(self.backgroundRunNumberField, 1, 0)
-        self.layout.addWidget(self.sampleDropdown, 2, 0)
-        self.layout.addWidget(self.groupingFileDropdown, 2, 1)
+        _layout = self.layout()
+        _layout.addWidget(self.runNumberField, 0, 0)
+        _layout.addWidget(self.liteModeToggle, 0, 1)
+        _layout.addWidget(self.backgroundRunNumberField, 1, 0)
+        _layout.addWidget(self.sampleDropdown, 2, 0)
+        _layout.addWidget(self.groupingFileDropdown, 2, 1)
 
     def populateGroupingDropdown(self, groups):
         self.groupingFileDropdown.setItems(groups)
@@ -53,3 +54,11 @@ class NormalizationRequestView(BackendRequestView):
 
     def getRunNumber(self):
         return self.runNumberField.text()
+
+    def setInteractive(self, flag: bool):
+        # TODO: put widgets here to allow them to be enabled or disabled by the presenter.
+        self.runNumberField.setEnabled(flag)
+        self.backgroundRunNumberField.setEnabled(flag)
+        self.liteModeToggle.setEnabled(flag)
+        self.sampleDropdown.setEnabled(flag)
+        self.groupingFileDropdown.setEnabled(flag)

--- a/src/snapred/ui/view/NormalizationSaveView.py
+++ b/src/snapred/ui/view/NormalizationSaveView.py
@@ -48,13 +48,14 @@ class NormalizationSaveView(BackendRequestView):
         self.fieldAuthor = self._labeledLineEdit("Author :")
         self.fieldAuthor.setToolTip("Author of the normalization.")
 
-        self.layout.addWidget(self.interactionText)
-        self.layout.addWidget(self.fieldRunNumber)
-        self.layout.addWidget(self.fieldBackgroundRunNumber)
-        self.layout.addWidget(self.fieldVersion)
-        self.layout.addWidget(self.fieldAppliesTo)
-        self.layout.addWidget(self.fieldComments)
-        self.layout.addWidget(self.fieldAuthor)
+        _layout = self.layout()
+        _layout.addWidget(self.interactionText)
+        _layout.addWidget(self.fieldRunNumber)
+        _layout.addWidget(self.fieldBackgroundRunNumber)
+        _layout.addWidget(self.fieldVersion)
+        _layout.addWidget(self.fieldAppliesTo)
+        _layout.addWidget(self.fieldComments)
+        _layout.addWidget(self.fieldAuthor)
 
     @Slot(str)
     def _updateRunNumber(self, runNumber: str):
@@ -76,3 +77,7 @@ class NormalizationSaveView(BackendRequestView):
         if self.fieldComments.text() == "":
             raise ValueError("You must add comments")
         return True
+
+    def setInteractive(self, flag: bool):
+        # TODO: put widgets here to allow them to be enabled or disabled by the presenter.
+        pass

--- a/src/snapred/ui/view/NormalizationTweakPeakView.py
+++ b/src/snapred/ui/view/NormalizationTweakPeakView.py
@@ -84,16 +84,17 @@ class NormalizationTweakPeakView(BackendRequestView):
         self.recalculationButton.clicked.connect(self.emitValueChange)
 
         # add all elements to the grid layout
-        self.layout.addWidget(self.navigationBar, 0, 0)
-        self.layout.addWidget(self.canvas, 1, 0, 1, -1)
-        self.layout.addWidget(self.fieldRunNumber, 2, 0)
-        self.layout.addWidget(self.fieldBackgroundRunNumber, 2, 1)
-        self.layout.addLayout(peakControlLayout, 3, 0, 1, 2)
-        self.layout.addWidget(self.sampleDropdown, 4, 0)
-        self.layout.addWidget(self.groupingFileDropdown, 4, 1)
-        self.layout.addWidget(self.recalculationButton, 5, 0, 1, 2)
+        layout_ = self.layout()
+        layout_.addWidget(self.navigationBar, 0, 0)
+        layout_.addWidget(self.canvas, 1, 0, 1, -1)
+        layout_.addWidget(self.fieldRunNumber, 2, 0)
+        layout_.addWidget(self.fieldBackgroundRunNumber, 2, 1)
+        layout_.addLayout(peakControlLayout, 3, 0, 1, 2)
+        layout_.addWidget(self.sampleDropdown, 4, 0)
+        layout_.addWidget(self.groupingFileDropdown, 4, 1)
+        layout_.addWidget(self.recalculationButton, 5, 0, 1, 2)
 
-        self.layout.setRowStretch(1, 10)
+        layout_.setRowStretch(1, 10)
 
         # store the initial layout without graphs
         self.initialLayoutHeight = self.size().height()
@@ -249,3 +250,7 @@ class NormalizationTweakPeakView(BackendRequestView):
     def verify(self):
         # TODO what needs to be verified?
         return True
+
+    def setInteractive(self, flag: bool):
+        # TODO: put widgets here to allow them to be enabled or disabled by the presenter.
+        pass

--- a/src/snapred/ui/view/WorkflowNodeView.py
+++ b/src/snapred/ui/view/WorkflowNodeView.py
@@ -6,23 +6,26 @@ class WorkflowNodeView(QWidget):
         super(WorkflowNodeView, self).__init__(parent)
         self.model = node
         self.view = node.view
-        self.layout = QGridLayout()
-        self.setLayout(self.layout)
+
+        # Do _not_ hide the `layout()` method!
+        layout_ = QGridLayout()
+        self.setLayout(layout_)
+
         # add a back and forward button to the top left
         self.backButton = QPushButton("Back \U00002b05", self)
-        self.layout.addWidget(self.backButton, 0, 0)
+        layout_.addWidget(self.backButton, 0, 0)
         if position == 0:
             self.backButton.setVisible(False)
 
         self.forwardButton = QPushButton("Forward \U000027a1", self)
-        self.layout.addWidget(self.forwardButton, 0, 1)
+        layout_.addWidget(self.forwardButton, 0, 1)
         self.forwardButton.setVisible(False)
 
-        self.layout.addWidget(self.view, 1, 0, 1, 2)
+        layout_.addWidget(self.view, 1, 0, 1, 2)
 
         # add a continue and quit button to the bottom
         self.continueButton = QPushButton("Continue \U00002705", self)
-        self.layout.addWidget(self.continueButton, 2, 0)
+        layout_.addWidget(self.continueButton, 2, 0)
 
         self.skipButton = QPushButton("Skip \U000023ed", self)
         self.skipButton.setVisible(False)
@@ -31,25 +34,27 @@ class WorkflowNodeView(QWidget):
         self.iterateButton.setVisible(False)
 
         self.cancelButton = QPushButton("Cancel \U0000274c", self)
-        self.layout.addWidget(self.cancelButton, 2, 1)
+        layout_.addWidget(self.cancelButton, 2, 1)
 
     def reset(self):
         self.view.reset()
 
     def enableSkip(self):
-        self.layout.removeWidget(self.continueButton)
-        self.layout.removeWidget(self.cancelButton)
-        self.layout.addWidget(self.continueButton, 2, 0)
-        self.layout.addWidget(self.skipButton, 2, 1)
-        self.layout.addWidget(self.cancelButton, 2, 2)
+        layout_ = self.layout()
+        layout_.removeWidget(self.continueButton)
+        layout_.removeWidget(self.cancelButton)
+        layout_.addWidget(self.continueButton, 2, 0)
+        layout_.addWidget(self.skipButton, 2, 1)
+        layout_.addWidget(self.cancelButton, 2, 2)
         self.skipButton.setVisible(True)
 
     def enableIterate(self):
-        self.layout.removeWidget(self.continueButton)
-        self.layout.removeWidget(self.cancelButton)
-        self.layout.addWidget(self.continueButton, 2, 0)
-        self.layout.addWidget(self.iterateButton, 2, 1)
-        self.layout.addWidget(self.cancelButton, 2, 2)
+        layout_ = self.layout()
+        layout_.removeWidget(self.continueButton)
+        layout_.removeWidget(self.cancelButton)
+        layout_.addWidget(self.continueButton, 2, 0)
+        layout_.addWidget(self.iterateButton, 2, 1)
+        layout_.addWidget(self.cancelButton, 2, 2)
         self.iterateButton.setVisible(True)
 
     def onBackButtonClicked(self, slot):

--- a/src/snapred/ui/view/WorkflowView.py
+++ b/src/snapred/ui/view/WorkflowView.py
@@ -12,14 +12,15 @@ class WorkflowView(QWidget):
         self.position = 0
         self.currentTab = 0
 
-        self.layout = QGridLayout()
-        self.setLayout(self.layout)
+        # Do _not_ hide the `layout()` method!
+        layout_ = QGridLayout()
+        self.setLayout(layout_)
 
         # add a tab widget
         self.tabWidget = QTabWidget()
         self.tabWidget.setObjectName("nodeTabs")
         self.tabWidget.tabBarClicked.connect(self.handleTabClicked)
-        self.layout.addWidget(self.tabWidget)
+        layout_.addWidget(self.tabWidget)
 
         # add a tab for each node
         for node in nodes:
@@ -74,15 +75,17 @@ class WorkflowView(QWidget):
     def cancelButton(self):
         return self.tabWidget.widget(self.currentTab).cancelButton
 
-    def reset(self, hard: bool = False):
+    def reset(self, hard: bool = False, manualMode: bool = True):
         """
         This resets the workflow
         """
         for i in range(0, self.tabWidget.count()):
             self.tabWidget.setTabEnabled(i, False)
             currentWidget = self.tabWidget.widget(i)
-            currentWidget.continueButton.setEnabled(True)
-            currentWidget.cancelButton.setEnabled(True)
+            if manualMode:
+                currentWidget.continueButton.setEnabled(True)
+                currentWidget.cancelButton.setEnabled(True)
+                currentWidget.view.setInteractive(True)
             currentWidget.forwardButton.setVisible(False)
             if hard:
                 currentWidget.reset()
@@ -91,6 +94,7 @@ class WorkflowView(QWidget):
         self.currentTab = 0
         self.position = 0
 
+    @Slot()
     def advanceWorkflow(self):
         if self.currentTab < self.totalNodes - 1:
             # enable forward button of previous tab

--- a/src/snapred/ui/view/reduction/ArtificialNormalizationView.py
+++ b/src/snapred/ui/view/reduction/ArtificialNormalizationView.py
@@ -74,7 +74,7 @@ class ArtificialNormalizationView(BackendRequestView):
         # add the adjust layout to this layout so it may be turned on and off
         self.adjustFrame = QFrame()
         self.adjustFrame.setLayout(self.adjustLayout)
-        self.layout.addWidget(self.adjustFrame, 0, 0, -1, -1)
+        self.layout().addWidget(self.adjustFrame, 0, 0, -1, -1)
         self.adjustFrame.show()
 
         # store the initial layout height without graphs
@@ -185,6 +185,10 @@ class ArtificialNormalizationView(BackendRequestView):
     def verify(self):
         # TODO what needs to be verified?
         return True
+
+    def setInteractive(self, flag: bool):
+        # TODO: put widgets here to allow them to be enabled or disabled by the presenter.
+        pass
 
     def showSkippedView(self):
         self.adjustFrame.hide()

--- a/src/snapred/ui/view/reduction/ReductionRequestView.py
+++ b/src/snapred/ui/view/reduction/ReductionRequestView.py
@@ -1,37 +1,163 @@
+from abc import abstractmethod
+from datetime import datetime, timedelta
 from typing import Callable, List, Optional
 
-from qtpy.QtCore import Slot
+from qtpy.QtCore import Qt, QTimer, Signal, Slot
+from qtpy.QtGui import QColor
 from qtpy.QtWidgets import (
+    QGridLayout,
     QHBoxLayout,
+    QLabel,
     QLineEdit,
     QListWidget,
     QMessageBox,
     QPushButton,
+    QSlider,
+    QStackedLayout,
     QVBoxLayout,
+    QWidget,
 )
 
+from snapred.backend.dao.LiveMetadata import LiveMetadata
 from snapred.backend.dao.state.RunNumber import RunNumber
 from snapred.backend.log.logger import snapredLogger
+from snapred.meta.Config import Config
+from snapred.meta.decorators.ExceptionToErrLog import ExceptionToErrLog
 from snapred.meta.decorators.Resettable import Resettable
+from snapred.meta.Enum import StrEnum
 from snapred.ui.view.BackendRequestView import BackendRequestView
+from snapred.ui.widget.LEDIndicator import LEDIndicator
 
 logger = snapredLogger.getLogger(__name__)
 
 
-@Resettable
-class ReductionRequestView(BackendRequestView):
+class _RequestViewBase(BackendRequestView):
+    liveDataModeChange = Signal(bool)
+
     def __init__(
         self,
         parent=None,
-        populatePixelMaskDropdown: Optional[Callable[[], None]] = None,
+        getCompatibleMasks: Optional[Callable[[List[str], bool], None]] = None,
         validateRunNumbers: Optional[Callable[[List[str]], None]] = None,
+        getLiveMetadata: Optional[Callable[[], LiveMetadata]] = None,
     ):
-        super(ReductionRequestView, self).__init__(parent=parent)
+        super(_RequestViewBase, self).__init__(parent=parent)
+        self.getCompatibleMasks = getCompatibleMasks
+        self.validateRunNumbers = validateRunNumbers
+        self.getLiveMetadata = getLiveMetadata
 
         self.runNumbers = []
         self.pixelMaskDropdown = self._multiSelectDropDown("Select Pixel Mask(s)", [])
-        self.populatePixelMaskDropdown = populatePixelMaskDropdown
-        self.validateRunNumbers = validateRunNumbers
+
+        # Lite mode toggle, pixel masks dropdown, and retain unfocused data checkbox
+        self.liteModeToggle = self._labeledToggle("Lite Mode", state=True)
+        self.liteModeToggle.toggle.setObjectName("liteModeToggle")
+
+        self.retainUnfocusedDataCheckbox = self._labeledCheckBox("Retain Unfocused Data")
+        self.convertUnitsDropdown = self._sampleDropDown(
+            "Convert Units", ["TOF", "dSpacing", "Wavelength", "MomentumTransfer"]
+        )
+        self.convertUnitsDropdown.setCurrentIndex(1)
+
+        self.unfocusedDataLayout = QHBoxLayout()
+        self.unfocusedDataLayout.addWidget(self.retainUnfocusedDataCheckbox, 1)
+        self.unfocusedDataLayout.addWidget(self.convertUnitsDropdown, 2)
+
+        # live-data toggle
+        self.liveDataToggle = self._labeledToggle("Live data", state=False)
+        self.liveDataToggle.toggle.setObjectName("liveDataToggle")
+
+        # Set field properties
+        self.liteModeToggle.setEnabled(False)
+        self.retainUnfocusedDataCheckbox.setEnabled(False)
+        self.pixelMaskDropdown.setEnabled(False)
+        self.convertUnitsDropdown.setEnabled(False)
+
+        # Connect buttons to methods
+        self.retainUnfocusedDataCheckbox.checkedChanged.connect(self.convertUnitsDropdown.setEnabled)
+        self.liteModeToggle.stateChanged.connect(self._populatePixelMaskDropdown)
+        self.liveDataToggle.stateChanged.connect(self.liveDataModeChange)
+
+    @ExceptionToErrLog
+    @Slot(bool)
+    def _populatePixelMaskDropdown(self, useLiteMode: bool):
+        runNumbers = self.getRunNumbers()
+
+        self.liteModeToggle.setEnabled(False)
+        self.pixelMaskDropdown.setEnabled(False)
+        self.retainUnfocusedDataCheckbox.setEnabled(False)
+
+        try:
+            # Get compatible masks for the current reduction state.
+            masks = []
+            if self.getCompatibleMasks:
+                masks = self.getCompatibleMasks(runNumbers, useLiteMode)
+
+            # Populate the dropdown with the mask names.
+            self.pixelMaskDropdown.setItems(masks)
+        except Exception as e:  # noqa: BLE001
+            print(f"Error retrieving compatible masks: {e}")
+            self.pixelMaskDropdown.setItems([])
+        finally:
+            # Re-enable UI elements.
+            self.liteModeToggle.setEnabled(True)
+            self.pixelMaskDropdown.setEnabled(True)
+            self.retainUnfocusedDataCheckbox.setEnabled(True)
+
+    def setInteractive(self, flag: bool):
+        # Enable or disable all controls _except_ for the workflow-node buttons (i.e. Continue, Cancel, and etc.).
+        self.liteModeToggle.setEnabled(flag)
+        self.liveDataToggle.setEnabled(flag)
+        self.pixelMaskDropdown.setEnabled(flag)
+        self.retainUnfocusedDataCheckbox.setEnabled(flag)
+        self.convertUnitsDropdown.setEnabled(flag)
+
+    @abstractmethod
+    def verify(self) -> bool:
+        # Occurs _after_ continue button is pressed.
+        pass
+
+    def useLiteMode(self) -> bool:
+        return self.liteModeToggle.getState()
+
+    def keepUnfocused(self) -> bool:
+        return self.retainUnfocusedDataCheckbox.isChecked()
+
+    def convertUnitsTo(self) -> str:
+        return self.convertUnitsDropdown.currentText()
+
+    def getPixelMasks(self):
+        return self.pixelMaskDropdown.checkedItems()
+
+    def liveDataMode(self) -> bool:
+        return False
+
+    def liveDataDuration(self) -> timedelta:
+        # default value: indicates that all available data should be loaded
+        return timedelta(seconds=0)
+
+    def liveDataUpdateInterval(self) -> timedelta:
+        # default value: two minute update time
+        return timedelta(seconds=120)
+
+    def getRunNumbers(self):
+        return self.runNumbers
+
+
+class _RequestView(_RequestViewBase):
+    def __init__(
+        self,
+        parent=None,
+        getCompatibleMasks: Optional[Callable[[List[str], bool], None]] = None,
+        validateRunNumbers: Optional[Callable[[List[str]], None]] = None,
+        getLiveMetadata: Optional[Callable[[], LiveMetadata]] = None,
+    ):
+        super(_RequestView, self).__init__(
+            parent=parent,
+            getCompatibleMasks=getCompatibleMasks,
+            validateRunNumbers=validateRunNumbers,
+            getLiveMetadata=getLiveMetadata,
+        )
 
         # Horizontal layout for run number input and button
         self.runNumberLayout = QHBoxLayout()
@@ -50,27 +176,14 @@ class ReductionRequestView(BackendRequestView):
         self.runNumberDisplay = QListWidget()
         self.runNumberDisplay.setSortingEnabled(False)
 
-        # Lite mode toggle, pixel masks dropdown, and retain unfocused data checkbox
-        self.liteModeToggle = self._labeledToggle("Lite Mode", True)
-        self.retainUnfocusedDataCheckbox = self._labeledCheckBox("Retain Unfocused Data")
-        self.convertUnitsDropdown = self._sampleDropDown(
-            "Convert Units", ["TOF", "dSpacing", "Wavelength", "MomentumTransfer"]
-        )
-        self.convertUnitsDropdown.setCurrentIndex(1)
-
-        # Set field properties
-        self.liteModeToggle.setEnabled(False)
-        self.retainUnfocusedDataCheckbox.setEnabled(False)
-        self.pixelMaskDropdown.setEnabled(False)
-        self.convertUnitsDropdown.setEnabled(False)
-
         # Add widgets to layout
-        self.layout.addLayout(self.runNumberLayout, 0, 0)
-        self.layout.addWidget(self.runNumberDisplay)
-        self.layout.addWidget(self.liteModeToggle)
-        self.layout.addWidget(self.pixelMaskDropdown)
-        self.layout.addWidget(self.retainUnfocusedDataCheckbox)
-        self.layout.addWidget(self.convertUnitsDropdown)
+        layout_ = self.layout()
+        layout_.addLayout(self.runNumberLayout, 0, 0, 1, 2)
+        layout_.addWidget(self.runNumberDisplay, 1, 0, 1, 2)
+        layout_.addWidget(self.liveDataToggle, 2, 0, 1, 1)
+        layout_.addWidget(self.liteModeToggle, 2, 1, 1, 1)
+        layout_.addWidget(self.pixelMaskDropdown, 3, 0, 1, 2)
+        layout_.addLayout(self.unfocusedDataLayout, 4, 0, 1, 2)
 
         # Connect buttons to methods
         self.enterRunNumberButton.clicked.connect(self.addRunNumber)
@@ -78,8 +191,6 @@ class ReductionRequestView(BackendRequestView):
 
     @Slot()
     def addRunNumber(self):
-        # TODO: FIX THIS!
-        #   We're not inside the SNAPResponseHandler here, so we can't just throw a `ValueError`.
         try:
             runNumberList = self.parseInputRunNumbers()
             if runNumberList is not None:
@@ -92,15 +203,14 @@ class ReductionRequestView(BackendRequestView):
                 self.runNumbers = noDuplicates
                 self.updateRunNumberList()
                 self.runNumberInput.clear()
-                if self.populatePixelMaskDropdown is not None:
-                    self.populatePixelMaskDropdown()
+                self._populatePixelMaskDropdown(self.useLiteMode())
         except ValueError as e:
             QMessageBox.warning(self, "Warning", str(e), buttons=QMessageBox.Ok, defaultButton=QMessageBox.Ok)
             self.runNumberInput.clear()
 
     def parseInputRunNumbers(self) -> List[str]:
-        # WARNING: run numbers are strings.
-        #   For now, it's OK to parse them as integer, but they should not be passed around that way.
+        # REMINDER: run numbers are strings.
+        #   Be careful parsing them as `int`.
         try:
             runs, errors = RunNumber.runsFromIntArrayProperty(self.runNumberInput.text(), False)
 
@@ -117,8 +227,8 @@ class ReductionRequestView(BackendRequestView):
                 messageBox.exec()
         except Exception:  # noqa BLE001
             raise ValueError(
-                "Bad input was given for Reduction runs,"
-                "please read mantid docs for IntArrayProperty on how to format input"
+                "Reduction run numbers were incorrectly formatted: "
+                "please read mantid docs for `IntArrayProperty` on how to format input"
             )
 
         return [str(num) for num in runs]
@@ -132,8 +242,12 @@ class ReductionRequestView(BackendRequestView):
         self.runNumberDisplay.clear()
         self.pixelMaskDropdown.setItems([])
 
+    ###
+    ### Abstract methods:
+    ###
+
     def verify(self):
-        runNumbers = [self.runNumberDisplay.item(x).text() for x in range(self.runNumberDisplay.count())]
+        runNumbers = self.runNumbers
         if not runNumbers:
             raise ValueError("Please enter at least one run number.")
         if runNumbers != self.runNumbers:
@@ -143,16 +257,427 @@ class ReductionRequestView(BackendRequestView):
                 raise ValueError(
                     "Please enter a valid run number or list of run numbers. (e.g. 46680, 46685, 46686, etc...)"
                 )
-        # They dont need to select a pixel mask
-        # if self.pixelMaskDropdown.currentIndex() < 0:
-        #     raise ValueError("Please select a pixel mask.")
-        if self.retainUnfocusedDataCheckbox.isChecked():
+        if self.keepUnfocused():
             if self.convertUnitsDropdown.currentIndex() < 0:
                 raise ValueError("Please select units to convert to")
         return True
 
-    def getRunNumbers(self):
-        return self.runNumbers
+    def setInteractive(self, flag: bool):
+        # Enable or disable all controls _except_ for the workflow-node buttons (i.e. Continue, Cancel, and etc.).
+        super().setInteractive(flag)
+        self.runNumberInput.setEnabled(flag)
+        self.enterRunNumberButton.setEnabled(flag)
+        self.clearButton.setEnabled(flag)
 
-    def getPixelMasks(self):
-        return self.pixelMaskDropdown.checkedItems()
+
+class _LiveDataView(_RequestViewBase):
+    def __init__(
+        self,
+        parent=None,
+        getCompatibleMasks: Optional[Callable[[List[str], bool], None]] = None,
+        validateRunNumbers: Optional[Callable[[List[str]], None]] = None,
+        getLiveMetadata: Optional[Callable[[], LiveMetadata]] = None,
+    ):
+        super(_LiveDataView, self).__init__(
+            parent=parent,
+            getCompatibleMasks=getCompatibleMasks,
+            validateRunNumbers=validateRunNumbers,
+            getLiveMetadata=getLiveMetadata,
+        )
+
+        self._liveMetadata = None
+        self._reductionStatus = None
+        self._lastDisplayedStatus = None
+        self._reductionInProgress = False
+
+        # Display and controls specific to `_LiveDataView`:
+        self.liveDataIndicator = LEDIndicator()
+        #  indicator itself is non-clickable:
+        self.liveDataIndicator.setDisabled(False)
+
+        self.liveDataStatus = QLabel()
+        self.liveDataSummary = QHBoxLayout()
+        self.liveDataSummary.addWidget(self.liveDataIndicator)
+        self.liveDataSummary.addWidget(self.liveDataStatus)
+
+        self.durationSlider = QSlider(parent=self, orientation=Qt.Horizontal)
+        self.durationSlider.setInvertedAppearance(True)  # Increase from the right
+        self.durationSlider.setMinimum(0)
+        self.durationSlider.setMaximum(100)  # set a reasonable positive value until first update
+        self.duration = self._labeledField(
+            "duration: use all available data", self.durationSlider, orientation=Qt.Vertical
+        )
+
+        self.updateIntervalSlider = QSlider(parent=self, orientation=Qt.Horizontal)
+        self.updateIntervalSlider.setMinimum(Config["liveData.updateIntervalMinimum"])
+        self.updateIntervalSlider.setMaximum(Config["liveData.updateIntervalMaximum"])
+        defaultUpdateInterval = Config["liveData.updateIntervalDefault"]
+        self.updateIntervalSlider.setValue(defaultUpdateInterval)
+        self.updateInterval = self._labeledField(
+            f"update interval (t0 < {self._formatDuration(defaultUpdateInterval)})",
+            self.updateIntervalSlider,
+            orientation=Qt.Vertical,
+        )
+        self._liveDataLayout = QVBoxLayout()
+        self._liveDataLayout.addLayout(self.liveDataSummary)
+        _sliders = QHBoxLayout()
+        _sliders.addWidget(self.duration)
+        _sliders.addWidget(self.updateInterval)
+        self._liveDataLayout.addLayout(_sliders)
+
+        # Add widgets to layout
+        layout_ = self.layout()
+        layout_.addLayout(self._liveDataLayout, 0, 0, 1, 2)
+        layout_.addWidget(self.liveDataToggle, 1, 0, 1, 1)
+        layout_.addWidget(self.liteModeToggle, 1, 1, 1, 1)
+        layout_.addWidget(self.pixelMaskDropdown, 2, 0, 1, 2)
+        layout_.addLayout(self.unfocusedDataLayout, 3, 0, 1, 2)
+
+        # Automatically update fields depending on time of day, once per second.
+        self._timeOfDayUpdateTimer = QTimer(self)
+        #   A "chain" update is used here, to prevent runaway-timer issues.
+        self._timeOfDayUpdateTimer.setSingleShot(True)
+        self._timeOfDayUpdateTimer.setTimerType(Qt.CoarseTimer)
+        self._timeOfDayUpdateTimer.setInterval(1000)
+        self._timeOfDayUpdateTimer.timeout.connect(self._updateLiveMetadata)
+
+        # Connect signals to slots
+        self.durationSlider.valueChanged.connect(self._updateDuration)
+        self.updateIntervalSlider.valueChanged.connect(self._updateUpdateInterval)
+
+    @Slot(bool)
+    def setReductionInProgress(self, flag: bool):
+        self._reductionInProgress = flag
+
+    @Slot(StrEnum)
+    def updateStatus(self, status: StrEnum):
+        self._reductionStatus = status
+        self._updateLiveMetadata()
+
+    @Slot(LiveMetadata, StrEnum)
+    def updateLiveMetadata(self, data: LiveMetadata):
+        self._liveMetadata = data
+        self._updateLiveMetadata()
+
+    @Slot()
+    def _updateLiveMetadata(self):
+        # Prevent circular import.
+        from snapred.ui.workflow.ReductionWorkflow import ReductionStatus
+
+        if self._timeOfDayUpdateTimer.isActive():
+            # This prevents co-incident updates.
+            self._timeOfDayUpdateTimer.stop()
+
+        data = self._liveMetadata
+        status = self._reductionStatus
+
+        # Special live-data status may override any incoming status already be set by the workflow.
+        if data is None:
+            status = ReductionStatus.CONNECTING
+        elif not data.hasActiveRun():
+            status = ReductionStatus.NO_ACTIVE_RUN
+        elif not data.beamState():
+            status = ReductionStatus.NO_BEAM
+
+        # Keep track of the displayed status, so that the flash sequences aren't constantly restarted.
+        statusChange = status != self._lastDisplayedStatus
+        self._lastDisplayedStatus = status
+
+        TIME_ONLY = "%H:%M:%S"
+        TIME_AND_DATE = "%b %d: %H:%M:%S"
+
+        now = datetime.now().astimezone()
+        LOCAL_TIMEZONE = now.tzinfo
+
+        startTime = None
+        timeFormat = None
+        if data is not None:
+            # Convert from time in UTC timezone.
+            startTime = data.startTime.astimezone(LOCAL_TIMEZONE)
+            timeFormat = TIME_ONLY if (now - startTime < timedelta(hours=12)) else TIME_AND_DATE
+            self.durationSlider.setEnabled(False)
+            self.durationSlider.setMinimum(0)
+            self.durationSlider.setMaximum(int(round((now - startTime).total_seconds())))
+            self.durationSlider.setEnabled(True)
+
+        match status:
+            case ReductionStatus.CONNECTING:
+                self.runNumbers = []
+                self.liveDataStatus.setText(f"<font size = 4><b>Live data:</b> {status}...</font>")
+
+                # WARNING (i.e. NOT READY) flash
+                if statusChange:
+                    self.liveDataIndicator.setFlashSequence(((QColor(255, 255, 0),), (0.5, 0.5)))
+                    self.liveDataIndicator.setFlash(True)
+
+            case ReductionStatus.NO_ACTIVE_RUN:
+                self.runNumbers = []
+                self.liveDataStatus.setText(f"<font size = 4><b>Live data:</b> {status}</font>")
+
+                # WARNING (i.e. NOT READY) flash
+                if statusChange:
+                    self.liveDataIndicator.setFlashSequence(((QColor(255, 255, 0),), (0.4, 0.6)))
+                    self.liveDataIndicator.setFlash(True)
+
+            case ReductionStatus.NO_BEAM:
+                self.runNumbers = []
+                self.liveDataStatus.setText(
+                    "<p><font size = 4><b>Live data:</b></font>"
+                    + "<font size = 4>"
+                    + f" running: {data.runNumber}, "
+                    + f" since: {startTime.strftime(timeFormat)}</p>"
+                    + "</font>"
+                    + f"<p><font size = 4> &nbsp;&nbsp; t0(now): {now.strftime(TIME_ONLY)}</font></p>"
+                    + f"<p><font size = 4><b>{str(status).upper()}.</b></font></p>"
+                )
+
+                # ERROR flash -- beam is down with a run active.
+                if statusChange:
+                    self.liveDataIndicator.setFlashSequence(((QColor(255, 0, 0),), (0.1, 0.4)))
+                    self.liveDataIndicator.setFlash(True)
+
+            case ReductionStatus.READY:
+                liveStateChange = not self.runNumbers or (self.runNumbers[0] != data.runNumber)
+                if liveStateChange:
+                    self.runNumbers = [data.runNumber]
+                    self._populatePixelMaskDropdown(self.useLiteMode())
+
+                # TODO: convert to the local time zone!!
+
+                self.liveDataStatus.setText(
+                    "<p><font size = 4><b>Live data:</b></font>"
+                    + "<font size = 4>"
+                    + f" running: {data.runNumber}, "
+                    + f" since: {startTime.strftime(timeFormat)}</p>"
+                    + "</font>"
+                    + f"<p><font size = 4> &nbsp;&nbsp; t0(now): {now.strftime(TIME_ONLY)}</font></p>"
+                    + "<p><font size = 4><b>Ready</b></p>"
+                )
+
+                # Solid color (yellow) "ready" indicator.
+                if statusChange:
+                    self.liveDataIndicator.setColor(QColor(255, 255, 0))
+                    self.liveDataIndicator.setChecked(True)
+
+            case ReductionStatus.CALCULATING_NORM:
+                self.liveDataStatus.setText(
+                    "<p><font size = 4><b>Live data:</b></font>"
+                    + "<font size = 4>"
+                    + f" running: {data.runNumber}, "
+                    + f" since: {startTime.strftime(timeFormat)}</p>"
+                    + "</font>"
+                    + f"<p><font size = 4> &nbsp;&nbsp; t0(now): {now.strftime(TIME_ONLY)}</font></p>"
+                    + "<p><font size = 4><b>Calculating artificial normalization...</b></p>"
+                )
+
+                # Green flashing "in progress" indicator.
+                if statusChange:
+                    self.liveDataIndicator.setFlashSequence(((QColor(0, 255, 0),), (0.4, 0.6)))
+                    self.liveDataIndicator.setFlash(True)
+
+            case ReductionStatus.REDUCING_DATA | ReductionStatus.WAITING_TO_LOAD | ReductionStatus.FINALIZING:
+                # For the moment, we do not break-out these states:
+                #   just display "Reducing data".
+                self.liveDataStatus.setText(
+                    "<p><font size = 4><b>Live data:</b></font>"
+                    + "<font size = 4>"
+                    + f" running: {data.runNumber}, "
+                    + f" since: {startTime.strftime(timeFormat)}</p>"
+                    + "</font>"
+                    + f"<p><font size = 4> &nbsp;&nbsp; t0(now): {now.strftime(TIME_ONLY)}</font></p>"
+                    + f"<p><font size = 4><b>{ReductionStatus.REDUCING_DATA}</b></p>"
+                )
+
+                # Green-blue flashing "in progress" indicator.
+                if statusChange:
+                    self.liveDataIndicator.setFlashSequence(((QColor(0, 255, 0), QColor(127, 0, 255)), (1.5, 1.5)))
+                    self.liveDataIndicator.setFlash(True)
+
+            case ReductionStatus.USER_CANCELLATION:
+                self.liveDataStatus.setText(
+                    "<p><font size = 4><b>Live data:</b></font>"
+                    + "<font size = 4>"
+                    + f" running: {data.runNumber}, "
+                    + f" since: {startTime.strftime(timeFormat)}</p>"
+                    + "</font>"
+                    + f"<p><font size = 4> &nbsp;&nbsp; t0(now): {now.strftime(TIME_ONLY)}</font></p>"
+                    + "<p><font size = 4><b>Cancelling workflow, please wait...</b></p>"
+                )
+
+                # WARNING (i.e. NOT READY) flash
+                if statusChange:
+                    self.liveDataIndicator.setFlashSequence(((QColor(255, 255, 0),), (0.4, 0.6)))
+                    self.liveDataIndicator.setFlash(True)
+
+            case _:
+                raise RuntimeError(f"`ReductionRequestView`: unrecognized live-data status {status}")
+
+        # Automatically update any fields depending on time of day, once per second:
+        # -- chain single shot.
+        self._timeOfDayUpdateTimer.start()
+
+    def hideEvent(self, event):  # noqa: ARG002
+        if self._timeOfDayUpdateTimer.isActive():
+            self._timeOfDayUpdateTimer.stop()
+
+    def showEvent(self, event):  # noqa: ARG002
+        # Automatically update any fields depending on time of day, once per second:
+        self._updateLiveMetadata()
+
+    def _formatDuration(self, seconds: int) -> str:
+        # Format a time duration.
+        # Note that `timedelta` retains `days` and `seconds` internally,
+        #   however days will be prefixed, when appropriate, by `timedelta.__str__`.
+        dt = timedelta(seconds=seconds)
+        units = "h" if dt.seconds >= 60**2 else "m" if dt.seconds >= 60 else "s"
+        return f"{dt}{units}"
+
+    @Slot(int)
+    def _updateDuration(self, seconds: int):
+        text = f"duration ({self._formatDuration(seconds)} < t0)" if seconds > 0 else "duration: use all available data"
+        self.duration.setLabelText(text)
+
+    @Slot(int)
+    def _updateUpdateInterval(self, seconds: int):
+        self.updateInterval.setLabelText(f"update interval (t0 < {self._formatDuration(seconds)})")
+
+    ###
+    ### Abstract methods:
+    ###
+
+    def verify(self) -> bool:
+        if self._liveMetadata is None:
+            raise RuntimeError("usage error: `verify` called before first call to `updateLiveMetadata`")
+
+        # -- For completeness, these checks should also be here, but they are redundant: --
+        if not self._liveMetadata.hasActiveRun():
+            raise ValueError("No live-data run is active.")
+        if not self._liveMetadata.beamState():
+            raise ValueError("The beam is down")
+        # -- end: redundant checks --
+
+        if self.keepUnfocused():
+            if self.convertUnitsDropdown.currentIndex() < 0:
+                raise ValueError("Please select units to convert to")
+        return True
+
+    def setInteractive(self, flag: bool):
+        # Enable or disable all controls _except_ for the workflow-node buttons (i.e. Continue, Cancel, and etc.).
+        super().setInteractive(flag)
+
+    def liveDataMode(self) -> bool:
+        return True
+
+    def liveDataDuration(self) -> timedelta:
+        _value = self.durationSlider.value()
+        # a duration of seconds=0 indicates that all of the available data should be loaded
+        return timedelta(seconds=_value)
+
+    def liveDataUpdateInterval(self) -> timedelta:
+        _value = self.updateIntervalSlider.value()
+        return timedelta(seconds=_value)
+
+
+@Resettable
+class ReductionRequestView(QWidget):
+    liveDataModeChange = Signal(bool)
+
+    def __init__(
+        self,
+        parent=None,
+        getCompatibleMasks: Optional[Callable[[List[str], bool], None]] = None,
+        validateRunNumbers: Optional[Callable[[List[str]], None]] = None,
+        getLiveMetadata: Optional[Callable[[], LiveMetadata]] = None,
+    ):
+        super(ReductionRequestView, self).__init__(parent=parent)
+
+        self._requestView = _RequestView(
+            parent=parent,
+            getCompatibleMasks=getCompatibleMasks,
+            validateRunNumbers=validateRunNumbers,
+            getLiveMetadata=getLiveMetadata,
+        )
+        self._liveDataView = _LiveDataView(
+            parent=parent,
+            getCompatibleMasks=getCompatibleMasks,
+            validateRunNumbers=validateRunNumbers,
+            getLiveMetadata=getLiveMetadata,
+        )
+
+        self.setLayout(QGridLayout())
+        self._stackedLayout = QStackedLayout()
+        self._stackedLayout.addWidget(self._requestView)
+        self._stackedLayout.addWidget(self._liveDataView)
+        self.layout().addLayout(self._stackedLayout, 0, 0)
+
+        # Connect signals to slots
+        self._requestView.liveDataModeChange.connect(self.liveDataModeChange)
+        self._liveDataView.liveDataModeChange.connect(self.liveDataModeChange)
+        self.liveDataModeChange.connect(self._setLiveDataMode)
+
+    @Slot(bool)
+    def _setLiveDataMode(self, flag: bool):
+        self._stackedLayout.setCurrentWidget(self._liveDataView if flag else self._requestView)
+        view = self._stackedLayout.currentWidget()
+        view.liveDataToggle.toggle.setEnabled(False)
+
+        if flag:
+            view.liveDataToggle.setState(True)
+        else:
+            view.liveDataToggle.setState(False)
+
+        view.liveDataToggle.toggle.setEnabled(True)
+
+    @Slot(LiveMetadata)
+    def updateLiveMetadata(self, data: LiveMetadata):
+        if self.liveDataMode():
+            self._liveDataView.updateLiveMetadata(data)
+
+    @Slot(StrEnum)
+    def updateStatus(self, status: StrEnum):
+        if self.liveDataMode():
+            self._liveDataView.updateStatus(status)
+
+    @Slot(bool)
+    def setReductionInProgress(self, flag: bool):
+        if self.liveDataMode():
+            self._liveDataView.setReductionInProgress(flag)
+
+    @Slot(bool)
+    def setLiveDataToggleEnabled(self, flag: bool):
+        self._requestView.liveDataToggle.setEnabled(flag)
+        self._liveDataView.liveDataToggle.setEnabled(flag)
+
+    ###
+    ### Abstract methods: ??? derive methods separately?
+    ###
+
+    def verify(self) -> bool:
+        return self._stackedLayout.currentWidget().verify()
+
+    def setInteractive(self, flag: bool):
+        self._stackedLayout.currentWidget().setInteractive(flag)
+
+    def useLiteMode(self) -> bool:
+        return self._stackedLayout.currentWidget().useLiteMode()
+
+    def keepUnfocused(self) -> bool:
+        return self._stackedLayout.currentWidget().keepUnfocused()
+
+    def convertUnitsTo(self) -> str:
+        return self._stackedLayout.currentWidget().convertUnitsTo()
+
+    def liveDataMode(self) -> bool:
+        return self._stackedLayout.currentWidget().liveDataMode()
+
+    def liveDataDuration(self) -> timedelta:
+        return self._stackedLayout.currentWidget().liveDataDuration()
+
+    def liveDataUpdateInterval(self) -> timedelta:
+        return self._stackedLayout.currentWidget().liveDataUpdateInterval()
+
+    def getRunNumbers(self) -> List[str]:
+        return self._stackedLayout.currentWidget().getRunNumbers()
+
+    def getPixelMasks(self) -> List[str]:
+        return self._stackedLayout.currentWidget().getPixelMasks()

--- a/src/snapred/ui/view/reduction/ReductionSaveView.py
+++ b/src/snapred/ui/view/reduction/ReductionSaveView.py
@@ -22,7 +22,7 @@ class ReductionSaveView(BackendRequestView):
         self.signalSavePath.connect(self._updateSavePath)
 
         self.saveMessage = QLabel("Please use available Workbench tools to save your workspaces before proceeding.")
-        self.layout.addWidget(self.saveMessage)
+        self.layout().addWidget(self.saveMessage)
 
     def updateContinueAnyway(self, continueAnywayFlags: ContinueWarning.Type):
         self.signalContinueAnyway.emit(continueAnywayFlags)
@@ -61,3 +61,7 @@ class ReductionSaveView(BackendRequestView):
 
     def verify(self):
         return True
+
+    def setInteractive(self, flag: bool):
+        # TODO: put widgets here to allow them to be enabled or disabled by the presenter.
+        pass

--- a/src/snapred/ui/widget/ActionPrompt.py
+++ b/src/snapred/ui/widget/ActionPrompt.py
@@ -3,11 +3,11 @@ from snapred.ui.view.ActionPromptView import ActionPromptView
 
 
 class ActionPrompt:
-    def __init__(self, title, message, action, parent=None):
+    def __init__(self, title, message, action, parent=None, buttonNames=("Continue", "Cancel")):
         self.title = title
         self.message = message
         self.action = action
-        self.view = ActionPromptView(self.title, self.message, parent)
+        self.view = ActionPromptView(self.title, self.message, parent=parent, buttonNames=buttonNames)
         self.presenter = ActionPromptPresenter(self.view, self.action)
         self.view.show()
 
@@ -17,5 +17,5 @@ class ActionPrompt:
 
     # A static "factory" method to facilitate testing.
     @staticmethod
-    def prompt(title, message, action, parent=None):
-        ActionPrompt(title, message, action, parent)
+    def prompt(title, message, action, parent=None, buttonNames=("Continue", "Cancel")):
+        ActionPrompt(title, message, action, parent, buttonNames)

--- a/src/snapred/ui/widget/LEDIndicator.py
+++ b/src/snapred/ui/widget/LEDIndicator.py
@@ -1,0 +1,249 @@
+import sys
+from typing import Tuple
+
+from qtpy.QtCore import Property, QPointF, Qt, QTimer, Slot
+from qtpy.QtGui import QBrush, QColor, QPainter, QPen, QRadialGradient
+from qtpy.QtWidgets import QAbstractButton
+
+## "sphinx" work-around:
+if "sphinx" in sys.modules:
+    # Why do we use sphinx?
+    # "sphinx" can't deal with `Slot(QColor)` or `Property(QColor)`,
+    #   but Python itself can.
+    QColor = object
+
+_styleSheet = """
+    /* Color */
+    qproperty-color: rgb(255, 0, 0);
+    /* Intensity at edge of indicator, when on */
+    qproperty-onContrast: 0.75;
+
+    /* Intensity at center, when off */
+    qproperty-offFactor: 0.5;
+    /* Intensity at edge, when off */
+    qproperty-offContrast: 0.1;
+
+    /* Bezel color */
+    qproperty-bezelColor: rgb(224, 224, 224);
+    qproperty-bezelContrast: 0.1;
+
+    /* Fixed size */
+    min-width: 24px; max-width: 24px;
+    min-height: 24px; max-height: 24px;
+"""
+
+
+class LEDIndicator(QAbstractButton):
+    scaledSize = 1000.0
+
+    def __init__(self, parent=None):
+        super().__init__(parent=parent)
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground)
+        self.setAttribute(Qt.WidgetAttribute.WA_StyleSheetTarget)
+
+        self.setMinimumSize(24, 24)  #
+        self.setCheckable(True)
+        self.setChecked(False)
+
+        # Default values:
+        #    will be overridden by the stylesheet.
+        self._color = QColor(0, 255, 0)
+        self._onContrast = 0.75
+        self._offFactor = 0.5
+        self._offContrast = 0.1
+        self._bezelColor = QColor(224, 224, 224)
+        self._bezelContrast = 0.1
+
+        self._flash = False
+        """ # heart beat
+        self._flashColors = (QColor(0, 255, 0),)
+        self._flashDurations = (0.20, 1.80)
+        """
+        self._flashColors = (QColor(0, 0, 255), QColor(0, 255, 0))
+        self._flashDurations = (0.2, 1.80)
+
+        self._flashTimer = QTimer(self)
+        #   A "chain" update is used here, to prevent runaway-timer issues.
+        self._flashTimer.setSingleShot(True)
+        self._flashTimer.setTimerType(Qt.CoarseTimer)
+        self._flashTimer.timeout.connect(self._continueFlash)
+
+        # For now, we use a class-local style sheet.
+        #   TODO: add `LEDIndicator` properties to the global style sheet.
+        self.setStyleSheet(_styleSheet)  # THIS works!
+
+    @Slot(QColor)
+    def setColor(self, color: QColor):
+        self.setFlash(False)
+        self._setColor(color)
+
+    def _setColor(self, color: QColor):
+        self.color = color
+
+    @Slot(object)
+    def setFlashSequence(self, pairs: Tuple[Tuple[QColor, ...], Tuple[float, ...]]):
+        # Set the flash sequence from QColor, duration pairs:
+        #   one `QColor` => on / off flash with timing as `on: float, off: float` in seconds;
+        #   otherwise the number of `QColor` and number of duration intervals must match.
+
+        # Signal(Tuple[Tuple[QColor,...], Tuple[float,...]]) as Signal(object)
+        if self._flash:
+            self._resetFlash()
+
+        colors, durations = pairs
+        if len(colors) == 1:
+            if not len(durations) == 2:
+                raise RuntimeError(
+                    "'LEDIndicator.setFlashSequence': an on off flash requires a single color, "
+                    + "and an on-time  / off-time tuple:\n"
+                    + "  for example 'setFlashSequence(Qt.red, (1.0, 1.5))': indicates a one-second on, "
+                    + "1.5 seconds off flash sequence."
+                )
+        elif len(colors) != len(durations):
+            raise RuntimeError("'LEDIndicator.setFlashSequence': color and durations tuples must have the same length.")
+        self._flashColors = colors
+        self._flashDurations = durations
+
+        if self._flash:
+            self._continueFlash()
+
+    @Slot()
+    def _resetFlash(self):
+        if self._flashTimer.isActive():
+            self._flashTimer.stop()
+        self.setChecked(False)
+        self._flashIndex = 0
+
+    @Slot(bool)
+    def setFlash(self, flag: bool):
+        if flag != self._flash:
+            self._resetFlash()
+            self._flash = flag
+            if self._flash:
+                self._continueFlash()
+
+    @Slot()
+    def _continueFlash(self):
+        if self._flash:
+            if self._flashIndex >= len(self._flashColors):
+                self.setChecked(False)  # off time
+            else:
+                self._setColor(self._flashColors[self._flashIndex])
+                self.setChecked(True)  # on time: may be single or multi-color sequence
+            ms = int(round(self._flashDurations[self._flashIndex] * 1000.0))
+            self._flashIndex += 1
+            self._flashIndex %= len(self._flashDurations)
+            self._flashTimer.setInterval(ms)
+            self._flashTimer.start()
+
+    @Property(QColor)
+    def color(self) -> QColor:
+        return self._color
+
+    @color.setter
+    def color(self, color_: QColor):
+        self._color = color_
+
+    @Property(float)
+    def onContrast(self) -> float:
+        return self._onContrast
+
+    @onContrast.setter
+    def onContrast(self, contrast: float):
+        self._onContrast = contrast
+
+    @Property(float)
+    def offFactor(self) -> float:
+        return self._offFactor
+
+    @offFactor.setter
+    def offFactor(self, factor: float):
+        self._offFactor = factor
+
+    @Property(float)
+    def offContrast(self) -> float:
+        return self._offContrast
+
+    @offContrast.setter
+    def offContrast(self, factor: float):
+        self._offContrast = factor
+
+    @Property(QColor)
+    def bezelColor(self) -> QColor:
+        return self._bezelColor
+
+    @bezelColor.setter
+    def bezelColor(self, color: QColor):
+        self._bezelColor = color
+
+    @Property(float)
+    def bezelContrast(self) -> float:
+        return self._bezelContrast
+
+    @bezelContrast.setter
+    def bezelContrast(self, contrast: float):
+        self._bezelContrast = contrast
+
+    @staticmethod
+    def scaleColor(color: QColor, factor: float) -> QColor:
+        # scale a `QColor` value by an intensity factor in `[0.0, 1.0]`.
+        return QColor(
+            int(round(factor * color.red())), int(round(factor * color.green())), int(round(factor * color.blue()))
+        )
+
+    """
+    def changeEvent(self, event):
+        print(str(event))
+        if event.type() == Qt.EnabledChange:
+            if not self.isEnabled():
+                self._resetFlash()
+    """
+
+    def hideEvent(self, event):  # noqa: ARG002
+        if self._flash:
+            self._resetFlash()
+
+    def showEvent(self, event):  # noqa: ARG002
+        if self._flash:
+            self._continueFlash()
+
+    def resizeEvent(self, QResizeEvent):  # noqa: ARG002
+        self.update()
+
+    def paintEvent(self, QPaintEvent):  # noqa: ARG002
+        realSize = min(self.width(), self.height())
+
+        painter = QPainter(self)
+        pen = QPen(Qt.black)
+        pen.setWidth(1)
+
+        painter.setRenderHint(QPainter.Antialiasing)
+        painter.translate(self.width() / 2, self.height() / 2)
+        painter.scale(realSize / self.scaledSize, realSize / self.scaledSize)
+
+        gradient = QRadialGradient(QPointF(-500, -500), 1500, QPointF(-500, -500))
+        gradient.setColorAt(0, self.bezelColor)
+        gradient.setColorAt(1, self.scaleColor(self.bezelColor, self.bezelContrast))
+        painter.setPen(pen)
+        painter.setBrush(QBrush(gradient))
+        painter.drawEllipse(QPointF(0, 0), 500, 500)
+
+        gradient = QRadialGradient(QPointF(500, 500), 1500, QPointF(500, 500))
+        gradient.setColorAt(0, self.bezelColor)
+        gradient.setColorAt(1, self.scaleColor(self.bezelColor, self.bezelContrast))
+        painter.setPen(pen)
+        painter.setBrush(QBrush(gradient))
+        painter.drawEllipse(QPointF(0, 0), 450, 450)
+
+        painter.setPen(pen)
+        if self.isChecked():
+            gradient = QRadialGradient(QPointF(-500, -500), 1500, QPointF(-500, -500))
+            gradient.setColorAt(0, self.color)
+            gradient.setColorAt(1, self.scaleColor(self.color, self.onContrast))
+        else:
+            gradient = QRadialGradient(QPointF(500, 500), 1500, QPointF(500, 500))
+            gradient.setColorAt(0, self.scaleColor(self.color, self.offFactor))
+            gradient.setColorAt(1, self.scaleColor(self.color, self.offContrast))
+
+        painter.setBrush(gradient)
+        painter.drawEllipse(QPointF(0, 0), 400, 400)

--- a/src/snapred/ui/widget/LabeledField.py
+++ b/src/snapred/ui/widget/LabeledField.py
@@ -1,25 +1,42 @@
-from qtpy.QtWidgets import QHBoxLayout, QLabel, QLineEdit, QWidget
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QHBoxLayout, QLabel, QLineEdit, QVBoxLayout, QWidget
 
 
 class LabeledField(QWidget):
-    def __init__(self, label, field=None, text=None, parent=None):
+    def __init__(self, label, field=None, text=None, parent=None, orientation=Qt.Horizontal, sizeHint=None):  # noqa: ARG002
         super(LabeledField, self).__init__(parent)
+
+        # TODO: Set this from the application style sheet.
+        #    Otherwise, this OVERRIDES the application style sheet!
         self.setStyleSheet("background-color: #F5E9E2;")
-        layout = QHBoxLayout()
-        self.setLayout(layout)
+
+        if field is not None:
+            # bubble up the size policy from the field
+            self.setSizePolicy(field.sizePolicy())
+
+        _layout = None
+        match orientation:
+            case Qt.Horizontal:
+                _layout = QHBoxLayout()
+            case Qt.Vertical:
+                _layout = QVBoxLayout()
+            case _:
+                raise RuntimeError(f"unexpected orientation for `LabeledField`: {orientation}")
 
         self._label = QLabel(label)
         if field is not None:
             self._field = field
         else:
             self._field = QLineEdit(parent=self)
-            self._field.setText(text)
+            self._field.setText(text if text is not None else "")
 
-        layout.addWidget(self._label)
-        layout.addWidget(self._field)
+        _layout.addWidget(self._label)
+        _layout.addWidget(self._field)
         # adjust layout size such that label has no whitespace
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(0)
+        _layout.setContentsMargins(0, 0, 0, 0)
+        _layout.setSpacing(0)
+        self.setLayout(_layout)
+
         self._label.adjustSize()
         self._field.adjustSize()
         self.adjustSize()
@@ -42,14 +59,20 @@ class LabeledField(QWidget):
             return default
         return self.text()
 
+    def convertCommaSeparatedToList(self):
+        return self.text().split(",")
+
     def text(self):
         return self._field.text()
 
-    def convertCommaSepartedToList(self):
-        return self.text().split(",")
-
     def setText(self, text):
         self._field.setText(text)
+
+    def labelText(self):
+        return self._label.text()
+
+    def setLabelText(self, text):
+        self._label.setText(text)
 
     def clear(self):
         self._field.clear()

--- a/src/snapred/ui/widget/LabeledToggle.py
+++ b/src/snapred/ui/widget/LabeledToggle.py
@@ -12,19 +12,19 @@ class LabeledToggle(QWidget):
         self.setStyleSheet("background-color: #F5E9E2;")
 
         self._label = QLabel(label + ":", self)
-        self._toggle = Toggle(state=state, parent=self)
+        self.toggle = Toggle(state=state, parent=self)
 
-        layout = QHBoxLayout()
-        layout.addWidget(self._label)
-        layout.addWidget(self._toggle)
-        layout.addStretch(1)
-        layout.setContentsMargins(5, 5, 5, 5)
-        self.setLayout(layout)
+        _layout = QHBoxLayout()
+        _layout.addWidget(self._label)
+        _layout.addWidget(self.toggle)
+        _layout.addStretch(1)
+        _layout.setContentsMargins(5, 5, 5, 5)
+        self.setLayout(_layout)
 
-        self._toggle.stateChanged.connect(self.stateChanged)
+        self.toggle.stateChanged.connect(self.stateChanged)
 
     def getState(self):
-        return self._toggle.getState()
+        return self.toggle.getState()
 
     def setState(self, state):
-        self._toggle.setState(state)
+        self.toggle.setState(state)

--- a/src/snapred/ui/widget/SuccessPrompt.py
+++ b/src/snapred/ui/widget/SuccessPrompt.py
@@ -1,4 +1,4 @@
-from qtpy.QtCore import Qt, Slot
+from qtpy.QtCore import QMetaObject, Qt, Slot
 from qtpy.QtWidgets import QDialog, QLabel, QPushButton, QVBoxLayout
 
 
@@ -20,22 +20,25 @@ class SuccessPrompt(QDialog):
         self.setWindowModality(Qt.ApplicationModal)
         self.setWindowTitle("Success")
         self.setFixedSize(300, 120)
-        layout = QVBoxLayout()
+
+        # Do not hide the `QWidget.layout()` method!
+        layout_ = QVBoxLayout()
 
         label = QLabel("State initialized successfully.")
-        layout.addWidget(label)
+        layout_.addWidget(label)
 
         self.okButton = QPushButton("OK")
-        layout.addWidget(self.okButton)
+        layout_.addWidget(self.okButton)
         self.okButton.clicked.connect(self.accept)
 
-        self.setLayout(layout)
+        self.setLayout(layout_)
 
     @Slot()
     def accept(self):
         super().accept()
         if self.parent():
-            self.parent().close()
+            # Queuing this allows "parent" to close "self".
+            QMetaObject.invokeMethod(self.parent(), "close", Qt.QueuedConnection)
 
     # A static "factory" method to facilitate testing.
     @staticmethod

--- a/src/snapred/ui/widget/Toggle.py
+++ b/src/snapred/ui/widget/Toggle.py
@@ -1,6 +1,43 @@
+import sys
+
 from qtpy.QtCore import Property, QEasingCurve, QPropertyAnimation, Qt, Signal, Slot
-from qtpy.QtGui import QLinearGradient, QPainter
-from qtpy.QtWidgets import QWidget
+from qtpy.QtGui import QColor, QLinearGradient, QPainter
+from qtpy.QtWidgets import QSizePolicy, QWidget
+
+## "sphinx" work-around:
+if "sphinx" in sys.modules:
+    # Why do we use sphinx?
+    # "sphinx" can't deal with `Slot(QColor)` or `Property(QColor)`,
+    #   but Python itself can.
+    QColor = object
+
+# HOW TO USE QSS to modify the appearance of this widget (now set using `src/snapred/resources/style.qss`):
+_styleSheet = """
+    /* DEFAULT values for all `Toggle`: */
+
+    .Toggle {
+        /* fixed height and width */
+        min-height: 30px; max-height: 30px;
+        min-width: 60px; max-width: 60px;
+
+        /* Toggle-switch background */
+        qproperty-backgroundColor: rgb(0, 128, 0); /* Qt.darkGreen */
+
+        /* Toggle-switch bar: vertical gradient */
+        qproperty-gradStartColor: rgb(0, 255, 0);
+        qproperty-gradEndColor: rgb(0, 128, 128); /* Qt.darkCyan */
+    }
+
+    /* OVERRIDE for a _specific_ _named_ `Toggle`:
+         use `self.field.setObjectName("the_object_name")`. */
+
+    /* WARNING: this is the name of the `LabeledField.field`, which is of class `Toggle`,
+         not the `LabeledField` itself! */
+
+    Toggle#the_object_name {
+        /* Whatever you want to override goes in here: */
+    }
+"""
 
 
 class Toggle(QWidget):
@@ -8,15 +45,30 @@ class Toggle(QWidget):
 
     def __init__(self, parent=None, state=False):
         super().__init__(parent=parent)
+
+        # Setting this size policy here allows a parent `QWidget` (e.g. `LabeledField`)
+        #   to automatically set its `sizePolicy`.
+        #   => only allow expansion in the horizontal direction.
+        self.setSizePolicy(QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed))
+
         self._state = state
-        self._ellipsePosition = 0.0
+        self._ellipsePosition = 1.0 if state else 0.0
         self.toggleAnimation = QPropertyAnimation(self, b"ellipsePosition")
-        # fixed height width ratio
-        self.setFixedHeight(30)
-        self.setFixedWidth(60)
-        # self.update = self._doNothing
+
+        # Complete the animation _first_, and only _then_ emit the stateChange signal:
+        self.toggleAnimation.finished.connect(lambda: self.stateChanged.emit(self._state))
         self.toggleAnimation.finished.connect(self.update)
-        self.animateClick()
+
+        # The following properties are now set using the SNAPRed application's style sheet:
+        #   fixed height width
+        # self.setFixedHeight(30)
+        # self.setFixedWidth(60)
+        self._backgroundColor = QColor(0, 128, 0)  # will be overridden by the style sheet
+        self._gradStartColor = QColor(0, 255, 0)  # " "
+        self._gradEndColor = QColor(0, 128, 128)  # " "
+
+        # Do _not_ animate at initial setup!
+        # self.animateClick()
 
     @Property(float)
     def ellipsePosition(self):
@@ -34,31 +86,65 @@ class Toggle(QWidget):
     def setState(self, state):
         if self._state != state:
             self._state = state
-            self.stateChanged.emit(state)
-            self.animateClick()
+            if self.isEnabled():
+                # animate first, _then_ emit the signal
+                self.animateClick()
+            else:
+                # IMPORTANT: do not animate or emit `stateChange` when disabled!
+                self._ellipsePosition = 1.0 if state else 0.0
 
     def connectUpdate(self, update):  # noqa: ARG002
+        # TODO: Is this method actually used anywhere?
         self.toggleAnimation.finished.connect(update)
-
-    def _doNothing(self):
-        pass
 
     def getState(self):
         return self._state
 
+    @Property(QColor)
+    def backgroundColor(self):
+        # Be careful here: don't hide the widget's `background-color` property (or function)!
+        return self._backgroundColor
+
+    @backgroundColor.setter
+    def backgroundColor(self, color: QColor):
+        self._backgroundColor = color
+
+    @Property(QColor)
+    def gradStartColor(self):
+        return self._gradStartColor
+
+    @gradStartColor.setter
+    def gradStartColor(self, color: QColor):
+        self._gradStartColor = color
+
+    @Property(QColor)
+    def gradEndColor(self):
+        return self._gradEndColor
+
+    @gradEndColor.setter
+    def gradEndColor(self, color: QColor):
+        self._gradEndColor = color
+
     def paintEvent(self, event):  # noqa: ARG002
+        backgroundColor = self.backgroundColor
+        gradStartColor = self.gradStartColor
+        gradEndColor = self.gradEndColor
+
         painter = QPainter(self)
         painter.setRenderHint(QPainter.Antialiasing)
         painter.setPen(Qt.NoPen)
-        painter.setBrush(Qt.gray if not self._state else Qt.darkGreen)
+
         # draw the background
+        painter.setBrush(Qt.gray if not self._state else backgroundColor)
         painter.drawRoundedRect(self.rect(), self.width(), self.height() / 2)
+
         # add gradient to background
         gradient = QLinearGradient(self.rect().topLeft(), self.rect().bottomLeft())
-        gradient.setColorAt(1, Qt.darkCyan)
-        gradient.setColorAt(0.3, Qt.gray if not self._state else Qt.green)
+        gradient.setColorAt(1.0, gradEndColor)
+        gradient.setColorAt(0.3, Qt.gray if not self._state else gradStartColor)
         painter.setBrush(gradient)
         painter.drawRoundedRect(self.rect(), self.width(), self.height() / 2)
+
         # draw the ellipse
         painter.setBrush(Qt.lightGray)
         painter.drawEllipse(int((self.width() / 2) * self._ellipsePosition), 0, int(self.width() / 2), self.height())
@@ -77,5 +163,4 @@ class Toggle(QWidget):
 
     def mouseReleaseEvent(self, event):
         self.toggle()
-        self.update()
         super().mouseReleaseEvent(event)

--- a/src/snapred/ui/widget/Workflow.py
+++ b/src/snapred/ui/widget/Workflow.py
@@ -11,7 +11,7 @@ class Workflow:
         iterateLambda=None,
         resetLambda=None,
         cancelLambda=None,
-        completionMessageLambda=None,
+        completeWorkflowLambda=None,
         parent=None,
     ):
         # default loading subview
@@ -21,7 +21,7 @@ class Workflow:
             iterateLambda=iterateLambda,
             resetLambda=resetLambda,
             cancelLambda=cancelLambda,
-            completionMessageLambda=completionMessageLambda,
+            completeWorkflowLambda=completeWorkflowLambda,
             parent=parent,
         )
 

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -89,15 +89,15 @@ class DiffCalWorkflow(WorkflowImplementer):
         self._saveView = DiffCalSaveView(parent)
 
         # connect signal to populate the grouping dropdown after run is selected
-        self._requestView.litemodeToggle.stateChanged.connect(self._switchLiteNativeGroups)
+        self._requestView.liteModeToggle.stateChanged.connect(self._switchLiteNativeGroups)
         self._requestView.runNumberField.editingFinished.connect(self._populateGroupingDropdown)
         self._requestView.sampleDropdown.dropDown.currentIndexChanged.connect(self._lookForOverrides)
         self._tweakPeakView.signalValueChanged.connect(self.onValueChange)
         self._tweakPeakView.signalPurgeBadPeaks.connect(self.purgeBadPeaks)
 
         # connect the lite mode toggles across the views
-        self._requestView.litemodeToggle.stateChanged.connect(self._tweakPeakView.litemodeToggle.setState)
-        self._tweakPeakView.litemodeToggle.stateChanged.connect(self._requestView.litemodeToggle.setState)
+        self._requestView.liteModeToggle.stateChanged.connect(self._tweakPeakView.liteModeToggle.setState)
+        self._tweakPeakView.liteModeToggle.stateChanged.connect(self._requestView.liteModeToggle.setState)
 
         # connect the skip pixelcal toggles across the views
         self._requestView.skipPixelCalToggle.stateChanged.connect(self._tweakPeakView.skipPixelCalToggle.setState)
@@ -145,7 +145,7 @@ class DiffCalWorkflow(WorkflowImplementer):
 
     def __setInteraction(self, state: bool, interactionType: str):
         if interactionType == "populateGroupDropdown":
-            self._requestView.litemodeToggle.setEnabled(state)
+            self._requestView.liteModeToggle.setEnabled(state)
             self._requestView.skipPixelCalToggle.setEnabled(state)
             self._requestView.groupingFileDropdown.setEnabled(state)
         elif interactionType == "lookForOverrides":
@@ -156,7 +156,7 @@ class DiffCalWorkflow(WorkflowImplementer):
     def _populateGroupingDropdown(self):
         # when the run number is updated, freeze the drop down to populate it
         runNumber = self._requestView.runNumberField.text()
-        useLiteMode = self._requestView.litemodeToggle.getState()
+        useLiteMode = self._requestView.liteModeToggle.getState()
 
         self.__setInteraction(False, "populateGroupDropdown")
         self.workflow.presenter.handleAction(
@@ -249,7 +249,7 @@ class DiffCalWorkflow(WorkflowImplementer):
     @Slot()
     def _switchLiteNativeGroups(self):
         # determine resolution mode
-        useLiteMode = self._requestView.litemodeToggle.getState()
+        useLiteMode = self._requestView.liteModeToggle.getState()
 
         # set default state for skipPixelCalToggle
         # in native mode, skip by default
@@ -275,7 +275,7 @@ class DiffCalWorkflow(WorkflowImplementer):
 
         # fetch the data from the view
         self.runNumber = view.runNumberField.text()
-        self.useLiteMode = view.litemodeToggle.getState()
+        self.useLiteMode = view.liteModeToggle.getState()
         self.focusGroupPath = view.groupingFileDropdown.currentText()
         self.calibrantSamplePath = view.sampleDropdown.currentText()
         self.peakFunction = view.peakFunctionDropdown.currentText()

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -65,7 +65,7 @@ class NormalizationWorkflow(WorkflowImplementer):
         self._saveView = NormalizationSaveView(parent)
 
         # connect signal to populate the grouping dropdown after run is selected
-        self._requestView.litemodeToggle.stateChanged.connect(self._switchLiteNativeGroups)
+        self._requestView.liteModeToggle.stateChanged.connect(self._switchLiteNativeGroups)
         self._requestView.runNumberField.editingFinished.connect(self._populateGroupingDropdown)
         self._requestView.backgroundRunNumberField.editingFinished.connect(self._verifyBackgroundRunNumber)
         self._tweakPeakView.signalValueChanged.connect(self.onNormalizationValueChange)
@@ -87,8 +87,8 @@ class NormalizationWorkflow(WorkflowImplementer):
             .build()
         )
 
-    def __setInteraction(self, state: bool):
-        self._requestView.litemodeToggle.setEnabled(state)
+    def _setInteractive(self, state: bool):
+        self._requestView.liteModeToggle.setEnabled(state)
         self._requestView.groupingFileDropdown.setEnabled(state)
 
     @EntryExitLogger(logger=logger)
@@ -97,13 +97,13 @@ class NormalizationWorkflow(WorkflowImplementer):
     def _populateGroupingDropdown(self):
         # when the run number is updated, grab the grouping map and populate grouping drop down
         runNumber = self._requestView.runNumberField.text()
-        self.useLiteMode = self._requestView.litemodeToggle.getState()
+        self.useLiteMode = self._requestView.liteModeToggle.getState()
 
-        self.__setInteraction(False)
+        self._setInteractive(False)
         self.workflow.presenter.handleAction(
             self.handleDropdown,
             args=(runNumber, self.useLiteMode),
-            onSuccess=lambda: self.__setInteraction(True),
+            onSuccess=lambda: self._setInteractive(True),
         )
 
     def handleDropdown(self, runNumber, useLiteMode):
@@ -145,7 +145,7 @@ class NormalizationWorkflow(WorkflowImplementer):
     @Slot()
     def _switchLiteNativeGroups(self):
         # when the run number is updated, freeze the drop down to populate it
-        useLiteMode = self._requestView.litemodeToggle.getState()
+        useLiteMode = self._requestView.liteModeToggle.getState()
 
         self._requestView.groupingFileDropdown.setEnabled(False)
 
@@ -167,7 +167,7 @@ class NormalizationWorkflow(WorkflowImplementer):
         # pull fields from view for normalization
 
         self.runNumber = view.runNumberField.field.text()
-        self.useLiteMode = view.litemodeToggle.getState()
+        self.useLiteMode = view.liteModeToggle.getState()
         self.backgroundRunNumber = view.backgroundRunNumberField.field.text()
         self.sampleIndex = view.sampleDropdown.currentIndex()
         self.prevGroupingIndex = view.groupingFileDropdown.currentIndex()

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -1,20 +1,25 @@
-from typing import Dict, List
+from datetime import timedelta
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
-from qtpy.QtCore import Slot
+from qtpy.QtCore import Qt, QTimer, Signal, Slot
 
 from snapred.backend.dao.ingredients import ArtificialNormalizationIngredients
+from snapred.backend.dao.LiveMetadata import LiveMetadata
 from snapred.backend.dao.request import (
     CreateArtificialNormalizationRequest,
     MatchRunsRequest,
     ReductionExportRequest,
     ReductionRequest,
 )
+from snapred.backend.dao.response.ReductionResponse import ReductionResponse
 from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.log.logger import snapredLogger
-from snapred.meta.decorators.ExceptionToErrLog import ExceptionToErrLog
+from snapred.meta.Config import Config
+from snapred.meta.Enum import StrEnum
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
+from snapred.ui.presenter.WorkflowPresenter import WorkflowPresenter
 from snapred.ui.view.reduction.ArtificialNormalizationView import ArtificialNormalizationView
 from snapred.ui.view.reduction.ReductionRequestView import ReductionRequestView
 from snapred.ui.workflow.WorkflowBuilder import WorkflowBuilder
@@ -23,20 +28,49 @@ from snapred.ui.workflow.WorkflowImplementer import WorkflowImplementer
 logger = snapredLogger.getLogger(__name__)
 
 
+class ReductionStatus(StrEnum):
+    """
+    Implementation notes:
+
+    This is just a "first pass" on a workflow-status enum:
+
+    -- This could also have been a _part_ of a more generalized workflow state.
+
+    -- This enum class may or may not generalize _across_ workflows; in this initial design
+    it is assumed that it does not.
+    """
+
+    READY = "Ready"
+    CALCULATING_NORM = "Calculating normalization"
+    REDUCING_DATA = "Reducing data"
+    FINALIZING = "Finalizing reduction"
+    USER_CANCELLATION = "Cancelling workflow"
+
+    # Special to live data:
+    CONNECTING = "Connecting to listener"
+    WAITING_TO_LOAD = "Waiting to load next chunk"
+    NO_ACTIVE_RUN = "No run is active"
+    NO_BEAM = "Beam is down"
+
+
 class ReductionWorkflow(WorkflowImplementer):
+    _liveMetadataUpdate = Signal(LiveMetadata)
+    _statusUpdate = Signal(ReductionStatus)
+
     def __init__(self, parent=None):
         super().__init__(parent)
 
         self._reductionRequestView = ReductionRequestView(
             parent=parent,
-            populatePixelMaskDropdown=self._populatePixelMaskDropdown,
+            getCompatibleMasks=self._getCompatibleMasks,
             validateRunNumbers=self._validateRunNumbers,
+            getLiveMetadata=self._getLiveMetadata,
         )
-        self._compatibleMasks: Dict[str, WorkspaceName] = {}
+        if not self._hasLiveDataConnection():
+            # Only enable live-data mode if there is a connection to the listener.
+            self._reductionRequestView.setLiveDataToggleEnabled(False)
 
-        self._reductionRequestView.liteModeToggle.stateChanged.connect(lambda: self._populatePixelMaskDropdown())
-        self._reductionRequestView.enterRunNumberButton.clicked.connect(lambda: self._populatePixelMaskDropdown())
-        self._reductionRequestView.pixelMaskDropdown.dropDown.view().pressed.connect(self._onPixelMaskSelection)
+        self._compatibleMasks: Dict[str, WorkspaceName] = {}
 
         self._artificialNormalizationView = ArtificialNormalizationView(parent=parent)
 
@@ -45,7 +79,8 @@ class ReductionWorkflow(WorkflowImplementer):
                 startLambda=self.start,
                 # Retain reduction-output workspaces.
                 resetLambda=lambda: self.reset(True),
-                completionMessageLambda=self.completionMessage,
+                cancelLambda=self.cancelWorkflow,
+                completeWorkflowLambda=self.completeWorkflow,
                 parent=parent,
             )
             .addNode(
@@ -61,78 +96,292 @@ class ReductionWorkflow(WorkflowImplementer):
             )
             .build()
         )
-        self._keeps = set()
-        self._reductionRequestView.retainUnfocusedDataCheckbox.checkedChanged.connect(self._enableConvertToUnits)
+
+        ##
+        ## WORKFLOW-STATE attributes:
+        ##
+
+        self.setStatus(ReductionStatus.READY)
+
+        # Quite a few of these attributes are also at `self._triggerReduction`
+        #   using the current settings from `ReductionRequestView`.
+
+        self._keeps: Set[WorkspaceName] = set()
+        self.runNumbers: List[str] = []
+        self.useLiteMode: bool = True
+
+        self.liveDataMode: bool = False
+        self.liveDataDuration: timedelta = timedelta(seconds=0)
+
+        # Initialize a timer to control the live-data metadata update.
+        self._liveDataUpdateTimer = QTimer(self)
+        #   A "chain" update is used here, to prevent runaway-timer issues.
+        self._liveDataUpdateTimer.setSingleShot(True)
+        self._liveDataUpdateTimer.setTimerType(Qt.CoarseTimer)
+        self._liveDataUpdateTimer.setInterval(Config["liveData.updateIntervalDefault"] * 1000)
+        self._liveDataUpdateTimer.timeout.connect(self.updateLiveMetadata)
+
+        self.addResetHook(
+            # Note: when _not_ in live-data mode, this controls the live-data toggle enable.
+            #   In live-data mode, the toggle is enabled when the workflow is not cycling.
+            lambda: self._reductionRequestView.setLiveDataToggleEnabled(True) if not self.liveDataMode else None
+        )
+
+        # Initialize a separate timer for the control of the live-data reduction-workflow loop.
+        self._workflowTimer = QTimer(self)
+        self._workflowTimer.setSingleShot(True)
+        self._workflowTimer.setTimerType(Qt.CoarseTimer)
+        self._workflowTimer.setInterval(Config["liveData.updateIntervalDefault"] * 1000)
+        self._lastReductionRequest = None  # used by `_reduceLiveDataChunk`
+        self._lastReductionResponse = None  # used by `_reduceLiveDataChunk`
+        self._workflowTimer.timeout.connect(self._reduceLiveDataChunk)
+
+        self.pixelMasks: List[WorkspaceName] = []
+
+        ##
+        ## Connect signals to slots:
+        ##
+
+        self._reductionRequestView.liveDataModeChange.connect(self.setLiveDataMode)
+
+        # `_getLiveMetadata` updates the live-data view:
+        self._liveMetadataUpdate.connect(self._updateLiveMetadata)
+
+        # `setStatus` updates the live-data view:
+        self._statusUpdate.connect(self._reductionRequestView.updateStatus)
+
+        # Presenter signals the live-data view that a reduction is in progress:
+        self.workflow.presenter.workflowInProgressChange.connect(self._reductionRequestView.setReductionInProgress)
+
+        # Status summary shows "CANCELLING WORKFLOW" on any cancellatioin request:
+        self.workflow.presenter.cancellationRequest.connect(lambda: self.setStatus(ReductionStatus.USER_CANCELLATION))
+
+        # Status summary is updated to "READY" at the completion of reset:
+        self.workflow.presenter.resetCompleted.connect(lambda: self.setStatus(ReductionStatus.READY))
+
         self._artificialNormalizationView.signalValueChanged.connect(self.onArtificialNormalizationValueChange)
 
-    def _enableConvertToUnits(self):
-        state = self._reductionRequestView.retainUnfocusedDataCheckbox.isChecked()
-        self._reductionRequestView.convertUnitsDropdown.setEnabled(state)
+        # Note: in order to simplify the flow-of-control,
+        #   all of the `ReductionRequestView` signal connections have been moved to `ReductionRequestView` itself,
+        #     which is now a `QStackedOverlay` consisting of multiple sub-views.
 
-    def _nothing(self, workflowPresenter):  # noqa: ARG002
+    @property
+    def status(self) -> ReductionStatus:
+        return self._status
+
+    def setStatus(self, status: ReductionStatus):
+        # Following `Qt` style, this is _not_ @<property>.setter!
+        self._status = status
+        self._statusUpdate.emit(status)
+
+    def _nothing(self, workflowPresenter: WorkflowPresenter):  # noqa: ARG002
         return SNAPResponse(code=200)
 
-    def completionMessage(self):
-        panelText = ""
-        if (
-            self.continueAnywayFlags is not None
-            and ContinueWarning.Type.NO_WRITE_PERMISSIONS in self.continueAnywayFlags
-        ):
-            panelText = (
-                "<p>You didn't have permissions to write to "
-                + f"<br><b>{self.savePath}</b>,<br>"
-                + "but you can still save using the workbench tools.</p>"
-                + "<p>Please remember to save your output workspaces!</p>"
-            )
+    def start(self):
+        self._reductionRequestView.setInteractive(False)
+        super().start()
+
+    @Slot()
+    def cancelWorkflow(self):
+        # This method exists in order to correctly shut down the live-data loop.
+        def _safeShutdown():
+            if self._workflowTimer.isActive():
+                self._workflowTimer.stop()
+            self._reductionRequestView.setInteractive(True)
+            self.workflow.presenter.safeShutdown()
+
+        self.workflow.presenter.resetWithPermission(shutdownLambda=_safeShutdown)
+
+    @Slot()
+    def completeWorkflow(self):
+        if not self.liveDataMode:
+            panelText = ""
+            if (
+                self.continueAnywayFlags is not None
+                and ContinueWarning.Type.NO_WRITE_PERMISSIONS in self.continueAnywayFlags
+            ):
+                panelText = (
+                    "<p>You didn't have permissions to write to "
+                    + f"<br><b>{self.savePath}</b>,<br>"
+                    + "but you can still save using the workbench tools.</p>"
+                    + "<p>Please remember to save your output workspaces!</p>"
+                )
+            else:
+                panelText = (
+                    "<p>Reduction has completed successfully!"
+                    + "<br>Reduction workspaces have been saved to "
+                    + f"<br><b>{self.savePath}</b>.<br></p>"
+                    + "<p>If required later, these can be reloaded into Mantid workbench using 'LoadNexus'.</p>"
+                )
+            self.workflow.presenter.completeWorkflow(message=panelText)
         else:
-            panelText = (
-                "<p>Reduction has completed successfully!"
-                + "<br>Reduction workspaces have been saved to "
-                + f"<br><b>{self.savePath}</b>.<br></p>"
-                + "<p>If required later, these can be reloaded into Mantid workbench using 'LoadNexus'.</p>"
-            )
-        return panelText
+            # Prepare and submit the next live-data reduction request.
+            self._cycleLiveData(True)
 
-    def __setInteractive(self, state: bool):
-        self._reductionRequestView.liteModeToggle.setEnabled(state)
-        self._reductionRequestView.pixelMaskDropdown.setEnabled(state)
-        self._reductionRequestView.retainUnfocusedDataCheckbox.setEnabled(state)
+    @Slot(bool)
+    def _cycleLiveData(self, success: bool):
+        # Prepare the next live-data reduction request, and start its submission timer.
+        status = success
+        if status:
+            try:
+                # Retain the last completed `ReductionRequest`,
+                #   and its `ReductionResponse` before any `reset` is called.
 
-    @ExceptionToErrLog
-    def _populatePixelMaskDropdown(self):
-        self.useLiteMode = self._reductionRequestView.liteModeToggle.getState()  # noqa: F841
-        runNumbers = self._reductionRequestView.getRunNumbers()
-        if not runNumbers:
-            self._reductionRequestView.pixelMaskDropdown.setItems([])
-            return []
+                # TODO: I'd prefer if `self._lastReductionRequest` and `self._lastReductionResponse`
+                #   were local variables, which could then be passed to the submitted reduction-service
+                #   'reduction' for each live-data cycle.
+                # However, in order to use non-static `QTimer` methods,
+                #   the slot target of the `_workflowTimer.timeout` needs to be fixed at `__init__`,
+                #   so for the moment these are passed as attributes of the workflow.
 
-        self.useLiteMode = self._reductionRequestView.liteModeToggle.getState()  # noqa: F841
+                # Right now, the <normalization> and <artificial normalization> reduction paths
+                #   just happen to have the same last-request index.  If this changes,
+                #   then setting of `self._lastReductionRequest` and `self._lastReductionResponse`
+                #   must take that into account.
 
-        self.__setInteractive(False)
-        self.workflow.presenter.handleAction(
-            self.handlePixelMaskDropdown,
-            args=(runNumbers[0], self.useLiteMode),
-            onSuccess=lambda: self.__setInteractive(True),
-        )
-        return list(self._compatibleMasks.keys())
+                lastRequestIndex = -2
+                self._lastReductionRequest: ReductionRequest = self.requests[lastRequestIndex].payload
+                self._lastReductionResponse: ReductionResponse = self.responses[lastRequestIndex].data
 
-    def handlePixelMaskDropdown(self, firstRunNumber, useLiteMode):
+                # Calling `presenter.resetSoft()` gets us back to the live-data summary panel.
+                self.workflow.presenter.resetSoft()
+
+                updateInterval = self._liveDataUpdateInterval()
+
+                # If the user has set the updateInterval to too small a value, we just do the best we can.
+                # (We do _not_ screw up non-interactivity by spamming the logs with a WARNING!)
+
+                waitTime: timedelta = updateInterval - self._lastReductionResponse.executionTime
+                if waitTime < timedelta(seconds=0):
+                    waitTime = timedelta(seconds=0)
+
+                self.setStatus(ReductionStatus.WAITING_TO_LOAD)
+
+                # Submit the reduction request for the next live-data chunk:
+                #   the slot target of the `_workflowTimer.timeout` has been set to
+                #  `_reduceLiveDataChunk` during `__init__`.
+                self._workflowTimer.setInterval(waitTime.seconds * 1000)
+                self._workflowTimer.start()
+            except (AttributeError, IndexError) as e:
+                logger.error(f"_cycleLiveData: unexpected: {e}")
+                status = False
+        if not status:
+            if self.status != ReductionStatus.READY:
+                # "READY" indicates that this `reset` would be redundant.
+                # (e.g. User cancellation has its own `reset` pathway.)
+                self.workflow.presenter.reset()
+
+    @Slot()
+    def _reduceLiveDataChunk(self):
+        # Submit a live-data reduction request.
+
+        def _reduceLiveData():
+            self.setStatus(ReductionStatus.REDUCING_DATA)
+
+            response = self.request(path="reduction/", payload=self._lastReductionRequest)
+            if response.code == ResponseCode.OK:
+                # Finalize the reduction.
+                record, unfocusedData = response.data.record, response.data.unfocusedData
+                self._finalizeReduction(record, unfocusedData)
+
+            # after each cycle, clean workspaces except groupings, calibrations, normalizations, and outputs
+            self._keeps.update(self.outputs)
+            self._clearWorkspaces(exclude=self._keeps, clearCachedWorkspaces=True)
+
+            return self.responses[-1]
+
+        # Resubmit the previous request, which will then act on the next live-data chunk.
+        self._submitActionToPresenter(_reduceLiveData, None, self._cycleLiveData)
+
+    def _submitActionToPresenter(
+        self,
+        action: Callable[[Any], Any],
+        args: Tuple[Any, ...] | Any | None = None,
+        onSuccess: Callable[[bool], None] = lambda flag: None,  # noqa: ARG005
+        isWorkflow: bool = True,
+    ):
+        # Submit an action to this workflow's presenter's thread pool.
+        self.workflow.presenter.handleAction(action, args, onSuccess, isWorkflow=isWorkflow)
+
+    def _getCompatibleMasks(self, runNumbers: List[str], useLiteMode: bool) -> List[str]:
         # Get compatible masks for the current reduction state.
-        compatibleMasks = self.request(
-            path="reduction/getCompatibleMasks",
-            payload=ReductionRequest(
-                # All runNumbers are from the same state => any one can be used here
-                runNumber=firstRunNumber,
-                useLiteMode=useLiteMode,
-            ),
-        ).data
+        masks = []
 
-        # Map mask names to their corresponding WorkspaceName objects.
-        self._compatibleMasks = {name.toString(): name for name in compatibleMasks}
+        if runNumbers:
+            compatibleMasks = self.request(
+                path="reduction/getCompatibleMasks",
+                payload=ReductionRequest(
+                    # All runNumbers are from the same state => any one can be used here
+                    runNumber=runNumbers[0],
+                    useLiteMode=useLiteMode,
+                ),
+            ).data
 
-        # Populate the dropdown with the mask names.
-        self._reductionRequestView.pixelMaskDropdown.setItems(list(self._compatibleMasks.keys()))
-        return SNAPResponse(code=ResponseCode.OK)
+            # Map from mask-name strings to their corresponding WorkspaceName objects.
+            self._compatibleMasks = {name.toString(): name for name in compatibleMasks}
+            masks = list(self._compatibleMasks.keys())
+
+        return masks
+
+    def _liveDataUpdateInterval(self) -> timedelta:
+        return self._reductionRequestView.liveDataUpdateInterval()
+
+    @Slot(bool)
+    def setLiveDataMode(self, flag: bool):
+        self.liveDataMode = flag
+        if self._liveDataUpdateTimer.isActive():
+            self._liveDataUpdateTimer.stop()
+        if self.liveDataMode:
+            # After the first continue click from the request panel,
+            #   and from the artificial-normalization panel, if it's used,
+            #   workflow nodes in live-data mode are automatically continued.
+            self.workflow.presenter.setManualMode(False)
+
+            # Start the metadata update sequence.
+            self.updateLiveMetadata(True)
+        else:
+            self.workflow.presenter.setManualMode(True)
+
+            # Live-data mode can disable the continue button,
+            #   so we need to re-enable it here, just in case.
+            self.workflow.presenter.enableButtons(True)
+
+    @Slot()
+    def updateLiveMetadata(self, startup: bool = False):
+        # This method continues the live-metadata timer chain.
+        # If `startup` is True, then the `reductionRequestView` will be re-initialized.
+
+        #   The actual update of the live-metadata view occurs
+        #   via the `metadataUpdate` signal, emitted by `_getLiveMetadata`, triggering the `_updateLiveMetadata` slot.
+        if self.liveDataMode:
+            if startup:
+                # After any live-data mode change,
+                #   the `reductionRequestView` always starts with the "connecting to listener..." message,
+                #   so that it won't display _stale_ metadata.
+                self._reductionRequestView.updateLiveMetadata(None)
+                self._reductionRequestView.updateStatus(self.status)
+
+            # Don't additionally harass the data listener for metadata update
+            #   while any workflow-related action is in process.
+            if not self.workflow.presenter.workflowIsRunning:
+                self._submitActionToPresenter(self._getLiveMetadata, None, isWorkflow=False)
+
+            # Continue the automatic metadata update sequence.
+            self._liveDataUpdateTimer.start()
+
+    @Slot(object)  # Signal(Optional[LiveMetaData]) as Signal(object)
+    def _updateLiveMetadata(self, data: Optional[LiveMetadata]):
+        self._reductionRequestView.updateLiveMetadata(data)
+
+    def _hasLiveDataConnection(self) -> bool:
+        return self.request(path="reduction/hasLiveDataConnection").data
+
+    def _getLiveMetadata(self) -> SNAPResponse:
+        # This method defines an action so that the live metadata can be retrieved in a background thread.
+        response = self.request(path="reduction/getLiveMetadata")
+        if response.code == ResponseCode.OK:
+            self._liveMetadataUpdate.emit(response.data)
+        return response
 
     def _validateRunNumbers(self, runNumbers: List[str]):
         # For now, all run numbers in a reduction batch must be from the same instrument state.
@@ -148,17 +397,6 @@ class ReductionWorkflow(WorkflowImplementer):
     def _reconstructPixelMaskNames(self, pixelMasks: List[str]) -> List[WorkspaceName]:
         return [self._compatibleMasks[name] for name in pixelMasks]
 
-    @Slot()
-    def _onPixelMaskSelection(self):
-        pass
-        #  The previous version of this method actually does nothing:  :(
-        #
-        # selectedKeys = self._reductionRequestView.getPixelMasks()
-        # selectedWorkspaceNames = self._reconstructPixelMaskNames(selectedKeys)
-        # ReductionRequest.pixelMasks = selectedWorkspaceNames
-        #
-        # ## Why would I want to set the ~obfuscated-by-pydantic~ `pixelMasks` field of the class object?
-
     def _createReductionRequest(self, runNumber, artificialNormalizationIngredients=None):
         """
         Create a standardized ReductionRequest object for passing to the ReductionService
@@ -166,33 +404,45 @@ class ReductionWorkflow(WorkflowImplementer):
         return ReductionRequest(
             runNumber=str(runNumber),
             useLiteMode=self.useLiteMode,
+            liveDataMode=self.liveDataMode,
+            liveDataDuration=self.liveDataDuration,
             timestamp=self.timestamp,
             continueFlags=self.continueAnywayFlags,
             pixelMasks=self.pixelMasks,
-            keepUnfocused=self._reductionRequestView.retainUnfocusedDataCheckbox.isChecked(),
-            convertUnitsTo=self._reductionRequestView.convertUnitsDropdown.currentText(),
+            keepUnfocused=self._reductionRequestView.keepUnfocused(),
+            convertUnitsTo=self._reductionRequestView.convertUnitsTo(),
             artificialNormalizationIngredients=artificialNormalizationIngredients,
         )
 
-    def _triggerReduction(self, workflowPresenter):
+    def _triggerReduction(self, workflowPresenter: WorkflowPresenter):
         view = workflowPresenter.widget.tabView  # noqa: F841
 
         self.runNumbers = self._reductionRequestView.getRunNumbers()
+        self.useLiteMode = self._reductionRequestView.useLiteMode()
+        self.liveDataMode = self._reductionRequestView.liveDataMode()
+        self.liveDataDuration = self._reductionRequestView.liveDataDuration()
         self.pixelMasks = self._reconstructPixelMaskNames(self._reductionRequestView.getPixelMasks())
+
+        # Set status to indicate the normal reduction workflow.
+        # (This will be overridden in several cases, including the use of artificial normalization.)
+        self.setStatus(ReductionStatus.REDUCING_DATA)
 
         # Use one timestamp for the entire set of runNumbers:
         self.timestamp = self.request(path="reduction/getUniqueTimestamp").data
 
-        # all runs in same state, use the first run to load groupings
+        # All runs are from the same state, use the first run to load groupings.
         request_ = self._createReductionRequest(self.runNumbers[0])
         response = self.request(path="reduction/groupings", payload=request_)
         self._keeps = set(response.data["groupingWorkspaces"])
+
+        # Reload the lite-grouping-map only when necessary.
+        self._keeps.add(wng.liteDataMap().build())
 
         # Validate reduction; if artificial normalization is needed, handle it
         # NOTE: this logic ONLY works because we are forbidding mixed cases of artnorm or loaded norm
         response = self.request(path="reduction/validate", payload=request_)
 
-        # get the calibration and normalization versions for all runs to be processed
+        # Get the calibration and normalization versions for all runs to be processed
         matchRequest = MatchRunsRequest(runNumbers=self.runNumbers, useLiteMode=self.useLiteMode)
         loadedCalibrations, calVersions = self.request(path="calibration/fetchMatches", payload=matchRequest).data
         loadedNormalizations, normVersions = self.request(path="normalization/fetchMatches", payload=matchRequest).data
@@ -215,33 +465,39 @@ class ReductionWorkflow(WorkflowImplementer):
                     "single run at a time.  Please clear your run list and try again."
                 )
             for runNumber in self.runNumbers:
+                # Set status to indicate that the artificial normalization is being calculated.
+                self.setStatus(ReductionStatus.CALCULATING_NORM)
+
                 self._artificialNormalizationView.updateRunNumber(runNumber)
                 self._artificialNormalizationView.showAdjustView()
+
                 request_ = self._createReductionRequest(runNumber)
                 response = self.request(path="reduction/grabWorkspaceforArtificialNorm", payload=request_)
                 self._artificialNormalization(workflowPresenter, response.data, runNumber)
         else:
             for runNumber in self.runNumbers:
                 self._artificialNormalizationView.showSkippedView()
+
                 request_ = self._createReductionRequest(runNumber)
                 response = self.request(path="reduction/", payload=request_)
                 if response.code == ResponseCode.OK:
                     self._finalizeReduction(response.data.record, response.data.unfocusedData)
+
                 # after each run, clean workspaces except groupings, calibrations, normalizations, and outputs
                 self._keeps.update(self.outputs)
                 self._clearWorkspaces(exclude=self._keeps, clearCachedWorkspaces=True)
-            workflowPresenter.advanceWorkflow()
-        # SPECIAL FOR THE REDUCTION WORKFLOW: clear everything _except_ the output workspaces
-        #   _before_ transitioning to the "save" panel.
-        # TODO: make '_clearWorkspaces' a public method (i.e make this combination a special `cleanup` method).
 
-        # NOTE: should this not occur in the 'finalizeReduction' method?
-        # self._clearWorkspaces(exclude=self.outputs, clearCachedWorkspaces=True)
+            workflowPresenter.advanceWorkflow()
+
         return self.responses[-1]
 
     def _artificialNormalization(self, workflowPresenter, responseData, runNumber):
         """Handles artificial normalization for the workflow."""
         view = workflowPresenter.widget.tabView  # noqa: F841
+
+        # Set status to indicate that the artificial normalization is being calculated.
+        self.setStatus(ReductionStatus.CALCULATING_NORM)
+
         request_ = CreateArtificialNormalizationRequest(
             runNumber=runNumber,
             useLiteMode=self.useLiteMode,
@@ -252,6 +508,7 @@ class ReductionWorkflow(WorkflowImplementer):
             diffractionWorkspace=responseData,
             outputWorkspace=wng.artificialNormalizationPreview().runNumber(runNumber).group(wng.Groups.COLUMN).build(),
         )
+
         response = self.request(path="reduction/artificialNormalization", payload=request_)
         # Update artificial normalization view with the response
         if response.code == ResponseCode.OK:
@@ -280,46 +537,67 @@ class ReductionWorkflow(WorkflowImplementer):
         )
 
         response = self.request(path="reduction/artificialNormalization", payload=request_)
+
+        #
+        # TODO: why isn't this checking that the request actually succeeded?
+        #   More significantly, why isn't this entire method just a call to `self._artificialNormalization`?
+        #   (Or, if that's an issue, `self._artificialNormalization` should just include a call to this method.)
+        #
+
         self._artificialNormalizationView.updateWorkspaces(diffractionWorkspace, response.data)
         self._artificialNormalizationView.enableRecalculateButton()
 
     def _continueWithNormalization(self, workflowPresenter):  # noqa: ARG002
         """Continues the workflow using the artificial normalization workspace."""
+
+        # Indicate that we're back to the normal reduction workflow.
+        self.setStatus(ReductionStatus.REDUCING_DATA)
+
         artificialNormIngredients = ArtificialNormalizationIngredients(
             peakWindowClippingSize=self._artificialNormalizationView.getPeakWindowClippingSize(),
             smoothingParameter=self._artificialNormalizationView.getSmoothingParameter(),
             decreaseParameter=self._artificialNormalizationView.getDecreaseParameter(),
             lss=self._artificialNormalizationView.getLSS(),
         )
-        pixelMasks = self._reconstructPixelMaskNames(self._reductionRequestView.getPixelMasks())
-        timestamp = self.request(path="reduction/getUniqueTimestamp").data
 
-        request_ = ReductionRequest(
-            runNumber=str(self._artificialNormalizationView.fieldRunNumber.text()),
-            useLiteMode=self._reductionRequestView.liteModeToggle.getState(),
-            timestamp=timestamp,
-            continueFlags=self.continueAnywayFlags,
-            pixelMasks=pixelMasks,
-            keepUnfocused=self._reductionRequestView.retainUnfocusedDataCheckbox.isChecked(),
-            convertUnitsTo=self._reductionRequestView.convertUnitsDropdown.currentText(),
+        # Here we use the standardized `_createReductionRequest` method.
+        # We do NOT set a new timestamp,
+        #   nor do we re-initialize any other values "by hand" that may have nothing to do
+        #   with this artificial normalization step.
+        request_ = self._createReductionRequest(
+            runNumber=self._artificialNormalizationView.fieldRunNumber.text(),
             artificialNormalizationIngredients=artificialNormIngredients,
         )
-
         response = self.request(path="reduction/", payload=request_)
+
         if response.code == ResponseCode.OK:
             record, unfocusedData = response.data.record, response.data.unfocusedData
             self._finalizeReduction(record, unfocusedData)
+
+        # In addition to clean up, this next `_clearWorkspaces` step symmetrizes the requests / responses queue between
+        #   the <has normalization> and <artificial normalization> cases.  So, if you need to remove it,
+        #   please adjust the `_cycleLiveData` `lastReductionRequest` and `lastReductionResponse` accordingly!
+
+        # After each run, clean workspaces except groupings, calibrations, normalizations, and outputs
+        self._keeps.update(self.outputs)
+        self._clearWorkspaces(exclude=self._keeps, clearCachedWorkspaces=True)
 
         return self.responses[-1]
 
     def _finalizeReduction(self, record, unfocusedData):
         """Handles post-reduction tasks, including saving and workspace management."""
-        self.savePath = self.request(path="reduction/getSavePath", payload=record.runNumber).data
+
+        self.setStatus(ReductionStatus.FINALIZING)
+
         # Save the reduced data. (This is automatic: it happens before the "save" panel opens.)
-        if ContinueWarning.Type.NO_WRITE_PERMISSIONS not in self.continueAnywayFlags:
-            self.request(path="reduction/save", payload=ReductionExportRequest(record=record))
-            # Retain the output workspaces after the workflow is complete.
+        if not self.liveDataMode:
+            self.savePath = self.request(path="reduction/getSavePath", payload=record.runNumber).data
+            if ContinueWarning.Type.NO_WRITE_PERMISSIONS not in self.continueAnywayFlags:
+                self.request(path="reduction/save", payload=ReductionExportRequest(record=record))
+
+        # Retain the output workspaces after the workflow is complete.
         self.outputs.extend(record.workspaceNames)
+
         # Also retain the unfocused data after the workflow is complete (if the box was checked),
         #   but do not actually save it as part of the reduction-data file.
         # The unfocused data does not get added to the response.workspaces list.

--- a/src/snapred/ui/workflow/WorkflowBuilder.py
+++ b/src/snapred/ui/workflow/WorkflowBuilder.py
@@ -1,4 +1,3 @@
-from snapred.meta.Config import Config
 from snapred.ui.model.WorkflowNodeModel import WorkflowNodeModel
 from snapred.ui.widget.Workflow import Workflow
 
@@ -11,15 +10,15 @@ class WorkflowBuilder:
         iterateLambda=None,
         resetLambda=None,
         cancelLambda=None,
+        completeWorkflowLambda=None,
         parent=None,
-        completionMessageLambda=lambda: Config["ui.default.workflow.completionMessage"],
     ):
         self.parent = parent
         self._startLambda = startLambda
         self._iterateLambda = iterateLambda
         self._resetLambda = resetLambda
         self._cancelLambda = cancelLambda
-        self._completionMessageLambda = completionMessageLambda
+        self._completeWorkflowLambda = completeWorkflowLambda
         self._workflow = None
 
     def addNode(
@@ -57,6 +56,6 @@ class WorkflowBuilder:
             iterateLambda=self._iterateLambda,
             resetLambda=self._resetLambda,
             cancelLambda=self._cancelLambda,
-            completionMessageLambda=self._completionMessageLambda,
+            completeWorkflowLambda=self._completeWorkflowLambda,
             parent=self.parent,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,7 +135,9 @@ from util.state_helpers import state_root_fixture
 from util.IPTS_override import IPTS_override_fixture
 from util.Config_helpers import Config_override_fixture
 from util.pytest_helpers import (
+    calibration_home_from_mirror,
     cleanup_workspace_at_exit,
     cleanup_class_workspace_at_exit,
     get_unique_timestamp,
+    reduction_home_from_mirror
 )

--- a/tests/integration/test_normalization.py
+++ b/tests/integration/test_normalization.py
@@ -150,7 +150,7 @@ class TestNormalizationPanels:
 
             requestView = workflowNodeTabs.currentWidget().view
             assert isinstance(requestView, NormalizationRequestView)
-            requestView.litemodeToggle.setState(False)
+            requestView.liteModeToggle.setState(False)
             self.testSummary.SUCCESS()
 
             # Verify tweak peak and save tabs are disabled
@@ -203,7 +203,11 @@ class TestNormalizationPanels:
             mpCrit = MockQMessageBox().critical(msg)
             with mpCrit[0]:
                 requestView.runNumberField.setText("58810")
+                qtbot.keyClick(requestView.runNumberField._field, Qt.Key_Return)
                 requestView.backgroundRunNumberField.setText("58813")
+                qtbot.keyClick(requestView.backgroundRunNumberField._field, Qt.Key_Return)
+                qapp.processEvents()
+
                 qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
                 qtbot.wait(100)
                 # Verify error msg box to select sample shows up

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -8,6 +8,9 @@ orchestration:
   path:
     delimiter: /
 
+facility:
+  name: SNS
+
 instrument:
   name: SNAP
   # "instrument.home" is overridden in "test.yml":
@@ -46,9 +49,50 @@ instrument:
       file: ${module.root}/resources/inputs/pixel_grouping/SNAPLite_Definition.xml
     map:
       file: ${instrument.calibration.home}/Powder/LiteGroupMap.hdf
+
+  PVLogs:
+    # Swap these when running with ultralite data
+    rootGroup: "entry/DASlogs"
+    # rootGroup: "mantid_workspace_1/logs"
+
+    # PV-log keys relating to instrument settings:
+    instrumentKeys:
+    - "BL3:Chop:Gbl:WavelengthReq"
+    - "BL3:Chop:Skf1:WavelengthUserReq"
+    - "det_arc1"
+    - "det_arc2"
+    - "BL3:Det:TH:BL:Frequency"
+    - "BL3:Mot:OpticsPos:Pos"
+    - "det_lin1"
+    - "det_lin2"
+
   startingRunNumber: 10000
   minimumRunNumber: 46342
   maxNumberOfRuns: 10
+
+liveData:
+  # Override 'liveData.facility' and 'liveData.instrument'
+  #   in order to use the mock listener for testing
+  #   without overriding the real instrument.
+  facility:
+    name: ${facility.name}
+    # name: TEST_LIVE
+  instrument:
+    name: ${instrument.name}
+    # name: ADARA_FileReader
+  accumulationMethod: Replace
+  testInput:
+    inputFilename: SNAP_46680.nxs.h5
+    # WARNING: "chunks" seems a bit glitchy:
+    #   event workspaces are not loaded uniformly with respect to
+    #   event _pixel_ assignment.
+    # For thorough testing "1" might actually be the best value!
+    chunks: 1 # 50
+
+  # Update-interval slider limits and position in seconds.
+  updateIntervalMinimum: 60
+  updateIntervalDefault: 120
+  updateIntervalMaximum: 900
 
 nexus:
   lite:
@@ -115,6 +159,7 @@ mantid:
         delimiter: "_"
         template:
           run: "_{unit},{group},{lite},{auxiliary},{runNumber}"
+          liteDataMap: "lite_grouping_map"
           diffCal:
             input: "_{unit},{runNumber},raw"
             table: "_diffract_consts,{runNumber},{version}"
@@ -216,9 +261,6 @@ constants:
   PeakIntensityFractionThreshold: 0.05
   m2cm: 10000.0 # conversion factor for m^2 to cm^2
   maskedPixelThreshold: 0.15
-  # Swap these when running with ultralite data
-  logsLocation: "entry/DASlogs"
-  # logsLocation: "/mantid_workspace_1/logs"
 
   CrystallographicInfo:
     crystalDMin: 0.4

--- a/tests/resources/integration_test.yml
+++ b/tests/resources/integration_test.yml
@@ -12,7 +12,6 @@ IPTS:
 constants:
   # For tests with '46680' this seems to be necessary.
   maskedPixelThreshold: 1.0
-  logsLocation: "/mantid_workspace_1/logs"
 
   DetectorPeakPredictor:
     fwhm: 1.17741002252 # used to convert gaussian to fwhm (2 * log_e(2))
@@ -32,6 +31,22 @@ instrument:
       file: ${module.root}/resources/ultralite/CRACKLELite_Definition.xml
     map:
       file: ${module.root}/resources/ultralite/CRACKLELiteDataMap.xml
+
+  PVLogs:
+    # Swap these when running with ultralite data
+    # rootGroup: "entry/DASlogs"
+    rootGroup: "/mantid_workspace_1/logs"
+
+    # PV-log keys relating to instrument settings:
+    instrumentPVKeys:
+    - "BL3:Chop:Gbl:WavelengthReq"
+    - "BL3:Chop:Skf1:WavelengthUserReq"
+    - "det_arc1"
+    - "det_arc2"
+    - "BL3:Det:TH:BL:Frequency"
+    - "BL3:Mot:OpticsPos:Pos"
+    - "det_lin1"
+    - "det_lin2"
 
 mantid:
   workspace:

--- a/tests/unit/backend/dao/test_DetectorState.py
+++ b/tests/unit/backend/dao/test_DetectorState.py
@@ -5,22 +5,33 @@ from snapred.backend.dao.state.DetectorState import DetectorState
 
 
 class TestDetectorstate(unittest.TestCase):
-    def test_getLogValues(self):
-        exp = {
-            "det_lin1": "1.0",
-            "det_lin2": "1.1",
-            "det_arc1": "2.2",
-            "det_arc2": "2.3",
-            "BL3:Chop:Skf1:WavelengthUserReq": "3.4",
-            "BL3:Det:TH:BL:Frequency": "4.5",
-            "BL3:Mot:OpticsPos:Pos": "2",
+    def setUp(self):
+        self.logs = {
+            "det_lin1": (1.0,),
+            "det_lin2": (1.1,),
+            "det_arc1": (2.2,),
+            "det_arc2": (2.3,),
+            "BL3:Chop:Skf1:WavelengthUserReq": (3.4,),
+            "BL3:Det:TH:BL:Frequency": (4.5,),
+            "BL3:Mot:OpticsPos:Pos": (2,),
         }
-        detectorState = DetectorState.constructFromLogValues(exp)
-        assert detectorState.arc[0] == float(exp["det_arc1"])
-        assert detectorState.arc[1] == float(exp["det_arc2"])
-        assert detectorState.lin[0] == float(exp["det_lin1"])
-        assert detectorState.lin[1] == float(exp["det_lin2"])
-        assert detectorState.wav == float(exp["BL3:Chop:Skf1:WavelengthUserReq"])
-        assert detectorState.freq == float(exp["BL3:Det:TH:BL:Frequency"])
-        assert detectorState.guideStat == float(exp["BL3:Mot:OpticsPos:Pos"])
-        assert exp == detectorState.getLogValues()
+        self.detectorState = DetectorState(
+            lin=(self.logs["det_lin1"][0], self.logs["det_lin2"][0]),
+            arc=(self.logs["det_arc1"][0], self.logs["det_arc2"][0]),
+            wav=self.logs["BL3:Chop:Skf1:WavelengthUserReq"][0],
+            freq=self.logs["BL3:Det:TH:BL:Frequency"][0],
+            guideStat=self.logs["BL3:Mot:OpticsPos:Pos"][0],
+        )
+
+    def test_fromLogs(self):
+        detectorState = DetectorState.fromLogs(self.logs)
+        assert detectorState.arc[0] == self.logs["det_arc1"][0]
+        assert detectorState.arc[1] == self.logs["det_arc2"][0]
+        assert detectorState.lin[0] == self.logs["det_lin1"][0]
+        assert detectorState.lin[1] == self.logs["det_lin2"][0]
+        assert detectorState.wav == self.logs["BL3:Chop:Skf1:WavelengthUserReq"][0]
+        assert detectorState.freq == self.logs["BL3:Det:TH:BL:Frequency"][0]
+        assert detectorState.guideStat == self.logs["BL3:Mot:OpticsPos:Pos"][0]
+
+    def test_toLogs(self):
+        assert self.logs == self.detectorState.toLogs()

--- a/tests/unit/backend/dao/test_GroceryListBuilder.py
+++ b/tests/unit/backend/dao/test_GroceryListBuilder.py
@@ -1,6 +1,7 @@
 # ruff: noqa: E722, PT011, PT012
-
+# Add test-related imports last.
 import unittest
+from datetime import timedelta
 
 import pytest
 from mantid.simpleapi import (
@@ -9,6 +10,7 @@ from mantid.simpleapi import (
 )
 from pydantic import ValidationError
 
+from snapred.backend.dao.ingredients.GroceryListItem import LiveDataArgs
 from snapred.meta.builder.GroceryListBuilder import GroceryListBuilder
 from snapred.meta.Config import Resource
 
@@ -57,6 +59,11 @@ class TestGroceryListBuilder(unittest.TestCase):
             assert item.runNumber == self.runNumber
             assert item.useLiteMode == useLite
             assert item.workspaceType == "neutron"
+
+    def test_nexus_liveData(self):
+        duration = timedelta(seconds=123)
+        item = GroceryListBuilder().neutron(self.runNumber).native().liveData(duration=duration).build()
+        assert item.liveDataArgs == LiveDataArgs(duration=duration)
 
     def test_nexus_propname(self):
         propertyName = "inputWorkspace"

--- a/tests/unit/backend/dao/test_VersionedObject.py
+++ b/tests/unit/backend/dao/test_VersionedObject.py
@@ -211,7 +211,7 @@ def recordWithVersion(version):
         version=version,
         runNumber="xyz",
         useLiteMode=True,
-        calculationParameters=CalculationParameters.construct(),
+        calculationParameters=CalculationParameters.model_construct(),
     )
 
 

--- a/tests/unit/backend/data/test_Indexer.py
+++ b/tests/unit/backend/data/test_Indexer.py
@@ -3,7 +3,11 @@
 import importlib
 import logging
 import tempfile
+
+# Place test-specific imports after other required imports, in order to retain the import order
+#   as much as possible.
 import unittest
+from datetime import datetime
 from pathlib import Path
 from random import randint
 from typing import List
@@ -93,7 +97,7 @@ class TestIndexer(unittest.TestCase):
             instrumentState=self.instrumentState,
             seedRun=randint(1000, 5000),
             useLiteMode=bool(randint(0, 1)),
-            creationDate=0,
+            creationDate=datetime.today().isoformat(),
             name="",
             version=version,
         )
@@ -535,10 +539,13 @@ class TestIndexer(unittest.TestCase):
         assert indexer.nextVersion() == here + 1
 
         record = self.record(here + 1)
-        # NOTE: Writing aribitrary records to disk is not allowed.
+        # NOTE: Writing arbitrary records to disk is not allowed.
         #       Our code should never produce an unindexed record.
         #       What value is there in writing a record that is
         #       inherently missing metadata supplied by the index?
+
+        # Which kind of suggests that that data should have been a part of the record, does it not?  :)
+
         with pytest.raises(ValueError, match=".*not found in index, please write an index entry first.*"):
             indexer.writeRecord(record)
 

--- a/tests/unit/backend/data/util/test_PV_logs_util.py
+++ b/tests/unit/backend/data/util/test_PV_logs_util.py
@@ -1,0 +1,310 @@
+##
+## In order to keep the rest of the import sequence unmodified: any test-related imports are added at the end.
+##
+import unittest
+from collections.abc import Iterable
+from unittest import mock
+
+import numpy as np
+import pytest
+from mantid.simpleapi import (
+    CreateSampleWorkspace,
+    DeleteWorkspace,
+    DeleteWorkspaces,
+    LoadInstrument,
+    mtd,
+)
+from util.dao import DAOFactory
+from util.instrument_helpers import addInstrumentLogs, getInstrumentLogDescriptors
+
+from snapred.backend.dao.state import DetectorState
+from snapred.backend.data.util.PV_logs_util import *
+from snapred.meta.Config import Config, Resource
+
+
+class TestTransferInstrumentPVLogs(unittest.TestCase):
+    @classmethod
+    def createSampleWorkspace(cls):
+        wsName = mtd.unique_hidden_name()
+        CreateSampleWorkspace(
+            OutputWorkspace=wsName,
+            # WorkspaceType="Histogram",
+            Function="User Defined",
+            UserDefinedFunction="name=Gaussian,Height=10,PeakCentre=1.2,Sigma=0.2",
+            Xmin=0,
+            Xmax=5,
+            BinWidth=0.001,
+            XUnit="dSpacing",
+            NumBanks=4,  # must produce same number of pixels as fake instrument
+            BankPixelWidth=2,  # each bank has 4 pixels, 4 banks, 16 total
+        )
+        LoadInstrument(
+            Workspace=wsName,
+            Filename=Resource.getPath("inputs/testInstrument/fakeSNAP_Definition.xml"),
+            RewriteSpectraMap=True,
+        )
+        return wsName
+
+    def setUp(self):
+        self.wsWithStandardLogs = self.createSampleWorkspace()
+
+        # Add the standard instrument PV-logs to the workspace's `Run` attribute.
+        self.detectorState = DAOFactory.real_detector_state
+        self.instrumentKeys = [
+            k for k in Config["instrument.PVLogs.instrumentKeys"] if k != "BL3:Chop:Gbl:WavelengthReq"
+        ]
+        logsDescriptors = getInstrumentLogDescriptors(self.detectorState)
+        addInstrumentLogs(self.wsWithStandardLogs, **logsDescriptors)
+        self.standardLogs = dict(zip(logsDescriptors["logNames"], logsDescriptors["logValues"]))
+
+        # Add the alterate instrument PV-logs.
+        self.wsWithAlternateLogs = self.createSampleWorkspace()
+        self.alternateInstrumentKeys = [
+            k for k in Config["instrument.PVLogs.instrumentKeys"] if k != "BL3:Chop:Skf1:WavelengthUserReq"
+        ]
+        logsDescriptors["logNames"] = [
+            k if k != "BL3:Chop:Skf1:WavelengthUserReq" else "BL3:Chop:Gbl:WavelengthReq"
+            for k in logsDescriptors["logNames"]
+        ]
+        addInstrumentLogs(self.wsWithAlternateLogs, **logsDescriptors)
+        self.alternateLogs = dict(zip(logsDescriptors["logNames"], logsDescriptors["logValues"]))
+
+    def tearDown(self):
+        DeleteWorkspaces(WorkspaceList=[self.wsWithStandardLogs, self.wsWithAlternateLogs])
+
+    def test_Config_keys(self):
+        # Verify that the standard instrument PV-logs have been attached to the test workspace.
+        # (This test additionally verifies that the `addInstrumentLogs` interface is using the keys from `Config`.)
+        run = mtd[self.wsWithStandardLogs].run()
+        for key in Config["instrument.PVLogs.instrumentKeys"]:
+            if key == "BL3:Chop:Gbl:WavelengthReq":
+                continue
+            assert run.hasProperty(key)
+            assert f"{run.getProperty(key).value[0]:.16f}" == self.standardLogs[key]
+
+        # Verify the test workspace with the alternate instrument PV-logs.
+        run = mtd[self.wsWithAlternateLogs].run()
+        for key in Config["instrument.PVLogs.instrumentKeys"]:
+            if key == "BL3:Chop:Skf1:WavelengthUserReq":
+                continue
+            assert run.hasProperty(key)
+            assert f"{run.getProperty(key).value[0]:.16f}" == self.alternateLogs[key]
+
+    def verify_transfer(self, srcWs: str, keys: Iterable, alternateKeys: Iterable):
+        testWs = self.createSampleWorkspace()
+        ws = mtd[testWs]
+        for key in keys:
+            assert not ws.run().hasProperty(key)
+
+        transferInstrumentPVLogs(mtd[testWs].mutableRun(), mtd[srcWs].run(), keys)
+        populateInstrumentParameters(testWs)
+
+        run = mtd[testWs].run()
+        srcRun = mtd[srcWs].run()
+
+        # Verify the log transfer.
+        for key in keys:
+            assert run.hasProperty(key)
+            assert run.getProperty(key).value == srcRun.getProperty(key).value
+
+        # Verify that there are no extra "alternate" entries.
+        for key in alternateKeys:
+            if key not in keys:
+                assert not run.hasProperty(key)
+
+        DeleteWorkspace(testWs)
+
+    def test_transfer(self):
+        self.verify_transfer(self.wsWithStandardLogs, self.instrumentKeys, self.alternateInstrumentKeys)
+
+    def test_alternate_transfer(self):
+        self.verify_transfer(self.wsWithAlternateLogs, self.alternateInstrumentKeys, self.instrumentKeys)
+
+    def test_instrument_update(self):
+        # The PV-logs are transferred between the workspace's `Run` attributes.
+        # Any change in an instrument-related PV-log must also be _applied_ as a transformation
+        # to the workspace's parameterized instrument.
+        # This test verifies that, following a logs transfer, such an update works correctly.
+
+        testWs = self.createSampleWorkspace()
+
+        # Verify that [some of the] detector pixels of the standard source workspace have been moved
+        #   from their original locations. Here, we don't care about the specifics of the transformation.
+        originalPixels = mtd[testWs].detectorInfo()
+        sourcePixels = mtd[self.wsWithStandardLogs].detectorInfo()
+        instrumentUpdateApplied = False
+        for n in range(sourcePixels.size()):
+            if sourcePixels.position(n) != originalPixels.position(n) or sourcePixels.rotation(
+                n
+            ) != originalPixels.rotation(n):
+                instrumentUpdateApplied = True
+                break
+        assert instrumentUpdateApplied
+
+        transferInstrumentPVLogs(mtd[testWs].mutableRun(), mtd[self.wsWithStandardLogs].run(), self.instrumentKeys)
+        populateInstrumentParameters(testWs)
+
+        # Verify that the same instrument transformation
+        #   has been applied to the source and to the destination workspace.
+        newPixels = mtd[testWs].detectorInfo()
+        sourcePixels = mtd[self.wsWithStandardLogs].detectorInfo()
+        instrumentUpdateApplied = True
+        for n in range(sourcePixels.size()):
+            # If these don't match _exactly_, then the values have not been transferred at full precision.
+            if newPixels.position(n) != sourcePixels.position(n) or newPixels.rotation(n) != sourcePixels.rotation(n):
+                instrumentUpdateApplied = False
+                break
+        assert instrumentUpdateApplied
+
+
+class TestMappingFromRun(unittest.TestCase):
+    def setUp(self):
+        self.wsName = mtd.unique_hidden_name()
+        CreateSampleWorkspace(
+            OutputWorkspace=self.wsName,
+            # WorkspaceType="Histogram",
+            Function="User Defined",
+            UserDefinedFunction="name=Gaussian,Height=10,PeakCentre=1.2,Sigma=0.2",
+            Xmin=0,
+            Xmax=5,
+            BinWidth=0.001,
+            XUnit="dSpacing",
+            NumBanks=4,  # must produce same number of pixels as fake instrument
+            BankPixelWidth=2,  # each bank has 4 pixels, 4 banks, 16 total
+        )
+        LoadInstrument(
+            Workspace=self.wsName,
+            Filename=Resource.getPath("inputs/testInstrument/fakeSNAP_Definition.xml"),
+            RewriteSpectraMap=True,
+        )
+        self.ws = mtd[self.wsName]
+
+    def tearDown(self):
+        DeleteWorkspace(self.wsName)
+
+    def test_init(self):
+        map_ = mappingFromRun(self.ws.getRun())  # noqa: F841
+
+    def test_get_item(self):
+        map_ = mappingFromRun(self.ws.getRun())
+
+        assert map_["run_title"] == "Test Workspace"
+        assert map_["start_time"] == np.datetime64("2010-01-01T00:00:00", "ns")
+        assert map_["end_time"] == np.datetime64("2010-01-01T01:00:00", "ns")
+
+    def test_iter(self):
+        map_ = mappingFromRun(self.ws.getRun())
+        assert [k for k in map_] == ["run_title", "start_time", "end_time", "run_start", "run_end"]
+
+    def test_len(self):
+        map_ = mappingFromRun(self.ws.getRun())
+        assert len(map_) == 5
+
+    @mock.patch("mantid.api.Run.hasProperty")
+    def test_contains(self, mockHasProperty):
+        mockHasProperty.return_value = True
+        map_ = mappingFromRun(self.ws.getRun())
+        assert "anything" in map_
+        mockHasProperty.assert_called_once_with("anything")
+
+    @mock.patch("mantid.api.Run.keys")
+    def test_keys(self, mockKeys):
+        mockKeys.return_value = ["we", "are", "the", "keys"]
+        map_ = mappingFromRun(self.ws.getRun())
+        assert map_.keys() == mockKeys.return_value
+        mockKeys.assert_called_once()
+
+
+class TestMappingFromNeXusLogs(unittest.TestCase):
+    def _mockPVFile(self, detectorState: DetectorState) -> mock.Mock:
+        # Note: `PV_logs_util.mappingFromNeXusLogs` will open the 'entry/DASlogs' group,
+        #   so this `dict` mocks the HDF5 group, not the PV-file itself.
+
+        dict_ = {
+            "BL3:Chop:Skf1:WavelengthUserReq/value": [detectorState.wav],
+            "det_arc1/value": [detectorState.arc[0]],
+            "det_arc2/value": [detectorState.arc[1]],
+            "BL3:Det:TH:BL:Frequency/value": [detectorState.freq],
+            "BL3:Mot:OpticsPos:Pos/value": [detectorState.guideStat],
+            "det_lin1/value": [detectorState.lin[0]],
+            "det_lin2/value": [detectorState.lin[1]],
+        }
+
+        def del_item(key: str):
+            # bypass <class>.__delitem__
+            del dict_[key]
+
+        mock_ = mock.MagicMock(spec=h5py.Group)
+
+        mock_.get = lambda key, default=None: dict_.get(key, default)
+        mock_.del_item = del_item
+
+        # Use of the h5py.File starts with access to the "entry/DASlogs" group:
+        mock_.__getitem__.side_effect = lambda key: mock_ if key == "entry/DASlogs" else dict_[key]
+
+        mock_.__setitem__.side_effect = dict_.__setitem__
+        mock_.__contains__.side_effect = dict_.__contains__
+        mock_.keys.side_effect = dict_.keys
+        return mock_
+
+    def setUp(self):
+        self.detectorState = DetectorState(arc=(1.0, 2.0), wav=1.1, freq=1.2, guideStat=1, lin=(1.0, 2.0))
+        self.mockPVFile = self._mockPVFile(self.detectorState)
+
+    def tearDown(self):
+        pass
+
+    def test_init(self):
+        map_ = mappingFromNeXusLogs(self.mockPVFile)  # noqa: F841
+
+    def test_get_item(self):
+        map_ = mappingFromNeXusLogs(self.mockPVFile)
+        assert map_["BL3:Chop:Skf1:WavelengthUserReq"][0] == 1.1
+
+    def test_get_item_key_error(self):
+        map_ = mappingFromNeXusLogs(self.mockPVFile)
+        with pytest.raises(KeyError, match="something else"):
+            map_["something else"]
+
+    def test_iter(self):
+        map_ = mappingFromNeXusLogs(self.mockPVFile)
+
+        # For each key, the ending "/value" should have been removed
+        assert [k for k in map_] == [
+            "BL3:Chop:Skf1:WavelengthUserReq",
+            "det_arc1",
+            "det_arc2",
+            "BL3:Det:TH:BL:Frequency",
+            "BL3:Mot:OpticsPos:Pos",
+            "det_lin1",
+            "det_lin2",
+        ]
+
+    def test_len(self):
+        map_ = mappingFromNeXusLogs(self.mockPVFile)
+        assert len(map_) == 7
+
+    def test_contains(self):
+        map_ = mappingFromNeXusLogs(self.mockPVFile)
+        assert "BL3:Chop:Skf1:WavelengthUserReq" in map_
+        self.mockPVFile.__contains__.assert_called_once_with("BL3:Chop:Skf1:WavelengthUserReq/value")
+
+    def test_contains_False(self):
+        map_ = mappingFromNeXusLogs(self.mockPVFile)
+        assert "anything" not in map_
+        self.mockPVFile.__contains__.assert_called_once_with("anything/value")
+
+    def test_keys(self):
+        map_ = mappingFromNeXusLogs(self.mockPVFile)
+
+        # For each key, the ending "/value" should have been removed
+        assert map_.keys() == [
+            "BL3:Chop:Skf1:WavelengthUserReq",
+            "det_arc1",
+            "det_arc2",
+            "BL3:Det:TH:BL:Frequency",
+            "BL3:Mot:OpticsPos:Pos",
+            "det_lin1",
+            "det_lin2",
+        ]
+        self.mockPVFile.keys.assert_called_once()

--- a/tests/unit/backend/error/test_LiveDataState.py
+++ b/tests/unit/backend/error/test_LiveDataState.py
@@ -1,0 +1,55 @@
+# Test-related imports go last:
+import pytest
+
+from snapred.backend.error.LiveDataState import LiveDataState
+
+
+def test_LiveDataState():
+    # all properties are initialized correctly
+    state = LiveDataState("message", LiveDataState.Type.RUN_START, "12345", "0")
+    assert state.message == "message"
+    assert state.transition == LiveDataState.Type.RUN_START
+    assert state.endRunNumber == "12345"
+    assert state.startRunNumber == "0"
+
+
+def test_LiveDataState_runStateTransition_start():
+    # a transition from "no run" state is recognized as a start of run
+    state = LiveDataState.runStateTransition("12345", "0")
+    assert state.message.startswith("start of run")
+    assert "12345" in state.message
+    assert "0" not in state.message
+
+
+def test_LiveDataState_runStateTransition_end():
+    # a transition to a "no run" state is recognized as an end of run
+    state = LiveDataState.runStateTransition("0", "12345")
+    assert state.message.startswith("end of run")
+    assert "12345" in state.message
+    assert "0" not in state.message
+
+
+def test_LiveDataState_runStateTransition_gap():
+    # a gap in run-number values, without an intervening "no run" state, is recognized
+    state = LiveDataState.runStateTransition("12346", "12345")
+    assert state.message.startswith("run-number gap:")
+    assert "12346" in state.message
+    assert "12345" in state.message
+
+
+def test_LiveDataState_runStateTransition_unexpected():
+    # all run numbers must be greater than zero
+    with pytest.raises(ValueError, match=r"unexpected run-state transition:.*"):
+        LiveDataState.runStateTransition("-1", "-2")
+
+
+def test_LiveDataState_runStateTransition_no_transition():
+    # start and end run numbers cannot be the same
+    with pytest.raises(ValueError, match=r"not a run-state transition:.*"):
+        LiveDataState.runStateTransition("12345", "12345")
+
+
+def test_LiveDataState_runStateTransition_invalid_transition():
+    # run numbers cannot decrease, except to zero
+    with pytest.raises(ValueError, match=r"not a run-state transition:.*"):
+        LiveDataState.runStateTransition("12344", "12345")

--- a/tests/unit/backend/error/test_UserCancellation.py
+++ b/tests/unit/backend/error/test_UserCancellation.py
@@ -1,0 +1,17 @@
+# Test-related imports go last:
+
+from snapred.backend.error.UserCancellation import UserCancellation
+
+
+def test_UserCancellation():
+    msg = "User cancellation request"
+    e = UserCancellation(msg)
+    assert e.message == msg
+
+
+def test_UserCancellation_parse_raw():
+    msg = "User cancellation request"
+    raw = f'{{"message": "{msg}"}}'
+    e = UserCancellation.parse_raw(raw)
+    assert e.message == msg
+    assert isinstance(e, UserCancellation)

--- a/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
@@ -74,7 +74,7 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
     @classmethod
     def tearDownClass(cls) -> None:
         """
-        Delete all workspaces created by this test, and remove the ceated filed.
+        Delete all workspaces created by this test, and remove any created files.
         This is run once at the end of this test suite.
         """
         for ws in mtd.getObjectNames():
@@ -279,4 +279,4 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         assert algo.execute()
         algo.mantidSnapper.LoadGroupingDefinition.assert_called_once()
         assert algo.mantidSnapper.mtd.doesExist.call_count == 2
-        assert algo.mantidSnapper.executeQueue.call_count == 2
+        assert algo.mantidSnapper.executeQueue.call_count == 1

--- a/tests/unit/backend/recipe/test_Recipe.py
+++ b/tests/unit/backend/recipe/test_Recipe.py
@@ -70,13 +70,18 @@ class RecipeTest(unittest.TestCase):
         badIngredients = {"nothing": 0}
         with pytest.raises(ValueError, match="Ingredients must be a Pydantic BaseModel."):
             recipe.validateInputs(badIngredients, groceries)
-        badGroceries = {"ws": mtd.unique_name(prefix="bad")}
+        propertyName = "ws"
+        badGroceries = {propertyName: mtd.unique_name(prefix="bad")}
         with pytest.raises(
-            RuntimeError, match=f"The indicated workspace {badGroceries['ws']} not found in Mantid ADS."
+            RuntimeError,
+            match=f"The required workspace property for key '{propertyName}': "
+            + f"'{badGroceries[propertyName]}' was not found in the Mantid ADS.",
         ):
             recipe.validateInputs(ingredients, badGroceries)
         worseGroceries = {}
-        with pytest.raises(RuntimeError, match="The workspace property ws was not found in the groceries"):
+        with pytest.raises(
+            RuntimeError, match=f"The required workspace property '{propertyName}' was not found in the grocery list"
+        ):
             recipe.validateInputs(ingredients, worseGroceries)
         tooManyGroceries = {"ws": groceries["ws"], "another": groceries["ws"]}
         with pytest.raises(ValueError, match=r".*invalid keys.*"):
@@ -86,7 +91,7 @@ class RecipeTest(unittest.TestCase):
         groceries = self._make_groceries()
         recipe = DummyRecipe()
 
-        with pytest.raises(ValueError, match="The key for the grocery must be a string."):
+        with pytest.raises(ValueError, match=r"The keys for the grocery list must be strings, not.*"):
             recipe._validateGrocery(123, groceries["ws"])
 
     def test_validate_ingredients_fail(self):

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -46,7 +46,7 @@ from snapred.backend.dao.StateConfig import StateConfig
 from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.meta.builder.GroceryListBuilder import GroceryListBuilder
 from snapred.meta.Config import Config
-from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName, WorkspaceType
+from snapred.meta.mantid.WorkspaceNameGenerator import NameBuilder, WorkspaceName, WorkspaceType
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceType as wngt
 from snapred.meta.redantic import parse_file_as
@@ -435,6 +435,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             ),
             createRecordRequest=CreateCalibrationRecordRequest(**record.model_dump()),
         )
+
         with state_root_redirect(self.localDataService) as tmpRoot:
             self.instance.save(request)
             savedRecord = parse_file_as(
@@ -601,10 +602,10 @@ class TestCalibrationServiceMethods(unittest.TestCase):
     def test_load_quality_assessment_dsp_and_diag(self):
         calibRecord = DAOFactory.calibrationRecord(
             workspaces={
-                "diffCalOutput": ["_dsp_diffoc_057514"],
-                "diffCalDiagnostic": ["_diagnostic_diffoc_057514"],
-                "diffCalTable": ["_diffract_consts_057514"],
-                "diffCalMask": ["_diffract_consts_mask_057514"],
+                wngt.DIFFCAL_OUTPUT: ["_dsp_diffoc_057514"],
+                wngt.DIFFCAL_DIAG: ["_diagnostic_diffoc_057514"],
+                wngt.DIFFCAL_TABLE: ["_diffract_consts_057514"],
+                wngt.DIFFCAL_MASK: ["_diffract_consts_mask_057514"],
             }
         )
         self.instance.dataFactoryService.getCalibrationRecord = mock.Mock(return_value=calibRecord)
@@ -627,10 +628,10 @@ class TestCalibrationServiceMethods(unittest.TestCase):
     def test_load_quality_assessment_unexpected_type(self):
         calibRecord = DAOFactory.calibrationRecord()
         calibRecord.workspaces = {
-            "diffCalOutput": ["_dsp_diffoc_057514"],
-            "diffCalTable": ["_diffract_consts_057514"],
-            "diffCalMask": ["_diffract_consts_mask_057514"],
-            "rawVanadium": ["_unexpected_workspace_type"],
+            wngt.DIFFCAL_OUTPUT: ["_dsp_diffoc_057514"],
+            wngt.DIFFCAL_TABLE: ["_diffract_consts_057514"],
+            wngt.DIFFCAL_MASK: ["_diffract_consts_mask_057514"],
+            wngt.RAW_VANADIUM: ["_unexpected_workspace_type"],
         }
         self.instance.dataFactoryService.getCalibrationRecord = mock.Mock(return_value=calibRecord)
 
@@ -708,7 +709,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
     @mock.patch(thisService + "SimpleDiffCalRequest", spec_set=SimpleDiffCalRequest)
     def test_diffractionCalibration_calls_others(self, SimpleDiffCalRequest):
         # mock out external functionalties
-        SimpleDiffCalRequest.return_value = SimpleDiffCalRequest.construct(groceries={"previousCalibration": ""})
+        SimpleDiffCalRequest.return_value = SimpleDiffCalRequest.model_construct(groceries={"previousCalibration": ""})
         self.instance.dataFactoryService.getCifFilePath = mock.Mock(return_value="bundt/cake.egg")
         self.instance.dataExportService.getCalibrationStateRoot = mock.Mock(return_value=mock.sentinel.stateroot)
         self.instance.dataExportService.checkWritePermissions = mock.Mock(return_value=True)
@@ -762,7 +763,9 @@ class TestCalibrationServiceMethods(unittest.TestCase):
 
     @mock.patch(thisService + "SimpleDiffCalRequest")
     def test_diffractionCalibration_pixel_fail(self, mockSimpleDiffCalRequest):
-        mockSimpleDiffCalRequest.return_value = SimpleDiffCalRequest.construct(groceries={"previousCalibration": ""})
+        mockSimpleDiffCalRequest.return_value = SimpleDiffCalRequest.model_construct(
+            groceries={"previousCalibration": ""}
+        )
         self.instance.validateRequest = mock.Mock()
         mockPixelRxServing = mock.Mock(
             result=False,
@@ -774,14 +777,16 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         self.instance.pixelCalibration = mock.Mock(return_value=mockPixelRxServing)
 
         # Call the method with the provided parameters
-        request = DiffractionCalibrationRequest.construct()
+        request = DiffractionCalibrationRequest.model_construct()
         with pytest.raises(RuntimeError) as e:
             self.instance.diffractionCalibration(request)
         assert str(e.value) == "Pixel Calibration failed"
 
     @mock.patch(thisService + "SimpleDiffCalRequest")
     def test_diffractionCalibration_group_fail(self, mockSimpleDiffCalRequest):
-        mockSimpleDiffCalRequest.return_value = SimpleDiffCalRequest.construct(groceries={"previousCalibration": ""})
+        mockSimpleDiffCalRequest.return_value = SimpleDiffCalRequest.model_construct(
+            groceries={"previousCalibration": ""}
+        )
         self.instance.validateRequest = mock.Mock()
         mockPixelRxServing = mock.Mock(
             result=True,
@@ -801,20 +806,20 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         self.instance.groupCalibration = mock.Mock(return_value=mockGroupRxServing)
 
         # Call the method with the provided parameters
-        request = DiffractionCalibrationRequest.construct()
+        request = DiffractionCalibrationRequest.model_construct()
         with pytest.raises(RuntimeError) as e:
             self.instance.diffractionCalibration(request)
         assert str(e.value) == "Group Calibration failed"
 
     @mock.patch(thisService + "PixelDiffCalRecipe", spec_set=PixelDiffCalRecipe)
     def test_pixelCalibration_success(self, PixelRx):
-        mock.sentinel.result = PixelDiffCalServing.construct(
+        mock.sentinel.result = PixelDiffCalServing.model_construct(
             maskWorkspace=self.sampleMaskWS,
         )
         PixelRx().cook.return_value = mock.sentinel.result
 
         # Call the method with the provided parameters
-        request = SimpleDiffCalRequest.construct(
+        request = SimpleDiffCalRequest.model_construct(
             ingredients=mock.sentinel.ingredients,
             groceries=mock.sentinel.groceries,
         )
@@ -836,13 +841,13 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             maskWS.setY(pixel, [1.0])
 
         # mock out the return
-        mock.sentinel.result = PixelDiffCalServing.construct(
+        mock.sentinel.result = PixelDiffCalServing.model_construct(
             maskWorkspace=self.sampleMaskWS,
         )
         PixelRx().cook.return_value = mock.sentinel.result
 
         # Call the method with the provided parameters
-        request = SimpleDiffCalRequest.construct(
+        request = SimpleDiffCalRequest.model_construct(
             ingredients=mock.sentinel.ingredients,
             groceries=mock.sentinel.groceries,
         )
@@ -855,7 +860,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         GroupRx().cook.return_value = mock.sentinel.result
 
         # Call the method with the provided parameters
-        request = SimpleDiffCalRequest.construct(
+        request = SimpleDiffCalRequest.model_construct(
             ingredients=mock.sentinel.ingredients,
             groceries=mock.sentinel.groceries,
         )
@@ -1061,10 +1066,19 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         self.instance.groceryService.fetchGroceryList = mock.Mock(return_value=mockGroceries)
         self.instance.groceryClerk = mock.Mock()
 
-        request = mock.Mock(runNumbers=[mock.sentinel.run1, mock.sentinel.run2], useLiteMode=True)
-        groceries, cal = self.instance.fetchMatchingCalibrations(request)
-        assert groceries == {mock.sentinel.grocery1, mock.sentinel.grocery2}
-        assert cal == mockCalibrations
+        with mock.patch.object(NameBuilder, "build", autospec=True) as mockNameBuilder_build:
+            mockNameBuilder_build.side_effect = lambda self_: tuple(self_.props.values())
+
+            request = mock.Mock(runNumbers=[mock.sentinel.run1, mock.sentinel.run2], useLiteMode=True)
+            groceries, cal = self.instance.fetchMatchingCalibrations(request)
+            assert groceries == {
+                mock.sentinel.grocery1,  # diffcal-table #1
+                mock.sentinel.grocery2,  # diffcal-table #2
+                # Be careful here: there's some implicit ordering going on in the 'values' tuples.
+                (mock.sentinel.version1, WorkspaceType.DIFFCAL_MASK, False, mock.sentinel.run1),  # diffcal-mask #1
+                (mock.sentinel.version2, WorkspaceType.DIFFCAL_MASK, False, mock.sentinel.run2),  # diffcal-mask #2
+            }
+            assert cal == mockCalibrations
 
     def test_initializeState(self):
         testCalibration = DAOFactory.calibrationParameters()
@@ -1080,7 +1094,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
 
     def test_getState(self):
         testCalibration = DAOFactory.calibrationParameters()
-        testConfig = StateConfig.construct()
+        testConfig = StateConfig.model_construct()
         testConfig.calibration = testCalibration
         states = [deepcopy(testConfig), deepcopy(testConfig), deepcopy(testConfig)]
         states[0].calibration.instrumentState.id = "0000000000000000"

--- a/tests/unit/backend/service/test_LiteDataService.py
+++ b/tests/unit/backend/service/test_LiteDataService.py
@@ -14,7 +14,7 @@ from snapred.meta.Config import Resource
 
 class TestLiteDataService(unittest.TestCase):
     @patch("snapred.backend.service.LiteDataService.Recipe.executeRecipe")
-    def test_reduceLiteData_calls_executeRecipe_with_correct_arguments(
+    def test_createLiteData_calls_executeRecipe_with_correct_arguments(
         self,
         executeRecipe,
     ):
@@ -42,7 +42,7 @@ class TestLiteDataService(unittest.TestCase):
             assert not outputPath.exists()
             liteDataService.dataExportService.getFullLiteDataFilePath = mock.Mock(return_value=outputPath)
 
-            liteDataService.reduceLiteData(inputWorkspace, outputWorkspace)
+            liteDataService.createLiteData(inputWorkspace, outputWorkspace)
             assert outputPath.exists()
 
         executeRecipe.assert_called_with(
@@ -55,7 +55,7 @@ class TestLiteDataService(unittest.TestCase):
 
         liteDataService.dataExportService = Mock()
         with Config_override("constants.LiteDataCreationAlgo.toggleCompressionTolerance", True):
-            liteDataService.reduceLiteData(inputWorkspace, outputWorkspace)
+            liteDataService.createLiteData(inputWorkspace, outputWorkspace)
             executeRecipe.assert_called_with(
                 InputWorkspace=inputWorkspace,
                 OutputWorkspace=outputWorkspace,
@@ -66,7 +66,7 @@ class TestLiteDataService(unittest.TestCase):
             )
 
     @patch("snapred.backend.recipe.GenericRecipe.GenericRecipe.executeRecipe")
-    def test_reduceLiteData_fails(self, mock_executeRecipe):
+    def test_createLiteData_fails(self, mock_executeRecipe):
         mock_executeRecipe.return_value = {}
         mock_executeRecipe.side_effect = RuntimeError("oops!")
 
@@ -80,5 +80,5 @@ class TestLiteDataService(unittest.TestCase):
         outputWorkspace = "_test_output_lite_"
 
         with pytest.raises(RuntimeError) as e:
-            liteDataService.reduceLiteData(inputWorkspace, outputWorkspace)
+            liteDataService.createLiteData(inputWorkspace, outputWorkspace)
         assert "oops!" in str(e.value)

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -238,7 +238,7 @@ class TestSousChef(unittest.TestCase):
             self.ingredients.calibrantSamplePath,
             None,
         )
-        self.instance._pixelGroupCache[key] = PixelGroup.construct(timeOfFlight={"minimum": 0})
+        self.instance._pixelGroupCache[key] = PixelGroup.model_construct(timeOfFlight={"minimum": 0})
 
         res = self.instance.prepPixelGroup(self.ingredients)
         res.timeOfFlight["minimum"] = 2
@@ -394,7 +394,7 @@ class TestSousChef(unittest.TestCase):
             True,
         )
         # ensure the cache is prepared
-        self.instance._peaksCache[key] = [GroupPeakList.construct(groupId=2, peaks=[2])]
+        self.instance._peaksCache[key] = [GroupPeakList.model_construct(groupId=2, peaks=[2])]
         self.instance.prepCalibrantSample = mock.Mock()
         self.instance._getThresholdFromCalibrantSample = mock.Mock(return_value=0.5)
 

--- a/tests/unit/ui/widget/test_Workflow.py
+++ b/tests/unit/ui/widget/test_Workflow.py
@@ -25,8 +25,15 @@ class _TestView(QWidget):
     def handleContinueButtonClicked(self):
         pass
 
+    ##
+    ## Required abstract methods from `BackendRequestView`.
+    ##
+
     def verify(self):
         return True
+
+    def setInteractive(self, flag: bool):
+        pass
 
 
 def _generateWorkflow():

--- a/tests/unit/ui/workflow/test_DiffCalWorkflow.py
+++ b/tests/unit/ui/workflow/test_DiffCalWorkflow.py
@@ -1,4 +1,8 @@
 from random import randint
+
+##
+## Place the test imports at the end, so that the normal non-test import order is unmodified.
+##
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/util/InstaEats.py
+++ b/tests/util/InstaEats.py
@@ -1,8 +1,16 @@
 # ruff: noqa: F811 ARG005 ARG002
-import os
+## Python standard imports
+import datetime
+import json
+from pathlib import Path
 from typing import Any, Dict, List
+
+##
+## Test-related imports come last.
+##
 from unittest import mock
 
+## Mantid imports
 from mantid.simpleapi import (
     CreateEmptyTableWorkspace,
     CreateSampleWorkspace,
@@ -12,17 +20,21 @@ from mantid.simpleapi import (
     mtd,
 )
 from pydantic import validate_call
+from util.mock_util import mock_instance_methods
 from util.WhateversInTheFridge import WhateversInTheFridge
 
+## SNAPRed imports
 from snapred.backend.dao.ingredients import GroceryListItem
 from snapred.backend.dao.state import DetectorState
 from snapred.backend.data.GroceryService import GroceryService
+from snapred.backend.error.LiveDataState import LiveDataState
 from snapred.meta.Config import Config, Resource
 from snapred.meta.decorators.Singleton import Singleton
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
 
 @Singleton
+@mock_instance_methods
 class InstaEats(GroceryService):
     """
     No self-respecting chef would ever be caught dead ordering groceries from InstaEats...
@@ -32,13 +44,12 @@ class InstaEats(GroceryService):
     """
 
     def __init__(self):
-        super().__init__(dataService=WhateversInTheFridge)
-        self.dataService = WhateversInTheFridge()
+        super().__init__(dataService=WhateversInTheFridge())
         self.groupingMap = self.dataService._readDefaultGroupingMap()
         self.testInstrumentFile = Resource.getPath("inputs/testInstrument/fakeSNAP_Definition.xml")
         self.instrumentDonorWorkspace = mtd.unique_name(prefix="_instrument_donor")
         self.grocer.executeRecipe = mock.Mock(
-            side_effect=lambda filename, workspace, loader, *args, **kwargs: (
+            side_effect=lambda filename="", workspace="", loader="", *args, **kwargs: (
                 {"result": True, "loader": loader, "workspace": workspace}
             )
         )
@@ -48,11 +59,11 @@ class InstaEats(GroceryService):
     def getIPTS(self, runNumber: str, instrumentName: str = None) -> str:
         return Resource.getPath("inputs/testInstrument/IPTS-456/")
 
-    def _createNeutronFilename(self, runNumber: str, useLiteMode: bool) -> str:
+    def _createNeutronFilename(self, runNumber: str, useLiteMode: bool) -> Path:
         instr = "nexus.lite" if useLiteMode else "nexus.native"
         pre = instr + ".prefix"
         ext = instr + ".extension"
-        return self.getIPTS(runNumber) + Config[pre] + str(runNumber) + Config[ext]
+        return Path(self.getIPTS(runNumber) + Config[pre] + str(runNumber) + Config[ext])
 
     @validate_call
     def _createGroupingFilename(self, runNumber: str, groupingScheme: str, useLiteMode: bool) -> str:
@@ -107,60 +118,156 @@ class InstaEats(GroceryService):
                 raise RuntimeError(f"unable to load workspace {name} from {filePath}")
         return data
 
-    def fetchNeutronDataCached(self, runNumber: str, useLiteMode: bool, loader: str = "") -> Dict[str, Any]:
-        key = self._key(runNumber, useLiteMode)
-        rawWorkspaceName: WorkspaceName = self._createRawNeutronWorkspaceName(runNumber, useLiteMode)
-        filename: str = self._createNeutronFilename(runNumber, useLiteMode)
+    def fetchNeutronDataCached(self, item: GroceryListItem) -> Dict[str, Any]:
+        """
+        Fetch a nexus data file using a cache system to prevent double-loading from disk
 
-        loadedFromNative: bool = False
+        :param item: the grocery-list item
+        :type item: GroceryListItem
+        :return: a dictionary with the following keys
+
+            - "result": true if everything ran correctly
+            - "loader": the loader that was used by the algorithm; use it next time
+            - "workspace": the name of the workspace created in the ADS
+
+        :rtype: Dict[str, Any]
+        """
+
+        runNumber, useLiteMode, loader, liveDataArgs = item.runNumber, item.useLiteMode, item.loader, item.liveDataArgs
+
+        # Live-data mode can be requested explicitly,
+        #   but it also serves as the fallback mode.
+        liveDataMode = loader == "LoadLiveData" or liveDataArgs is not None
+
+        success = False
+        convertToLiteMode = False
 
         self._updateNeutronCacheFromADS(runNumber, useLiteMode)
+
+        key = self._key(runNumber, useLiteMode)
+        rawWorkspaceName: WorkspaceName = self._createRawNeutronWorkspaceName(runNumber, useLiteMode)
+        nativeRawWorkspaceName: WorkspaceName = self._createRawNeutronWorkspaceName(runNumber, False)
 
         # if the raw data has already been loaded, clone it
         if self._loadedRuns.get(key) is not None:
             data = {"loader": "cached"}
-        # if the data is not cached, but the file exists
-        elif os.path.isfile(filename):
-            data = self.grocer.executeRecipe(filename, rawWorkspaceName, loader)
-            self._loadedRuns[key] = 0
-        # if the file does not exist, and this is native resolution data, this represents an error condition
-        elif useLiteMode is False:
-            raise RuntimeError(f"Could not load run {runNumber} from file {filename}")
-        # if in Lite mode, and no raw workspace and no file exists, look if native data has been loaded from cache
-        # if so, then clone the native data and reduce it
-        elif self._loadedRuns.get(self._key(runNumber, False)) is not None:
-            nativeRawWorkspaceName = self._createRawNeutronWorkspaceName(runNumber, False)
-            data = {"loader": "cached"}
-            loadedFromNative = True
-        # neither lite nor native data in cache and lite file does not exist
-        # then load native data, clone it, and reduce it
-        elif os.path.isfile(self._createNeutronFilename(runNumber, False)):
-            # load the native resolution data
-            goingNative = (runNumber, False)
-            nativeRawWorkspaceName = self._createRawNeutronWorkspaceName(*goingNative)
-            nativeFilename = self._createNeutronFilename(*goingNative)
-            data = self.grocer.executeRecipe(nativeFilename, rawWorkspaceName, loader)
-            # keep track of the loaded raw native data
-            self._loadedRuns[self._key(*goingNative)] = 0
-            loadedFromNative = True
-        # the data cannot be loaded -- this is an error condition
-        else:
-            raise RuntimeError(f"Could not load run {runNumber} from file {filename}")
+            success = True
 
-        if loadedFromNative:
-            # clone the native raw workspace
-            # then reduce its resolution to make the lite raw workspace
-            self.getCloneOfWorkspace(nativeRawWorkspaceName, rawWorkspaceName)
-            self._loadedRuns[key] = 0
-            self.convertToLiteMode(rawWorkspaceName)
+        if not success and not liveDataMode:
+            liteModeFilePath: Path = self._createNeutronFilename(runNumber, True)
+            nativeModeFilePath: Path = self._createNeutronFilename(runNumber, False)
+            cachedNativeMode = self._loadedRuns.get(self._key(runNumber, False)) is not None
 
-        # create a copy of the raw data for use
-        workspaceName = self._createCopyNeutronWorkspaceName(runNumber, useLiteMode, self._loadedRuns[key] + 1)
-        data["result"] = True
-        data["workspace"] = workspaceName
-        self._loadedRuns[key] += 1
+            match (useLiteMode, cachedNativeMode, liteModeFilePath.exists(), nativeModeFilePath.exists()):
+                # THERE ARE MANY SPECIAL CASES HERE, but basically the end result of a cached fetch will be
+                #   a raw copy in the cache, and the return of a cloned copy.
+                #   In addition, when converted from native mode
+                #   there may be an additional native copy in the cache.
+
+                case (True, _, True, _):
+                    # lite mode and lite-mode exists on disk
+                    data = self.grocer.executeRecipe(str(liteModeFilePath), rawWorkspaceName, loader)
+                    self._loadedRuns[key] = 0
+                    self._liveDataKeys.append(key)
+                    success = True
+
+                case (True, True, _, _):
+                    # lite mode and native is cached
+                    data = {"loader": "cached"}
+                    convertToLiteMode = True
+                    success = True
+
+                case (True, _, _, True):
+                    # lite mode and native exists on disk
+                    goingNative = self._key(runNumber, False)
+                    data = self.grocer.executeRecipe(str(nativeModeFilePath), nativeRawWorkspaceName, loader="")
+                    self._loadedRuns[self._key(*goingNative)] = 0
+                    self._liveDataKeys.append(self._key(*goingNative))
+                    convertToLiteMode = True
+                    success = True
+
+                case (False, _, _, True):
+                    # native mode and native exists on disk
+                    data = self.grocer.executeRecipe(str(nativeModeFilePath), nativeRawWorkspaceName, loader)
+                    self._loadedRuns[key] = 0
+                    self._liveDataKeys.append(key)
+                    success = True
+
+                case _:
+                    # live data fallback
+                    pass
+
+        if not success:
+            # Live-data fallback
+            liveDataMode = True
+
+            if self.dataService.hasLiveDataConnection():
+                # When not specified in the `liveDataArgs`,
+                #   default behavior will be to load the entire run.
+                startTime = (
+                    (datetime.datetime.utcnow() - liveDataArgs.duration).isoformat() if liveDataArgs is not None else ""
+                )
+
+                loaderArgs = {
+                    "Facility": Config["liveData.facility.name"],
+                    "Instrument": Config["liveData.instrument.name"],
+                    "AccumulationMethod": Config["liveData.accumulationMethod"],
+                    "PreserveEvents": True,
+                    "StartTime": startTime,
+                }
+                data = self.grocer.executeRecipe(
+                    workspace=nativeRawWorkspaceName, loader="LoadLiveData", loaderArgs=json.dumps(loaderArgs)
+                )
+                if data["result"]:
+                    # For `InstaEats` purposes: here we are never going to trigger this case:
+                    """
+                    liveRunNumber = self.mantidSnapper.mtd[workspace].getRun().runNumber()
+                    """
+                    liveRunNumber = runNumber
+
+                    if int(runNumber) != int(liveRunNumber):
+                        self.deleteWorkspaceUnconditional(nativeRawWorkspaceName)
+                        data = {"result": False}
+                        if liveDataArgs is not None:
+                            # the live-data run isn't the expected one => a live-data state change has occurred
+                            raise LiveDataState.runStateTransition(liveRunNumber, runNumber)
+                        raise RuntimeError(
+                            f"Neutron data for run '{runNumber}' is not present on disk, nor is it the live-data run"
+                        )
+                    self._loadedRuns[self._key(runNumber, False)] = 0
+                    self._liveDataKeys.append(self._key(runNumber, False))
+                    success = True
+            else:
+                raise RuntimeError(
+                    f"Neutron data for run '{runNumber}' is not present on disk, "
+                    + "and no live-data connection is available"
+                )
+
+        if success:
+            if convertToLiteMode:
+                # clone the native raw workspace
+                # then reduce its resolution to make the lite raw workspace
+                self.getCloneOfWorkspace(nativeRawWorkspaceName, rawWorkspaceName)
+                self._loadedRuns[key] = 0
+                self._liveDataKeys.append(key)
+                self.convertToLiteMode(rawWorkspaceName, export=not liveDataMode)
+
+            # create a copy of the raw data for use
+            workspaceName = self._createCopyNeutronWorkspaceName(runNumber, useLiteMode, self._loadedRuns[key] + 1)
+            data["result"] = True
+            data["workspace"] = workspaceName
+            self._loadedRuns[key] += 1
 
         return data
+
+    def clearLiveDataCache(self):
+        """
+        Clear cache for and delete any live-data workspaces.
+        """
+        while self._liveDataKeys:
+            key = self._liveDataKeys.pop()
+            del self._loadedRuns[key]
+            self.deleteWorkspaceUnconditional(self._createRawNeutronWorkspaceName(key))
 
     def fetchGroupingDefinition(self, item: GroceryListItem) -> Dict[str, Any]:
         key = self._key(item.groupingScheme, item.runNumber, item.useLiteMode)
@@ -235,9 +342,9 @@ class InstaEats(GroceryService):
                 # for neutron data stored in a nexus file
                 case "neutron":
                     if item.keepItClean:
-                        res = self.fetchNeutronDataCached(item.runNumber, item.useLiteMode, item.loader)
+                        res = self.fetchNeutronDataCached(item)
                     else:
-                        res = self.fetchNeutronDataSingleUse(item.runNumber, item.useLiteMode, item.loader)
+                        res = self.fetchNeutronDataSingleUse(item)
                 # for grouping definitions
                 case "grouping":
                     res = self.fetchGroupingDefinition(item)
@@ -270,13 +377,11 @@ class InstaEats(GroceryService):
                     res["workspace"] = maskWorkspaceName
                 case "normalization":
                     res = self.fetchNormalizationWorkspace(item)
-                case "reduction_pixel_mask":
-                    res = self.fetchReductionPixelMask(item)
                 case _:
                     raise RuntimeError(f"unrecognized 'workspaceType': '{item.workspaceType}'")
             # check that the fetch operation succeeded and if so append the workspace
             if res["result"] is True:
                 groceries.append(res["workspace"])
             else:
-                raise RuntimeError(f"Error fetching item {item.json(indent=2)}")
+                raise RuntimeError(f"Error fetching item {item.model_dump_json(indent=2)}")
         return groceries

--- a/tests/util/SculleryBoy.py
+++ b/tests/util/SculleryBoy.py
@@ -2,7 +2,12 @@ from typing import Dict, List, Optional
 from unittest import mock
 
 import pydantic
+
+##
+## Put test-related imports at the end, so that the normal non-test import sequence is unmodified.
+##
 from util.dao import DAOFactory
+from util.mock_util import mock_instance_methods
 
 from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.ingredients import (
@@ -23,6 +28,7 @@ from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 from snapred.meta.redantic import parse_file_as
 
 
+@mock_instance_methods
 class SculleryBoy:
     """
     The scullery boy is a poor substitute for a sous chef,
@@ -30,6 +36,8 @@ class SculleryBoy:
 
     Should be able to mock out the SousChef.
     """
+
+    # TODO: Why isn't this `class SculleryBoy(SousChef)`?!
 
     def __init__(
         self,

--- a/tests/util/TestSummary.py
+++ b/tests/util/TestSummary.py
@@ -1,6 +1,9 @@
+from util.script_as_test import not_a_test
+
 from snapred.meta.Enum import StrEnum
 
 
+@not_a_test
 class TestSummary:
     def __init__(self):
         self._index = 0

--- a/tests/util/WhateversInTheFridge.py
+++ b/tests/util/WhateversInTheFridge.py
@@ -6,7 +6,12 @@ from typing import Any, Dict, Optional, Tuple
 
 from mantid.simpleapi import CreateSingleValuedWorkspace, mtd
 from pydantic import validate_call
+
+##
+## Put test-related imports at the end, so that the normal non-test import sequence is unmodified.
+##
 from util.dao import DAOFactory
+from util.mock_util import mock_instance_methods
 
 from snapred.backend.dao.calibration.CalibrationRecord import CalibrationRecord
 from snapred.backend.dao.indexing.CalculationParameters import CalculationParameters
@@ -29,6 +34,7 @@ logger = snapredLogger.getLogger(__name__)
 
 
 @Singleton
+@mock_instance_methods
 class WhateversInTheFridge(LocalDataService):
     """
     Yeah, it'd be nice to go to the LocalDataService to get all this...
@@ -42,8 +48,8 @@ class WhateversInTheFridge(LocalDataService):
     iptsCache: Dict[Tuple[str, str], Any] = {}
 
     def __init__(self) -> None:
-        self.verifyPaths = False
-        self.instrumentConfig = self.readInstrumentConfig()
+        self._verifyPaths = False
+        self._instrumentConfig = self._readInstrumentConfig()
         self.mantidSnapper = MantidSnapper(None, "Utensils")
         self.latestVersion = Config["version.start"]
 
@@ -64,9 +70,10 @@ class WhateversInTheFridge(LocalDataService):
         return str(self.iptsCache[key])
 
     @ExceptionHandler(StateValidationException)
-    def generateStateId(self, runId: str) -> Tuple[str, str]:
-        stateId = DAOFactory.magical_state_id.copy()
-        return stateId.hex, stateId.decodedKey
+    def generateStateId(self, runId: str) -> Tuple[str, DetectorState]:
+        stateId = DAOFactory.real_state_id.copy()
+        detectorState = DAOFactory.real_detector_state.copy()
+        return stateId.hex, detectorState
 
     ### CALIBRATION METHODS ###
 

--- a/tests/util/dao.py
+++ b/tests/util/dao.py
@@ -23,10 +23,36 @@ from snapred.backend.dao.state.PixelGroup import PixelGroup
 from snapred.backend.dao.state.PixelGroupingParameters import PixelGroupingParameters
 from snapred.meta.Config import Resource
 from snapred.meta.mantid.WorkspaceNameGenerator import ValueFormatter as wnvf
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceType as wngt
 
 
 class DAOFactory:
+    ## DETECTOR STATE
+
+    real_detector_state = DetectorState(
+        arc=(-65.3, 104.95),
+        wav=2.1,
+        freq=60.0,
+        guideStat=1,
+        lin=(0.045, 0.043),
+    )
+
+    unreal_detector_state = DetectorState(  # TODO remove this object?
+        arc=(1, 2),
+        wav=1.1,
+        freq=1.2,
+        guideStat=1,
+        lin=(1, 2),
+    )
+
     ## STATE ID
+
+    # state-id corresponding to `real_detector_state`:
+    real_state_id = ObjectSHA(
+        hex="04bd2c53f6bf6754",
+        decodedKey="{'vdet_arc1': -65.5, 'vdet_arc2': 105.0, 'WavelengthUserReq': 2.1, 'Frequency': 60, 'Pos': 1}",
+    )
+
     magical_state_id = ObjectSHA(
         hex="0a1b2c3d0a1b2c3d",
         decodedKey=None,
@@ -58,7 +84,7 @@ class DAOFactory:
         "nexusDirectory": "nexus/",
         "reducedDataDirectory": "shared/manualReduced/",
         "reductionRecordDirectory": "shared/manualReduced/reductionRecord/",
-        "bandwidth": "3.0",
+        "bandwidth": 3.0,
         "L1": 15.0,
         "L2": 0.5,
         "delTOverT": 0.002,
@@ -79,24 +105,6 @@ class DAOFactory:
         maxBandwidth=3.0,
         delLOverL=6.453e-05,
         delThNoGuide=0.0032,
-    )
-
-    ## DETECTOR STATE
-
-    real_detector_state = DetectorState(
-        arc=(-65.3, 104.95),
-        wav=2.1,
-        freq=60.0,
-        guideStat=1,
-        lin=(0.045, 0.043),
-    )
-
-    unreal_detector_state = DetectorState(  # TODO remove this object?
-        arc=(1, 2),
-        wav=1.1,
-        freq=1.2,
-        guideStat=1,
-        lin=(1, 2),
     )
 
     ## GSAS PARAMETERS
@@ -269,29 +277,29 @@ class DAOFactory:
     ## GROUPING MAP
 
     @classmethod
-    def groupingMap_SNAP(cls, stateId=magical_state_id.copy()) -> GroupingMap:
+    def groupingMap_SNAP(cls, stateId=magical_state_id.model_copy()) -> GroupingMap:
         return GroupingMap(
             stateId=stateId,
             liteFocusGroups=[
-                cls.focus_group_SNAP_all_lite.copy(),
-                cls.focus_group_SNAP_bank_lite.copy(),
-                cls.focus_group_SNAP_column_lite.copy(),
+                cls.focus_group_SNAP_all_lite.model_copy(),
+                cls.focus_group_SNAP_bank_lite.model_copy(),
+                cls.focus_group_SNAP_column_lite.model_copy(),
             ],
             nativeFocusGroups=[
-                cls.focus_group_SNAP_all_native.copy(),
-                cls.focus_group_SNAP_bank_native.copy(),
-                cls.focus_group_SNAP_column_native.copy(),
+                cls.focus_group_SNAP_all_native.model_copy(),
+                cls.focus_group_SNAP_bank_native.model_copy(),
+                cls.focus_group_SNAP_column_native.model_copy(),
             ],
         )
 
     @classmethod
-    def groupingMap_POP(cls, stateId=magical_state_id.copy()) -> GroupingMap:
+    def groupingMap_POP(cls, stateId=magical_state_id.model_copy()) -> GroupingMap:
         return GroupingMap(
             stateId=stateId,
             liteFocusGroups=[],
             nativeFocusGroups=[
-                cls.focus_group_POP_column_native.copy(),
-                cls.focus_group_POP_natural_native.copy(),
+                cls.focus_group_POP_column_native.model_copy(),
+                cls.focus_group_POP_natural_native.model_copy(),
             ],
         )
 
@@ -299,7 +307,7 @@ class DAOFactory:
 
     @classmethod
     def xtalInfo(cls, runNumber: str, useLiteMode: bool):  # noqa ARG003
-        return cls.default_xtal_info.copy()
+        return cls.default_xtal_info.model_copy()
 
     default_xtal_peak = CrystallographicPeak(
         hkl=(0, 0, 0),
@@ -323,7 +331,7 @@ class DAOFactory:
 
     synthetic_pixel_group = PixelGroup(
         # fake pixel group . json
-        focusGroup=synthetic_focus_group_natural.copy(),
+        focusGroup=synthetic_focus_group_natural.model_copy(),
         timeOfFlight=BinnedValue(
             minimum=10,
             maximum=1000,
@@ -383,7 +391,7 @@ class DAOFactory:
     )
 
     good_pixel_group = PixelGroup(
-        focusGroup=synthetic_focus_group_natural.copy(),
+        focusGroup=synthetic_focus_group_natural.model_copy(),
         timeOfFlight=BinnedValue(
             minimum=1959.0,
             maximum=14496.6,
@@ -453,22 +461,22 @@ class DAOFactory:
 
     @classmethod
     def pixelGroups(cls):
-        return [cls.synthetic_pixel_group.copy()]
+        return [cls.synthetic_pixel_group.model_copy()]
 
     ## PEAK INGREDIENTS
 
     fake_peak_ingredients = PeakIngredients(
-        instrumentState=pop_instrument_state.copy(),
+        instrumentState=pop_instrument_state.model_copy(),
         peakIntensityThreshold=1,
-        pixelGroup=synthetic_pixel_group.copy(),
-        crystalInfo=default_xtal_info.copy(),
+        pixelGroup=synthetic_pixel_group.model_copy(),
+        crystalInfo=default_xtal_info.model_copy(),
     )
 
     good_peak_ingredients = PeakIngredients(
-        instrumentState=pop_instrument_state.copy(),
+        instrumentState=pop_instrument_state.model_copy(),
         peakIntensityThreshold=0.05,
-        pixelGroup=good_pixel_group.copy(),
-        crystalInfo=good_xtal_info.copy(),
+        pixelGroup=good_pixel_group.model_copy(),
+        crystalInfo=good_xtal_info.model_copy(),
     )
 
     ## CALIBRATION PARAMETERS
@@ -482,7 +490,7 @@ class DAOFactory:
         *,
         creationDate="2024-04-03",
         name="test",
-        instrumentState=default_instrument_state.copy(),
+        instrumentState=default_instrument_state.model_copy(),
     ) -> Calibration:
         return Calibration(
             seedRun=runNumber,
@@ -503,23 +511,25 @@ class DAOFactory:
         version: int = randint(2, 120),
         **other_properties,
     ) -> CalibrationRecord:
-        other_properties.setdefault("crystalInfo", cls.default_xtal_info.copy())
+        other_properties.setdefault("crystalInfo", cls.default_xtal_info.model_copy())
         other_properties.setdefault("pixelGroups", cls.pixelGroups())
         other_properties.setdefault(
             "workspaces",
             {
-                "diffCalOutput": [f"_dsp_column_{wnvf.formatRunNumber(runNumber)}_{wnvf.formatVersion(version)}"],
-                "diffCalDiagnostic": [
+                wngt.DIFFCAL_OUTPUT: [f"_dsp_column_{wnvf.formatRunNumber(runNumber)}_{wnvf.formatVersion(version)}"],
+                wngt.DIFFCAL_DIAG: [
                     f"_diagnostic_column_{wnvf.formatRunNumber(runNumber)}_{wnvf.formatVersion(version)}"
                 ],
-                "diffCalTable": [f"_diffract_consts_{wnvf.formatRunNumber(runNumber)}_{wnvf.formatVersion(version)}"],
-                "diffCalMask": [
+                wngt.DIFFCAL_TABLE: [
+                    f"_diffract_consts_{wnvf.formatRunNumber(runNumber)}_{wnvf.formatVersion(version)}"
+                ],
+                wngt.DIFFCAL_MASK: [
                     f"_diffract_consts_mask_{wnvf.formatRunNumber(runNumber)}_{wnvf.formatVersion(version)}"
                 ],
             },
         )
         other_properties.setdefault("calculationParameters", cls.calibrationParameters(runNumber, useLiteMode, version))
-        other_properties.setdefault("focusGroupCalibrationMetrics", cls.focusGroupCalibrationMetric_Column.copy())
+        other_properties.setdefault("focusGroupCalibrationMetrics", cls.focusGroupCalibrationMetric_Column.model_copy())
         return CalibrationRecord(
             runNumber=runNumber,
             useLiteMode=useLiteMode,
@@ -538,7 +548,7 @@ class DAOFactory:
         *,
         creationDate="2024-04-03",
         name="test",
-        instrumentState=default_instrument_state.copy(),
+        instrumentState=default_instrument_state.model_copy(),
     ) -> Normalization:
         if runNumber == "":
             runNumber = str(randint(5000, 10000))
@@ -578,7 +588,7 @@ class DAOFactory:
             ],
         )
         other_properties.setdefault("calibrationVersionUsed", randint(2, 120))
-        other_properties.setdefault("crystalDBounds", cls.default_xtal_dbounds.copy())
+        other_properties.setdefault("crystalDBounds", cls.default_xtal_dbounds.model_copy())
         other_properties.setdefault(
             "calculationParameters", cls.normalizationParameters(runNumber, useLiteMode, version)
         )
@@ -603,7 +613,7 @@ class DAOFactory:
 
     focusGroupCalibrationMetric_Column = FocusGroupMetric(
         focusGroupName="Column",
-        calibrationMetric=[default_calibration_metric.copy()] * 6,
+        calibrationMetric=[default_calibration_metric.model_copy()] * 6,
     )
 
     ## CalibrantSample

--- a/tests/util/helpers.py
+++ b/tests/util/helpers.py
@@ -89,9 +89,9 @@ def createNPixelWorkspace(wsname, numberOfPixels, detectorState: DetectorState =
             freq=60.0,
             guideStat=1,
         )
-    logs = detectorState.getLogValues()
+    logs = detectorState.toLogs()
     lognames = list(logs.keys())
-    logvalues = list(logs.values())
+    logvalues = [str(v[0]) for v in logs.values()]
     logtypes = ["Number Series"] * len(lognames)
     addInstrumentLogs(wsname, logNames=lognames, logTypes=logtypes, logValues=logvalues)
     return mtd[wsname]
@@ -185,7 +185,8 @@ def maskFromArray(mask: List[bool], maskWSname: str, parentWSname=None, detector
     maskWS = createCompatibleMask(maskWSname, parentWSname)
     assert len(mask) == maskWS.getNumberHistograms(), "The mask array was incompatible with the parent workspace."
 
-    wkspIndexToMask = np.argwhere(mask == 1)
+    wkspIndexToMask = [int(n) for n in np.flatnonzero(np.array(mask) == 1)]
+
     parentWS = mtd[parentWSname]
     maskSpectra(maskWS, parentWS, wkspIndexToMask)
     return maskWSname
@@ -227,6 +228,7 @@ def maskSpectra(maskWS: MaskWorkspace, inputWS: MatrixWorkspace, nss: Sequence[i
     # Set mask flags for all detectors contributing to each spectrum in the list of spectra
     for ns in nss:
         dets = inputWS.getSpectrum(ns).getDetectorIDs()
+
         for det in dets:
             maskWS.setValue(det, True)
 

--- a/tests/util/instrument_helpers.py
+++ b/tests/util/instrument_helpers.py
@@ -55,13 +55,13 @@ def getInstrumentLogDescriptors(detectorState: DetectorState):
             "Number Series",
         ],
         "logValues": [
-            str(detectorState.arc[0]),
-            str(detectorState.arc[1]),
-            str(detectorState.wav),
-            str(detectorState.freq),
-            str(detectorState.guideStat),
-            str(detectorState.lin[0]),
-            str(detectorState.lin[1]),
+            f"{detectorState.arc[0]:.16f}",
+            f"{detectorState.arc[1]:.16f}",
+            f"{detectorState.wav:.16f}",
+            f"{detectorState.freq:.16f}",
+            f"{detectorState.guideStat:.16f}",
+            f"{detectorState.lin[0]:.16f}",
+            f"{detectorState.lin[1]:.16f}",
         ],
     }
 

--- a/tests/util/mock_util.py
+++ b/tests/util/mock_util.py
@@ -1,0 +1,31 @@
+import inspect
+from functools import wraps
+from unittest import mock
+
+
+def mock_instance_methods(orig_cls):
+    """A class decorator to mock all of the methods of a class instance, with the default `side_effect`
+      being the original methods:
+    -- As instance methods (rather than class methods) are mocked, each instance is then associated
+       with distinct mocks;
+    -- In most cases, `mock.Mock(wraps=<class to wrap>)` should be used as an alternative to this decorator;
+       however, this decorator allows already-derived classes to be mocked, producing essentially the same behavior.
+    """
+
+    orig_init = orig_cls.__init__
+
+    @wraps(orig_cls.__init__)
+    def __init__(self, *args, **kwargs):
+        orig_init(self, *args, **kwargs)
+
+        # Each method still does what it originally did,
+        #   but this change allows us to do things like `<instance>.<method>.assert_called_once_with(...)`
+        #     without needing to build mocks for all of the methods "by hand".
+        for method in inspect.getmembers(self, predicate=inspect.ismethod):
+            if method[0].startswith("__"):
+                # For the moment, exclude 'builtin' methods (due to possible recursion issues).
+                continue
+            setattr(self, method[0], mock.Mock(side_effect=method[1]))
+
+    orig_cls.__init__ = __init__
+    return orig_cls

--- a/tests/util/pytest_helpers.py
+++ b/tests/util/pytest_helpers.py
@@ -1,27 +1,37 @@
+## Python standard imports
 import os
 import tempfile
 import time
 from contextlib import ExitStack
 from pathlib import Path
 from typing import List, Optional
+
+##
+## Test-related imports go *LAST*!
+## ----------------
 from unittest import mock
 
 import pytest
+
+## Mantid imports
 from mantid.simpleapi import DeleteWorkspaces, mtd
+
+## Qt imports
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QMessageBox,
 )
 from util.Config_helpers import Config_override
 
+## SNAPRed imports
 # I would prefer not to access `LocalDataService` within an integration test,
 #   however, for the moment, the reduction-data output relocation fixture is defined in the current file.
 from snapred.backend.data.LocalDataService import LocalDataService
 from snapred.meta.Config import Config
 from snapred.ui.view import InitializeStateCheckView
 
-# Import required test fixtures at the end of either the main `conftest.py`,
-#   or any `conftest.py` at the test-module level directory.
+## REMINDER: Import required test fixtures at the end of either the main `conftest.py`,
+##   or any `conftest.py` at the test-module level directory.
 
 
 ## WARNING:
@@ -233,6 +243,7 @@ def handleStateInit(waitForStateInit, stateId, qtbot, qapp, actionCompleted, wor
         )
         successPrompt.start()
         # --------------------------------------------------------------------------
+
         #    (1) respond to the "initialize state" request
         with qtbot.waitSignal(actionCompleted, timeout=60000):
             qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
@@ -247,6 +258,7 @@ def handleStateInit(waitForStateInit, stateId, qtbot, qapp, actionCompleted, wor
             o for o in qapp.topLevelWidgets() if isinstance(o, InitializeStateCheckView.InitializationMenu)
         ][0]
         stateInitDialog.stateNameField.setText("my happy state")
+
         qtbot.mouseClick(stateInitDialog.beginFlowButton, Qt.MouseButton.LeftButton)
         # State initialization dialog is "application modal" => no need to explicitly wait
         questionMessageBox.stop()

--- a/tests/util/state_helpers.py
+++ b/tests/util/state_helpers.py
@@ -93,7 +93,11 @@ class state_root_redirect:
         self.dataService.constructCalibrationStateRoot = self.old_constructCalibrationStateRoot
         self.dataService.generateStateId = self.old_generateStateId
         self.tmpdir.cleanup()
-        assert not self.tmppath.exists()
+
+        # For debugging purposes, you may want to re-add this line:
+        # assert not self.tmppath.exists()
+        # OTHERWISE, I'm NOT going to _assume_ that you never want to mock-out `pathlib.Path.exists`! :(
+
         del self.tmpdir
 
     def path(self) -> Path:
@@ -101,15 +105,21 @@ class state_root_redirect:
 
     def addFileAs(self, source: str, target: str):
         assert Path(self.tmpdir.name) in Path(target).parents
+
         Path(target).parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source, target)
-        assert Path(target).exists()
+
+        # For debugging purposes, you may want to re-add this line:
+        # assert Path(target).exists()
 
     def saveObjectAt(self, thing: BaseModel, target: str):
         assert Path(self.tmpdir.name) in Path(target).parents
+
         Path(target).parent.mkdir(parents=True, exist_ok=True)
         write_model_pretty(thing, target)
-        assert Path(target).exists()
+
+        # For debugging purposes, you may want to re-add this line:
+        # assert Path(target).exists()
 
 
 class reduction_root_redirect:
@@ -147,7 +157,10 @@ class reduction_root_redirect:
         self.dataService._constructReductionStateRoot = self.old_constructReductionStateRoot
         self.dataService.generateStateId = self.old_generateStateId
         self.tmpdir.cleanup()
-        assert not self.tmppath.exists()
+
+        # For debugging purposes, you may want to re-add this line:
+        # assert not self.tmppath.exists()
+
         del self.tmpdir
 
     def path(self) -> Path:
@@ -157,4 +170,6 @@ class reduction_root_redirect:
         assert self.tmppath in list(Path(target).parents)
         Path(target).parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(source, target)
-        assert Path(target).exists()
+
+        # For debugging purposes, you may want to re-add this line:
+        # assert Path(target).exists()

--- a/tests/util_tests/test_state_helpers.py
+++ b/tests/util_tests/test_state_helpers.py
@@ -4,11 +4,17 @@ import unittest.mock as mock
 from pathlib import Path
 from shutil import rmtree
 
+import h5py
 import pytest
+
+##
+## Put test-related imports at the end, so that the normal non-test import sequence is unmodified.
+##
 from util.dao import DAOFactory
 from util.state_helpers import reduction_root_redirect, state_root_override, state_root_redirect
 
 from snapred.backend.dao.indexing.Versioning import VERSION_START
+from snapred.backend.dao.state.DetectorState import DetectorState
 from snapred.backend.data.LocalDataService import LocalDataService
 from snapred.meta.Config import Config
 from snapred.meta.mantid.WorkspaceNameGenerator import ValueFormatter as wnvf
@@ -24,43 +30,68 @@ def _cleanup_directories():
         shutil.rmtree(stateRootPath)
 
 
-def initPVFileMock():
-    return {
-        "entry/DASlogs/BL3:Chop:Skf1:WavelengthUserReq/value": [1.1],
-        "entry/DASlogs/det_arc1/value": [1.0],
-        "entry/DASlogs/det_arc2/value": [2.0],
-        "entry/DASlogs/BL3:Det:TH:BL:Frequency/value": [1.2],
-        "entry/DASlogs/BL3:Mot:OpticsPos:Pos/value": [1],
-        "entry/DASlogs/det_lin1/value": [1.0],
-        "entry/DASlogs/det_lin2/value": [2.0],
+def mockPVFile(detectorState: DetectorState) -> mock.Mock:
+    # See also: `tests/unit/backend/data/util/test_PV_logs_util.py`.
+
+    # Note: `PV_logs_util.mappingFromNeXusLogs` will open the 'entry/DASlogs' group,
+    #   so this `dict` mocks the HDF5 group, not the PV-file itself.
+
+    # For the HDF5-file, each key requires the "/value" suffix.
+    dict_ = {
+        "run_number/value": "123456",
+        "start_time/value": "2023-06-14T14:06:40.429048667",
+        "end_time/value": "2023-06-14T14:07:56.123123123",
+        "BL3:Chop:Skf1:WavelengthUserReq/value": [detectorState.wav],
+        "det_arc1/value": [detectorState.arc[0]],
+        "det_arc2/value": [detectorState.arc[1]],
+        "BL3:Det:TH:BL:Frequency/value": [detectorState.freq],
+        "BL3:Mot:OpticsPos:Pos/value": [detectorState.guideStat],
+        "det_lin1/value": [detectorState.lin[0]],
+        "det_lin2/value": [detectorState.lin[1]],
     }
+
+    def del_item(key: str):
+        # bypass <class>.__delitem__
+        del dict_[key]
+
+    mock_ = mock.MagicMock(spec=h5py.Group)
+
+    mock_.get = lambda key, default=None: dict_.get(key, default)
+    mock_.del_item = del_item
+
+    # Use of the h5py.File starts with access to the "entry/DASlogs" group:
+    mock_.__getitem__.side_effect = lambda key: mock_ if key == "entry/DASlogs" else dict_[key]
+
+    mock_.__contains__.side_effect = dict_.__contains__
+    mock_.keys.side_effect = dict_.keys
+    return mock_
 
 
 @mock.patch.object(LocalDataService, "_writeDefaultDiffCalTable")
 @mock.patch.object(LocalDataService, "generateStateId")
 @mock.patch.object(LocalDataService, "_readDefaultGroupingMap")
-@mock.patch.object(LocalDataService, "readInstrumentConfig")
+@mock.patch.object(LocalDataService, "getInstrumentConfig")
 @mock.patch.object(LocalDataService, "_readPVFile")
 def test_state_root_override_enter(
     mockReadPVFile,
-    mockReadInstrumentConfig,
+    mockGetInstrumentConfig,
     mockReadDefaultGroupingMap,
     mockGenerateStateId,
     mockWriteDefaultDiffCalTable,  # noqa ARG001
 ):
     # see `test_LocalDataService::test_initializeState`
-    mockReadPVFile.return_value = initPVFileMock()
+    mockReadPVFile.return_value = mockPVFile(DAOFactory.unreal_detector_state)
 
     testCalibrationData = DAOFactory.calibrationParameters("57514", True, 1)
-    mockReadInstrumentConfig.return_value = testCalibrationData.instrumentState.instrumentConfig
+    mockGetInstrumentConfig.return_value = testCalibrationData.instrumentState.instrumentConfig
     mockReadDefaultGroupingMap.return_value = DAOFactory.groupingMap_SNAP()
 
     stateId = "ab8704b0bc2a2342"
     # NOTE delete the path first or the test can fail for confusing reasons
     expectedStateRootPath = Path(Config["instrument.calibration.powder.home"]) / stateId
     rmtree(expectedStateRootPath, ignore_errors=True)
-    decodedKey = None
-    mockGenerateStateId.return_value = (stateId, decodedKey)
+    detectorState = DAOFactory.unreal_detector_state
+    mockGenerateStateId.return_value = (stateId, detectorState)
     runNumber = "123456"
     stateName = "my happy state"
     useLiteMode = True
@@ -74,19 +105,19 @@ def test_state_root_override_enter(
 
 @mock.patch.object(LocalDataService, "_writeDefaultDiffCalTable")
 @mock.patch.object(LocalDataService, "_readDefaultGroupingMap")
-@mock.patch.object(LocalDataService, "readInstrumentConfig")
+@mock.patch.object(LocalDataService, "getInstrumentConfig")
 @mock.patch.object(LocalDataService, "_readPVFile")
 def test_state_root_override_exit(
     mockReadPVFile,
-    mockReadInstrumentConfig,
+    mockGetInstrumentConfig,
     mockReadDefaultGroupingMap,
     mockWriteDefaultDiffCalTable,  # noqa ARG001
 ):
     # see `test_LocalDataService::test_initializeState`
-    mockReadPVFile.return_value = initPVFileMock()
+    mockReadPVFile.return_value = mockPVFile(DAOFactory.unreal_detector_state)
 
     testCalibrationData = DAOFactory.calibrationParameters("57514", True, 1)
-    mockReadInstrumentConfig.return_value = testCalibrationData.instrumentState.instrumentConfig
+    mockGetInstrumentConfig.return_value = testCalibrationData.instrumentState.instrumentConfig
     mockReadDefaultGroupingMap.return_value = DAOFactory.groupingMap_SNAP()
 
     stateId = "ab8704b0bc2a2342"  # noqa: F841
@@ -103,19 +134,19 @@ def test_state_root_override_exit(
 
 @mock.patch.object(LocalDataService, "_writeDefaultDiffCalTable")
 @mock.patch.object(LocalDataService, "_readDefaultGroupingMap")
-@mock.patch.object(LocalDataService, "readInstrumentConfig")
+@mock.patch.object(LocalDataService, "getInstrumentConfig")
 @mock.patch.object(LocalDataService, "_readPVFile")
 def test_state_root_override_exit_no_delete(
     mockReadPVFile,
-    mockReadInstrumentConfig,
+    mockGetInstrumentConfig,
     mockReadDefaultGroupingMap,
     mockWriteDefaultDiffCalTable,  # noqa ARG001
 ):
     # see `test_LocalDataService::test_initializeState`
-    mockReadPVFile.return_value = initPVFileMock()
+    mockReadPVFile.return_value = mockPVFile(DAOFactory.unreal_detector_state)
 
     testCalibrationData = DAOFactory.calibrationParameters("57514", True, 1)
-    mockReadInstrumentConfig.return_value = testCalibrationData.instrumentState.instrumentConfig
+    mockGetInstrumentConfig.return_value = testCalibrationData.instrumentState.instrumentConfig
     mockReadDefaultGroupingMap.return_value = DAOFactory.groupingMap_SNAP()
 
     stateId = "ab8704b0bc2a2342"  # noqa: F841


### PR DESCRIPTION
## Description of work

This PR includes the complete SNAPRed reduction live-data implementation.  With respect to complexity, the required back-end changes probably came in within the original scope of this enabler.  In contrast, the required front-end changes, including the implementation of the non-linear workflow, were significantly more complicated than expected.

## Explanation of work

**LIVE-DATA back end:**

  * LIVE-DATA FALLBACK MODE: modifications to `GroceryService` `fetchNeutronDataSingleUse` and `fetchNeutronDataCached` methods so that loading from the live-data listener is used as a fallback.  This means that in addition to operating explicitly in live-data mode (described next), if the live-data run number is known, ALL WORKFLOWS can function with live data, simply by specifying this run number.

  * EXPLICIT LIVE-DATA MODE: this mode is triggered by using the new `liveData` `GroceryListBuilder` token.  This differs from the fallback mode, in that the data _duration_ can be specified.  Given an active run, either a subsection of its data can be loaded, specified using a time-duration prior to the present time, or all of the available data can be loaded.

  * A new `LiveMetadata` DAO, which encapsulates attributes of `mantid.api.Run` that are relevant to accessing the state of the live-data listener.  This object allows the convenient identification of significant live-data states, such as \<no run active\> and \<no beam active\>.

  * New `LocalDataService` live-data utility methods: `hasLiveDataConnection` and `getLiveMetadata`.  Note that due to limitations in the DAS / listener implementation, there is some minor code duplication here with the `FetchGroceriesAlgorithm` use of the `LoadLiveData` algorithm.  The primary objective of these `LocalDataService` methods is to detect whether a listener connection is available, and then if so, to load the _minimum_ possible in order to access the PV-logs associated with the live-data run.  (DAS-group itself needs an "enabler" to simply allow access to the PV-logs from the listener directly, but this issue has not been addressed yet.)

  * A new `LiveDataState` exception, which is another flow-control exception allowing changes in the live-data state to be detected and indicated.  For example, when a live-data run ends, the run number available from the listener changes to _zero_.  Or, when the beam goes down, the \<integrated proton charge\> goes to _zero_.

  * COARSE-GRAINED USER-CANCELLATION REQUEST: this uses a new `UserCancellation` flow-control exception in the `SNAPResponseHandler`, with an associated `ResponseCode` value.  This allows any workflow to be cancelled at the next "service point".  This is the only form of supported exit from the live-data reduction cycle.  Note that an implication of this is that now ALL WORKFLOWS support this type of user-cancellation request, and in general, the \<cancel button\> should always be enabled on the panel.

  * Modifications to `ReductionRecipe` so that all output workspaces, including the unfocused data, are updated "at once" at the appropriate processing stage.  This allows any open plots of these workspaces to display correctly, and not to show intermediate-calculation values.  All of this is important to the live-data standard usage scenario.

  * Any workspaces that are loaded in support of processing a `ReductionRequest` are retained between live-data cycles.  The input-data workspace itself is replaced at the start of each cycle.

  * Add calibration masks to `fetchCalibrations` workspaces list.  At present, the only use of this list is to add these workspaces to the retained-workspaces set. Both calibration table and mask workspaces should be retained across live-data cycles.

  * Move "lite_grouping_map" name to the `WorkspaceNameGenerator`.  This allows access to this name by the `ReductionWorkflow`, so that "lite_grouping_map" can be added to the workspaces retained across live-data cycles.

  * `ReductionWorkflow` now maintains a current `ReductionStatus` state set by using its `setStatus` method.  Retaining this state allows the live-data summary panel to show what part of the reduction process is presently active.

**LIVE-DATA front end:**

  * LIVE-DATA REDUCTION CYCLE: `ReductionWorkflow` now supports this new non-linear workflow.  During the first workflow pass, everything behaves _exactly_ like the current SNAPRed workflow, including the use of any required continue-anyway dialogs.  During future live-data cycles, the as specified `ReductionRequest` values are re-used.  Live-data cycling is canceled using the new `UserCancellation` system.  Once canceled, the entire sequence can be started again, possibly including the specification of new values.

  * LIVE-DATA STATE CHANGE: in addition to any `UserCancellation` exit, the live-data cycle will also be exited when a live-data state change is detected.  Normally, this would be the end of a live-data run, or rarely, the direct transition to another live-data run.

  * LIVE-DATA REQUEST PANEL: this panel shares most of its widget controls with the `ReductionRequestView`, which it is a variant of.  The key difference is that this panel supports an _active_ live-data run summary, using a combination of a steady state, or flashing `LEDIndicator` and a summary text display.  It also supports two slider controls, one for the data interval -- as a duration prior to the current time -- and one for the desired update interval.  Note that the normal `ReductionRequestView` variant replaces these controls with its run-number selection section.

  * TIME-OF-DAY UPDATE: this update occurs every second and is controlled by a separate `QTimer`.

  * METADATA UPDATE: this is a per-update interval update of the live-data panel's metadata, and is also controlled by a separate `QTimer`.  This update occurs _only_ when live-data reduction is not being processed, which will either be before the start of a live-data cycle, or between reduction-processing stages of an in-progress cycle.

  * LIVE-DATA REDUCTION, RESUBMISSION TIMING: this schedules the start of the next live-data cycle.  This uses the measured wallclock time of the previous reduction, in combination with the requested update interval.  This results in either a timed delay prior to the next submission, or possibly an immediate submission in case the wallclock time has exceeded the desired update interval.

**MISCELLANEOUS fixes:**

  * Allow SNAPRed to have its own `style.qss` or `workspace_style.qss` depending on how the application is loaded.  This then allows the centralization of SNAPRed's widget style properties.  (Previously, it did not have a separate style sheet at all when loaded under the workbench.)

  * Fix mix-up of static and non-static methods in `SNAPResponseHandler`.

  * Fix dialog modality, and parenting of the init-state message box, and its dialog.

  * Pass all former `groceries` arguments in the `ReductionRecipe` as explicit keyword arguments.  In general, the use of `groceries` in this recipe was completely abused.  Further, `ReductionRecipe._applyRecipe` is no longer called on any sub-recipe that doesn't actually need to be executed.  Removed redundant checking of keyword argument presence, as this is now handled by the `Recipe` base class itself.

  * An implicit (i.e. not specified in the naming template) 'hidden' token is now available for all `WorkspaceNameGenerator` workspace types.  When this token is set, the generated workspace name is prefixed with the Mantid \<hidden workspace\> double underscore.

  * Fix `StateValidationException` mixed-up code.  There is no reason at all that any end user would care whether or not they have permissions to write to the directory of the executing python file?!

  * `InitializeStateCheckView` dialog that potentially closes during its own initialization, now sends a queued signal (using `QMetaObject`), rather than calling `close` directly.  This fixes one type of GUI freeze behavior that has been observed.

  * \<cancel button\> "are you sure" dialog now displays "yes" "no", rather than "continue" "cancel" -- the previous behavior was really confusing!

  * \<cancel button\> is now active in all panels.  This is connected to the new `UserCancellation` flow-control exception.

  * Add complete instrument-parameter information to grouping and mask workspaces loaded by the `GroceryService`.  In addition work around the parameter-loading precision defect (a separate PR) in Mantid `SaveNexus` and `LoadNexus` by applying `populateInstrumentParameters` after all loading.  In combination, this allows grouping and mask workspaces to present the correct stateID-SHA, and also for all workspaces to meet Mantid's target accuracy for detector positions and rotations.

  * A new `PV_logs_util` module to allow presentation of `mantid.api.Run` and the NeXus logs as Python Mapping objects.  This centralizes the treatment of the DAS-log keys, and the initialization of the `DetectorState` objects, which are used during the computation of the stateID-SHA.  In addition, this module provides utility functions for transferring PV-logs between `mantid.api.Run` objects, and for triggering `ExperimentInfo.populateInstrumentParameters` (,prior to the merge of the Mantid PR that will expose that method to the Python api).

  * Add instrument-parameter PV-logs keys to `application.yml` -- this includes the alternative keys as well.

  * Return `(stateID-SHA, DetectorState)` from `LocalDataService.generateStateID`, as these are the values that are actually required for use.  This reduces the PV-logs parsing by a factor of two.

## To test

### Dev testing

I'll fill this in, as I go through each of these sections myself.

**Unit tests:**

  * I'm working to improve the code coverage right now.

**Mock live-data listener:**

It's important to start with these tests, so that one can get an expectation of how the system is _supposed_ to work.  Take a look at the new changes in the `liveData` section of `application.yml`.  Uncomment the appropriate values, as indicated.

  * Despite its failings, run "46680" is used as an example, although you can use any run that you'd prefer.  From both the live-data, and the non-live-data panels: all workflow variants, including with and without calibration and  normalization, should be examined. 
     For the live-data workflow: as mentioned above, the first-pass through the workflow sets the specifics used for future passes, which then continue automatically until either user-cancellation is requested, or the live-data state changes.  Mantid has memory-fragmentation issues.  This means that how many reduction cycles you can get through before you run out of memory really depends on the node you're running on.  I've managed to cycle continually through greater than thirty cycles (> 1/2 hour of total time for "46680").
  

**Tests with the real listener:**
For these tests, the `application.yml` `liveData` section should be reverted to its original state.

  * What behavior is observed here depends on the current active-run and beam state.  Hopefully I've dealt with all of the possible aspects of this state, but if not, any required additions will be spun off as new defects.  It will be useful here if there exists a calibration for the current run.  If there does, it will be located in the normal way.
  
**I'm expecting that we _will_ find defects, as these implementation changes are somewhat complicated.**  For any of these that don't have obvious quick fixes, we should spin off additional EWM items.
  

### CIS testing

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#755](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=755)

### Verification

- [ ] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] acceptance criterion 1
- [ ] acceptance criterion 2
