### PR TITLE
Ewm9431 exclude wavelengths

### DIFF
--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 from mantid.dataobjects import MaskWorkspace
 from mantid.simpleapi import (
-    CropWorkspace,
     mtd,
 )
 from pydantic import validate_call
@@ -878,12 +877,23 @@ class GroceryService:
             data["workspace"] = workspaceName
             print(f"Cropping {workspaceName}")
             instrumentState = self.dataService.generateInstrumentState(runNumber)
-            CropWorkspace(
+            self.mantidSnapper.CropWorkspace(
                 InputWorkspace=workspaceName,
                 OutputWorkspace=workspaceName,
                 XMin=instrumentState.particleBounds.tof.minimum,
                 XMax=instrumentState.particleBounds.tof.maximum,
             )
+            config = self.dataService.getInstrumentConfig()
+            width = config.width
+            frequency = config.frequency
+            self.mantidSnapper.RemovePromptPulse(
+                "Removing prompt pulse",
+                InputWorkspace=workspaceName,
+                OutputWorkspace=workspaceName,
+                Width=width,
+                Frequency=frequency,
+            )
+            self.mantidSnapper.executeQueue()
 
         return data
 
@@ -1022,12 +1032,24 @@ class GroceryService:
             wsClone = self.getCloneOfWorkspace(rawWorkspaceName, workspaceName) is not None
             print(f"Cropping {workspaceName}")
             instrumentState = self.dataService.generateInstrumentState(runNumber)
-            CropWorkspace(
+            self.mantidSnapper.CropWorkspace(
                 InputWorkspace=workspaceName,
                 OutputWorkspace=workspaceName,
                 XMin=instrumentState.particleBounds.tof.minimum,
                 XMax=instrumentState.particleBounds.tof.maximum,
             )
+            # self.dataService = LocalDataService()
+            config = self.dataService.getInstrumentConfig()
+            width = config.width
+            frequency = config.frequency
+            self.mantidSnapper.RemovePromptPulse(
+                "Removing prompt pulse",
+                InputWorkspace=workspaceName,
+                OutputWorkspace=workspaceName,
+                Width=width,
+                Frequency=frequency,
+            )
+            self.mantidSnapper.executeQueue()
             data["result"] = wsClone
             data["workspace"] = workspaceName
             self._loadedRuns[key] += 1

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -8,9 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 from mantid.dataobjects import MaskWorkspace
 from mantid.simpleapi import (
-    CreateWorkspace,
     CropWorkspace,
-    ExtractMask,
     mtd,
 )
 from pydantic import validate_call
@@ -1264,13 +1262,14 @@ class GroceryService:
         # Number of non-monitor pixels
         pixelCount = mtd[templateWSName].getInstrument().getNumberDetectors(True)
 
-        mask = CreateWorkspace(
+        mask = self.mantidSnapper.CreateWorkspace(
             OutputWorkspace=maskWSName,
             NSpec=pixelCount,
             DataX=list(np.zeros((pixelCount,))),
             DataY=list(np.zeros((pixelCount,))),
             ParentWorkspace=templateWSName,
         )
+        self.mantidSnapper.executeQueue()
 
         # Rebuild the spectra map "by hand" to exclude detectors which are monitors.
         info = mask.detectorInfo()
@@ -1287,7 +1286,8 @@ class GroceryService:
             wi += 1
 
         # Convert workspace to a MaskWorkspace instance.
-        ExtractMask(OutputWorkspace=maskWSName, InputWorkspace=maskWSName)
+        self.mantidSnapper.ExtractMask(OutputWorkspace=maskWSName, InputWorkspace=maskWSName)
+        self.mantidSnapper.executeQueue()
         assert isinstance(mtd[maskWSName], MaskWorkspace)
 
         return maskWSName

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -9,6 +9,7 @@ import numpy as np
 from mantid.dataobjects import MaskWorkspace
 from mantid.simpleapi import (
     CreateWorkspace,
+    CropWorkspace,
     ExtractMask,
     mtd,
 )
@@ -877,6 +878,14 @@ class GroceryService:
             # fetch single-use does not export converted to lite data
             self.convertToLiteMode(workspaceName, export=False)
             data["workspace"] = workspaceName
+            print(f"Cropping {workspaceName}")
+            instrumentState = self.dataService.generateInstrumentState(runNumber)
+            CropWorkspace(
+                InputWorkspace=workspaceName,
+                OutputWorkspace=workspaceName,
+                XMin=instrumentState.particleBounds.tof.minimum,
+                XMax=instrumentState.particleBounds.tof.maximum,
+            )
 
         return data
 
@@ -1012,7 +1021,16 @@ class GroceryService:
 
             # create a copy of the raw data for use
             workspaceName = self._createCopyNeutronWorkspaceName(runNumber, useLiteMode, self._loadedRuns[key] + 1)
-            data["result"] = self.getCloneOfWorkspace(rawWorkspaceName, workspaceName) is not None
+            wsClone = self.getCloneOfWorkspace(rawWorkspaceName, workspaceName) is not None
+            print(f"Cropping {workspaceName}")
+            instrumentState = self.dataService.generateInstrumentState(runNumber)
+            CropWorkspace(
+                InputWorkspace=workspaceName,
+                OutputWorkspace=workspaceName,
+                XMin=instrumentState.particleBounds.tof.minimum,
+                XMax=instrumentState.particleBounds.tof.maximum,
+            )
+            data["result"] = wsClone
             data["workspace"] = workspaceName
             self._loadedRuns[key] += 1
 

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -878,6 +878,7 @@ class GroceryService:
             print(f"Cropping {workspaceName}")
             instrumentState = self.dataService.generateInstrumentState(runNumber)
             self.mantidSnapper.CropWorkspace(
+                "Cropping workspace",
                 InputWorkspace=workspaceName,
                 OutputWorkspace=workspaceName,
                 XMin=instrumentState.particleBounds.tof.minimum,
@@ -1033,6 +1034,7 @@ class GroceryService:
             print(f"Cropping {workspaceName}")
             instrumentState = self.dataService.generateInstrumentState(runNumber)
             self.mantidSnapper.CropWorkspace(
+                "Cropping workspace",
                 InputWorkspace=workspaceName,
                 OutputWorkspace=workspaceName,
                 XMin=instrumentState.particleBounds.tof.minimum,
@@ -1285,6 +1287,7 @@ class GroceryService:
         pixelCount = mtd[templateWSName].getInstrument().getNumberDetectors(True)
 
         mask = self.mantidSnapper.CreateWorkspace(
+            "Creating pixel mask workspace",
             OutputWorkspace=maskWSName,
             NSpec=pixelCount,
             DataX=list(np.zeros((pixelCount,))),
@@ -1292,6 +1295,7 @@ class GroceryService:
             ParentWorkspace=templateWSName,
         )
         self.mantidSnapper.executeQueue()
+        mask = self.mantidSnapper.mtd[mask]
 
         # Rebuild the spectra map "by hand" to exclude detectors which are monitors.
         info = mask.detectorInfo()
@@ -1308,7 +1312,7 @@ class GroceryService:
             wi += 1
 
         # Convert workspace to a MaskWorkspace instance.
-        self.mantidSnapper.ExtractMask(OutputWorkspace=maskWSName, InputWorkspace=maskWSName)
+        self.mantidSnapper.ExtractMask("Extracting mask", OutputWorkspace=maskWSName, InputWorkspace=maskWSName)
         self.mantidSnapper.executeQueue()
         assert isinstance(mtd[maskWSName], MaskWorkspace)
 

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -804,7 +804,7 @@ class GroceryService:
 
                 case (True, _, True, _):
                     # lite mode and lite-mode exists on disk
-                    data = self.grocer.executeRecipe(str(liteModeFilePath), workspaceName, loader, runNumber=runNumber)
+                    data = self.grocer.executeRecipe(str(liteModeFilePath), workspaceName, loader)
                     success = True
 
                 case (True, True, _, _):
@@ -819,17 +819,13 @@ class GroceryService:
 
                 case (True, _, _, True):
                     # lite mode and native exists on disk
-                    data = self.grocer.executeRecipe(
-                        str(nativeModeFilePath), workspaceName, loader, runNumber=runNumber
-                    )
+                    data = self.grocer.executeRecipe(str(nativeModeFilePath), workspaceName, loader)
                     convertToLiteMode = True
                     success = True
 
                 case (False, _, _, True):
                     # native mode and native exists on disk
-                    data = self.grocer.executeRecipe(
-                        str(nativeModeFilePath), workspaceName, loader, runNumber=runNumber
-                    )
+                    data = self.grocer.executeRecipe(str(nativeModeFilePath), workspaceName, loader)
                     success = True
 
                 case _:
@@ -855,7 +851,6 @@ class GroceryService:
                     workspace=workspaceName,
                     loader="LoadLiveData",
                     loaderArgs=json.dumps(loaderArgs),
-                    runNumber=runNumber,
                 )
                 if data["result"]:
                     logs = self.mantidSnapper.mtd[workspaceName].getRun()
@@ -895,7 +890,7 @@ class GroceryService:
                 raise RuntimeError(
                     "Code Err: Run number is required for event nexus files so we can remove the prompt pulse"
                 )
-            config = self.dataService.readInstrumentConfig(runNumber)
+            config = instrumentState.instrumentConfig
             width = config.width
             frequency = config.frequency
             self.mantidSnapper.RemovePromptPulse(
@@ -957,9 +952,7 @@ class GroceryService:
 
                 case (True, _, True, _):
                     # lite mode and lite-mode exists on disk
-                    data = self.grocer.executeRecipe(
-                        str(liteModeFilePath), rawWorkspaceName, loader, runNumber=runNumber
-                    )
+                    data = self.grocer.executeRecipe(str(liteModeFilePath), rawWorkspaceName, loader)
                     self._loadedRuns[key] = 0
                     success = True
 
@@ -972,18 +965,14 @@ class GroceryService:
                 case (True, _, _, True):
                     # lite mode and native exists on disk
                     goingNative = self._key(runNumber, False)
-                    data = self.grocer.executeRecipe(
-                        str(nativeModeFilePath), nativeRawWorkspaceName, loader="", runNumber=runNumber
-                    )
+                    data = self.grocer.executeRecipe(str(nativeModeFilePath), nativeRawWorkspaceName, loader="")
                     self._loadedRuns[self._key(*goingNative)] = 0
                     convertToLiteMode = True
                     success = True
 
                 case (False, _, _, True):
                     # native mode and native exists on disk
-                    data = self.grocer.executeRecipe(
-                        str(nativeModeFilePath), nativeRawWorkspaceName, loader, runNumber=runNumber
-                    )
+                    data = self.grocer.executeRecipe(str(nativeModeFilePath), nativeRawWorkspaceName, loader)
                     self._loadedRuns[key] = 0
                     success = True
 
@@ -1011,7 +1000,6 @@ class GroceryService:
                     workspace=nativeRawWorkspaceName,
                     loader="LoadLiveData",
                     loaderArgs=json.dumps(loaderArgs),
-                    runNumber=runNumber,
                 )
                 if data["result"]:
                     logs = self.mantidSnapper.mtd[nativeRawWorkspaceName].getRun()
@@ -1064,7 +1052,7 @@ class GroceryService:
                 raise RuntimeError(
                     "Code Err: Run number is required for event nexus files so we can remove the prompt pulse"
                 )
-            config = self.dataService.readInstrumentConfig(runNumber)
+            config = instrumentState.instrumentConfig
             width = config.width
             frequency = config.frequency
             self.mantidSnapper.RemovePromptPulse(

--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict
 
-from snapred.backend.data.LocalDataService import LocalDataService
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.FetchGroceriesAlgorithm import FetchGroceriesAlgorithm
 from snapred.backend.recipe.algorithm.Utensils import Utensils
@@ -63,20 +62,6 @@ class FetchGroceriesRecipe:
             data["result"] = algo.execute()
             data["loader"] = algo.getPropertyValue("LoaderType")
             data["workspace"] = workspace
-
-            if data["loader"] in ("LoadEventNexus", "LoadLiveData"):
-                self.dataService = LocalDataService()
-                config = self.dataService.getInstrumentConfig()
-                width = config.width
-                frequency = config.frequency
-                self.mantidSnapper.RemovePromptPulse(
-                    "Removing prompt pulse",
-                    InputWorkspace=workspace,
-                    OutputWorkspace=workspace,
-                    Width=width,
-                    Frequency=frequency,
-                )
-                self.mantidSnapper.executeQueue()
         except RuntimeError as e:
             raise RuntimeError(str(e).split("\n")[0]) from e
 

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -861,6 +861,7 @@ class TestGroceryService(unittest.TestCase):
         """Test the correct behavior when fetching raw nexus data"""
 
         self.instance.convertToLiteMode = mock.Mock()
+        self.instance.mantidSnapper = mock.MagicMock()
 
         # mock out _createNeutronFilePath so that only a native version exists on disk
         nonExistentPath = Path("does/not/exist.nxs")
@@ -940,6 +941,7 @@ class TestGroceryService(unittest.TestCase):
         """Test the correct behavior when fetching nexus data"""
         self.instance._createNeutronFilePath = mock.Mock()
         self.instance.dataService.hasLiveDataConnection = mock.Mock(return_value=False)
+        self.instance.mantidSnapper = mock.MagicMock()
 
         testItem = mock.Mock(
             spec=GroceryListItem, runNumber=self.runNumber, useLiteMode=False, loader="", liveDataArgs=None
@@ -1009,6 +1011,7 @@ class TestGroceryService(unittest.TestCase):
         self.instance.convertToLiteMode = mock.Mock()
         self.instance._createNeutronFilePath = mock.Mock()
         self.instance.dataService.hasLiveDataConnection = mock.Mock(return_value=False)
+        self.instance.mantidSnapper = mock.MagicMock()
 
         testItem = mock.Mock(
             spec=GroceryListItem, runNumber=self.runNumber, useLiteMode=True, loader="", liveDataArgs=None
@@ -1116,6 +1119,7 @@ class TestGroceryService(unittest.TestCase):
                 mock.patch.object(instance.dataService, "hasLiveDataConnection") as mockHasLiveDataConnection,
                 mock.patch.object(instance, "getCloneOfWorkspace") as mockGetCloneOfWorkspace,
                 mock.patch.object(instance, "convertToLiteMode") as mockConvertToLiteMode,
+                mock.patch.object(instance, "mantidSnapper") as mockSnapper,  # noqa F841
             ):
                 # Mocks for flow-control branching:
                 mockHasLiveDataConnection.return_value = False
@@ -1708,6 +1712,7 @@ class TestGroceryService(unittest.TestCase):
                 mock.patch.object(instance.dataService, "hasLiveDataConnection") as mockHasLiveDataConnection,
                 mock.patch.object(instance, "getCloneOfWorkspace") as mockGetCloneOfWorkspace,
                 mock.patch.object(instance, "convertToLiteMode") as mockConvertToLiteMode,
+                mock.patch.object(instance, "mantidSnapper") as mockSnapper,  # noqa F841
             ):
                 # Mocks for flow-control branching:
                 mockHasLiveDataConnection.return_value = False

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -862,6 +862,10 @@ class TestGroceryService(unittest.TestCase):
 
         self.instance.convertToLiteMode = mock.Mock()
         self.instance.mantidSnapper = mock.MagicMock()
+        testCalibrationData = DAOFactory.calibrationParameters()
+        self.instance.dataService.generateInstrumentState = mock.MagicMock(
+            return_value=testCalibrationData.instrumentState
+        )
 
         # mock out _createNeutronFilePath so that only a native version exists on disk
         nonExistentPath = Path("does/not/exist.nxs")
@@ -942,6 +946,10 @@ class TestGroceryService(unittest.TestCase):
         self.instance._createNeutronFilePath = mock.Mock()
         self.instance.dataService.hasLiveDataConnection = mock.Mock(return_value=False)
         self.instance.mantidSnapper = mock.MagicMock()
+        testCalibrationData = DAOFactory.calibrationParameters()
+        self.instance.dataService.generateInstrumentState = mock.MagicMock(
+            return_value=testCalibrationData.instrumentState
+        )
 
         testItem = mock.Mock(
             spec=GroceryListItem, runNumber=self.runNumber, useLiteMode=False, loader="", liveDataArgs=None
@@ -1012,6 +1020,10 @@ class TestGroceryService(unittest.TestCase):
         self.instance._createNeutronFilePath = mock.Mock()
         self.instance.dataService.hasLiveDataConnection = mock.Mock(return_value=False)
         self.instance.mantidSnapper = mock.MagicMock()
+        testCalibrationData = DAOFactory.calibrationParameters()
+        self.instance.dataService.generateInstrumentState = mock.MagicMock(
+            return_value=testCalibrationData.instrumentState
+        )
 
         testItem = mock.Mock(
             spec=GroceryListItem, runNumber=self.runNumber, useLiteMode=True, loader="", liveDataArgs=None
@@ -1107,6 +1119,11 @@ class TestGroceryService(unittest.TestCase):
             nativeModeFilePath = mock.MagicMock(spec=Path)
             nativeModeFilePath.__str__.return_value = "nativeModeFilePath"
 
+            testCalibrationData = DAOFactory.calibrationParameters()
+            instance.dataService.generateInstrumentState = mock.MagicMock(
+                return_value=testCalibrationData.instrumentState
+            )
+
             # In order to avoid contaminating other tests, all mocks must be applied
             #   as context managers.
             with (
@@ -1181,7 +1198,7 @@ class TestGroceryService(unittest.TestCase):
                         # lite mode and lite-mode exists on disk
                         assert result == mockFetchGroceriesRecipe.executeRecipe.return_value
                         mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                            str(liteModeFilePath), workspaceName, item.loader, runNumber=runNumber
+                            str(liteModeFilePath), workspaceName, item.loader
                         )
                         mockConvertToLiteMode.assert_not_called()
 
@@ -1197,7 +1214,7 @@ class TestGroceryService(unittest.TestCase):
                         # lite mode and native exists on disk
                         assert result == mockFetchGroceriesRecipe.executeRecipe.return_value
                         mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                            str(nativeModeFilePath), workspaceName, item.loader, runNumber=runNumber
+                            str(nativeModeFilePath), workspaceName, item.loader
                         )
                         mockConvertToLiteMode.assert_called_once_with(workspaceName, export=False)
 
@@ -1205,7 +1222,7 @@ class TestGroceryService(unittest.TestCase):
                         # native mode and native exists on disk
                         assert result == mockFetchGroceriesRecipe.executeRecipe.return_value
                         mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                            str(nativeModeFilePath), workspaceName, item.loader, runNumber=runNumber
+                            str(nativeModeFilePath), workspaceName, item.loader
                         )
                         mockConvertToLiteMode.assert_not_called()
 
@@ -1248,6 +1265,11 @@ class TestGroceryService(unittest.TestCase):
                 "PreserveEvents": True,
                 "StartTime": expectedStartTime.isoformat(),
             }
+
+            testCalibrationData = DAOFactory.calibrationParameters()
+            instance.dataService.generateInstrumentState = mock.MagicMock(
+                return_value=testCalibrationData.instrumentState
+            )
 
             # In order to avoid contaminating other tests, all mocks must be applied
             #   as context managers.
@@ -1339,7 +1361,6 @@ class TestGroceryService(unittest.TestCase):
                     workspace=workspaceName,
                     loader="LoadLiveData",
                     loaderArgs=json.dumps(expectedLoaderArgs),
-                    runNumber=runNumber,
                 )
                 if useLiteMode:
                     mockConvertToLiteMode.assert_called_once_with(workspaceName, export=False)
@@ -1372,6 +1393,11 @@ class TestGroceryService(unittest.TestCase):
                 "PreserveEvents": True,
                 "StartTime": expectedStartTime.isoformat(),
             }
+
+            testCalibrationData = DAOFactory.calibrationParameters()
+            instance.dataService.generateInstrumentState = mock.MagicMock(
+                return_value=testCalibrationData.instrumentState
+            )
 
             # In order to avoid contaminating other tests, all mocks must be applied
             #   as context managers.
@@ -1466,7 +1492,6 @@ class TestGroceryService(unittest.TestCase):
                     workspace=workspaceName,
                     loader="LoadLiveData",
                     loaderArgs=json.dumps(expectedLoaderArgs),
-                    runNumber=runNumber,
                 )
                 mockConvertToLiteMode.assert_not_called()
                 mockDeleteWorkspace.assert_called_once_with(workspaceName)
@@ -1493,6 +1518,11 @@ class TestGroceryService(unittest.TestCase):
                 "PreserveEvents": True,
                 "StartTime": "",
             }
+
+            testCalibrationData = DAOFactory.calibrationParameters()
+            instance.dataService.generateInstrumentState = mock.MagicMock(
+                return_value=testCalibrationData.instrumentState
+            )
 
             # In order to avoid contaminating other tests, all mocks must be applied
             #   as context managers.
@@ -1575,7 +1605,6 @@ class TestGroceryService(unittest.TestCase):
                     workspace=workspaceName,
                     loader="LoadLiveData",
                     loaderArgs=json.dumps(expectedLoaderArgs),
-                    runNumber=runNumber,
                 )
                 if useLiteMode:
                     mockConvertToLiteMode.assert_called_once_with(workspaceName, export=False)
@@ -1604,6 +1633,11 @@ class TestGroceryService(unittest.TestCase):
                 "PreserveEvents": True,
                 "StartTime": "",
             }
+
+            testCalibrationData = DAOFactory.calibrationParameters()
+            instance.dataService.generateInstrumentState = mock.MagicMock(
+                return_value=testCalibrationData.instrumentState
+            )
 
             # In order to avoid contaminating other tests, all mocks must be applied
             #   as context managers.
@@ -1691,7 +1725,6 @@ class TestGroceryService(unittest.TestCase):
                     workspace=workspaceName,
                     loader="LoadLiveData",
                     loaderArgs=json.dumps(expectedLoaderArgs),
-                    runNumber=runNumber,
                 )
                 mockConvertToLiteMode.assert_not_called()
                 mockDeleteWorkspace.assert_called_once_with(workspaceName)
@@ -1710,6 +1743,13 @@ class TestGroceryService(unittest.TestCase):
 
             nativeModeFilePath = mock.MagicMock(spec=Path)
             nativeModeFilePath.__str__.return_value = "nativeModeFilePath"
+
+            testCalibrationData = DAOFactory.calibrationParameters()
+            instance.dataService.generateInstrumentState = mock.MagicMock(
+                return_value=testCalibrationData.instrumentState
+            )
+
+            # instance.dataService.readInstrumentConfig
 
             # In order to avoid contaminating other tests, all mocks must be applied
             #   as context managers.
@@ -1796,7 +1836,7 @@ class TestGroceryService(unittest.TestCase):
                         assert result == mockFetchGroceriesRecipe.executeRecipe.return_value
                         assert instance._loadedRuns[(runNumber, useLiteMode)] == 1
                         mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                            str(liteModeFilePath), liteRawWorkspaceName, item.loader, runNumber=runNumber
+                            str(liteModeFilePath), liteRawWorkspaceName, item.loader
                         )
                         mockConvertToLiteMode.assert_not_called()
 
@@ -1814,7 +1854,7 @@ class TestGroceryService(unittest.TestCase):
                         assert instance._loadedRuns[(runNumber, False)] == 0
                         assert instance._loadedRuns[(runNumber, useLiteMode)] == 1
                         mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                            str(nativeModeFilePath), nativeRawWorkspaceName, loader=item.loader, runNumber=runNumber
+                            str(nativeModeFilePath), nativeRawWorkspaceName, loader=item.loader
                         )
                         mockConvertToLiteMode.assert_called_once_with(liteRawWorkspaceName, export=True)
 
@@ -1823,7 +1863,7 @@ class TestGroceryService(unittest.TestCase):
                         assert result == mockFetchGroceriesRecipe.executeRecipe.return_value
                         assert instance._loadedRuns[(runNumber, useLiteMode)] == (1 if not useLiteMode else 0)
                         mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                            str(nativeModeFilePath), nativeRawWorkspaceName, item.loader, runNumber=runNumber
+                            str(nativeModeFilePath), nativeRawWorkspaceName, item.loader
                         )
                         mockConvertToLiteMode.assert_not_called()
 
@@ -1866,6 +1906,11 @@ class TestGroceryService(unittest.TestCase):
                 "PreserveEvents": True,
                 "StartTime": expectedStartTime.isoformat(),
             }
+
+            testCalibrationData = DAOFactory.calibrationParameters()
+            instance.dataService.generateInstrumentState = mock.MagicMock(
+                return_value=testCalibrationData.instrumentState
+            )
 
             # In order to avoid contaminating other tests, all mocks must be applied
             #   as context managers.
@@ -1962,7 +2007,6 @@ class TestGroceryService(unittest.TestCase):
                     workspace=nativeRawWorkspaceName,
                     loader="LoadLiveData",
                     loaderArgs=json.dumps(expectedLoaderArgs),
-                    runNumber=runNumber,
                 )
                 if useLiteMode:
                     assert instance._loadedRuns[(runNumber, False)] == 0
@@ -2092,7 +2136,6 @@ class TestGroceryService(unittest.TestCase):
                     workspace=nativeRawWorkspaceName,
                     loader="LoadLiveData",
                     loaderArgs=json.dumps(expectedLoaderArgs),
-                    runNumber=runNumber,
                 )
                 mockConvertToLiteMode.assert_not_called()
                 mockDeleteWorkspace.assert_called_once_with(nativeRawWorkspaceName)
@@ -2207,7 +2250,6 @@ class TestGroceryService(unittest.TestCase):
                     workspace=nativeRawWorkspaceName,
                     loader="LoadLiveData",
                     loaderArgs=json.dumps(expectedLoaderArgs),
-                    runNumber=runNumber,
                 )
                 if useLiteMode:
                     assert instance._loadedRuns[(runNumber, False)] == 0
@@ -2326,7 +2368,6 @@ class TestGroceryService(unittest.TestCase):
                     workspace=nativeRawWorkspaceName,
                     loader="LoadLiveData",
                     loaderArgs=json.dumps(expectedLoaderArgs),
-                    runNumber=runNumber,
                 )
                 mockConvertToLiteMode.assert_not_called()
                 mockDeleteWorkspace.assert_called_once_with(nativeRawWorkspaceName)

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -125,7 +125,6 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         mock_instance = mockAlgo.return_value
         mock_instance.execute.return_value = "data"
         mock_instance.getPropertyValue.return_value = "LoadEventNexus"
-        self.rx.mantidSnapper.RemovePromptPulse = mock.MagicMock()
 
         self.clearoutWorkspaces()
         res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadEventNexus")
@@ -133,7 +132,6 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         assert res["result"]
         assert res["loader"] == "LoadEventNexus"
         assert res["workspace"] == self.fetchedWSname
-        assert self.rx.mantidSnapper.RemovePromptPulse.called
 
     @mock.patch("snapred.backend.recipe.FetchGroceriesRecipe.logger")
     @mock.patch("snapred.backend.recipe.FetchGroceriesRecipe.FetchGroceriesAlgorithm")
@@ -142,7 +140,6 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         mock_instance = mockAlgo.return_value
         mock_instance.execute.return_value = "data"
         mock_instance.getPropertyValue.return_value = "LoadEventNexus"
-        self.rx.mantidSnapper.RemovePromptPulse = mock.MagicMock()
 
         self.clearoutWorkspaces()
 
@@ -157,7 +154,6 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         mock_instance = mockAlgo.return_value
         mock_instance.execute.return_value = "data"
         mock_instance.getPropertyValue.return_value = "LoadLiveData"
-        self.rx.mantidSnapper.RemovePromptPulse = mock.MagicMock()
 
         self.clearoutWorkspaces()
 
@@ -171,7 +167,6 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         mock_instance = mockAlgo.return_value
         mock_instance.execute.return_value = "data"
         mock_instance.getPropertyValue.return_value = "LoadLiveData"
-        self.rx.mantidSnapper.RemovePromptPulse = mock.Mock()
 
         self.clearoutWorkspaces()
         res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadLiveData")
@@ -179,7 +174,6 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         assert res["result"]
         assert res["loader"] == "LoadLiveData"
         assert res["workspace"] == self.fetchedWSname
-        assert self.rx.mantidSnapper.RemovePromptPulse.called
 
     def test_fetch_failed(self):
         # this is some file that it can't load

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -127,15 +127,11 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         mock_instance.getPropertyValue.return_value = "LoadEventNexus"
 
         self.clearoutWorkspaces()
-        self.rx.dataService.readInstrumentConfig = mock.MagicMock()
-        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadEventNexus", runNumber=555)
+        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadEventNexus")
         assert len(res) > 0
         assert res["result"]
         assert res["loader"] == "LoadEventNexus"
         assert res["workspace"] == self.fetchedWSname
-
-        with pytest.raises(RuntimeError, match="Run number is required for event nexus files"):
-            self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadEventNexus")
 
     @mock.patch("snapred.backend.recipe.FetchGroceriesRecipe.logger")
     @mock.patch("snapred.backend.recipe.FetchGroceriesRecipe.FetchGroceriesAlgorithm")
@@ -146,8 +142,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         mock_instance.getPropertyValue.return_value = "LoadEventNexus"
 
         self.clearoutWorkspaces()
-        self.rx.dataService.readInstrumentConfig = mock.MagicMock()
-        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadEventNexus", runNumber=555)
+        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadEventNexus")
         mockLogger.info.assert_called_with(f"Fetching data from {self.filePath} into {res['workspace']}")
         mockLogger.debug.assert_called_with(f"Finished fetching {res['workspace']} from {self.filePath}")
 
@@ -160,8 +155,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         mock_instance.getPropertyValue.return_value = "LoadLiveData"
 
         self.clearoutWorkspaces()
-        self.rx.dataService.readInstrumentConfig = mock.MagicMock()
-        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadLiveData", runNumber=555)
+        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadLiveData")
         mockLogger.info.assert_called_with(f"Fetching live data into {res['workspace']}")
         mockLogger.debug.assert_called_with(f"Finished fetching {res['workspace']} from live-data listener")
 
@@ -173,8 +167,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         mock_instance.getPropertyValue.return_value = "LoadLiveData"
 
         self.clearoutWorkspaces()
-        self.rx.dataService.readInstrumentConfig = mock.MagicMock()
-        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadLiveData", runNumber=555)
+        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadLiveData")
         assert len(res) > 0
         assert res["result"]
         assert res["loader"] == "LoadLiveData"


### PR DESCRIPTION
## Description of work

This crops workspaces after being loaded and moves RemovePromptPulse outside of the recipe.

## Explanation of work

When neutron data copies are made within GroceryService, CropWorkspace is called so that certain wavelengths are excluded. RemovePromptPulse was also moved to be inside GroceryService so that LocalDataService isn't accessed with the FetchGroceriesRecipe.

## To test

### Dev testing

Run DiffCal and Normalization with any valid run number in lite mode, and before saving, look at the workspace browser. Look at the "raw" and corresponding "copy" workspaces. You should see that the "copy" workspace has less bins than the "raw" workspace. You should also be able to see this in reduction, but you have to be quick, the workspaces get cleaned up when reduction is finished.

### CIS testing

See Dev testing

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#9431](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9431)

### Verification

- [ ] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] "Copy" workspace(s) are cropped in diffcal
- [ ] "Copy" workspace(s) are cropped in normalization
- [ ] "Copy" workspace(s) are cropped in reduction
