### PR TITLE
Don't swallow 'instrument parameters not found' error

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
 - python=3.10
 - pip
 - pydantic>=2.7.3,<3
-- mantidworkbench=6.11.0.4rc1
+- mantidworkbench=6.11.0.5rc1
 - qtpy
 - pre-commit
 - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "A desktop application for Lifecycle Managment of data collected f
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "mantidworkbench >= 6.11.0.4rc1",
+    "mantidworkbench >= 6.11.0.5rc1",
     "pyoncat ~= 1.6"
 ]
 readme = "README.md"

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -204,14 +204,7 @@ class GroceryService:
         return str(ipts)
 
     def _createNeutronFilePath(self, runNumber: str, useLiteMode: bool) -> Path:
-        # TODO: fully normalize this to pathlib.Path:
-        #   -- problems (among others): `GetIPTS` returns with an '/' at the end?
-
-        IPTS = self.getIPTS(runNumber)
-        instr = "nexus.lite" if useLiteMode else "nexus.native"
-        pre = instr + ".prefix"
-        ext = instr + ".extension"
-        return Path(IPTS + Config[pre] + str(runNumber) + Config[ext])
+        return self.dataService.createNeutronFilePath(runNumber, useLiteMode)
 
     @validate_call
     def _createGroupingFilename(self, runNumber: str, groupingScheme: str, useLiteMode: bool) -> str:

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -229,7 +229,7 @@ class LocalDataService:
 
     def _readRunConfig(self, runId: str) -> RunConfig:
         # lookup path for IPTS number
-        iptsPath = self.getIPTS(runId)        
+        iptsPath = self.getIPTS(runId)
         instrumentConfig = self.readInstrumentConfig(runId)
         return RunConfig(
             IPTS=iptsPath,
@@ -250,8 +250,8 @@ class LocalDataService:
             if fileName.exists():
                 return h5py.File(fileName, "r")
         except RuntimeError as e:
-            if not "Cannot find IPTS directory" in str(e):
-                raise # the existing exception is sufficient
+            if "Cannot find IPTS directory" not in str(e):
+                raise  # the existing exception is sufficient
         raise FileNotFoundError(f"No PVFile exists for run: '{runId}'")
 
     # NOTE `lru_cache` decorator needs to be on the outside
@@ -885,8 +885,7 @@ class LocalDataService:
         try:
             detectorState = self._detectorStateFromMapping(mappingFromNeXusLogs(self._readPVFile(runNumber)))
         except FileNotFoundError as e:
-        
-            if not "PVFile" in str(e) or not self.hasLiveDataConnection():
+            if "PVFile" not in str(e) or not self.hasLiveDataConnection():
                 raise  # the existing exception is sufficient
             metadata = self.readLiveMetadata()
             if metadata.runNumber == runNumber:
@@ -1279,7 +1278,7 @@ class LocalDataService:
                 #   we're expecting a `socket.gaierror`, but any exception will indicate that there's no connection
                 logger.debug(f"`hasLiveDataConnection` returns `False`: exception: {e}")
                 status = False
-        
+
         return status
 
     def _liveMetadataFromRun(self, run: Run) -> LiveMetadata:

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -73,6 +73,7 @@ instrument:
   maxNumberOfRuns: 10
 
 liveData:
+  enabled: true
   # Override 'liveData.facility' and 'liveData.instrument'
   #   in order to use the mock listener for testing
   #   without overriding the real instrument.

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -73,6 +73,7 @@ instrument:
   maxNumberOfRuns: 10
 
 liveData:
+  enabled: true
   # Override 'liveData.facility' and 'liveData.instrument'
   #   in order to use the mock listener for testing
   #   without overriding the real instrument.

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -292,18 +292,13 @@ class TestGroceryService(unittest.TestCase):
 
     def test_nexus_filename(self):
         """Test the creation of the nexus filename"""
-        res = str(self.instance._createNeutronFilePath(self.runNumber, False))
-        assert self.instance.dataService.getIPTS(self.runNumber) in res
-        assert Config["nexus.native.prefix"] in res
-        assert self.runNumber in res
-        assert "lite" not in res.lower()
-
-        # now use lite mode
-        res = str(self.instance._createNeutronFilePath(self.runNumber, True))
-        assert self.instance.dataService.getIPTS(self.runNumber) in res
-        assert Config["nexus.lite.prefix"] in res
-        assert self.runNumber in res
-        assert "lite" in res.lower()
+        for useLiteMode in (False, True):
+            self.instance._createNeutronFilePath(self.runNumber, useLiteMode)
+            self.instance.dataService.createNeutronFilePath.assert_called_once_with(
+                self.runNumber,
+                useLiteMode
+            )
+            self.instance.dataService.createNeutronFilePath.reset_mock()
 
     def test_grouping_filename(self):
         """Test the creation of the grouping filename"""

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -294,10 +294,7 @@ class TestGroceryService(unittest.TestCase):
         """Test the creation of the nexus filename"""
         for useLiteMode in (False, True):
             self.instance._createNeutronFilePath(self.runNumber, useLiteMode)
-            self.instance.dataService.createNeutronFilePath.assert_called_once_with(
-                self.runNumber,
-                useLiteMode
-            )
+            self.instance.dataService.createNeutronFilePath.assert_called_once_with(self.runNumber, useLiteMode)
             self.instance.dataService.createNeutronFilePath.reset_mock()
 
     def test_grouping_filename(self):

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -896,17 +896,13 @@ def test_constructPVFilePath():
         path = localDataService._constructPVFilePath(runNumber)
         # the path should be /path/to/testInstrument/IPTS-456/nexus/SNAP_<runNumber>.nxs.h5
         assert Path(mockIPTS) == path.parents[1]
-        localDataService.getIPTS.assert_called_once_with(
-            runNumber
-        )
+        localDataService.getIPTS.assert_called_once_with(runNumber)
 
 
 @mock.patch("h5py.File", return_value="not None")
 def test_readPVFile(h5pyMock):  # noqa: ARG001
     localDataService = LocalDataService()
-    localDataService._constructPVFilePath = mock.Mock(
-        return_value=mock.Mock(spec=Path)
-    )
+    localDataService._constructPVFilePath = mock.Mock(return_value=mock.Mock(spec=Path))
     actual = localDataService._readPVFile(mock.Mock())
     assert actual is not None
 
@@ -916,14 +912,12 @@ def test_readPVFile_does_not_exist(h5pyMock):  # noqa: ARG001
     runNumber = "12345"
     localDataService = LocalDataService()
     localDataService._instrumentConfig = getMockInstrumentConfig()
-    
+
     PVFilePath = "/the/PVFile.nxs.h5"
     mockPath = mock.MagicMock(spec=Path)
     mockPath.__str__.return_value = PVFilePath
     mockPath.exists.return_value = False
-    localDataService._constructPVFilePath = mock.Mock(
-        return_value=mockPath
-    )
+    localDataService._constructPVFilePath = mock.Mock(return_value=mockPath)
     with pytest.raises(FileNotFoundError, match=f"No PVFile exists for run: '{runNumber}'"):
         localDataService._readPVFile(runNumber)
 
@@ -933,10 +927,8 @@ def test_readPVFile_no_IPTS():
     runNumber = "12345"
     localDataService = LocalDataService()
     localDataService._instrumentConfig = getMockInstrumentConfig()
-    localDataService._constructPVFilePath = mock.Mock(
-        side_effect=RuntimeError("Cannot find IPTS directory")
-    )
-    with pytest.raises(FileNotFoundError, match=f"No PVFile exists for run: '{runNumber}'"): 
+    localDataService._constructPVFilePath = mock.Mock(side_effect=RuntimeError("Cannot find IPTS directory"))
+    with pytest.raises(FileNotFoundError, match=f"No PVFile exists for run: '{runNumber}'"):
         localDataService._readPVFile(runNumber)
 
 
@@ -945,10 +937,8 @@ def test_readPVFile_exception_passthrough():
     runNumber = "12345"
     localDataService = LocalDataService()
     localDataService._instrumentConfig = getMockInstrumentConfig()
-    localDataService._constructPVFilePath = mock.Mock(
-        side_effect=RuntimeError("lah dee dah")
-    )
-    with pytest.raises(RuntimeError, match="lah dee dah"): 
+    localDataService._constructPVFilePath = mock.Mock(side_effect=RuntimeError("lah dee dah"))
+    with pytest.raises(RuntimeError, match="lah dee dah"):
         localDataService._readPVFile(runNumber)
 
 
@@ -2319,10 +2309,7 @@ def test_readDetectorState_no_PVFile():
     instance._readPVFile = mock.Mock(side_effect=FileNotFoundError("No PVFile exists for run"))
     instance.readLiveMetadata = mock.Mock(return_value=mock.MagicMock(runNumber=-1))
     instance.hasLiveDataConnection = mock.Mock(return_value=True)
-    with pytest.raises(
-        RuntimeError,
-        match=f"No PVFile exists for run {runNumber}, and it isn't the live run."
-    ):
+    with pytest.raises(RuntimeError, match=f"No PVFile exists for run {runNumber}, and it isn't the live run."):
         instance.readDetectorState(runNumber)
 
 


### PR DESCRIPTION

## Description of work

After the new changes to how instrument-parameter files work, it was found that when an instrument parameters file was not present on the system, the associated error message was not passed to the log.  This was due to defects in `LocalDataService._readPVFile` and `LocalDataService.readDetectorState`.

## Explanation of work

This commit includes the following changes:

  * in `LocalDataService._readPVFile`: don't swallow 'instrument parameters not found' error;

  * in `LocalDataService._readPVFile`: allow the case that a run may not have an IPTS directory.  This is a valid live-data case;

  * in `LocalDataService.readDetectorState`: don't swallow any non-PVFile related exceptions;

  * in `LocalDataService.hasLiveDataConnection`: check `Config['liveData.enabled']` flag;

  * add 'liveData.enabled' flag in `application.yml`.

## To test
Unit tests have been added to cover the new changes.
### Dev testing


### CIS testing
This is a SNAPRed-internal (i.e. development-related) item.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#9759](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=9759)

