### PR TITLE
Ewm7732 normalize by direct beam monitor

### DIFF
--- a/src/snapred/backend/dao/WorkspaceMetadata.py
+++ b/src/snapred/backend/dao/WorkspaceMetadata.py
@@ -27,6 +27,15 @@ class NormalizationStateMetadata(StrEnum):
     FAKE: str = "fake"  # proceed by creating a "fake vanadium"
 
 
+class ParticleNormalizationMethod(StrEnum):
+    """Class to hold tags related to a workspace"""
+
+    UNSET: str = UNSET  # the default condition before any settings
+    PROTON_CHARGE: str = "proton_charge"  # the state exists and the corresponding .h5 file located
+    MONITOR_COUNTS: str = "monitor_counts"  # the user supplied an alternate .h5 that they believe is usable
+    NONE: str = "none"  # proceed without applying any normalization
+
+
 class WorkspaceMetadata(BaseModel):
     """Class to hold tags related to a workspace"""
 
@@ -34,5 +43,8 @@ class WorkspaceMetadata(BaseModel):
     normalizationState: NormalizationStateMetadata = UNSET
     # NOTE: variables not allowed in type declarations
     liteDataCompressionTolerance: Union[float, Literal["unset"]] = UNSET
+    normalizeByMonitorFactor: Union[float, Literal["unset"]] = UNSET
+    normalizeByMonitorID: Union[int, Literal["unset"]] = UNSET
+    particleNormalizationMethod: ParticleNormalizationMethod = UNSET
 
     model_config = ConfigDict(extra="forbid", use_enum_values=True)

--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -55,6 +55,7 @@ class GroceryListItem(BaseModel):
     loader: Literal[
         "",
         "LoadCalibrationWorkspaces",
+        "LoadNexusMonitors",
         "LoadEventNexus",
         "LoadGroupingDefinition",
         "LoadLiveData",

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -1205,7 +1205,10 @@ class GroceryService:
         return maskWSName
 
     def _createMonitorWorkspaceName(self, runNumber: str, useLiteMode: bool) -> WorkspaceName:
-        return wng.monitor().runNumber(runNumber).lite(useLiteMode).build()
+        builder = wng.monitor().runNumber(runNumber)
+        if useLiteMode:
+            builder.lite(wng.Lite.TRUE)
+        return builder.build()
 
     def fetchMonitorWorkspace(self, item: GroceryListItem) -> WorkspaceName:
         runNumber, useLiteMode = item.runNumber, False

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -3,7 +3,7 @@ import json
 from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 from mantid.dataobjects import MaskWorkspace
@@ -395,7 +395,7 @@ class GroceryService:
         """
         return mtd.doesExist(name)
 
-    def renameWorkspace(self, oldName: WorkspaceName, newName: WorkspaceName):
+    def renameWorkspace(self, oldName: WorkspaceName, newName: WorkspaceName) -> WorkspaceName:
         """
         Renames a workspace in Mantid's ADS.
 
@@ -404,12 +404,14 @@ class GroceryService:
         :param newName: the name to replace the workspace name in the ADS
         :type newName: WorkspaceName
         """
-        self.mantidSnapper.RenameWorkspace(
-            f"Renaming {oldName} to {newName}",
-            InputWorkspace=oldName,
-            OutputWorkspace=newName,
-        )
-        self.mantidSnapper.executeQueue()
+        if oldName != newName:
+            self.mantidSnapper.RenameWorkspace(
+                f"Renaming {oldName} to {newName}",
+                InputWorkspace=oldName,
+                OutputWorkspace=newName,
+            )
+            self.mantidSnapper.executeQueue()
+        return newName
 
     def renameWorkspaces(self, oldNames: List[WorkspaceName], newNames: List[WorkspaceName]):
         """
@@ -458,13 +460,13 @@ class GroceryService:
         :return: a pointer to the cloned workspace in the ADS
         :rtype: a python wrapped, C++ shared pointer to a Workspace
         """
-        from mantid.simpleapi import CloneWorkspace  # noqa : TID251
-
-        if self.workspaceDoesExist(name):
-            ws = CloneWorkspace(InputWorkspace=name, OutputWorkspace=copy)
-        else:
-            ws = None
-        return ws
+        self.mantidSnapper.CloneWorkspace(
+            f"Cloning {name} to {copy}",
+            InputWorkspace=name,
+            OutputWorkspace=copy,
+        )
+        self.mantidSnapper.executeQueue()
+        return copy
 
     def writeWorkspaceMetadataAsTags(self, workspaceName: WorkspaceName, workspaceMetadata: WorkspaceMetadata):
         """
@@ -748,7 +750,7 @@ class GroceryService:
                 raise RuntimeError(f"unable to load workspace {name} from {filePath}")
         return data
 
-    def fetchNeutronDataSingleUse(self, item: GroceryListItem) -> Dict[str, Any]:
+    def _fetchNeutronDataSingleUse(self, item: GroceryListItem, missingDataHandler: Callable) -> Dict[str, Any]:
         """
         Fetch a neutron data file, without copy-protection.
         If the workspace is truly only needed once, this saves time and memory.
@@ -765,116 +767,158 @@ class GroceryService:
         :rtype: Dict[str, Any]
         """
 
-        runNumber, useLiteMode, loader, liveDataArgs = item.runNumber, item.useLiteMode, item.loader, item.liveDataArgs
+        runNumber, useLiteMode, loader = item.runNumber, item.useLiteMode, item.loader
 
-        # Live-data mode can be requested explicitly,
-        #   but it also serves as the fallback mode.
-        liveDataMode = loader == "LoadLiveData" or liveDataArgs is not None
+        data = {}
+        key = self._key(runNumber, useLiteMode)
+        rawWorkspaceName: WorkspaceName = self._createRawNeutronWorkspaceName(runNumber, useLiteMode)
+        filepath: Path = self._createNeutronFilePath(runNumber, useLiteMode)
 
-        workspaceName: str = self._createNeutronWorkspaceName(runNumber, useLiteMode)
-
-        success = False
-        convertToLiteMode = False
-
+        # This checks to make sure existing cache is valid
         self._updateNeutronCacheFromADS(runNumber, useLiteMode)
 
-        if self._loadedRuns.get(self._key(runNumber, useLiteMode)) is not None:
-            # a cached copy exists: clone it
-            self.getCloneOfWorkspace(self._createRawNeutronWorkspaceName(runNumber, useLiteMode), workspaceName)
-            data = {
-                "result": True,
-                "loader": "cached",
-                "workspace": workspaceName,
-            }
-            success = True
+        # 1. check cache
+        # 2. check if file exists
+        # e. cannot find data.
+        workspaceName: str = None
+        if self._loadedRuns.get(key) is not None:
+            data = {"loader": "cached"}
+            workspaceName = self._createNeutronWorkspaceName(runNumber, useLiteMode)
+            self.getCloneOfWorkspace(rawWorkspaceName, workspaceName)
+        elif filepath.exists() and item.liveDataArgs is None:
+            workspaceName = self._createNeutronWorkspaceName(runNumber, useLiteMode)
+            data = self.grocer.executeRecipe(str(filepath), workspaceName, loader)
+        else:
+            data = missingDataHandler()
+            workspaceName = data["workspace"]
 
-        if not success and not liveDataMode:
-            liteModeFilePath: Path = self._createNeutronFilePath(runNumber, True)
-            nativeModeFilePath: Path = self._createNeutronFilePath(runNumber, False)
-            cachedNativeMode = self._loadedRuns.get(self._key(runNumber, False)) is not None
-
-            match (useLiteMode, cachedNativeMode, liteModeFilePath.exists(), nativeModeFilePath.exists()):
-                # THERE ARE MANY SPECIAL CASES HERE, but basically a single-use fetch will use
-                #   cached (or on-disk lite versions) if available, but will not create any new cache entries if not.
-
-                case (True, _, True, _):
-                    # lite mode and lite-mode exists on disk
-                    data = self.grocer.executeRecipe(str(liteModeFilePath), workspaceName, loader)
-                    success = True
-
-                case (True, True, _, _):
-                    # lite mode and native is cached
-                    data = {"loader": "cached", "workspace": workspaceName}
-                    data["result"] = (
-                        self.getCloneOfWorkspace(self._createRawNeutronWorkspaceName(runNumber, False), workspaceName)
-                        is not None
-                    )
-                    convertToLiteMode = True
-                    success = True
-
-                case (True, _, _, True):
-                    # lite mode and native exists on disk
-                    data = self.grocer.executeRecipe(str(nativeModeFilePath), workspaceName, loader)
-                    convertToLiteMode = True
-                    success = True
-
-                case (False, _, _, True):
-                    # native mode and native exists on disk
-                    data = self.grocer.executeRecipe(str(nativeModeFilePath), workspaceName, loader)
-                    success = True
-
-                case _:
-                    # live data fallback
-                    pass
-
-        if not success:
-            # Live-data fallback
-            if self.dataService.hasLiveDataConnection():
-                liveDataMode = True
-                # When not specified in the `liveDataArgs`,
-                #   default behavior will be to load the entire run.
-                startTime = (datetime.utcnow() - liveDataArgs.duration).isoformat() if liveDataArgs is not None else ""
-
-                loaderArgs = {
-                    "Facility": Config["liveData.facility.name"],
-                    "Instrument": Config["liveData.instrument.name"],
-                    "AccumulationMethod": Config["liveData.accumulationMethod"],
-                    "PreserveEvents": True,
-                    "StartTime": startTime,
-                }
-                data = self.grocer.executeRecipe(
-                    workspace=workspaceName,
-                    loader="LoadLiveData",
-                    loaderArgs=json.dumps(loaderArgs),
-                )
-                if data["result"]:
-                    logs = self.mantidSnapper.mtd[workspaceName].getRun()
-                    liveRunNumber = logs.getProperty("run_number").value if logs.hasProperty("run_number") else 0
-                    if int(runNumber) != int(liveRunNumber):
-                        self.deleteWorkspaceUnconditional(workspaceName)
-                        data = {"result": False}
-                        if liveDataArgs is not None:
-                            # the live-data run isn't the expected one => a live-data state change has occurred
-                            raise LiveDataState.runStateTransition(liveRunNumber, runNumber)
-                        raise RuntimeError(
-                            f"Neutron data for run '{runNumber}' is not present on disk, "
-                            + "nor is it the live-data run"
-                        )
-                    convertToLiteMode = useLiteMode
-                    success = True
-            else:
-                raise RuntimeError(
-                    f"Neutron data for run '{runNumber}' is not present on disk, "
-                    + "and no live-data connection is available"
-                )
-
-        if success and convertToLiteMode:
-            # fetch single-use does not export converted to lite data
-            self.convertToLiteMode(workspaceName, export=False)
-            data["workspace"] = workspaceName
-            self._processNeutronDataCopy(runNumber, workspaceName)
-
+        data["workspace"] = workspaceName
+        # NOTE: When would it ever be false?  If the workspace is not found, it should raise an error.
+        data["result"] = True
         return data
+
+    def _fetchLiveData(self, item: GroceryListItem):
+        loader = "LoadLiveData"
+        runNumber, useLiteMode, liveDataArgs = item.runNumber, item.useLiteMode, item.liveDataArgs
+        workspaceName: WorkspaceName = self._createNeutronWorkspaceName(runNumber, useLiteMode)
+        # Live-data fallback
+        if self.dataService.hasLiveDataConnection():
+            # When not specified in the `liveDataArgs`,
+            #   default behavior will be to load the entire run.
+            startTime = (datetime.utcnow() - liveDataArgs.duration).isoformat() if liveDataArgs is not None else ""
+
+            loaderArgs = {
+                "Facility": Config["liveData.facility.name"],
+                "Instrument": Config["liveData.instrument.name"],
+                "AccumulationMethod": Config["liveData.accumulationMethod"],
+                "PreserveEvents": True,
+                "StartTime": startTime,
+            }
+            data = self.grocer.executeRecipe(workspace=workspaceName, loader=loader, loaderArgs=json.dumps(loaderArgs))
+            data["fromLiveData"] = True
+            if data["result"]:
+                logs = self.mantidSnapper.mtd[workspaceName].getRun()
+                liveRunNumber = logs.getProperty("run_number").value if logs.hasProperty("run_number") else 0
+                if int(runNumber) != int(liveRunNumber):
+                    self.deleteWorkspaceUnconditional(workspaceName)
+                    data = {"result": False}
+                    if liveDataArgs is not None:
+                        # the live-data run isn't the expected one => a live-data state change has occurred
+                        raise LiveDataState.runStateTransition(liveRunNumber, runNumber)
+                    raise RuntimeError(
+                        f"Neutron data for run '{runNumber}' is not present on disk, " + "nor is it the live-data run"
+                    )
+                self._loadedRuns[self._key(runNumber, False)] = 0
+                self._liveDataKeys.append(self._key(runNumber, False))
+        else:
+            raise ConnectionError("no live-data connection is available")
+        return data
+
+    def _fetchNeutronDataNative(self, item: GroceryListItem) -> Dict[str, Any]:
+        _item = item.copy(deep=True)
+        _item.useLiteMode = False
+
+        def tryLiveData():
+            try:
+                return self._fetchLiveData(_item)
+            except ConnectionError:
+                raise RuntimeError(
+                    (
+                        f"Neutron data for run '{_item.runNumber}' is not present on disk,"
+                        " and no live-data connection is available."
+                    )
+                )
+
+        return self._fetchNeutronDataSingleUse(_item, tryLiveData)
+
+    def _fetchNeutronDataLite(self, item: GroceryListItem, export=False) -> Dict[str, Any]:
+        _item = item.copy(deep=True)
+        _item.useLiteMode = True
+
+        def tryNative():
+            data = self._fetchNeutronDataNative(_item)
+            data["fromNative"] = data["workspace"]
+            nativeWorkspaceName = data["workspace"]
+            liteWorkspaceName = self._createNeutronWorkspaceName(_item.runNumber, True)
+            self.getCloneOfWorkspace(nativeWorkspaceName, liteWorkspaceName)
+            self.convertToLiteMode(liteWorkspaceName, export=data.get("fromLiveData") is None and export)
+            data["workspace"] = liteWorkspaceName
+            return data
+
+        return self._fetchNeutronDataSingleUse(_item, tryNative)
+
+    def _fetchNeutronDataCached(self, item: GroceryListItem, loadMethod: Callable, **kwargs) -> Dict[str, Any]:
+        # 1. get single use neutron data
+        # 2. rename it to raw
+        # 3. clone it with proper name scheme
+        runNumber, useLiteMode = item.runNumber, item.useLiteMode
+
+        # NOTE: This relies on _fetchNeutronDataSingleUse to handle the case where the data is not found/cached
+        data = loadMethod(item, **kwargs)
+        rawWorkspaceName = data["workspace"]
+        key = self._key(runNumber, useLiteMode)
+        if key not in self._loadedRuns:
+            self._loadedRuns[key] = 0
+            rawWorkspaceName = self.renameWorkspace(
+                rawWorkspaceName, self._createRawNeutronWorkspaceName(runNumber, useLiteMode)
+            )
+        if "fromNative" in data:
+            nativeKey = self._key(runNumber, False)
+            if nativeKey not in self._loadedRuns:
+                self._loadedRuns[nativeKey] = 0
+                self.renameWorkspace(data["fromNative"], self._createRawNeutronWorkspaceName(runNumber, False))
+
+        workspaceName = self._createCopyNeutronWorkspaceName(runNumber, useLiteMode, self._loadedRuns[key] + 1)
+        data["result"] = self.getCloneOfWorkspace(rawWorkspaceName, workspaceName) is not None
+        data["workspace"] = workspaceName
+        self._loadedRuns[key] += 1
+        return data
+
+    def fetchNeutronDataSingleUse(self, item: GroceryListItem) -> Dict[str, Any]:
+        """
+        Fetch a neutron data file, without copy-protection.
+        If the workspace is truly only needed once, this saves time and memory.
+        If the workspace needs to be loaded more than once, use the cached method.
+
+        :param item: the grocery-list item
+        :type item: GroceryListItem
+        :return: a dictionary with the following keys
+
+            - "result": true if everything ran correctly
+            - "loader": the loader that was used by the algorithm; use it next time
+            - "workspace": the name of the workspace created in the ADS
+
+        :rtype: Dict[str, Any]
+        """
+        useLiteMode = item.useLiteMode
+        result = None
+
+        if useLiteMode:
+            result = self._fetchNeutronDataLite(item, export=False)
+        else:
+            result = self._fetchNeutronDataNative(item)
+        self._processNeutronDataCopy(item, result["workspace"])
+        return result
 
     def fetchNeutronDataCached(self, item: GroceryListItem) -> Dict[str, Any]:
         """
@@ -890,133 +934,15 @@ class GroceryService:
 
         :rtype: Dict[str, Any]
         """
+        useLiteMode = item.useLiteMode
+        result = None
 
-        runNumber, useLiteMode, loader, liveDataArgs = item.runNumber, item.useLiteMode, item.loader, item.liveDataArgs
-
-        # Live-data mode can be requested explicitly,
-        #   but it also serves as the fallback mode.
-        liveDataMode = loader == "LoadLiveData" or liveDataArgs is not None
-
-        success = False
-        convertToLiteMode = False
-
-        self._updateNeutronCacheFromADS(runNumber, useLiteMode)
-
-        key = self._key(runNumber, useLiteMode)
-        rawWorkspaceName: WorkspaceName = self._createRawNeutronWorkspaceName(runNumber, useLiteMode)
-        nativeRawWorkspaceName: WorkspaceName = self._createRawNeutronWorkspaceName(runNumber, False)
-
-        # if the raw data has already been loaded, clone it
-        if self._loadedRuns.get(key) is not None:
-            data = {"loader": "cached"}
-            success = True
-
-        if not success and not liveDataMode:
-            liteModeFilePath: Path = self._createNeutronFilePath(runNumber, True)
-            nativeModeFilePath: Path = self._createNeutronFilePath(runNumber, False)
-            cachedNativeMode = self._loadedRuns.get(self._key(runNumber, False)) is not None
-
-            match (useLiteMode, cachedNativeMode, liteModeFilePath.exists(), nativeModeFilePath.exists()):
-                # THERE ARE MANY SPECIAL CASES HERE, but basically the end result of a cached fetch will be
-                #   a raw copy in the cache, and the return of a cloned copy.
-                #   In addition, when converted from native mode
-                #   there may be an additional native copy in the cache.
-
-                case (True, _, True, _):
-                    # lite mode and lite-mode exists on disk
-                    data = self.grocer.executeRecipe(str(liteModeFilePath), rawWorkspaceName, loader)
-                    self._loadedRuns[key] = 0
-                    success = True
-
-                case (True, True, _, _):
-                    # lite mode and native is cached
-                    data = {"loader": "cached"}
-                    convertToLiteMode = True
-                    success = True
-
-                case (True, _, _, True):
-                    # lite mode and native exists on disk
-                    goingNative = self._key(runNumber, False)
-                    data = self.grocer.executeRecipe(str(nativeModeFilePath), nativeRawWorkspaceName, loader="")
-                    self._loadedRuns[self._key(*goingNative)] = 0
-                    convertToLiteMode = True
-                    success = True
-
-                case (False, _, _, True):
-                    # native mode and native exists on disk
-                    data = self.grocer.executeRecipe(str(nativeModeFilePath), nativeRawWorkspaceName, loader)
-                    self._loadedRuns[key] = 0
-                    success = True
-
-                case _:
-                    # live data fallback
-                    pass
-
-        if not success:
-            # Live-data fallback
-            if self.dataService.hasLiveDataConnection():
-                liveDataMode = True
-
-                # When not specified in the `liveDataArgs`,
-                #   default behavior will be to load the entire run.
-                startTime = (datetime.utcnow() - liveDataArgs.duration).isoformat() if liveDataArgs is not None else ""
-
-                loaderArgs = {
-                    "Facility": Config["liveData.facility.name"],
-                    "Instrument": Config["liveData.instrument.name"],
-                    "AccumulationMethod": Config["liveData.accumulationMethod"],
-                    "PreserveEvents": True,
-                    "StartTime": startTime,
-                }
-                data = self.grocer.executeRecipe(
-                    workspace=nativeRawWorkspaceName,
-                    loader="LoadLiveData",
-                    loaderArgs=json.dumps(loaderArgs),
-                )
-                if data["result"]:
-                    logs = self.mantidSnapper.mtd[nativeRawWorkspaceName].getRun()
-                    liveRunNumber = logs.getProperty("run_number").value if logs.hasProperty("run_number") else 0
-                    if int(runNumber) != int(liveRunNumber):
-                        self.deleteWorkspaceUnconditional(nativeRawWorkspaceName)
-                        data = {"result": False}
-                        if liveDataArgs is not None:
-                            # the live-data run isn't the expected one => a live-data state change has occurred
-                            raise LiveDataState.runStateTransition(liveRunNumber, runNumber)
-                        raise RuntimeError(
-                            f"Neutron data for run '{runNumber}' is not present on disk, "
-                            + "nor is it the live-data run"
-                        )
-                    self._loadedRuns[self._key(runNumber, False)] = 0
-                    self._liveDataKeys.append(self._key(runNumber, False))
-                    convertToLiteMode = useLiteMode
-                    success = True
-            else:
-                if liveDataMode:
-                    raise RuntimeError("no live-data connection is available")
-                raise RuntimeError(
-                    f"Neutron data for run '{runNumber}' is not present on disk, "
-                    + "and no live-data connection is available"
-                )
-
-        if success:
-            if convertToLiteMode:
-                # clone the native raw workspace
-                # then reduce its resolution to make the lite raw workspace
-                self.getCloneOfWorkspace(nativeRawWorkspaceName, rawWorkspaceName)
-                self._loadedRuns[key] = 0
-                if liveDataMode:
-                    self._liveDataKeys.append(key)
-                self.convertToLiteMode(rawWorkspaceName, export=not liveDataMode)
-
-            # create a copy of the raw data for use
-            workspaceName = self._createCopyNeutronWorkspaceName(runNumber, useLiteMode, self._loadedRuns[key] + 1)
-            wsClone = self.getCloneOfWorkspace(rawWorkspaceName, workspaceName) is not None
-            self._processNeutronDataCopy(runNumber, workspaceName)
-            data["result"] = wsClone
-            data["workspace"] = workspaceName
-            self._loadedRuns[key] += 1
-
-        return data
+        if useLiteMode:
+            result = self._fetchNeutronDataCached(item, self._fetchNeutronDataLite, export=True)
+        else:
+            result = self._fetchNeutronDataCached(item, self._fetchNeutronDataNative)
+        self._processNeutronDataCopy(item, result["workspace"])
+        return result
 
     def clearLiveDataCache(self):
         """
@@ -1186,7 +1112,7 @@ class GroceryService:
                 loader="LoadNexusProcessed",
             )
             data["workspace"] = workspaceName
-
+            self._processNeutronDataCopy(item, workspaceName)
         return data
 
     def fetchReductionPixelMask(self, item: GroceryListItem) -> Dict[str, Any]:
@@ -1277,6 +1203,20 @@ class GroceryService:
         assert isinstance(mtd[maskWSName], MaskWorkspace)
 
         return maskWSName
+
+    def _createMonitorWorkspaceName(self, runNumber: str, useLiteMode: bool) -> WorkspaceName:
+        return wng.monitor().runNumber(runNumber).lite(useLiteMode).build()
+
+    def fetchMonitorWorkspace(self, item: GroceryListItem) -> WorkspaceName:
+        runNumber, useLiteMode = item.runNumber, False
+        workspaceName = self._createMonitorWorkspaceName(runNumber, useLiteMode)
+
+        # monitors take ~1 second to load, probably unnecessary to cache
+
+        filepath: Path = self._createNeutronFilePath(runNumber, useLiteMode)
+        self.grocer.executeRecipe(str(filepath), workspaceName, "LoadNexusMonitors")
+
+        return workspaceName
 
     def fetchGroceryList(self, groceryList: Iterable[GroceryListItem]) -> List[WorkspaceName]:
         """
@@ -1392,6 +1332,7 @@ class GroceryService:
         :return: the workspace names of the fetched groceries, matched to their original keys
         :rtype: List[WorkspaceName]
         """
+
         groceryList = groceryDict.values()
         groceryNames = groceryDict.keys()
         groceries = self.fetchGroceryList(groceryList)
@@ -1492,7 +1433,7 @@ class GroceryService:
             workspaces = workspaces.difference(self.getCachedWorkspaces())
         return list(workspaces)
 
-    def _processNeutronDataCopy(self, runNumber, workspaceName):
+    def _filterEvents(self, runNumber, workspaceName):
         instrumentState = self.dataService.generateInstrumentState(runNumber)
         self.mantidSnapper.CropWorkspace(
             "Cropping workspace",
@@ -1511,4 +1452,25 @@ class GroceryService:
             Width=width,
             Frequency=frequency,
         )
-        self.mantidSnapper.executeQueue()
+
+    def _processNeutronDataCopy(self, item: GroceryListItem, workspaceName):
+        runNumber = item.runNumber
+        self._filterEvents(runNumber, workspaceName)
+
+        if Config["mantid.workspace.normalizeByBeamMonitor"]:
+            monitorNormID = Config["mantid.workspace.normMonitorID"]
+            # 1. get monitor workspace
+            # TODO: the width used for remove prompt pulse is different for monitors, same with particle bounds maybe?
+            monitorWs = self.fetchMonitorWorkspace(item)
+            # 2. apply the above croping and removing prompt pulse to the monitor workspace
+            self._filterEvents(runNumber, monitorWs)
+            # 3. get the number of events in the monitor workspace
+            normalizationFactor = self.mantidSnapper.mtd[monitorWs].getSpectrum(monitorNormID).getNumberEvents()
+            # 4. save this as normalization factor in the logs
+            metadata = WorkspaceMetadata(
+                normalizeByMonitorFactor=normalizationFactor, normalizeByMonitorID=monitorNormID
+            )
+
+            self.writeWorkspaceMetadataAsTags(workspaceName, metadata)
+
+            self.deleteWorkspaceUnconditional(monitorWs)

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -1204,15 +1204,13 @@ class GroceryService:
 
         return maskWSName
 
-    def _createMonitorWorkspaceName(self, runNumber: str, useLiteMode: bool) -> WorkspaceName:
-        builder = wng.monitor().runNumber(runNumber)
-        if useLiteMode:
-            builder.lite(wng.Lite.TRUE)
-        return builder.build()
+    def _createMonitorWorkspaceName(self, runNumber: str) -> WorkspaceName:
+        # a monitor cannot be lite
+        return wng.monitor().runNumber(runNumber).build()
 
     def fetchMonitorWorkspace(self, item: GroceryListItem) -> WorkspaceName:
         runNumber, useLiteMode = item.runNumber, False
-        workspaceName = self._createMonitorWorkspaceName(runNumber, useLiteMode)
+        workspaceName = self._createMonitorWorkspaceName(runNumber)
 
         # monitors take ~1 second to load, probably unnecessary to cache
 

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -835,7 +835,7 @@ class GroceryService:
         return data
 
     def _fetchNeutronDataNative(self, item: GroceryListItem) -> Dict[str, Any]:
-        _item = item.copy(deep=True)
+        _item = item.model_copy(deep=True)
         _item.useLiteMode = False
 
         def tryLiveData():
@@ -852,7 +852,7 @@ class GroceryService:
         return self._fetchNeutronDataSingleUse(_item, tryLiveData)
 
     def _fetchNeutronDataLite(self, item: GroceryListItem, export=False) -> Dict[str, Any]:
-        _item = item.copy(deep=True)
+        _item = item.model_copy(deep=True)
         _item.useLiteMode = True
 
         def tryNative():

--- a/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
@@ -58,6 +58,7 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
                     "LoadLiveData",
                     "LoadNexus",
                     "LoadNexusProcessed",
+                    "LoadNexusMonitors",
                 ]
             ),
             direction=Direction.InOut,

--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -12,7 +12,7 @@ from snapred.backend.log.logger import snapredLogger
 
 # must import to register with AlgorithmManager
 from snapred.meta.Callback import callback
-from snapred.meta.Config import Resource
+from snapred.meta.Config import Config, Resource
 from snapred.meta.pointer import access_pointer, create_pointer
 
 logger = snapredLogger.getLogger(__name__)
@@ -34,6 +34,15 @@ class _CustomMtd:
 
     def unique_hidden_name(self):
         return mtd.unique_hidden_name()
+
+    def getSNAPRedLog(self, wsName, logname):
+        realLogName = f"{Config['metadata.tagPrefix']}{logname}"
+        try:
+            return self[wsName].getRun().getLogData(realLogName).value
+        except RuntimeError as e:
+            if "Unknown property search object" in str(e):
+                raise KeyError(f"SNAPRed log {realLogName} not found in {wsName}")
+            raise
 
 
 class MantidSnapper:

--- a/src/snapred/backend/recipe/algorithm/NormalizeByCurrentButTheCorrectWay.py
+++ b/src/snapred/backend/recipe/algorithm/NormalizeByCurrentButTheCorrectWay.py
@@ -1,6 +1,6 @@
 from mantid.api import AlgorithmFactory, MatrixWorkspaceProperty, PropertyMode, PythonAlgorithm
 from mantid.kernel import Direction
-from mantid.simpleapi import CloneWorkspace, NormaliseByCurrent, mtd
+from mantid.simpleapi import CloneWorkspace, NormaliseByCurrent, Scale, mtd
 
 
 class NormalizeByCurrentButTheCorrectWay(PythonAlgorithm):
@@ -8,6 +8,7 @@ class NormalizeByCurrentButTheCorrectWay(PythonAlgorithm):
     You want to normalise but current.
     But you don't want it to just crash if you already did.
     This makes sure it won't.
+    aka NormaliseByProtonCharge
     """
 
     def category(self):
@@ -24,6 +25,7 @@ class NormalizeByCurrentButTheCorrectWay(PythonAlgorithm):
             doc="Name of the output workspace",
         )
         self.declareProperty("RecalculatePCharge", False, direction=Direction.Input)  # noqa: F821
+        self.declareProperty("NormalizeByMonitorCounts", 0.0, direction=Direction.Input)
         self.setRethrows(True)
 
     def PyExec(self):
@@ -35,11 +37,32 @@ class NormalizeByCurrentButTheCorrectWay(PythonAlgorithm):
                 OutputWorkspace=self.getPropertyValue("OutputWorkspace"),
             )
         else:
-            NormaliseByCurrent(
-                InputWorkspace=workspace,
-                OutputWorkspace=self.getPropertyValue("OutputWorkspace"),
-                RecalculatePCharge=self.getProperty("RecalculatePCharge").value,
-            )
+            if not self.getProperty("NormalizeByMonitorCounts").isDefault:
+                # pull the normalization factor from the workspace log
+                normVal = 1.0 / self.getProperty("NormalizeByMonitorCounts").value
+
+                if self.getPropertyValue("InputWorkspace") != self.getPropertyValue("OutputWorkspace"):
+                    CloneWorkspace(
+                        InputWorkspace=workspace,
+                        OutputWorkspace=self.getPropertyValue("OutputWorkspace"),
+                    )
+
+                workspace = self.getPropertyValue("OutputWorkspace")
+
+                workspace = Scale(InputWorkspace=workspace, Factor=normVal, Operation="Multiply")
+                # add the normalization factor to the workspace log
+                workspace.getRun().addProperty(
+                    "NormalizationFactor",
+                    normVal,
+                    False,
+                )
+                self.setProperty("OutputWorkspace", workspace)
+            else:
+                NormaliseByCurrent(
+                    InputWorkspace=workspace,
+                    OutputWorkspace=self.getPropertyValue("OutputWorkspace"),
+                    RecalculatePCharge=self.getProperty("RecalculatePCharge").value,
+                )
 
 
 # Register algorithm with Mantid

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -25,6 +25,8 @@ class WorkspaceType(str, Enum):
     DIFFCAL_METRIC = "diffCalMetric"
     DIFFCAL_TIMED_METRIC = "diffCalTimedMetric"
 
+    MONITOR = "monitor"
+
     # TODO: REBASE NOTE: inconsistent naming:
     #   these next should be `NORMCAL_RAW_VANADIUM` and etc.
     RAW_VANADIUM = "rawVanadium"
@@ -457,6 +459,9 @@ class _WorkspaceNameGenerator:
             unit=self.Units.DSP,
             type=self.ArtificialNormWorkspaceType.PREVIEW,
         )
+
+    def monitor(self):
+        return NameBuilder(WorkspaceType.MONITOR, self._monitorTemplate, self._monitorTemplateKeys, self._delimiter)
 
     def normCalResidual(self):
         return NameBuilder(

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -461,7 +461,12 @@ class _WorkspaceNameGenerator:
         )
 
     def monitor(self):
-        return NameBuilder(WorkspaceType.MONITOR, self._monitorTemplate, self._monitorTemplateKeys, self._delimiter)
+        return NameBuilder(
+            WorkspaceType.MONITOR,
+            self._monitorTemplate,
+            self._monitorTemplateKeys,
+            self._delimiter,
+        )
 
     def normCalResidual(self):
         return NameBuilder(

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -172,7 +172,7 @@ mantid:
           mask: "diffract_consts,mask,{runNumber},{version}"
           metric: "calib_metrics,{metricName},{runNumber},{version}"
           timedMetric: "calib_metrics,{metricName},{runNumber},{timestamp}"
-        monitor: "monitor,{lite},{runNumber}"
+        monitor: "monitor,{runNumber}"
         normCal:
           rawVanadium: "{unit},{group},{runNumber},raw_van_corr,{version}"
           focusedRawVanadium: "{unit},{group},{runNumber},raw_van_corr,{version}"

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -73,7 +73,7 @@ instrument:
   maxNumberOfRuns: 10
 
 liveData:
-  enabled: true
+  enabled: false
   # Override 'liveData.facility' and 'liveData.instrument'
   #   in order to use the mock listener for testing
   #   without overriding the real instrument.
@@ -157,6 +157,8 @@ reduction:
 
 mantid:
   workspace:
+    normalizeByBeamMonitor: false
+    normMonitorID: 0
     nameTemplate:
       delimiter: "_"
       template:
@@ -170,6 +172,7 @@ mantid:
           mask: "diffract_consts,mask,{runNumber},{version}"
           metric: "calib_metrics,{metricName},{runNumber},{version}"
           timedMetric: "calib_metrics,{metricName},{runNumber},{timestamp}"
+        monitor: "monitor,{lite},{runNumber}"
         normCal:
           rawVanadium: "{unit},{group},{runNumber},raw_van_corr,{version}"
           focusedRawVanadium: "{unit},{group},{runNumber},raw_van_corr,{version}"

--- a/tests/cis_tests/normalizebybeammonitor_proto.py
+++ b/tests/cis_tests/normalizebybeammonitor_proto.py
@@ -1,0 +1,107 @@
+from snapred.backend.dao.Limit import Limit, Pair
+from snapred.backend.dao import GSASParameters, ParticleBounds
+
+from snapred.backend.dao.request.FarmFreshIngredients import FarmFreshIngredients
+
+from snapred.backend.service.SousChef import SousChef
+from snapred.backend.service.ReductionService import ReductionService
+
+from snapred.backend.recipe.ReductionGroupProcessingRecipe import ReductionGroupProcessingRecipe
+
+from snapred.backend.data.GroceryService import GroceryService
+from snapred.backend.data.LocalDataService import LocalDataService
+
+from snapred.meta.Config import Config
+
+
+from mantid.simpleapi import CropWorkspace, RemovePromptPulse, mtd, Scale, LoadEventNexus, LoadNexusMonitors
+
+##############################################################################################
+
+#  Metadata
+
+
+MonitorNormID=0
+runId="59039"
+useLiteMode=True
+
+reductionService = ReductionService()
+groups = reductionService.loadAllGroupings(runId, useLiteMode)
+# find column group
+columnGroup = next((group for group in groups["focusGroups"] if "column" in group.name.lower()), None)
+columnGroupWorkspace = next(
+    (group for group in groups["groupingWorkspaces"] if "column" in group.lower()), None
+)
+
+updatedFarmFresh = FarmFreshIngredients(
+    runNumber=runId,
+    useLiteMode=useLiteMode,
+    focusGroups=[columnGroup], 
+)
+    
+pixelGroup = SousChef().prepPixelGroup(updatedFarmFresh)
+
+dataService = LocalDataService()
+instrumentConfig = dataService.readInstrumentConfig()
+width = instrumentConfig.width # what should this be?
+frequency = instrumentConfig.frequency
+
+detectorState = dataService.readDetectorState(runId)
+defaultGroupSliceValue = Config["calibration.parameters.default.groupSliceValue"]
+fwhmMultipliers = Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
+peakTailCoefficient = Config["calibration.parameters.default.peakTailCoefficient"]
+gsasParameters = GSASParameters(
+    alpha=Config["calibration.parameters.default.alpha"], beta=Config["calibration.parameters.default.beta"]
+)
+# then calculate the derived values
+lambdaLimit = Limit(
+    minimum=detectorState.wav - (instrumentConfig.bandwidth / 2) + instrumentConfig.lowWavelengthCrop,
+    maximum=detectorState.wav + (instrumentConfig.bandwidth / 2),
+)
+L = instrumentConfig.L1 + instrumentConfig.L2
+tofLimit = Limit(
+    minimum=lambdaLimit.minimum * L / dataService.CONVERSION_FACTOR,
+    maximum=lambdaLimit.maximum * L / dataService.CONVERSION_FACTOR,
+)
+particleBounds = ParticleBounds(wavelength=lambdaLimit, tof=tofLimit)
+
+
+
+##############################################################################################
+
+# Data
+
+groceryService = GroceryService()
+print(groceryService._createNeutronFilename("59039", False))
+def loadDataAndMonitors():
+    # runWorkspaceData = LoadEventNexus(Filename='/SNS/SNAP/IPTS-28913/shared/lite/SNAP_59039.lite.nxs.h5', OutputWorkspace='tof_all_lite_raw_059039', LoadMonitors=True)
+    runWorkspaceData = groceryService.fetchNeutronDataCached(runId, useLiteMode, "")
+    monitorWorkspace = LoadNexusMonitors(Filename=groceryService._createNeutronFilename(runId, False), OutputWorkspace=runWorkspaceData["workspace"]+"_monitor") 
+    return runWorkspaceData["workspace"]
+
+runWorkspaceName = loadDataAndMonitors()
+monitorWorkspaceName = runWorkspaceName + "_monitor"
+    
+
+##############################################################################################
+
+# Algorithm
+
+normalizedWorkspaceName = runWorkspaceName + "_normalized"
+
+groceries = {
+            "inputWorkspace": runWorkspaceName,
+            "groupingWorkspace": columnGroupWorkspace,
+            "outputWorkspace": runWorkspaceName,
+        }
+ 
+print(pixelGroup.json())
+ReductionGroupProcessingRecipe().cook(ReductionGroupProcessingRecipe.Ingredients(pixelGroup=pixelGroup), groceries)
+
+
+RemovePromptPulse(InputWorkspace=monitorWorkspaceName, OutputWorkspace=monitorWorkspaceName, Width=width, Frequency=frequency)
+CropWorkspace(InputWorkspace=monitorWorkspaceName, OutputWorkspace=monitorWorkspaceName, XMin=tofLimit.minimum, XMax=tofLimit.maximum)
+normVal = mtd[monitorWorkspaceName].getSpectrum(MonitorNormID).getNumberEvents()
+
+
+Scale(InputWorkspace=runWorkspaceName, OutputWorkspace=normalizedWorkspaceName, Factor=1/normVal, Operation="Multiply")

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -173,7 +173,7 @@ mantid:
             mask: "_diffract_consts,mask,{runNumber},{version}"
             metric: "_calib_metrics,{metricName},{runNumber},{version}"
             timedMetric: "_calib_metrics,{metricName},{runNumber},{timestamp}"
-          monitor: "monitor,{lite},{runNumber}"
+          monitor: "monitor,{runNumber}"
           normCal:
             rawVanadium: "_{unit},{group},raw_van_corr,{runNumber},{version}"
             focusedRawVanadium: "_{unit},{group},raw_van_corr,{runNumber},{version}"

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -158,6 +158,8 @@ reduction:
 
 mantid:
     workspace:
+      normalizeByBeamMonitor: false
+      normMonitorID: 0
       nameTemplate:
         delimiter: "_"
         template:
@@ -171,6 +173,7 @@ mantid:
             mask: "_diffract_consts,mask,{runNumber},{version}"
             metric: "_calib_metrics,{metricName},{runNumber},{version}"
             timedMetric: "_calib_metrics,{metricName},{runNumber},{timestamp}"
+          monitor: "monitor,{lite},{runNumber}"
           normCal:
             rawVanadium: "_{unit},{group},raw_van_corr,{runNumber},{version}"
             focusedRawVanadium: "_{unit},{group},raw_van_corr,{runNumber},{version}"

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -296,7 +296,7 @@ class TestDataFactoryService(unittest.TestCase):
         mtd.add(wsname1, ws1)
         assert self.instance.workspaceDoesExist(wsname1)
         ws2 = self.instance.getCloneOfWorkspace(wsname1, wsname2)
-        assert ws1.getComment() == ws2.getComment()
+        assert mtd[str(ws1)].getComment() == mtd[str(ws2)].getComment()
         DeleteWorkspace(wsname1)
         assert self.instance.workspaceDoesExist(wsname2)
         DeleteWorkspace(wsname2)

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -3476,11 +3476,11 @@ class TestGroceryService(unittest.TestCase):
             mock.patch.object(instance, "_createNeutronFilePath", wraps=instance._createNeutronFilePath) as _,
             mock.patch.object(instance, "grocer") as _,
         ):
-            instance.fetchMonitorWorkspace(item)
+            name = instance.fetchMonitorWorkspace(item)
 
+            assert name == wng.monitor().runNumber("123").build()
             assert instance._createMonitorWorkspaceName.call_count == 1
             assert instance._createMonitorWorkspaceName.call_args[0][0] == item.runNumber
-            assert not instance._createMonitorWorkspaceName.call_args[0][1]
 
             assert instance._createNeutronFilePath.call_count == 1
             assert instance._createNeutronFilePath.call_args[0][0] == item.runNumber

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -29,6 +29,8 @@ from mantid.simpleapi import (
     LoadEmptyInstrument,
     LoadInstrument,
     MaskDetectors,
+    RenameWorkspace,
+    RenameWorkspaces,
     SaveDiffCal,
     SaveNexus,
     SaveNexusProcessed,
@@ -93,6 +95,7 @@ class TestGroceryService(unittest.TestCase):
             DataX=[0.5, 1.5] * 16,
             DataY=[3] * 16,
             NSpec=16,
+            UnitX="TOF",
         )
         LoadInstrument(
             Workspace=cls.sampleWS,
@@ -497,7 +500,8 @@ class TestGroceryService(unittest.TestCase):
         wsname2 = "_cloned_ws_"
         assert not mtd.doesExist(wsname1)
         assert not mtd.doesExist(wsname2)
-        assert not self.instance.getCloneOfWorkspace(wsname1, wsname2)
+        with pytest.raises(ValueError, match="was not found in the Analysis Data Service"):
+            self.instance.getCloneOfWorkspace(wsname1, wsname2)
 
     def test_getCloneOfWorkspace_works(self):
         wsname1 = "_test_ws_"
@@ -506,7 +510,8 @@ class TestGroceryService(unittest.TestCase):
         assert mtd.doesExist(wsname1)
         assert not mtd.doesExist(wsname2)
         ws = self.instance.getCloneOfWorkspace(wsname1, wsname2)
-        assert ws.name() == wsname2  # checks that the workspace pointer can be used
+        # We dont pass around workspace pointers, those are not reliable
+        assert ws == wsname2
         assert mtd.doesExist(wsname2)
         assert_wksp_almost_equal(
             Workspace1=wsname1,
@@ -854,6 +859,15 @@ class TestGroceryService(unittest.TestCase):
 
         self.instance.convertToLiteMode = mock.Mock()
         self.instance.mantidSnapper = mock.MagicMock()
+        self.instance.mantidSnapper.CloneWorkspace = mock.MagicMock(
+            side_effect=lambda _, **kwargs: CloneWorkspace(**kwargs)
+        )
+        self.instance.mantidSnapper.RenameWorkspaces = mock.MagicMock(
+            side_effect=lambda _, **kwargs: RenameWorkspaces(**kwargs)
+        )
+        self.instance.mantidSnapper.RenameWorkspace = mock.MagicMock(
+            side_effect=lambda _, **kwargs: RenameWorkspace(**kwargs)
+        )
         testCalibrationData = DAOFactory.calibrationParameters()
         self.instance.dataService.generateInstrumentState = mock.MagicMock(
             return_value=testCalibrationData.instrumentState
@@ -868,9 +882,13 @@ class TestGroceryService(unittest.TestCase):
             else nonExistentPath
         )
 
-        testItem = mock.Mock(
-            spec=GroceryListItem, runNumber=self.runNumber, useLiteMode=False, loader="", liveDataArgs=None
-        )
+        def generateTestItem(deep=False):  # noqa: ARG001
+            return mock.Mock(
+                spec=GroceryListItem, runNumber=self.runNumber, useLiteMode=False, loader="", liveDataArgs=None
+            )
+
+        testItem = generateTestItem()
+        testItem.copy.side_effect = generateTestItem
 
         # ensure a clean ADS
         workspaceName = self.instance._createNeutronWorkspaceName(testItem.runNumber, testItem.useLiteMode)
@@ -904,7 +922,10 @@ class TestGroceryService(unittest.TestCase):
         assert not mtd.doesExist(workspaceName)
         # create a clean version so a raw exists in cache
         res = self.instance.fetchNeutronDataCached(testItem)
-        assert mtd.doesExist(rawWorkspaceName)
+        assert self.instance.mantidSnapper.CloneWorkspace.call_count == 1
+        assert mtd.doesExist(
+            rawWorkspaceName
+        ), f"Raw workspace {rawWorkspaceName} not available in {mtd.getObjectNames()}"
         assert not mtd.doesExist(workspaceName)
         assert len(self.instance._loadedRuns) == 1
         testKey = self.instance._key(testItem.runNumber, testItem.useLiteMode)
@@ -922,9 +943,14 @@ class TestGroceryService(unittest.TestCase):
         )
 
         # test calling with Lite data, that it will call to lite service
-        liteItem = mock.Mock(
-            spec=GroceryListItem, runNumber=self.runNumber, useLiteMode=True, loader="", liveDataArgs=None
-        )
+        def generateTestItem(deep=False):  # noqa: ARG001
+            m = mock.Mock(
+                spec=GroceryListItem, runNumber=self.runNumber, useLiteMode=True, loader="", liveDataArgs=None
+            )
+            m.copy.side_effect = generateTestItem
+            return m
+
+        liteItem = generateTestItem()
 
         testKeyLite = self.instance._key(liteItem.runNumber, liteItem.useLiteMode)
         res = self.instance.fetchNeutronDataSingleUse(liteItem)
@@ -938,14 +964,28 @@ class TestGroceryService(unittest.TestCase):
         self.instance._createNeutronFilePath = mock.Mock()
         self.instance.dataService.hasLiveDataConnection = mock.Mock(return_value=False)
         self.instance.mantidSnapper = mock.MagicMock()
+        self.instance.mantidSnapper.CloneWorkspace = mock.MagicMock(
+            side_effect=lambda _, **kwargs: CloneWorkspace(**kwargs)
+        )
+        self.instance.mantidSnapper.RenameWorkspaces = mock.MagicMock(
+            side_effect=lambda _, **kwargs: RenameWorkspaces(**kwargs)
+        )
+        self.instance.mantidSnapper.RenameWorkspace = mock.MagicMock(
+            side_effect=lambda _, **kwargs: RenameWorkspace(**kwargs)
+        )
+
         testCalibrationData = DAOFactory.calibrationParameters()
         self.instance.dataService.generateInstrumentState = mock.MagicMock(
             return_value=testCalibrationData.instrumentState
         )
 
-        testItem = mock.Mock(
-            spec=GroceryListItem, runNumber=self.runNumber, useLiteMode=False, loader="", liveDataArgs=None
-        )
+        def generateTestItem(deep=False):  # noqa: ARG001
+            return mock.Mock(
+                spec=GroceryListItem, runNumber=self.runNumber, useLiteMode=False, loader="", liveDataArgs=None
+            )
+
+        testItem = generateTestItem()
+        testItem.copy.side_effect = generateTestItem
         testKey = self.instance._key(testItem.runNumber, testItem.useLiteMode)
 
         workspaceNameRaw = self.instance._createRawNeutronWorkspaceName(testItem.runNumber, testItem.useLiteMode)
@@ -977,8 +1017,12 @@ class TestGroceryService(unittest.TestCase):
         assert res["workspace"] == workspaceNameCopy1
         assert self.instance._loadedRuns == {testKey: 1}
         # assert the correct workspaces exist: a raw and a copy
-        assert mtd.doesExist(workspaceNameRaw)
-        assert mtd.doesExist(workspaceNameCopy1)
+        assert mtd.doesExist(
+            workspaceNameRaw
+        ), f"Raw workspace {workspaceNameRaw} not available in {mtd.getObjectNames()}"
+        assert mtd.doesExist(
+            workspaceNameCopy1
+        ), f"Copy workspace {workspaceNameCopy1} not available in {mtd.getObjectNames()}"
         # test the workspace is correct
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
@@ -1012,19 +1056,40 @@ class TestGroceryService(unittest.TestCase):
         self.instance._createNeutronFilePath = mock.Mock()
         self.instance.dataService.hasLiveDataConnection = mock.Mock(return_value=False)
         self.instance.mantidSnapper = mock.MagicMock()
+        self.instance.mantidSnapper.CloneWorkspace = mock.MagicMock(
+            side_effect=lambda _, **kwargs: CloneWorkspace(**kwargs)
+        )
+        self.instance.mantidSnapper.RenameWorkspaces = mock.MagicMock(
+            side_effect=lambda _, **kwargs: RenameWorkspaces(**kwargs)
+        )
+        self.instance.mantidSnapper.RenameWorkspace = mock.MagicMock(
+            side_effect=lambda _, **kwargs: RenameWorkspace(**kwargs)
+        )
+
         testCalibrationData = DAOFactory.calibrationParameters()
         self.instance.dataService.generateInstrumentState = mock.MagicMock(
             return_value=testCalibrationData.instrumentState
         )
 
-        testItem = mock.Mock(
-            spec=GroceryListItem, runNumber=self.runNumber, useLiteMode=True, loader="", liveDataArgs=None
-        )
+        def generateTestItem(deep=False):  # noqa: ARG001
+            m = mock.Mock(
+                spec=GroceryListItem, runNumber=self.runNumber, useLiteMode=True, loader="", liveDataArgs=None
+            )
+            m.copy.side_effect = generateTestItem
+            return m
+
+        testItem = generateTestItem()
+
         testKey = self.instance._key(testItem.runNumber, testItem.useLiteMode)
 
-        nativeItem = mock.Mock(
-            spec=GroceryListItem, runNumber=self.runNumber, useLiteMode=False, loader="", liveDataArgs=None
-        )
+        def generateTestItem(deep=False):  # noqa: ARG001
+            return mock.Mock(
+                spec=GroceryListItem, runNumber=self.runNumber, useLiteMode=False, loader="", liveDataArgs=None
+            )
+
+        nativeItem = generateTestItem()
+        nativeItem.copy.side_effect = generateTestItem
+
         nativeKey = self.instance._key(nativeItem.runNumber, nativeItem.useLiteMode)
 
         workspaceNameNativeRaw = self.instance._createRawNeutronWorkspaceName(
@@ -1062,13 +1127,13 @@ class TestGroceryService(unittest.TestCase):
 
         # there is no lite file and nothing cached
         # load native resolution from file, then clone/reduce the native data
-
+        testItem.useLiteMode = True
         res = self.instance.fetchNeutronDataCached(testItem)
         assert res["result"]
         assert res["loader"] == "LoadNexusProcessed"
         assert res["workspace"] == workspaceNameLiteCopy1
         for ws in [workspaceNameNativeRaw, workspaceNameLiteRaw, workspaceNameLiteCopy1]:
-            assert mtd.doesExist(ws)
+            assert mtd.doesExist(ws), f"Workspace {ws} does not exist in {mtd.getObjectNames()}"
         assert self.instance._loadedRuns == {testKey: 1, nativeKey: 0}
         # make sure it calls to convert to lite mode
         self.instance.convertToLiteMode.assert_called_once()
@@ -1178,12 +1243,11 @@ class TestGroceryService(unittest.TestCase):
                 except RuntimeError as e:
                     exceptionRaised = e
 
-                mockUpdateNeutronCache.assert_called_once_with(runNumber, useLiteMode)
-
                 match (useLiteMode, nativeInCache, liteOnDisk, nativeOnDisk):
                     case (False, True, _, _):
                         # native mode and native in cache:
                         #   not tested _here_.
+                        mockUpdateNeutronCache.assert_called_with(runNumber, False)
                         continue
 
                     case (True, _, True, _):
@@ -1193,22 +1257,42 @@ class TestGroceryService(unittest.TestCase):
                             str(liteModeFilePath), workspaceName, item.loader
                         )
                         mockConvertToLiteMode.assert_not_called()
+                        mockUpdateNeutronCache.assert_called_with(runNumber, True)
 
                     case (True, True, _, _):
                         # lite mode and native is cached
-                        assert result == {"result": True, "loader": "cached", "workspace": workspaceName}
-                        mockGetCloneOfWorkspace.assert_called_once_with(
-                            mockCreateRawNeutronWorkspaceName(runNumber, False), workspaceName
+                        assert result == {
+                            "fromNative": mock.sentinel.nativeWorkspaceName,
+                            "result": True,
+                            "loader": "cached",
+                            "workspace": workspaceName,
+                        }
+                        mockGetCloneOfWorkspace.assert_has_calls(
+                            [
+                                mock.call(
+                                    mockCreateRawNeutronWorkspaceName(runNumber, False),
+                                    mock.sentinel.nativeWorkspaceName,
+                                ),
+                                mock.call(mock.sentinel.nativeWorkspaceName, workspaceName),
+                            ]
                         )
                         mockConvertToLiteMode.assert_called_once_with(workspaceName, export=False)
+                        mockUpdateNeutronCache.assert_has_calls(
+                            [mock.call(runNumber, True), mock.call(runNumber, False)]
+                        )
 
                     case (True, _, _, True):
                         # lite mode and native exists on disk
                         assert result == mockFetchGroceriesRecipe.executeRecipe.return_value
                         mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                            str(nativeModeFilePath), workspaceName, item.loader
+                            str(nativeModeFilePath),
+                            mockCreateNeutronWorkspaceName(runNumber, False),
+                            item.loader,
                         )
                         mockConvertToLiteMode.assert_called_once_with(workspaceName, export=False)
+                        mockUpdateNeutronCache.assert_has_calls(
+                            [mock.call(runNumber, True), mock.call(runNumber, False)]
+                        )
 
                     case (False, _, _, True):
                         # native mode and native exists on disk
@@ -1217,6 +1301,7 @@ class TestGroceryService(unittest.TestCase):
                             str(nativeModeFilePath), workspaceName, item.loader
                         )
                         mockConvertToLiteMode.assert_not_called()
+                        mockUpdateNeutronCache.assert_called_with(runNumber, False)
 
                     case _:
                         # live data fallback: NOT tested here
@@ -1227,9 +1312,10 @@ class TestGroceryService(unittest.TestCase):
                         assert isinstance(exceptionRaised, RuntimeError)
                         assert (
                             f"Neutron data for run '{runNumber}' is not present on disk, "
-                            + "and no live-data connection is available"
+                            + "and no live-data connection is available."
                             == str(exceptionRaised)
                         )
+                        mockUpdateNeutronCache.assert_called_with(runNumber, False)
 
     def test_fetchNeutronDataSingleUse_live_data(self):
         # Test live data, non-fallback cases.
@@ -1305,7 +1391,8 @@ class TestGroceryService(unittest.TestCase):
 
                 mockGetCloneOfWorkspace.return_value = mock.sentinel.clonedWorkspace
 
-                workspaceName = mockCreateNeutronWorkspaceName(runNumber, useLiteMode)
+                # Initial output ws from livedata will always be native before it gets converted to lite mode.
+                workspaceName = mockCreateNeutronWorkspaceName(runNumber, False)
 
                 # Mock `instance.mantidSnapper.mtd` to return a workspace that has the correct run number.
                 def _valid_key(key: str, validKey: str):
@@ -1347,7 +1434,7 @@ class TestGroceryService(unittest.TestCase):
                     exceptionRaised = e
 
                 assert exceptionRaised is None
-                mockUpdateNeutronCache.assert_called_once_with(runNumber, useLiteMode)
+                mockUpdateNeutronCache.assert_called_with(runNumber, False)
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
                     workspace=workspaceName,
@@ -1355,7 +1442,8 @@ class TestGroceryService(unittest.TestCase):
                     loaderArgs=json.dumps(expectedLoaderArgs),
                 )
                 if useLiteMode:
-                    mockConvertToLiteMode.assert_called_once_with(workspaceName, export=False)
+                    workspaceLiteName = mockCreateNeutronWorkspaceName(runNumber, True)
+                    mockConvertToLiteMode.assert_called_once_with(workspaceLiteName, export=False)
                 else:
                     mockConvertToLiteMode.assert_not_called()
 
@@ -1433,12 +1521,12 @@ class TestGroceryService(unittest.TestCase):
 
                 mockGetCloneOfWorkspace.return_value = mock.sentinel.clonedWorkspace
 
-                workspaceName = mockCreateNeutronWorkspaceName(runNumber, useLiteMode)
+                # Initial output ws from livedata will always be native before it gets converted to lite mode.
+                workspaceName = mockCreateNeutronWorkspaceName(runNumber, False)
 
                 # Mock `instance.mantidSnapper.mtd` to return a workspace that DOES NOT HAVE the correct run number.
                 def _valid_key(key: str, validKey: str):
-                    if key != validKey:
-                        raise KeyError(f"key '{key}', expecting '{validKey}'")
+                    assert key == validKey, f"key '{key}', expecting '{validKey}'"
                     return True
 
                 mockWs = mock.Mock()
@@ -1471,14 +1559,13 @@ class TestGroceryService(unittest.TestCase):
                 result = None  # noqa: F841
                 try:
                     result = instance.fetchNeutronDataSingleUse(item)  # noqa: F841
-                except Exception as e:  # noqa: BLE001
+                except LiveDataState as e:  # noqa: BLE001
                     exceptionRaised = e
 
-                assert isinstance(exceptionRaised, LiveDataState)
                 assert (
                     exceptionRaised.model == LiveDataState.runStateTransition(str(int(runNumber) + 1), runNumber).model
                 )
-                mockUpdateNeutronCache.assert_called_once_with(runNumber, useLiteMode)
+                mockUpdateNeutronCache.assert_called_with(runNumber, False)
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
                     workspace=workspaceName,
@@ -1555,7 +1642,8 @@ class TestGroceryService(unittest.TestCase):
 
                 mockGetCloneOfWorkspace.return_value = mock.sentinel.clonedWorkspace
 
-                workspaceName = mockCreateNeutronWorkspaceName(runNumber, useLiteMode)
+                # Live data is always initially native until it is converted to lite mode.
+                workspaceName = mockCreateNeutronWorkspaceName(runNumber, False)
 
                 # Mock `instance.mantidSnapper.mtd` to return a workspace that has the correct run number.
                 def _valid_key(key: str, validKey: str):
@@ -1591,7 +1679,7 @@ class TestGroceryService(unittest.TestCase):
                     exceptionRaised = e
 
                 assert exceptionRaised is None
-                mockUpdateNeutronCache.assert_called_once_with(runNumber, useLiteMode)
+                mockUpdateNeutronCache.assert_called_with(runNumber, False)
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
                     workspace=workspaceName,
@@ -1599,7 +1687,8 @@ class TestGroceryService(unittest.TestCase):
                     loaderArgs=json.dumps(expectedLoaderArgs),
                 )
                 if useLiteMode:
-                    mockConvertToLiteMode.assert_called_once_with(workspaceName, export=False)
+                    workspaceLiteName = mockCreateNeutronWorkspaceName(runNumber, True)
+                    mockConvertToLiteMode.assert_called_once_with(workspaceLiteName, export=False)
                 else:
                     mockConvertToLiteMode.assert_not_called()
 
@@ -1670,7 +1759,8 @@ class TestGroceryService(unittest.TestCase):
 
                 mockGetCloneOfWorkspace.return_value = mock.sentinel.clonedWorkspace
 
-                workspaceName = mockCreateNeutronWorkspaceName(runNumber, useLiteMode)
+                # Live data is always initially native until it is converted to lite mode.
+                workspaceName = mockCreateNeutronWorkspaceName(runNumber, False)
 
                 # Mock `instance.mantidSnapper.mtd` to return a workspace that DOES NOT HAVE the correct run number.
                 def _valid_key(key: str, validKey: str):
@@ -1711,7 +1801,7 @@ class TestGroceryService(unittest.TestCase):
                     in str(exceptionRaised)
                 )
 
-                mockUpdateNeutronCache.assert_called_once_with(runNumber, useLiteMode)
+                mockUpdateNeutronCache.assert_called_with(runNumber, False)
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
                     workspace=workspaceName,
@@ -1755,6 +1845,7 @@ class TestGroceryService(unittest.TestCase):
                 mock.patch.object(instance, "_createCopyNeutronWorkspaceName") as mockCreateCopyNeutronWorkspaceName,
                 mock.patch.object(instance.dataService, "hasLiveDataConnection") as mockHasLiveDataConnection,
                 mock.patch.object(instance, "getCloneOfWorkspace") as mockGetCloneOfWorkspace,
+                mock.patch.object(instance, "renameWorkspace") as mockRenameWorkspace,
                 mock.patch.object(instance, "convertToLiteMode") as mockConvertToLiteMode,
                 mock.patch.object(instance, "mantidSnapper") as mockSnapper,  # noqa F841
             ):
@@ -1791,10 +1882,9 @@ class TestGroceryService(unittest.TestCase):
 
                 mockGetCloneOfWorkspace.return_value = mock.sentinel.clonedWorkspace
 
+                mockRenameWorkspace.side_effect = lambda _, newName: newName
+
                 workspaceName = mockCreateNeutronWorkspaceName(runNumber, useLiteMode)
-                nativeRawWorkspaceName = mockCreateRawNeutronWorkspaceName(runNumber, False)
-                liteRawWorkspaceName = mockCreateRawNeutronWorkspaceName(runNumber, True)
-                liteCopyWorkspaceName = mockCreateCopyNeutronWorkspaceName(runNumber, True, 1)
 
                 # Action-related mocks:
                 mockFetchGroceriesRecipe.executeRecipe.return_value = {
@@ -1815,8 +1905,6 @@ class TestGroceryService(unittest.TestCase):
                 except RuntimeError as e:
                     exceptionRaised = e
 
-                mockUpdateNeutronCache.assert_called_once_with(runNumber, useLiteMode)
-
                 match (useLiteMode, nativeInCache, liteOnDisk, nativeOnDisk):
                     case (False, True, _, _):
                         # native mode and native in cache:
@@ -1827,18 +1915,26 @@ class TestGroceryService(unittest.TestCase):
                         # lite mode and lite-mode exists on disk
                         assert result == mockFetchGroceriesRecipe.executeRecipe.return_value
                         assert instance._loadedRuns[(runNumber, useLiteMode)] == 1
+                        liteWorkspaceName = mockCreateNeutronWorkspaceName(runNumber, True)
                         mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                            str(liteModeFilePath), liteRawWorkspaceName, item.loader
+                            str(liteModeFilePath),
+                            liteWorkspaceName,
+                            item.loader,
                         )
                         mockConvertToLiteMode.assert_not_called()
+                        mockUpdateNeutronCache.assert_has_calls([mock.call(runNumber, True)])
 
                     case (True, True, _, _):
                         # lite mode and native is cached
                         assert instance._loadedRuns[(runNumber, useLiteMode)] == 1
                         assert instance._loadedRuns[(runNumber, False)] == 0
-                        mockGetCloneOfWorkspace.assert_any_call(nativeRawWorkspaceName, liteRawWorkspaceName)
-                        mockGetCloneOfWorkspace.assert_called_with(liteRawWorkspaceName, liteCopyWorkspaceName)
-                        mockConvertToLiteMode.assert_called_once_with(liteRawWorkspaceName, export=True)
+                        nativeWorkspaceName = mockCreateNeutronWorkspaceName(runNumber, False)
+                        liteWorkspaceName = mockCreateNeutronWorkspaceName(runNumber, True)
+                        mockGetCloneOfWorkspace.assert_any_call(nativeWorkspaceName, liteWorkspaceName)
+                        mockConvertToLiteMode.assert_called_once_with(liteWorkspaceName, export=True)
+                        mockUpdateNeutronCache.assert_has_calls(
+                            [mock.call(runNumber, True), mock.call(runNumber, False)]
+                        )
 
                     case (True, _, _, True):
                         # lite mode and native exists on disk
@@ -1846,18 +1942,23 @@ class TestGroceryService(unittest.TestCase):
                         assert instance._loadedRuns[(runNumber, False)] == 0
                         assert instance._loadedRuns[(runNumber, useLiteMode)] == 1
                         mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                            str(nativeModeFilePath), nativeRawWorkspaceName, loader=item.loader
+                            str(nativeModeFilePath), mockCreateNeutronWorkspaceName(runNumber, False), item.loader
                         )
-                        mockConvertToLiteMode.assert_called_once_with(liteRawWorkspaceName, export=True)
+                        liteWorkspaceName = mockCreateNeutronWorkspaceName(runNumber, True)
+                        mockConvertToLiteMode.assert_called_once_with(liteWorkspaceName, export=True)
+                        mockUpdateNeutronCache.assert_has_calls(
+                            [mock.call(runNumber, True), mock.call(runNumber, False)]
+                        )
 
                     case (False, _, _, True):
                         # native mode and native exists on disk
                         assert result == mockFetchGroceriesRecipe.executeRecipe.return_value
                         assert instance._loadedRuns[(runNumber, useLiteMode)] == (1 if not useLiteMode else 0)
                         mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                            str(nativeModeFilePath), nativeRawWorkspaceName, item.loader
+                            str(nativeModeFilePath), workspaceName, item.loader
                         )
                         mockConvertToLiteMode.assert_not_called()
+                        mockUpdateNeutronCache.assert_has_calls([mock.call(runNumber, False)])
 
                     case _:
                         # live data fallback: NOT tested here
@@ -1868,7 +1969,7 @@ class TestGroceryService(unittest.TestCase):
                         assert isinstance(exceptionRaised, RuntimeError)
                         assert (
                             f"Neutron data for run '{runNumber}' is not present on disk, "
-                            + "and no live-data connection is available"
+                            + "and no live-data connection is available."
                             == str(exceptionRaised)
                         )
 
@@ -1946,9 +2047,8 @@ class TestGroceryService(unittest.TestCase):
 
                 mockGetCloneOfWorkspace.return_value = mock.sentinel.clonedWorkspace
 
-                workspaceName = mockCreateNeutronWorkspaceName(runNumber, useLiteMode)
-                nativeRawWorkspaceName = mockCreateRawNeutronWorkspaceName(runNumber, False)
-                liteRawWorkspaceName = mockCreateRawNeutronWorkspaceName(runNumber, True)
+                # Initial output ws from livedata will always be native before it gets converted to lite mode.
+                workspaceName = mockCreateNeutronWorkspaceName(runNumber, False)
 
                 # Mock `instance.mantidSnapper.mtd` to return a workspace that has the correct run number.
                 def _valid_key(key: str, validKey: str):
@@ -1963,7 +2063,7 @@ class TestGroceryService(unittest.TestCase):
                     lambda key: RunNumberProperty(runNumber) if _valid_key(key, "run_number") else None
                 )
                 mockSnapper.mtd.__getitem__.side_effect = (
-                    lambda wsName: mockWs if _valid_key(wsName, nativeRawWorkspaceName) else None
+                    lambda wsName: mockWs if _valid_key(wsName, workspaceName) else None
                 )
 
                 # Action-related mocks:
@@ -1991,19 +2091,24 @@ class TestGroceryService(unittest.TestCase):
 
                 assert exceptionRaised is None
                 assert instance._loadedRuns[(runNumber, useLiteMode)] == 1
-                assert (runNumber, useLiteMode) in instance._liveDataKeys
+                # If live data is used, the run number is stored in the cache as native
+                assert (runNumber, False) in instance._liveDataKeys
 
-                mockUpdateNeutronCache.assert_called_once_with(runNumber, useLiteMode)
+                if not useLiteMode:
+                    mockUpdateNeutronCache.assert_called_once_with(runNumber, False)
+                else:
+                    mockUpdateNeutronCache.assert_has_calls([mock.call(runNumber, True), mock.call(runNumber, False)])
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                    workspace=nativeRawWorkspaceName,
+                    workspace=workspaceName,
                     loader="LoadLiveData",
                     loaderArgs=json.dumps(expectedLoaderArgs),
                 )
                 if useLiteMode:
                     assert instance._loadedRuns[(runNumber, False)] == 0
                     assert (runNumber, False) in instance._liveDataKeys
-                    mockConvertToLiteMode.assert_called_once_with(liteRawWorkspaceName, export=False)
+                    workspaceLiteName = mockCreateNeutronWorkspaceName(runNumber, True)
+                    mockConvertToLiteMode.assert_called_once_with(workspaceLiteName, export=False)
                 else:
                     mockConvertToLiteMode.assert_not_called()
 
@@ -2076,8 +2181,8 @@ class TestGroceryService(unittest.TestCase):
 
                 mockGetCloneOfWorkspace.return_value = mock.sentinel.clonedWorkspace
 
-                workspaceName = mockCreateNeutronWorkspaceName(runNumber, useLiteMode)
-                nativeRawWorkspaceName = mockCreateRawNeutronWorkspaceName(runNumber, False)
+                # Live data is always initially native until it is converted to lite mode.
+                workspaceName = mockCreateNeutronWorkspaceName(runNumber, False)
 
                 # Mock `instance.mantidSnapper.mtd` to return a workspace that DOES NOT HAVE the correct run number.
                 def _valid_key(key: str, validKey: str):
@@ -2092,7 +2197,7 @@ class TestGroceryService(unittest.TestCase):
                     lambda key: RunNumberProperty(str(int(runNumber) + 1)) if _valid_key(key, "run_number") else None
                 )
                 mockSnapper.mtd.__getitem__.side_effect = (
-                    lambda wsName: mockWs if _valid_key(wsName, nativeRawWorkspaceName) else None
+                    lambda wsName: mockWs if _valid_key(wsName, workspaceName) else None
                 )
 
                 # Action-related mocks:
@@ -2115,22 +2220,25 @@ class TestGroceryService(unittest.TestCase):
                 result = None  # noqa: F841
                 try:
                     result = instance.fetchNeutronDataCached(item)  # noqa: F841
-                except Exception as e:  # noqa: BLE001
+                except LiveDataState as e:  # noqa: BLE001
                     exceptionRaised = e
 
-                assert isinstance(exceptionRaised, LiveDataState)
                 assert (
                     exceptionRaised.model == LiveDataState.runStateTransition(str(int(runNumber) + 1), runNumber).model
                 )
-                mockUpdateNeutronCache.assert_called_once_with(runNumber, useLiteMode)
+                if not useLiteMode:
+                    mockUpdateNeutronCache.assert_called_once_with(runNumber, False)
+                else:
+                    mockUpdateNeutronCache.assert_has_calls([mock.call(runNumber, True), mock.call(runNumber, False)])
                 mockHasLiveDataConnection.assert_called_once()
+                # it gets loaded into the native workspace first, then cache renames it to raw
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                    workspace=nativeRawWorkspaceName,
+                    workspace=workspaceName,
                     loader="LoadLiveData",
                     loaderArgs=json.dumps(expectedLoaderArgs),
                 )
                 mockConvertToLiteMode.assert_not_called()
-                mockDeleteWorkspace.assert_called_once_with(nativeRawWorkspaceName)
+                mockDeleteWorkspace.assert_called_once_with(workspaceName)
 
     def test_fetchNeutronDataCached_live_data_fallback(self):
         # Test live data fallback cases.
@@ -2194,9 +2302,8 @@ class TestGroceryService(unittest.TestCase):
 
                 mockGetCloneOfWorkspace.return_value = mock.sentinel.clonedWorkspace
 
-                workspaceName = mockCreateNeutronWorkspaceName(runNumber, useLiteMode)
-                nativeRawWorkspaceName = mockCreateRawNeutronWorkspaceName(runNumber, False)
-                liteRawWorkspaceName = mockCreateRawNeutronWorkspaceName(runNumber, True)
+                # Live data is always initially native until it is converted to lite mode.
+                workspaceName = mockCreateNeutronWorkspaceName(runNumber, False)
 
                 # Mock `instance.mantidSnapper.mtd` to return a workspace that has the correct run number.
                 def _valid_key(key: str, validKey: str):
@@ -2211,7 +2318,7 @@ class TestGroceryService(unittest.TestCase):
                     lambda key: RunNumberProperty(runNumber) if _valid_key(key, "run_number") else None
                 )
                 mockSnapper.mtd.__getitem__.side_effect = (
-                    lambda wsName: mockWs if _valid_key(wsName, nativeRawWorkspaceName) else None
+                    lambda wsName: mockWs if _valid_key(wsName, workspaceName) else None
                 )
 
                 # Action-related mocks:
@@ -2234,19 +2341,26 @@ class TestGroceryService(unittest.TestCase):
                 assert exceptionRaised is None
 
                 assert instance._loadedRuns[(runNumber, useLiteMode)] == 1
-                assert (runNumber, useLiteMode) in instance._liveDataKeys
+                # live data is always native until it is converted to lite mode
+                # NOTE: How does cacheing a livedata run work?  is that even possible?
+                assert (runNumber, False) in instance._liveDataKeys
 
-                mockUpdateNeutronCache.assert_called_once_with(runNumber, useLiteMode)
+                if not useLiteMode:
+                    mockUpdateNeutronCache.assert_called_once_with(runNumber, False)
+                else:
+                    mockUpdateNeutronCache.assert_has_calls([mock.call(runNumber, True), mock.call(runNumber, False)])
+
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                    workspace=nativeRawWorkspaceName,
+                    workspace=workspaceName,
                     loader="LoadLiveData",
                     loaderArgs=json.dumps(expectedLoaderArgs),
                 )
                 if useLiteMode:
                     assert instance._loadedRuns[(runNumber, False)] == 0
                     assert (runNumber, False) in instance._liveDataKeys
-                    mockConvertToLiteMode.assert_called_once_with(liteRawWorkspaceName, export=False)
+                    workspaceLiteName = mockCreateNeutronWorkspaceName(runNumber, True)
+                    mockConvertToLiteMode.assert_called_once_with(workspaceLiteName, export=False)
                 else:
                     mockConvertToLiteMode.assert_not_called()
 
@@ -2312,8 +2426,8 @@ class TestGroceryService(unittest.TestCase):
 
                 mockGetCloneOfWorkspace.return_value = mock.sentinel.clonedWorkspace
 
-                workspaceName = mockCreateNeutronWorkspaceName(runNumber, useLiteMode)
-                nativeRawWorkspaceName = mockCreateRawNeutronWorkspaceName(runNumber, False)
+                # Live data is always initially native until it is converted to lite mode.
+                workspaceName = mockCreateNeutronWorkspaceName(runNumber, False)
 
                 # Mock `instance.mantidSnapper.mtd` to return a workspace that DOES NOT HAVE the correct run number.
                 def _valid_key(key: str, validKey: str):
@@ -2328,7 +2442,7 @@ class TestGroceryService(unittest.TestCase):
                     lambda key: RunNumberProperty(str(int(runNumber) + 1)) if _valid_key(key, "run_number") else None
                 )
                 mockSnapper.mtd.__getitem__.side_effect = (
-                    lambda wsName: mockWs if _valid_key(wsName, nativeRawWorkspaceName) else None
+                    lambda wsName: mockWs if _valid_key(wsName, workspaceName) else None
                 )
 
                 # Action-related mocks:
@@ -2345,24 +2459,26 @@ class TestGroceryService(unittest.TestCase):
                 result = None  # noqa: F841
                 try:
                     result = instance.fetchNeutronDataCached(item)  # noqa: F841
-                except Exception as e:  # noqa: BLE001
+                except RuntimeError as e:  # noqa: BLE001
                     exceptionRaised = e
 
-                assert isinstance(exceptionRaised, RuntimeError)
                 assert (
                     f"Neutron data for run '{runNumber}' is not present on disk, " + "nor is it the live-data run"
                     in str(exceptionRaised)
                 )
 
-                mockUpdateNeutronCache.assert_called_once_with(runNumber, useLiteMode)
+                if not useLiteMode:
+                    mockUpdateNeutronCache.assert_called_once_with(runNumber, False)
+                else:
+                    mockUpdateNeutronCache.assert_has_calls([mock.call(runNumber, True), mock.call(runNumber, False)])
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
-                    workspace=nativeRawWorkspaceName,
+                    workspace=workspaceName,
                     loader="LoadLiveData",
                     loaderArgs=json.dumps(expectedLoaderArgs),
                 )
                 mockConvertToLiteMode.assert_not_called()
-                mockDeleteWorkspace.assert_called_once_with(nativeRawWorkspaceName)
+                mockDeleteWorkspace.assert_called_once_with(workspaceName)
 
     def test_fetch_grouping(self):
         groupFilepath = Resource.getPath("inputs/testInstrument/fakeSNAPFocGroup_Natural.xml")
@@ -3283,3 +3399,94 @@ class TestGroceryService(unittest.TestCase):
         assert isinstance(mtd[nonemptymask], MaskWorkspace)
         assert mtd[nonemptymask].getNumberMasked() != 0
         assert self.instance.checkPixelMask(nonemptymask)
+
+    def test_processNeutronDataCopy(self):
+        # confirm that appropriate algorthims are applied to the workspace
+        testCalibrationData = DAOFactory.calibrationParameters()
+        instance = GroceryService()
+        with (
+            mock.patch.object(instance, "mantidSnapper") as _,
+            mock.patch.object(instance, "dataService") as _,
+        ):
+            instance.mantidSnapper = mock.Mock()
+            instance.dataService = mock.Mock()
+            instance.dataService.generateInstrumentState = mock.Mock(return_value=testCalibrationData.instrumentState)
+
+            item = GroceryListItem(workspaceType="neutron", runNumber="123", useLiteMode=True, loader="")
+            instance._processNeutronDataCopy(item, "wsName")
+
+            assert instance.mantidSnapper.CropWorkspace.call_count == 1
+            assert instance.mantidSnapper.CropWorkspace.call_args[1]["OutputWorkspace"] == "wsName"
+            assert (
+                instance.mantidSnapper.CropWorkspace.call_args[1]["XMin"]
+                == testCalibrationData.instrumentState.particleBounds.tof.minimum
+            )
+            assert (
+                instance.mantidSnapper.CropWorkspace.call_args[1]["XMax"]
+                == testCalibrationData.instrumentState.particleBounds.tof.maximum
+            )
+
+            assert instance.mantidSnapper.RemovePromptPulse.call_count == 1
+            assert instance.mantidSnapper.RemovePromptPulse.call_args[1]["OutputWorkspace"] == "wsName"
+            assert (
+                instance.mantidSnapper.RemovePromptPulse.call_args[1]["Width"]
+                == testCalibrationData.instrumentState.instrumentConfig.width
+            )
+            assert (
+                instance.mantidSnapper.RemovePromptPulse.call_args[1]["Frequency"]
+                == testCalibrationData.instrumentState.instrumentConfig.frequency
+            )
+
+            # reset mocks
+            instance.mantidSnapper.reset_mock()
+
+            with Config_override("mantid.workspace.normalizeByBeamMonitor", True):
+                instance.fetchMonitorWorkspace = mock.Mock(return_value="monitor")
+                instance.writeWorkspaceMetadataAsTags = mock.Mock()
+                instance.deleteWorkspaceUnconditional = mock.Mock()
+                instance.mantidSnapper.mtd = mock.MagicMock()
+                instance.mantidSnapper.mtd["monitor"].getSpectrum(0).getNumberEvents.return_value = 1000
+
+                instance._processNeutronDataCopy(item, "wsName")
+                assert instance.mantidSnapper.CropWorkspace.call_count == 2
+                assert instance.mantidSnapper.RemovePromptPulse.call_count == 2
+
+                assert instance.fetchMonitorWorkspace.call_count == 1
+                assert instance.fetchMonitorWorkspace.call_args[0][0] == item
+
+                assert instance.writeWorkspaceMetadataAsTags.call_count == 1
+                assert instance.writeWorkspaceMetadataAsTags.call_args[0][0] == "wsName"
+                assert instance.writeWorkspaceMetadataAsTags.call_args[0][1].dict().get("normalizeByMonitorID") == 0
+                assert (
+                    instance.writeWorkspaceMetadataAsTags.call_args[0][1].dict().get("normalizeByMonitorFactor") == 1000
+                )
+
+                assert instance.deleteWorkspaceUnconditional.call_count == 1
+                assert instance.deleteWorkspaceUnconditional.call_args[0][0] == "monitor"
+
+    def test_fetchMonitorWorkspace(self):
+        item = GroceryListItem(workspaceType="neutron", runNumber="123", useLiteMode=True, loader="")
+        instance = GroceryService()
+        instance.dataService.generateInstrumentState = mock.Mock(
+            return_value=DAOFactory.calibrationParameters().instrumentState
+        )
+        instance._createNeutronFilePath = mock.Mock(return_value="neutron")
+        with (
+            mock.patch.object(instance, "_createMonitorWorkspaceName", wraps=instance._createMonitorWorkspaceName) as _,
+            mock.patch.object(instance, "_createNeutronFilePath", wraps=instance._createNeutronFilePath) as _,
+            mock.patch.object(instance, "grocer") as _,
+        ):
+            instance.fetchMonitorWorkspace(item)
+
+            assert instance._createMonitorWorkspaceName.call_count == 1
+            assert instance._createMonitorWorkspaceName.call_args[0][0] == item.runNumber
+            assert not instance._createMonitorWorkspaceName.call_args[0][1]
+
+            assert instance._createNeutronFilePath.call_count == 1
+            assert instance._createNeutronFilePath.call_args[0][0] == item.runNumber
+            assert not instance._createNeutronFilePath.call_args[0][1]
+
+            assert instance.grocer.executeRecipe.call_count == 1
+            assert instance.grocer.executeRecipe.call_args[0][0] == str(
+                self.instance._createNeutronFilePath(item.runNumber, False)
+            )

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -888,7 +888,7 @@ class TestGroceryService(unittest.TestCase):
             )
 
         testItem = generateTestItem()
-        testItem.copy.side_effect = generateTestItem
+        testItem.model_copy.side_effect = generateTestItem
 
         # ensure a clean ADS
         workspaceName = self.instance._createNeutronWorkspaceName(testItem.runNumber, testItem.useLiteMode)
@@ -947,7 +947,7 @@ class TestGroceryService(unittest.TestCase):
             m = mock.Mock(
                 spec=GroceryListItem, runNumber=self.runNumber, useLiteMode=True, loader="", liveDataArgs=None
             )
-            m.copy.side_effect = generateTestItem
+            m.model_copy.side_effect = generateTestItem
             return m
 
         liteItem = generateTestItem()
@@ -985,7 +985,7 @@ class TestGroceryService(unittest.TestCase):
             )
 
         testItem = generateTestItem()
-        testItem.copy.side_effect = generateTestItem
+        testItem.model_copy.side_effect = generateTestItem
         testKey = self.instance._key(testItem.runNumber, testItem.useLiteMode)
 
         workspaceNameRaw = self.instance._createRawNeutronWorkspaceName(testItem.runNumber, testItem.useLiteMode)
@@ -1075,7 +1075,7 @@ class TestGroceryService(unittest.TestCase):
             m = mock.Mock(
                 spec=GroceryListItem, runNumber=self.runNumber, useLiteMode=True, loader="", liveDataArgs=None
             )
-            m.copy.side_effect = generateTestItem
+            m.model_copy.side_effect = generateTestItem
             return m
 
         testItem = generateTestItem()
@@ -1088,7 +1088,7 @@ class TestGroceryService(unittest.TestCase):
             )
 
         nativeItem = generateTestItem()
-        nativeItem.copy.side_effect = generateTestItem
+        nativeItem.model_copy.side_effect = generateTestItem
 
         nativeKey = self.instance._key(nativeItem.runNumber, nativeItem.useLiteMode)
 

--- a/tests/unit/backend/recipe/algorithm/test_NormalizeByCurrentButTheCorrectWay.py
+++ b/tests/unit/backend/recipe/algorithm/test_NormalizeByCurrentButTheCorrectWay.py
@@ -41,3 +41,18 @@ class TestNormalizeByCurrent(unittest.TestCase):
         assert ws.run().hasProperty("NormalizationFactor")
         print(ws.run().getProperty("NormalizationFactor").value)
         assert ws.dataY(0) == [value]
+
+    def test_normalize_by_monitor(self):
+        value = 16
+        wsname = mtd.unique_name()
+        ws = CreateWorkspace(OutputWorkspace=wsname, DataX=[1], DataY=[value])
+        ws = NormalizeByCurrentButTheCorrectWay(
+            InputWorkspace=wsname,
+            OutputWorkspace=wsname,
+            NormalizeByMonitorCounts=4,
+        )
+
+        assert ws.name() == wsname
+        assert ws.run().hasProperty("NormalizationFactor")
+        assert ws.run().getProperty("NormalizationFactor").value == 1 / 4
+        assert ws.dataY(0) == [value / 4]

--- a/tests/unit/backend/recipe/test_ReductionGroupProcessingRecipe.py
+++ b/tests/unit/backend/recipe/test_ReductionGroupProcessingRecipe.py
@@ -4,6 +4,8 @@ from unittest import mock
 from snapred.backend.recipe.algorithm.Utensils import Utensils
 from snapred.backend.recipe.ReductionGroupProcessingRecipe import ReductionGroupProcessingRecipe
 
+ModulePatch = "snapred.backend.recipe.ReductionGroupProcessingRecipe.{0}"
+
 
 # TODO: Add/update tests when EWM 4798 is complete
 class ReductionGroupProcessingRecipeTest(unittest.TestCase):
@@ -77,8 +79,9 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
             "outputWorkspace": "output",
             "groupingWorkspace": "groupingWS",
         }
-
-        output = recipe.cook(self.mockIngredients(), groceries)
+        with mock.patch(ModulePatch.format("WriteWorkspaceMetadata")) as mockMetadataRecipe:
+            output = recipe.cook(self.mockIngredients(), groceries)
+            assert mockMetadataRecipe.called
 
         assert recipe.rawInput == groceries["inputWorkspace"]
         assert recipe.outputWS == groceries["outputWorkspace"]
@@ -100,8 +103,9 @@ class ReductionGroupProcessingRecipeTest(unittest.TestCase):
             "outputWorkspace": "output",
             "groupingWorkspace": "groupingWS",
         }
-
-        output = recipe.cater([(self.mockIngredients(), groceries)])
+        with mock.patch(ModulePatch.format("WriteWorkspaceMetadata")) as mockMetadataRecipe:
+            output = recipe.cater([(self.mockIngredients(), groceries)])
+            assert mockMetadataRecipe.called
 
         assert recipe.rawInput == groceries["inputWorkspace"]
         assert recipe.outputWS == groceries["outputWorkspace"]

--- a/tests/unit/backend/service/test_ReductionService.py
+++ b/tests/unit/backend/service/test_ReductionService.py
@@ -138,6 +138,7 @@ class TestReductionService(unittest.TestCase):
     def test_fetchReductionGroceries(self):
         self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
         self.instance.dataFactoryService.getLatestApplicableNormalizationVersion = mock.Mock(return_value=1)
+        self.instance.groceryService._processNeutronDataCopy = mock.Mock()
         self.instance._markWorkspaceMetadata = mock.Mock()
         self.request.continueFlags = ContinueWarning.Type.UNSET
         res = self.instance.fetchReductionGroceries(self.request)
@@ -150,6 +151,7 @@ class TestReductionService(unittest.TestCase):
 
         self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
         self.instance.dataFactoryService.getLatestApplicableNormalizationVersion = mock.Mock(return_value=1)
+        self.instance.groceryService._processNeutronDataCopy = mock.Mock()
         self.instance._markWorkspaceMetadata = mock.Mock()
         self.instance.groceryService.dataService.hasLiveDataConnection = mock.Mock(return_value=True)
 
@@ -177,6 +179,7 @@ class TestReductionService(unittest.TestCase):
 
         self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
         self.instance.dataFactoryService.getLatestApplicableNormalizationVersion = mock.Mock(return_value=1)
+        self.instance.groceryService._processNeutronDataCopy = mock.Mock()
         self.instance._markWorkspaceMetadata = mock.Mock()
         self.instance.prepCombinedMask = mock.Mock(return_value=mock.sentinel.mask)
         self.request.continueFlags = ContinueWarning.Type.UNSET
@@ -210,6 +213,7 @@ class TestReductionService(unittest.TestCase):
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
         self.instance.dataFactoryService.getLatestApplicableNormalizationVersion = mock.Mock(return_value=1)
         self.instance.dataFactoryService.normalizationExists = mock.Mock(return_value=True)
+        self.instance.groceryService._processNeutronDataCopy = mock.Mock()
         self.instance._markWorkspaceMetadata = mock.Mock()
 
         result = self.instance.reduction(self.request)


### PR DESCRIPTION
## Description of work

This adds a toggle to tell snapred to normalize by events from the monitor rather than proton charge.

## Explanation of work

I refactored `GroceryService` to remove the two complex case statements, and instead model a more accurate fallback structure for loading native/lite/live data.

I then added the loading of monitor workspaces to the end, save the total events of the processed monitor workspace as a log, and use said log in normalization calculations down the line.

## To test

Run each workflow, ensure that they still work with the toggle off.
Record results as far as normalization by current is concerned( like the log 'NormalizationFactor')
Run them again, ensure that they work with the toggle on.
Observe the monitor workspace get loaded and then quickly deleted during load.
Compare the normalization factor this time around, confirm that they are different and that the toggle was effective.

Ensure the results of each workflow are as expected, no out of the ordinary graphs for the normal testing data.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#7732](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7732)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] There is a toggle in the application.yml for enabling this flow, and a config for which monitor to use (defaults false, and 0)
- [ ] Workspaces have additional logs indicating that this was their method of normalization
- [ ] The workspaces are in fact normalized this way (i.e. different results in the case of reduction, normalization, ect)
- [ ] The story mentions needing different 'width'/'L1'/'particleBouncs' for the RemovePromptPulse on the monitor workspace but did not provide a location for said width, however using the same ones provided normally seemed to yield decent results.
