### PR TITLE
mutex savenexus calls to prevent segfaults

### DIFF
--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -201,10 +201,14 @@ class MantidSnapper:
             self.cleanup()
             raise AlgorithmException(name, str(e)) from e
         finally:
-            self._waitForAlgorithmCompletion(name)
-            AlgorithmManager.removeById(algorithm.getAlgorithmID())
+            self._cleanupNonConcurrent(name, algorithm)
             if mutex is not None:
                 mutex.release()
+
+    def _cleanupNonConcurrent(self, name, algorithm):
+        if name in self._nonConcurrentAlgorithms:
+            self._waitForAlgorithmCompletion(name)
+            AlgorithmManager.removeById(algorithm.getAlgorithmID())
 
     def executeQueue(self):
         if self.parentAlgorithm:

--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -151,7 +151,7 @@ class MantidSnapper:
         currentTimeout = 0
         while len(AlgorithmManager.runningInstancesOf(name)) > 0:
             if currentTimeout >= self.timeout:
-                raise TimeoutError(f"Timeout occured while waiting for instance of {name} to cleanup")
+                raise TimeoutError(f"Timeout occurred while waiting for instance of {name} to cleanup")
             currentTimeout += self.checkInterval
             time.sleep(self.checkInterval)
 

--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -82,6 +82,8 @@ class MantidSnapper:
         self._algorithmQueue = []
         self._exportScript = ""
         self._export = False
+        self.timeout = 60  # seconds
+        self.checkInterval = 0.05  # 50 ms
         if self._export:
             self._cleanOldExport()
 
@@ -146,14 +148,12 @@ class MantidSnapper:
         return alg
 
     def _waitForAlgorithmCompletion(self, name):
-        timeout = 60  # seconds
-        checkInterval = 0.05  # 50 ms
         currentTimeout = 0
         while len(AlgorithmManager.runningInstancesOf(name)) > 0:
-            if currentTimeout >= timeout:
-                raise RuntimeError(f"Timeout occured while waiting for instance of {name} to cleanup")
-            currentTimeout += checkInterval
-            time.sleep(checkInterval)
+            if currentTimeout >= self.timeout:
+                raise TimeoutError(f"Timeout occured while waiting for instance of {name} to cleanup")
+            currentTimeout += self.checkInterval
+            time.sleep(self.checkInterval)
 
     def obtainMutex(self, name):
         mutex = self._nonReentrantMutexes.get(name)

--- a/tests/cis_tests/recreate_save_reduction_segfault.py
+++ b/tests/cis_tests/recreate_save_reduction_segfault.py
@@ -1,0 +1,39 @@
+from snapred.backend.dao.reduction.ReductionRecord import ReductionRecord
+from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
+from snapred.backend.recipe.algorithm.Utensils import Utensils
+import h5py
+from snapred.backend.data.NexusHDF5Metadata import NexusHDF5Metadata as n5m
+from snapred.meta.redantic import parse_file_as
+import time
+
+inputFile = "/SNS/users/wqp/SNAP/IPTS-24641/shared/SNAPRed/04bd2c53f6bf6754/lite/46680/2024-11-26T121144/reduced_046680_2024-11-26T121144.nxs.h5"
+outputFile = "/SNS/users/wqp/tmp/test_segfault_append.nxs"
+record = parse_file_as(ReductionRecord, "/SNS/users/wqp/SNAP/IPTS-24641/shared/SNAPRed/04bd2c53f6bf6754/lite/46680/2024-11-26T121144/ReductionRecord.json")
+
+untensils = Utensils()
+untensils.PyInit()
+mantidSnapper = untensils.mantidSnapper
+
+ws = mantidSnapper.LoadNexus("..", Filename=inputFile, OutputWorkspace="ws")
+mantidSnapper.executeQueue()
+
+with open("snapred_script.log", "w") as f:
+    import faulthandler
+    faulthandler.enable(file=f)
+    try:
+        for i in range(100):
+            for wsName in mantidSnapper.mtd[ws].getNames():
+                mantidSnapper.SaveNexus("..", InputWorkspace=wsName, Filename=outputFile, Append=True)
+                mantidSnapper.executeQueue()
+
+            # commented out to see if this somehow competed with SaveNexus, it does not
+            # with h5py.File(outputFile, "a") as h5:
+            #         n5m.insertMetadataGroup(h5, record.dict(), "/metadata")
+
+            import os
+            os.remove(outputFile)
+    finally:
+        faulthandler.disable()
+
+    
+    

--- a/tests/unit/backend/recipe/algorithm/test_MantidSnapper.py
+++ b/tests/unit/backend/recipe/algorithm/test_MantidSnapper.py
@@ -1,10 +1,13 @@
 import unittest
 from unittest import mock
 
+import pytest
 from mantid.kernel import Direction
 
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Callback import callback
+
+PatchRoot: str = "snapred.backend.recipe.algorithm.MantidSnapper.{0}"
 
 
 class TestMantidSnapper(unittest.TestCase):
@@ -17,7 +20,7 @@ class TestMantidSnapper(unittest.TestCase):
         self.fakeFunction.getProperties.return_value = [self.fakeOutput]
         self.fakeFunction.getProperty.return_value = self.fakeOutput
 
-    @mock.patch("snapred.backend.recipe.algorithm.MantidSnapper.AlgorithmManager")
+    @mock.patch(PatchRoot.format("AlgorithmManager"))
     def test_snapper_fake_algo(self, mock_AlgorithmManager):
         mock_AlgorithmManager.create.return_value = self.fakeFunction
         return_of_algo = "return of algo"
@@ -25,7 +28,7 @@ class TestMantidSnapper(unittest.TestCase):
         test = mantidSnapper.fakeFunction("test", fakeOutput=return_of_algo)
         assert str(test.__class__) == str(callback(return_of_algo.__class__).__class__)
 
-    @mock.patch("snapred.backend.recipe.algorithm.MantidSnapper.AlgorithmManager")
+    @mock.patch(PatchRoot.format("AlgorithmManager"))
     def test_snapper_fake_queue(self, mock_AlgorithmManager):
         mock_AlgorithmManager.create.return_value = self.fakeFunction
         return_of_algo = "return of algo"
@@ -33,3 +36,38 @@ class TestMantidSnapper(unittest.TestCase):
         mantidSnapper.fakeFunction("test", fakeOutput=return_of_algo)
         mantidSnapper.executeQueue()
         assert self.fakeFunction.execute.called
+
+    @mock.patch(PatchRoot.format("AlgorithmManager"))
+    def test_timeout(self, mockAlgorithmManager):
+        mockAlgorithmManager.runningInstancesOf = mock.Mock(return_value=["theAlgoThatNeverEnds"])
+        mockAlgorithmManager.create.return_value = self.fakeFunction
+
+        mantidSnapper = MantidSnapper(parentAlgorithm=None, name="")
+        mantidSnapper.timeout = 0.2
+        mantidSnapper.fakeFunction("test", fakeOutput="output")
+
+        with pytest.raises(TimeoutError, match="Timeout occured while waiting for instance of"):
+            mantidSnapper.executeQueue()
+
+    @mock.patch(PatchRoot.format("AlgorithmManager"))
+    def test_mutexIsObtained_nonConcurrent(self, mockAlgorithmManager):
+        mockAlgorithmManager.create.return_value = self.fakeFunction
+        mantidSnapper = MantidSnapper(parentAlgorithm=None, name="")
+        mantidSnapper.fakeFunction("test", fakeOutput="output")
+        mantidSnapper._nonConcurrentAlgorithms = mantidSnapper._nonConcurrentAlgorithms + ("fakeFunction",)
+        mantidSnapper._nonConcurrentAlgorithmMutex = mock.Mock()
+
+        mantidSnapper.executeQueue()
+        assert mantidSnapper._nonConcurrentAlgorithmMutex.acquire.called
+        assert mantidSnapper._nonConcurrentAlgorithmMutex.release.called
+
+    @mock.patch(PatchRoot.format("AlgorithmManager"))
+    def test_mutexIsObtained_nonReentrant(self, mockAlgorithmManager):
+        mockAlgorithmManager.create.return_value = self.fakeFunction
+        mantidSnapper = MantidSnapper(parentAlgorithm=None, name="")
+        mantidSnapper.fakeFunction("test", fakeOutput="output")
+        mantidSnapper._nonReentrantMutexes["fakeFunction"] = mock.Mock()
+
+        mantidSnapper.executeQueue()
+        assert mantidSnapper._nonReentrantMutexes["fakeFunction"].acquire.called
+        assert mantidSnapper._nonReentrantMutexes["fakeFunction"].release.called

--- a/tests/unit/backend/recipe/algorithm/test_MantidSnapper.py
+++ b/tests/unit/backend/recipe/algorithm/test_MantidSnapper.py
@@ -48,7 +48,7 @@ class TestMantidSnapper(unittest.TestCase):
         mantidSnapper._nonConcurrentAlgorithms = mantidSnapper._nonConcurrentAlgorithms + ("fakeFunction",)
         mantidSnapper._nonConcurrentAlgorithmMutex = mock.Mock()
 
-        with pytest.raises(TimeoutError, match="Timeout occured while waiting for instance of"):
+        with pytest.raises(TimeoutError, match="Timeout occurred while waiting for instance of"):
             mantidSnapper.executeQueue()
 
     @mock.patch(PatchRoot.format("AlgorithmManager"))


### PR DESCRIPTION
## Description of work

This adds a mutex for SaveNexus in MantidSnapper to mitigate the race condition we are experiencing 



## To test

**NOTE: Test script points to data in MY directory, update paths before you run!**

Attempt to reduce `64486`, default calibration and artificial normalization is fine.
run cis script in pr at the same time.
Repeat till self assured.
Observe no segfault.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#8534](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8534)

### Verification

- [ ] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] acceptance criterion 1
- [ ] acceptance criterion 2
