### PR TITLE
Add wavelength cropping of input neutron data used during normcal workflow

### DIFF
--- a/src/snapred/backend/dao/ingredients/NormalizationIngredients.py
+++ b/src/snapred/backend/dao/ingredients/NormalizationIngredients.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.state.CalibrantSample import CalibrantSample
 from snapred.backend.dao.state.PixelGroup import PixelGroup
+from snapred.backend.dao.state.InstrumentState import InstrumentState
 
 
 class NormalizationIngredients(BaseModel):
@@ -13,3 +14,4 @@ class NormalizationIngredients(BaseModel):
     pixelGroup: PixelGroup
     calibrantSample: CalibrantSample
     detectorPeaks: List[GroupPeakList]
+    instrumentState: InstrumentState

--- a/src/snapred/backend/recipe/algorithm/RawVanadiumCorrectionAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/RawVanadiumCorrectionAlgorithm.py
@@ -52,6 +52,8 @@ class RawVanadiumCorrectionAlgorithm(PythonAlgorithm):
         self.geometry = ingredients.calibrantSample.geometry
         self.material = ingredients.calibrantSample.material
         self.sampleShape = self.geometry.shape
+        self.lambdaMin = ingredients.instrumentState.particleBounds.wavelength.minimum
+        self.lambdaMax = ingredients.instrumentState.particleBounds.wavelength.maximum
 
     def unbagGroceries(self) -> None:
         self.inputVanadiumWS = self.getPropertyValue("InputWorkspace")
@@ -82,6 +84,8 @@ class RawVanadiumCorrectionAlgorithm(PythonAlgorithm):
             OutputWorkspace=outputWS,
             BinningMode="Logarithmic",
         )
+
+        print(f"/n I AM ABOUT TO CHOP TO THESE: {self.lambdaMin} {self.lambdaMax}\n")
 
         self.mantidSnapper.MakeDirtyDish(
             "make a copy of data after chop",

--- a/src/snapred/backend/recipe/algorithm/RawVanadiumCorrectionAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/RawVanadiumCorrectionAlgorithm.py
@@ -85,7 +85,28 @@ class RawVanadiumCorrectionAlgorithm(PythonAlgorithm):
             BinningMode="Logarithmic",
         )
 
-        print(f"/n I AM ABOUT TO CHOP TO THESE: {self.lambdaMin} {self.lambdaMax}\n")
+        #Malcolm added these lines ##################
+        self.mantidSnapper.ConvertUnits(
+            "Convert workspace to wavelength units",
+            InputWorkspace=outputWS,
+            Outputworkspace=outputWS,
+            Target="Wavelength",
+        )
+
+        self.mantidSnapper.CropWorkspace(
+            "crop all events outside of range",
+            InputWorkspace=outputWS,
+            Outputworkspace=outputWS,
+            XMin = self.lambdaMin,
+            XMax = self.lambdaMax)
+
+        self.mantidSnapper.ConvertUnits(
+            "Ensure workspace is in TOF units",
+            InputWorkspace=outputWS,
+            Outputworkspace=outputWS,
+            Target="TOF",
+        )
+        ################################
 
         self.mantidSnapper.MakeDirtyDish(
             "make a copy of data after chop",

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -302,6 +302,7 @@ class SousChef(Service):
             pixelGroup=self.prepPixelGroup(ingredients),
             calibrantSample=self.prepCalibrantSample(ingredients.calibrantSamplePath),
             detectorPeaks=self.prepDetectorPeaks(ingredients, purgePeaks=False),
+            instrumentState = self.prepInstrumentState(ingredients),
         )
 
     def prepDiffractionCalibrationIngredients(

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -216,8 +216,8 @@ constants:
     rebinParams: [2000, -0.001, 14500]
   CropFactors:
     lowWavelengthCrop: -0.04
-    lowdSpacingCrop: 0.05
-    highdSpacingCrop: 0.05
+    lowdSpacingCrop: 0.015
+    highdSpacingCrop: 0.022
   CrystallographicInfo:
     crystalDMin: 0.7
     crystalDMax: 100.0

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -12,7 +12,7 @@ instrument:
   name: SNAP
   home: ${IPTS.root}/SNAP
   calibration:
-    home: ${instrument.home}/shared/Calibration
+    home: ${instrument.home}/shared/Calibration_testing
     sample:
       home: ${instrument.calibration.home}/CalibrantSamples
       extensions:
@@ -215,11 +215,11 @@ constants:
     tofMax: 14500
     rebinParams: [2000, -0.001, 14500]
   CropFactors:
-    lowWavelengthCrop: 0.05
-    lowdSpacingCrop: 0.1
-    highdSpacingCrop: 0.15
+    lowWavelengthCrop: -0.04
+    lowdSpacingCrop: 0.05
+    highdSpacingCrop: 0.05
   CrystallographicInfo:
-    crystalDMin: 0.4
+    crystalDMin: 0.7
     crystalDMax: 100.0
   DetectorPeakPredictor:
     fwhm: 1.17741002252 # used to convert gaussian to fwhm (2 * log_e(2))
@@ -227,7 +227,7 @@ constants:
     toggleCompressionTolerance: false  # false = no tolerance compression, true = tolerance compression
     # tolerance: -0.004                 # tolerance override for calculated compression
   GroupDiffractionCalibration:
-    MaxChiSq: 100
+    MaxChiSq: 10000
   RawVanadiumCorrection:
     numberOfSlices: 10
     numberOfAnnuli: 10


### PR DESCRIPTION
## Description of work

At low and high wavelength ends of the spectral data in each neutron dataset, the background increases steeply. This is attributed to blade edge effects on the instrument choppers. 

If the events in this high background region aren't removed, the result is increased background at the edge of the diffraction-focused data in SNAPRed. This cannot be fixed with existing _d-space_ cropping options

This PR enables the removal of these events during Normcal. Future related
work should enable identical treatment of sample neutron data used during reduction.

## Explanation of work

The gist of this work is to use mantid `CropWorkspace` to remove the problematic events using as input parameters existing SNAPRed parameters that delineate max and min wavelength range. 

What is missing from this work is any assessment of impact on unit tests, or attempt to address this.

## To test

### Dev testing

<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing

CIS and IS have already tested the output of this PR and found it solves the issue. 

## Link to EWM item

This PR arose during prototyping not captured in EWM.

### Verification

- [ ] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

All events outside SNAPRed calculated wavelength limits are removed prior to saving of output raw vanadium correction.

