### PR TITLE
Added dictionary to MantidSnapper to keep track of workspaces 

### DIFF
--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -47,6 +47,8 @@ class MantidSnapper:
 
     typeTranslationTable = {"string": str, "number": float, "dbl list": list, "boolean": bool}
     _mtd = _CustomMtd()
+
+    _infoMutex = Lock()
     _workspacesInfo: Dict[str, Dict[str, Any]] = {}
 
     def __init__(self, parentAlgorithm, name):
@@ -265,11 +267,13 @@ class MantidSnapper:
         self._algorithmQueue = []
 
     @classmethod
-    def _addWorkspaceInfo(cls, workspaceName: str, algorithmName: str, workspaceProperty: str):
+    def _addWorkspaceInfo(cls, workspaceName: str, algorithmName: str, propertyName: str):
+        cls._infoMutex.acquire()
         cls._workspacesInfo[workspaceName] = {
-            "propertyName": workspaceProperty,
+            "propertyName": propertyName,
             "algorithm": algorithmName,
         }
+        cls._infoMutex.release()
 
     @classmethod
     def getWorkspacesInfo(cls) -> Dict[str, Dict[str, Any]]:
@@ -279,4 +283,5 @@ class MantidSnapper:
         :return: dict by workspace-name key of information about the output workspaces
         :rtype: Dict[str, Dict[str, Any]]
         """
+        # WARNING: for access that isn't READ-ONLY, synchronization will be required!
         return cls._workspacesInfo

--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -262,11 +262,10 @@ class MantidSnapper:
         self._algorithmQueue = []
 
     @classmethod
-    def _addWorkspaceInfo(cls, name, workspaceProperty: Property):
+    def _addWorkspaceInfo(cls, algorithmName: str, workspaceProperty: Property):
         cls._workspacesInfo[workspaceProperty.valueAsStr] = {
-            "name": workspaceProperty.valueAsStr,
-            "algorithm": name,
-            "Direction": workspaceProperty.direction,
+            "propertyName": workspaceProperty.name,
+            "algorithm": algorithmName,
         }
 
     @classmethod
@@ -274,7 +273,7 @@ class MantidSnapper:
         """
         Grab dictionary of workspaces created by MantidSnapper
 
-        :return: dict of workspace names containing dicts of the workspace name and which algo created it
+        :return: dict by workspace-name key of information about the output workspaces
         :rtype: Dict[str, Dict[str, Any]]
         """
         return cls._workspacesInfo

--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -199,7 +199,8 @@ class MantidSnapper:
                     returnVal = access_pointer(returnVal)
                 val.update(returnVal)
                 if "Workspace" in str(algorithm.getProperty(prop)):
-                    MantidSnapper._addWorkspaceInfo(returnVal, name)
+                    if returnVal != "":
+                        MantidSnapper._addWorkspaceInfo(returnVal, name)
         except (RuntimeError, TypeError) as e:
             logger.error(f"Algorithm {name} failed for the following arguments: \n {kwargs}")
             self.cleanup()

--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -266,6 +266,16 @@ class MantidSnapper:
                 del self.workspaceDict[val]
 
     def getWorkspaceInfo(self, workspace: str) -> Dict[str, str]:
+        """
+        Grab info about a workspace that exists in MantidSnapper.
+        If the workspace no longer exists in mtd, delete the workspace from the dictionary.
+        Raise an error if the workspace does not exist in mtd and MantidSnapper
+
+        :param workspace: the name of the workspace of the desired info
+        :type workspace: str
+        :return: dictionary containing the workspace name and which algo created it
+        :rtype: Dict[str, str]
+        """
         if self.mtd.doesExist(workspace):
             return self.workspaceDict[workspace]
         elif workspace in self.workspaceDict:

--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 from threading import Lock
 from typing import Dict
 
-from mantid.api import AlgorithmManager, Progress, mtd
+from mantid.api import AlgorithmManager, IWorkspaceProperty, Progress, mtd
 from mantid.kernel import Direction
 from mantid.kernel import ULongLongPropertyWithValue as PointerProperty
 
@@ -198,9 +198,11 @@ class MantidSnapper:
                 if isinstance(algorithm.getProperty(prop), PointerProperty):
                     returnVal = access_pointer(returnVal)
                 val.update(returnVal)
-                if "Workspace" in str(algorithm.getProperty(prop)):
-                    if returnVal != "":
-                        MantidSnapper._addWorkspaceInfo(returnVal, name)
+                if (
+                    isinstance(algorithm.getProperty(prop), IWorkspaceProperty)
+                    and not algorithm.getProperty(prop).isDefault
+                ):
+                    MantidSnapper._addWorkspaceInfo(returnVal, name)
         except (RuntimeError, TypeError) as e:
             logger.error(f"Algorithm {name} failed for the following arguments: \n {kwargs}")
             self.cleanup()


### PR DESCRIPTION
## Description of work

MantidSnapper now has a dictionary that keeps track of workspaces Snapper has created


## Explanation of work

Dictionary is keyed on workspace names, and value is a tuple of the workspace itself plus the algorithm that created the workspace. Error checking is done to make sure the workspace actually exists in the dictionary before deleting. A getWorkspace function was added to safely retrieve worksapces.

## To test

### Dev testing

Open workbench on analysis and run this simple script:

``` python
from snapred.backend.dao.reduction.ReductionRecord import ReductionRecord
from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
from snapred.backend.recipe.algorithm.Utensils import Utensils
import h5py
from snapred.backend.data.NexusHDF5Metadata import NexusHDF5Metadata as n5m
from snapred.meta.redantic import parse_file_as
import time

inputFile = "/SNS/users/wqp/SNAP/IPTS-24641/shared/SNAPRed/04bd2c53f6bf6754/lite/46680/2024-11-26T121144/reduced_046680_2024-11-26T121144.nxs.h5"
outputFile = "/SNS/users/wqp/tmp/test_segfault_append.nxs"
record = parse_file_as(ReductionRecord, "/SNS/users/wqp/SNAP/IPTS-24641/shared/SNAPRed/04bd2c53f6bf6754/lite/46680/2024-11-26T121144/ReductionRecord.json")

untensils = Utensils()
untensils.PyInit()
mantidSnapper = untensils.mantidSnapper

ws = mantidSnapper.LoadNexus("..", Filename=inputFile, OutputWorkspace="ws")
mantidSnapper.executeQueue()
#This will pass
mantidSnapper.getWorkspace("ws")
#This should fail since "wds" does not exist
mantidSnapper.getWorkspace("wds")
```

### CIS testing

None, this only used internally.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#9389](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9389)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] make sure workspaces are correctly added to dictionary
