### PR TITLE
Ewm9433 defect fix spectral edges

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
 - python=3.10
 - pip
 - pydantic>=2.7.3,<3
-- mantidworkbench=6.11.0.4rc1
+- mantidworkbench=6.11.0.5rc1
 - qtpy
 - pre-commit
 - pytest

--- a/src/snapred/backend/dao/state/PixelGroup.py
+++ b/src/snapred/backend/dao/state/PixelGroup.py
@@ -82,7 +82,7 @@ class PixelGroup(BaseModel):
         #   different Mantid algorithms use either "0.0" or "NaN" to indicate an unspecified value,
         #   so these values may need to be filtered.
         return [
-            self.pixelGroupingParameters[gid].dResolution.maximum + Config["constants.CropFactors.highdSpacingCrop"]
+            self.pixelGroupingParameters[gid].dResolution.maximum - Config["constants.CropFactors.highdSpacingCrop"]
             if not self.pixelGroupingParameters[gid].isMasked
             else default
             for gid in self.groupIDs
@@ -93,7 +93,7 @@ class PixelGroup(BaseModel):
         #   different Mantid algorithms use either "0.0" or "NaN" to indicate an unspecified value,
         #   so these values may need to be filtered.
         return [
-            self.pixelGroupingParameters[gid].dResolution.minimum - Config["constants.CropFactors.lowdSpacingCrop"]
+            self.pixelGroupingParameters[gid].dResolution.minimum + Config["constants.CropFactors.lowdSpacingCrop"]
             if not self.pixelGroupingParameters[gid].isMasked
             else default
             for gid in self.groupIDs

--- a/src/snapred/backend/dao/state/PixelGroup.py
+++ b/src/snapred/backend/dao/state/PixelGroup.py
@@ -82,7 +82,7 @@ class PixelGroup(BaseModel):
         #   different Mantid algorithms use either "0.0" or "NaN" to indicate an unspecified value,
         #   so these values may need to be filtered.
         return [
-            self.pixelGroupingParameters[gid].dResolution.maximum
+            self.pixelGroupingParameters[gid].dResolution.maximum + Config["constants.CropFactors.highdSpacingCrop"]
             if not self.pixelGroupingParameters[gid].isMasked
             else default
             for gid in self.groupIDs
@@ -93,7 +93,7 @@ class PixelGroup(BaseModel):
         #   different Mantid algorithms use either "0.0" or "NaN" to indicate an unspecified value,
         #   so these values may need to be filtered.
         return [
-            self.pixelGroupingParameters[gid].dResolution.minimum
+            self.pixelGroupingParameters[gid].dResolution.minimum - Config["constants.CropFactors.lowdSpacingCrop"]
             if not self.pixelGroupingParameters[gid].isMasked
             else default
             for gid in self.groupIDs

--- a/src/snapred/backend/recipe/RebinFocussedGroupDataRecipe.py
+++ b/src/snapred/backend/recipe/RebinFocussedGroupDataRecipe.py
@@ -28,6 +28,17 @@ class RebinFocussedGroupDataRecipe(Recipe[Ingredients]):
         Chops off the needed elements of the ingredients.
         We are mostly concerned about the drange for a ResampleX operation.
         """
+        lowdSpacingCrop = Config["constants.CropFactors.lowdSpacingCrop"]
+        highdSpacingCrop = Config["constants.CropFactors.highdSpacingCrop"]
+
+        if lowdSpacingCrop < 0:
+            raise ValueError("Low d-spacing crop factor must be positive")
+        if highdSpacingCrop < 0:
+            raise ValueError("High d-spacing crop factor must be positive")
+
+        if (lowdSpacingCrop > 100) or (highdSpacingCrop > 100):
+            raise ValueError("d-spacing crop factors are too large")
+
         self.pixelGroup = ingredients.pixelGroup
         dMin = self.pixelGroup.dMin()
         dMax = self.pixelGroup.dMax()

--- a/src/snapred/backend/recipe/RebinFocussedGroupDataRecipe.py
+++ b/src/snapred/backend/recipe/RebinFocussedGroupDataRecipe.py
@@ -29,23 +29,16 @@ class RebinFocussedGroupDataRecipe(Recipe[Ingredients]):
         We are mostly concerned about the drange for a ResampleX operation.
         """
         self.pixelGroup = ingredients.pixelGroup
-        # The adjustment below is a temp fix, will be permanently fixed in EWM 6262
-        lowdSpacingCrop = Config["constants.CropFactors.lowdSpacingCrop"]
-        if lowdSpacingCrop < 0:
-            raise ValueError("Low d-spacing crop factor must be positive")
+        dMin = self.pixelGroup.dMin()
+        dMax = self.pixelGroup.dMax()
+        dBin = self.pixelGroup.dBin()
 
-        highdSpacingCrop = Config["constants.CropFactors.highdSpacingCrop"]
-        if highdSpacingCrop < 0:
-            raise ValueError("High d-spacing crop factor must be positive")
+        if not all(_dMax > _dMin for _dMin, _dMax in zip(dMin, dMax)):
+            raise ValueError("Invalid d-spacing range detected: some dMax <= dMin.")
 
-        dMin = [x + lowdSpacingCrop for x in self.pixelGroup.dMin()]
-        dMax = [x - highdSpacingCrop for x in self.pixelGroup.dMax()]
-
-        if not dMax > dMin:
-            raise ValueError("d-spacing crop factors are too large -- resultant dMax must be > resultant dMin")
         self.dMin = dMin
         self.dMax = dMax
-        self.dBin = self.pixelGroup.dBin()
+        self.dBin = dBin
 
         self.preserveEvents = ingredients.preserveEvents
 

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -291,8 +291,8 @@ constants:
 
   CropFactors:
     lowWavelengthCrop: 0.05
-    lowdSpacingCrop: 0.1
-    highdSpacingCrop: 0.15
+    lowdSpacingCrop: 0.0
+    highdSpacingCrop: 0.0
 
   RawVanadiumCorrection:
     numberOfSlices: 1

--- a/tests/unit/backend/recipe/test_RebinFocussedGroupDataRecipe.py
+++ b/tests/unit/backend/recipe/test_RebinFocussedGroupDataRecipe.py
@@ -12,6 +12,7 @@ from util.Config_helpers import Config_override
 from util.dao import DAOFactory
 from util.SculleryBoy import SculleryBoy
 
+from snapred.backend.dao.Limit import Limit
 from snapred.backend.recipe.RebinFocussedGroupDataRecipe import RebinFocussedGroupDataRecipe as Recipe
 
 ThisRecipe: str = "snapred.backend.recipe.RebinFocussedGroupDataRecipe"
@@ -70,5 +71,23 @@ class TestRebinFocussedGroupDataRecipe(unittest.TestCase):
         with (
             Config_override("constants.CropFactors.highdSpacingCrop", -10.0),
             pytest.raises(ValueError, match="High d-spacing crop factor must be positive"),
+        ):
+            recipe.chopIngredients(ingredients)
+
+    def test_bad_dspacing_range(self):
+        pixel_group = self.sculleryBoy.prepPixelGroup()
+
+        first_group_id = list(pixel_group.pixelGroupingParameters.keys())[0]
+        group_params = pixel_group.pixelGroupingParameters[first_group_id]
+
+        group_params.dResolution = Limit[float](minimum=0.1, maximum=2.0)
+
+        ingredients = Recipe.Ingredients(pixelGroup=pixel_group, preserveEvents=True)
+        recipe = Recipe()
+
+        with (
+            Config_override("constants.CropFactors.lowdSpacingCrop", 3.0),
+            Config_override("constants.CropFactors.highdSpacingCrop", 0.0),
+            pytest.raises(ValueError, match="Invalid d-spacing range detected: some dMax <= dMin."),
         ):
             recipe.chopIngredients(ingredients)


### PR DESCRIPTION
## Description of work
This work is to address a discrepancy noticed by Malcolm in testing the workflows within SNAPRed. He discovered that due to the differences within the `dMin` & `dMax` values used within the Reduction workflow and within the Normalization workflow. 
<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work
Within this work, the object called `PixelGroup` was slightly refactored to update the `dMin` and `dMax` values to be defined as follows:
* `dMin =  dMin = ingredients.pixelGroups.pixelGoupingParmameters[n].dResolution.minimum + constants.CropFactors.lowdSpacingCrop`
* `dMax = ingredients.pixelGroups.pixelGoupingParmameters[n].dResolution.maximum - constants.CropFactors.highdSpacingCrop`

Following this refactor, I updated a small portion within `RebinFocussedGroupDataRecipe` where the above definition was previously employed already. Now that this is defined concretely within PixelGroup, we no longer needed the logic to update the dMin and dMax values as now they will be consistent globally across all workflows.
<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing
Please insure all pytests pass. Start SNAPRed and insure that all workflows execute successfully without any issues or crashes.
<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing
Please do an in-depth study of the workspaces to insure that the fix to dMin and dMax values to include cropping factors has fixed the issue. 
**Note:** You can mess around with the values within `application.yml` to find the proper cropping factors unless the values that are present are already nominal. The values for this are under `constants` -> `CropFactors`.
<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM # 9433](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9433)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] Updates values for dMin and dMax
- [x] All SNAPRed workflows are functional
