### PR TITLE
Ewm9125 add dictionary overrides diffraction

### DIFF
--- a/docs/source/api/snapred.backend.dao.request.rst
+++ b/docs/source/api/snapred.backend.dao.request.rst
@@ -100,6 +100,14 @@ snapred.backend.dao.request.NormalizationExportRequest module
    :undoc-members:
    :show-inheritance:
 
+snapred.backend.dao.request.OverrideRequest module
+--------------------------------------------------
+
+.. automodule:: snapred.backend.dao.request.OverrideRequest
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 snapred.backend.dao.request.RenameWorkspaceRequest module
 ---------------------------------------------------------
 

--- a/docs/source/api/snapred.ui.view.rst
+++ b/docs/source/api/snapred.ui.view.rst
@@ -52,7 +52,7 @@ snapred.ui.view.DiffCalTweakPeakView module
 .. automodule:: snapred.ui.view.DiffCalTweakPeakView
    :members:
    :undoc-members:
-   :exclude-members: signalRunNumberUpdate, signalValueChanged, signalUpdateRecalculationButton, signalPeakThresholdUpdate, signalMaxChiSqUpdate, signalContinueAnyway, signalPurgeBadPeaks
+   :exclude-members: signalRunNumberUpdate, signalValueChanged, signalUpdateRecalculationButton, signalPeakThresholdUpdate, signalMaxChiSqUpdate, signalContinueAnyway, signalPurgeBadPeaks, signalUpdateXTAL_DMIN, signalUpdateXTAL_DMAX
    :show-inheritance:
 
 

--- a/src/snapred/backend/dao/request/OverrideRequest.py
+++ b/src/snapred/backend/dao/request/OverrideRequest.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class OverrideRequest(BaseModel, extra="forbid"):
+    calibrantSamplePath: str

--- a/src/snapred/backend/dao/state/CalibrantSample/CalibrantSample.py
+++ b/src/snapred/backend/dao/state/CalibrantSample/CalibrantSample.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, field_validator
 
@@ -19,6 +19,7 @@ class CalibrantSample(BaseModel):
     material: Material
     crystallography: Optional[Crystallography] = None
     peakIntensityFractionThreshold: Optional[float] = Config["constants.PeakIntensityFractionThreshold"]
+    overrides: Optional[Dict[str, Any]] = None
 
     # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
     # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -31,9 +31,11 @@ from snapred.backend.dao.request import (
     InitializeStateRequest,
     LoadCalibrationRecordRequest,
     MatchRunsRequest,
+    OverrideRequest,
     SimpleDiffCalRequest,
 )
 from snapred.backend.dao.response.CalibrationAssessmentResponse import CalibrationAssessmentResponse
+from snapred.backend.dao.state.CalibrantSample import CalibrantSample
 from snapred.backend.data.DataExportService import DataExportService
 from snapred.backend.data.DataFactoryService import DataFactoryService
 from snapred.backend.data.GroceryService import GroceryService
@@ -102,6 +104,7 @@ class CalibrationService(Service):
         self.registerPath("validateWritePermissions", self.validateWritePermissions)
         self.registerPath("residual", self.calculateResidual)
         self.registerPath("fetchMatches", self.fetchMatchingCalibrations)
+        self.registerPath("override", self.handleOverrides)
         return
 
     @staticmethod
@@ -585,3 +588,11 @@ class CalibrationService(Service):
         )
 
         return CalibrationAssessmentResponse(record=record, metricWorkspaces=metricWorkspaces)
+
+    @FromString
+    def handleOverrides(self, request: OverrideRequest):
+        sample: CalibrantSample = self.dataFactoryService.getCalibrantSample(request.calibrantSamplePath)
+        if sample.overrides:
+            return sample.overrides
+        else:
+            return None

--- a/src/snapred/ui/view/DiffCalRequestView.py
+++ b/src/snapred/ui/view/DiffCalRequestView.py
@@ -79,3 +79,9 @@ class DiffCalRequestView(BackendRequestView):
 
     def getSkipPixelCalibration(self):
         return self.skipPixelCalToggle.getState()
+
+    def disablePeakFunction(self):
+        self.peakFunctionDropdown.setEnabled(False)
+
+    def enablePeakFunction(self):
+        self.peakFunctionDropdown.setEnabled(True)

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -332,3 +332,21 @@ class DiffCalTweakPeakView(BackendRequestView):
 
     def getSkipPixelCalibration(self):
         return self.skipPixelCalToggle.field.getState()
+
+    def setXtalDMin(self, value):
+        self.fieldXtalDMin.setText(str(value))
+
+    def disableXtalDMin(self):
+        self.fieldXtalDMin.setEnabled(False)
+
+    def enableXtalDMin(self):
+        self.fieldXtalDMin.setEnabled(True)
+
+    def setXtalDMax(self, value):
+        self.fieldXtalDMax.setText(str(value))
+
+    def disableXtalDMax(self):
+        self.fieldXtalDMax.setEnabled(False)
+
+    def enableXtalDMax(self):
+        self.fieldXtalDMax.setEnabled(True)

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -50,6 +50,8 @@ class DiffCalTweakPeakView(BackendRequestView):
     signalMaxChiSqUpdate = Signal(float)
     signalContinueAnyway = Signal(bool)
     signalPurgeBadPeaks = Signal(float)
+    signalUpdateXTAL_DMIN = Signal(float)
+    signalUpdateXTAL_DMAX = Signal(float)
 
     def __init__(self, samples=[], groups=[], parent=None):
         super().__init__(parent=parent)
@@ -60,6 +62,8 @@ class DiffCalTweakPeakView(BackendRequestView):
         self.maxChiSqField = self._labeledField("Max Chi Sq", text=str(self.MAX_CHI_SQ))
         self.signalRunNumberUpdate.connect(self._updateRunNumber)
         self.signalMaxChiSqUpdate.connect(self._updateMaxChiSq)
+        self.signalUpdateXTAL_DMIN.connect(self._setXtalDMin)
+        self.signalUpdateXTAL_DMAX.connect(self._setXtalDMax)
 
         # skip pixel calibration toggle
         self.skipPixelCalToggle = self._labeledToggle("Skip Pixel Calibration", False)
@@ -333,7 +337,11 @@ class DiffCalTweakPeakView(BackendRequestView):
     def getSkipPixelCalibration(self):
         return self.skipPixelCalToggle.field.getState()
 
-    def setXtalDMin(self, value):
+    def updateXtalDmin(self, value):
+        self.signalUpdateXTAL_DMIN.emit(value)
+
+    @Slot(float)
+    def _setXtalDMin(self, value):
         self.fieldXtalDMin.setText(str(value))
 
     def disableXtalDMin(self):
@@ -342,7 +350,11 @@ class DiffCalTweakPeakView(BackendRequestView):
     def enableXtalDMin(self):
         self.fieldXtalDMin.setEnabled(True)
 
-    def setXtalDMax(self, value):
+    def updateXtalDmax(self, value):
+        self.signalUpdateXTAL_DMAX.emit(value)
+
+    @Slot(float)
+    def _setXtalDMax(self, value):
         self.fieldXtalDMax.setText(str(value))
 
     def disableXtalDMax(self):

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -362,3 +362,9 @@ class DiffCalTweakPeakView(BackendRequestView):
 
     def enableXtalDMax(self):
         self.fieldXtalDMax.setEnabled(True)
+
+    def disablePeakFunction(self):
+        self.peakFunctionDropdown.setEnabled(False)
+
+    def enablePeakFunction(self):
+        self.peakFunctionDropdown.setEnabled(True)

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -201,9 +201,9 @@ class DiffCalWorkflow(WorkflowImplementer):
 
         if not overrides:
             self._requestView.enablePeakFunction()
-            self._tweakPeakView.setXtalDMin(self.prevXtalDMin)
+            self._tweakPeakView.updateXtalDmin(self.prevXtalDMin)
             self._tweakPeakView.enableXtalDMin()
-            self._tweakPeakView.setXtalDMax(self.prevXtalDMax)
+            self._tweakPeakView.updateXtalDmax(self.prevXtalDMax)
             self._tweakPeakView.enableXtalDMax()
             return SNAPResponse(code=ResponseCode.OK)
 
@@ -217,20 +217,20 @@ class DiffCalWorkflow(WorkflowImplementer):
 
         if "crystalDMin" in overrides:
             newDMin = overrides["crystalDMin"]
-            self._tweakPeakView.setXtalDMin(newDMin)
+            self._tweakPeakView.updateXtalDmin(newDMin)
             self._tweakPeakView.disableXtalDMin()
             self.prevXtalDMin = newDMin
         else:
-            self._tweakPeakView.setXtalDMin(self.prevXtalDMin)
+            self._tweakPeakView.updateXtalDmax(self.prevXtalDMin)
             self._tweakPeakView.enableXtalDMin()
 
         if "crystalDMax" in overrides:
             newDMax = overrides["crystalDMax"]
-            self._tweakPeakView.setXtalDMax(newDMax)
+            self._tweakPeakView.updateXtalDmax(newDMax)
             self._tweakPeakView.disableXtalDMax()
             self.prevXtalDMax = newDMax
         else:
-            self._tweakPeakView.setXtalDMax(self.prevXtalDMax)
+            self._tweakPeakView.updateXtalDmax(self.prevXtalDMax)
             self._tweakPeakView.enableXtalDMax()
 
         return SNAPResponse(code=ResponseCode.OK)

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -198,7 +198,7 @@ class DiffCalWorkflow(WorkflowImplementer):
     def handleOverride(self, sampleFile):
         payload = OverrideRequest(calibrantSamplePath=sampleFile)
         overrides = self.request(path="calibration/override", payload=payload.json()).data
-        breakpoint()
+
         if not overrides:
             self._requestView.enablePeakFunction()
             self._tweakPeakView.enablePeakFunction()
@@ -216,13 +216,13 @@ class DiffCalWorkflow(WorkflowImplementer):
             reqComboBox = self._requestView.peakFunctionDropdown.dropDown
             idxRQ = reqComboBox.findText(peakFunction)
             if idxRQ >= 0:
-                reqComboBox.setCurrentIndex(idxRQ + 1)
+                reqComboBox.setCurrentIndex(idxRQ)
             self._requestView.disablePeakFunction()
 
             twkComboBox = self._tweakPeakView.peakFunctionDropdown.dropDown
             idxTW = twkComboBox.findText(peakFunction)
             if idxTW >= 0:
-                twkComboBox.setCurrentIndex(idxTW + 1)
+                twkComboBox.setCurrentIndex(idxTW)
             self._tweakPeakView.disablePeakFunction()
 
         if "crystalDMin" in overrides:

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -201,31 +201,41 @@ class DiffCalWorkflow(WorkflowImplementer):
 
         if not overrides:
             self._requestView.enablePeakFunction()
+            self._tweakPeakView.enablePeakFunction()
+
             self._tweakPeakView.updateXtalDmin(self.prevXtalDMin)
             self._tweakPeakView.enableXtalDMin()
             self._tweakPeakView.updateXtalDmax(self.prevXtalDMax)
             self._tweakPeakView.enableXtalDMax()
+
             return SNAPResponse(code=ResponseCode.OK)
 
-        if "peakFunction" in overrides:
-            peakFunction = overrides["peakFunction"]
-            comboBox = self._tweakPeakView.peakFunctionDropdown.dropDown
-            idx = comboBox.findText(peakFunction)
-            if idx >= 0:
-                comboBox.setCurrentIndex(idx + 1)
+        if "PeakFunction" in overrides:
+            peakFunction = overrides["PeakFunction"]
+
+            reqComboBox = self._requestView.peakFunctionDropdown.dropDown
+            idxRQ = reqComboBox.findText(peakFunction)
+            if idxRQ >= 0:
+                reqComboBox.setCurrentIndex(idxRQ + 1)
             self._requestView.disablePeakFunction()
 
-        if "crystalDMin" in overrides:
-            newDMin = overrides["crystalDMin"]
+            twkComboBox = self._tweakPeakView.peakFunctionDropdown.dropDown
+            idxTW = twkComboBox.findText(peakFunction)
+            if idxTW >= 0:
+                twkComboBox.setCurrentIndex(idxTW + 1)
+            self._tweakPeakView.disablePeakFunction()
+
+        if "CrystalDMin" in overrides:
+            newDMin = overrides["CrystalDMin"]
             self._tweakPeakView.updateXtalDmin(newDMin)
             self._tweakPeakView.disableXtalDMin()
             self.prevXtalDMin = newDMin
         else:
-            self._tweakPeakView.updateXtalDmax(self.prevXtalDMin)
+            self._tweakPeakView.updateXtalDmin(self.prevXtalDMin)
             self._tweakPeakView.enableXtalDMin()
 
-        if "crystalDMax" in overrides:
-            newDMax = overrides["crystalDMax"]
+        if "CrystalDMax" in overrides:
+            newDMax = overrides["CrystalDMax"]
             self._tweakPeakView.updateXtalDmax(newDMax)
             self._tweakPeakView.disableXtalDMax()
             self.prevXtalDMax = newDMax

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -198,7 +198,7 @@ class DiffCalWorkflow(WorkflowImplementer):
     def handleOverride(self, sampleFile):
         payload = OverrideRequest(calibrantSamplePath=sampleFile)
         overrides = self.request(path="calibration/override", payload=payload.json()).data
-
+        breakpoint()
         if not overrides:
             self._requestView.enablePeakFunction()
             self._tweakPeakView.enablePeakFunction()
@@ -210,8 +210,8 @@ class DiffCalWorkflow(WorkflowImplementer):
 
             return SNAPResponse(code=ResponseCode.OK)
 
-        if "PeakFunction" in overrides:
-            peakFunction = overrides["PeakFunction"]
+        if "peakFunction" in overrides:
+            peakFunction = overrides["peakFunction"]
 
             reqComboBox = self._requestView.peakFunctionDropdown.dropDown
             idxRQ = reqComboBox.findText(peakFunction)
@@ -225,8 +225,8 @@ class DiffCalWorkflow(WorkflowImplementer):
                 twkComboBox.setCurrentIndex(idxTW + 1)
             self._tweakPeakView.disablePeakFunction()
 
-        if "CrystalDMin" in overrides:
-            newDMin = overrides["CrystalDMin"]
+        if "crystalDMin" in overrides:
+            newDMin = overrides["crystalDMin"]
             self._tweakPeakView.updateXtalDmin(newDMin)
             self._tweakPeakView.disableXtalDMin()
             self.prevXtalDMin = newDMin
@@ -234,8 +234,8 @@ class DiffCalWorkflow(WorkflowImplementer):
             self._tweakPeakView.updateXtalDmin(self.prevXtalDMin)
             self._tweakPeakView.enableXtalDMin()
 
-        if "CrystalDMax" in overrides:
-            newDMax = overrides["CrystalDMax"]
+        if "crystalDMax" in overrides:
+            newDMax = overrides["crystalDMax"]
             self._tweakPeakView.updateXtalDmax(newDMax)
             self._tweakPeakView.disableXtalDMax()
             self.prevXtalDMax = newDMax


### PR DESCRIPTION
## Description of work
This work is to facilitate the addition of override arguments within calibrant sample (.json) files in regards to a series of variables. These overrides, as requested, include the following values:
* `CrystalDMin`
* `CrystalDMax`
* `PeakFunction`

These overrides let users specify special minimum/maximum d-spacings or a custom peak function directly in the calibrant’s JSON rather than relying on the application defaults. If a calibrant is known to require different parameters, this mechanism ensures the workflow automatically applies them whenever the calibrant is loaded.
<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work
### Techniques & Approaches Used
* New `overrides` field in `CalibrantSample` (Pydantic model) to store calibrant-specific parameter changes.
* `OverrideRequest` to shuttle the `calibrantSamplePath` from front-end to service, simplifying the read of that JSON file.
* UI logic in `DiffCalWorkflow.handleOverride`: checks for override keys and updates or disables corresponding fields in DiffCalTweakPeakView.

### New Algorithms / Classes / Variables
* `class OverrideRequest`
A small Pydantic model for the override-check request.

* `overrides: Optional[Dict[str, Any]]` within `CalibrantSample`
Allows calibrant JSON to declare something like:
```json
"overrides": {
  "CrystalDMin": 0.35,
  "CrystalDMax": 60.0,
  "PeakFunction": "Gaussian"
}
```
<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing
To test this please modify any of the calibrant sample files within your local `Calibration` directory. And edit to include the following `overrides` dictionary within it:

```json
"peakIntensityFractionThreshold": 0.0 ,
    "overrides":{
        "peakFunction": "Gaussian",
        "crystalDMin": 0.3,
        "crystalDMax": 110.0
    }
}
```
After having done this change, modify the values to any that are desired and with a clean state folder, test the diffraction calibration workflow with a run number of choice. Please use the modified calibrant sample file to insure the desired UI behavior is presented within the first and second views within the diffraction calibration workflow.
<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing
Same as above.
<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM # 9125](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9125)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

For the parameters:
* PeakFunction
* CrystalDMin
* CrystalDMax
Do the following:
- [x] add these to the json that contains the other properties of the calibrant sample
- [x] read the values from the file if they are present within calibrant sample file
- [x] disable the corresponding fields in the test panel
