### PR TITLE
ReductionRecipe: check fully-masked group using PGP.isMasked flags

### DIFF
--- a/tests/unit/backend/recipe/test_ReductionRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionRecipe.py
@@ -37,7 +37,7 @@ class ReductionRecipeTest(TestCase):
             "normalizationWorkspace": normWS,
             "diffcalWorkspace": difcWS,
         }
-        
+
     def mockPixelGroup(self, name: str, isFullyMasked: bool, N_gid: int):
         # Create a mock `PixelGroup` named `name` with `N_gid` mock subgroup PGPs:
         #   `isFullyMasked` => all subgroups will have their `isMasked` flags set,
@@ -49,15 +49,13 @@ class ReductionRecipeTest(TestCase):
                     spec=PixelGroupingParameters,
                     # Unless it's fully masked,
                     #   generate sometimes masked subgroups when N_gid > 1.
-                    isMasked=True if isFullyMasked else (gid % 2 == 0)
-                ) for gid in range(N_gid)
+                    isMasked=True if isFullyMasked else (gid % 2 == 0),
+                )
+                for gid in range(N_gid)
             },
-            focusGroup=FocusGroup(
-                name=name,
-                definition=f"path_for_focus_group_{name}"
-            )
+            focusGroup=FocusGroup(name=name, definition=f"path_for_focus_group_{name}"),
         )
-            
+
     def test_validateInputs_bad_workspaces(self):
         groceries = {
             "inputWorkspace": mock.sentinel.input,
@@ -271,16 +269,8 @@ class ReductionRecipeTest(TestCase):
             useLiteMode=True,
             timestamp=time.time(),
             pixelGroups=[
-                self.mockPixelGroup(
-                    name="Column",
-                    isFullyMasked=False,
-                    N_gid=6
-                ),
-                self.mockPixelGroup(
-                    name="Bank",
-                    isFullyMasked=False,
-                    N_gid=2
-                )
+                self.mockPixelGroup(name="Column", isFullyMasked=False, N_gid=6),
+                self.mockPixelGroup(name="Bank", isFullyMasked=False, N_gid=2),
             ],
             detectorPeaksMany=[["peaks"], ["peaks2"]],
         )
@@ -479,7 +469,7 @@ class ReductionRecipeTest(TestCase):
         recipe.mantidSnapper = mockMantidSnapper
         recipe.queueAlgos()
         assert mockMantidSnapper.mock_calls == []
-    
+
     @mock.patch("mantid.simpleapi.mtd", create=True)
     def test_execute(self, mockMtd):
         mockMantidSnapper = mock.Mock()
@@ -506,16 +496,8 @@ class ReductionRecipeTest(TestCase):
             useLiteMode=True,
             timestamp=time.time(),
             pixelGroups=[
-                self.mockPixelGroup(
-                    name="Column",
-                    isFullyMasked=False,
-                    N_gid=6
-                ),
-                self.mockPixelGroup(
-                    name="Bank",
-                    isFullyMasked=False,
-                    N_gid=2
-                )
+                self.mockPixelGroup(name="Column", isFullyMasked=False, N_gid=6),
+                self.mockPixelGroup(name="Bank", isFullyMasked=False, N_gid=2),
             ],
             detectorPeaksMany=[["peaks"], ["peaks2"]],
         )
@@ -649,16 +631,8 @@ class ReductionRecipeTest(TestCase):
                 useLiteMode=True,
                 timestamp=time.time(),
                 pixelGroups=[
-                    self.mockPixelGroup(
-                        name="Column",
-                        isFullyMasked=False,
-                        N_gid=6
-                    ),
-                    self.mockPixelGroup(
-                        name="Bank",
-                        isFullyMasked=False,
-                        N_gid=2
-                    )
+                    self.mockPixelGroup(name="Column", isFullyMasked=False, N_gid=6),
+                    self.mockPixelGroup(name="Bank", isFullyMasked=False, N_gid=2),
                 ],
                 detectorPeaksMany=[["peaks"], ["peaks2"]],
             )
@@ -729,29 +703,13 @@ class ReductionRecipeTest(TestCase):
             useLiteMode=True,
             timestamp=time.time(),
             pixelGroups=[
-                self.mockPixelGroup(
-                    name="Column",
-                    isFullyMasked=False,
-                    N_gid=6
-                ),
-                self.mockPixelGroup(
-                    name="Bank",
-                    isFullyMasked=False,
-                    N_gid=2
-                ),
-                self.mockPixelGroup(
-                    name="Column2",
-                    isFullyMasked=True,
-                    N_gid=6
-                ),
-                self.mockPixelGroup(
-                    name="Bank2",
-                    isFullyMasked=True,
-                    N_gid=2
-                ),                                
+                self.mockPixelGroup(name="Column", isFullyMasked=False, N_gid=6),
+                self.mockPixelGroup(name="Bank", isFullyMasked=False, N_gid=2),
+                self.mockPixelGroup(name="Column2", isFullyMasked=True, N_gid=6),
+                self.mockPixelGroup(name="Bank2", isFullyMasked=True, N_gid=2),
             ],
         )
-        
+
         for n, flag in enumerate((False, False, True, True)):
             result = recipe._isGroupFullyMasked(n)
             assert result == flag
@@ -785,16 +743,8 @@ class ReductionRecipeTest(TestCase):
             useLiteMode=True,
             timestamp=time.time(),
             pixelGroups=[
-                self.mockPixelGroup(
-                    name="The_column_grouping",
-                    isFullyMasked=True,
-                    N_gid=6
-                ),
-                self.mockPixelGroup(
-                    name="The_bank_grouping",
-                    isFullyMasked=True,
-                    N_gid=2
-                ),                                
+                self.mockPixelGroup(name="The_column_grouping", isFullyMasked=True, N_gid=6),
+                self.mockPixelGroup(name="The_bank_grouping", isFullyMasked=True, N_gid=2),
             ],
         )
         recipe.ingredients.groupProcessing = mock.Mock(
@@ -833,11 +783,13 @@ class ReductionRecipeTest(TestCase):
             recipe.ingredients.pixelGroups[1].focusGroup.name,
         )
         expected_warning_message_group1 = (
-            f"\nAll pixels within the '{groupNames[0]}' grouping are masked.\n" "Skipping all algorithm execution for this grouping."
+            f"\nAll pixels within the '{groupNames[0]}' grouping are masked.\n"
+            "Skipping all algorithm execution for this grouping."
         )
 
         expected_warning_message_group2 = (
-            f"\nAll pixels within the '{groupNames[1]}' grouping are masked.\n" "Skipping all algorithm execution for this grouping."
+            f"\nAll pixels within the '{groupNames[1]}' grouping are masked.\n"
+            "Skipping all algorithm execution for this grouping."
         )
 
         # Check that the warnings were logged for both groups
@@ -856,7 +808,7 @@ class ReductionRecipeTest(TestCase):
 
         # Check the output result contains the mask workspace
         assert result["outputs"][0] == "mask", "Expected the mask workspace to be included in the outputs."
-        
+
     def test_cook(self):
         recipe = ReductionRecipe()
         recipe.prep = mock.Mock()


### PR DESCRIPTION
## Description of work
This fixes a critical defect due to the previous implementation of the `_isGroupFullyMasked` method.  In addition, the current implementation makes use of the already calculated `PixelGroupingParameters.isMasked` flags, which are set for any fully-masked subgroups in a grouping schema.


## Explanation of work
This commit includes the following changes:

  * Repair the implementation of `ReductionRecipe._isGroupFullyMasked` so it actually evaluates whether or not every pixel within every subgroup of a grouping schema is masked.

  The previous implementation of this method was based on the assumption that each spectrum of a grouping workspace contained a list of the indices of all of the pixels participating in a subgroup of the schema, with the subgroup-id corresponding to spectrum index.  On the contrary, each spectrum of a grouping workspace contains a single value, which is the subgroup-id of the pixel with the same detector-index as that the spectrum-index.  The net effect if this confusion was that any mask workspace that had a small number of the lowest-index pixels masked, corresponding to the number of subgroups in the schema (+ 1), would result in the method determining that every subgroup in the schema was fully masked, which was clearly incorrect.


## To test

### Dev testing
Existing unit tests have been modified to cover these new changes.

### CIS testing
To duplicate the original defect, please see the EWM item.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#9603](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=9603)
