### PR TITLE
Run Feedback Views

### DIFF
--- a/src/snapred/backend/dao/request/RunFeedbackRequest.py
+++ b/src/snapred/backend/dao/request/RunFeedbackRequest.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class RunFeedbackRequest(BaseModel):
+    runId: str

--- a/src/snapred/backend/dao/state/DetectorState.py
+++ b/src/snapred/backend/dao/state/DetectorState.py
@@ -1,6 +1,6 @@
 from enum import IntEnum
 from numbers import Number
-from typing import Dict, Literal, Tuple
+from typing import Dict, Literal, Optional, Tuple
 
 from pydantic import BaseModel, field_validator
 
@@ -17,6 +17,7 @@ class DetectorState(BaseModel):
     guideStat: Literal[1, 2]
     # two additional values that don't define state, but are useful
     lin: Tuple[float, float]
+    title: Optional[str] = None
 
     @field_validator("guideStat", mode="before")
     @classmethod
@@ -31,13 +32,21 @@ class DetectorState(BaseModel):
     def fromLogs(cls, logs: Dict[str, Number]):
         # NeXus/HDF5 and `mantid.api.Run` logs are time-series =>
         #   here we take only the first entry in each series.
-        return DetectorState(
+        ds = DetectorState(
             arc=(logs["det_arc1"][0], logs["det_arc2"][0]),
             lin=(logs["det_lin1"][0], logs["det_lin2"][0]),
             wav=logs.get("BL3:Chop:Skf1:WavelengthUserReq", logs.get("BL3:Chop:Gbl:WavelengthReq"))[0],
             freq=logs["BL3:Det:TH:BL:Frequency"][0],
             guideStat=int(logs["BL3:Mot:OpticsPos:Pos"][0]),
         )
+        if "title" in logs:
+            raw = logs["title"]
+            val = raw[0] if hasattr(raw, "__getitem__") else raw
+            if hasattr(val, "decode"):
+                val = val.decode("utf-8")
+            ds.title = str(val)
+
+        return ds
 
     def toLogs(self) -> Dict[str, Number]:
         # NeXus/HDF5 and `mantid.api.Run` logs are time-series =>

--- a/src/snapred/backend/data/util/PV_logs_util.py
+++ b/src/snapred/backend/data/util/PV_logs_util.py
@@ -118,23 +118,33 @@ def mappingFromNeXusLogs(h5: h5py.File) -> Mapping:
 
     class _Mapping(Mapping):
         def __init__(self, h5: h5py.File):
-            self._logs = h5[Config["instrument.PVLogs.rootGroup"]]
+            self._logGroup = h5[Config["instrument.PVLogs.rootGroup"]]
+            self._h5 = h5
 
         def __getitem__(self, key: str) -> Any:
-            return self._logs[key + "/value"]
+            if key == "title":
+                return self._h5["/entry/title"][...]
+            else:
+                return self._logGroup[f"{key}/value"][...]
 
-        def __iter__(self):
-            return self.keys().__iter__()
-
-        def __len__(
-            self,
-        ):
-            return len(self._logs.keys())
-
-        def __contains__(self, key: str):
-            return self._logs.__contains__(key + "/value")
+        def __contains__(self, key: str) -> bool:
+            if key == "title":
+                return "/entry/title" in self._h5
+            return f"{key}/value" in self._logGroup
 
         def keys(self):
-            return [k[0 : k.rfind("/value")] for k in self._logs.keys()]
+            baseKeys = []
+            for fullKey in self._logGroup.keys():
+                if fullKey.endswith("/value"):
+                    baseKeys.append(fullKey[: fullKey.rfind("/value")])
+            if "/entry/title" in self._h5:
+                baseKeys.append("title")
+            return baseKeys
+
+        def __iter__(self):
+            return iter(self.keys())
+
+        def __len__(self):
+            return len(self.keys())
 
     return _Mapping(h5)

--- a/src/snapred/backend/error/StateValidationException.py
+++ b/src/snapred/backend/error/StateValidationException.py
@@ -22,7 +22,7 @@ class StateValidationException(Exception):
 
     def __init__(self, exception: Exception):
         exceptionStr = str(exception)
-        breakpoint()
+
         if isinstance(exception, (FileNotFoundError, PermissionError)):
             self.message = f"The following error occurred: {exceptionStr}\n\n" + "Please contact your IS or CIS."
         else:

--- a/src/snapred/backend/error/StateValidationException.py
+++ b/src/snapred/backend/error/StateValidationException.py
@@ -22,7 +22,7 @@ class StateValidationException(Exception):
 
     def __init__(self, exception: Exception):
         exceptionStr = str(exception)
-
+        breakpoint()
         if isinstance(exception, (FileNotFoundError, PermissionError)):
             self.message = f"The following error occurred: {exceptionStr}\n\n" + "Please contact your IS or CIS."
         else:

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -32,6 +32,7 @@ from snapred.backend.dao.request import (
     LoadCalibrationRecordRequest,
     MatchRunsRequest,
     OverrideRequest,
+    RunFeedbackRequest,
     SimpleDiffCalRequest,
 )
 from snapred.backend.dao.response.CalibrationAssessmentResponse import CalibrationAssessmentResponse
@@ -105,6 +106,7 @@ class CalibrationService(Service):
         self.registerPath("residual", self.calculateResidual)
         self.registerPath("fetchMatches", self.fetchMatchingCalibrations)
         self.registerPath("override", self.handleOverrides)
+        self.registerPath("runFeedback", self.runFeedback)
         return
 
     @staticmethod
@@ -603,3 +605,8 @@ class CalibrationService(Service):
             return sample.overrides
         else:
             return None
+
+    @FromString
+    def runFeedback(self, request: RunFeedbackRequest):
+        stateId = self.dataFactoryService.constructStateId(request.runId)
+        return stateId

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -259,7 +259,7 @@ class NormalizationService(Service):
     def _sameStates(self, runnumber1, runnumber2):
         stateId1 = self.dataFactoryService.constructStateId(runnumber1)
         stateId2 = self.dataFactoryService.constructStateId(runnumber2)
-        return stateId1 == stateId2
+        return stateId1[0] == stateId2[0]
 
     def checkWritePermissions(self, runNumber: str) -> bool:
         path = self.dataExportService.getCalibrationStateRoot(runNumber)

--- a/src/snapred/ui/view/DiffCalRequestView.py
+++ b/src/snapred/ui/view/DiffCalRequestView.py
@@ -1,3 +1,5 @@
+from qtpy.QtCore import Signal, Slot
+
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
 from snapred.ui.view.BackendRequestView import BackendRequestView
@@ -18,19 +20,27 @@ class DiffCalRequestView(BackendRequestView):
 
     """
 
+    signalUpdateRunFeedback = Signal(str, str)
+
     def __init__(self, samples=[], groups=[], parent=None):
         super().__init__(parent=parent)
 
+        self.signalUpdateRunFeedback.connect(self._setRunFeedback)
+
         # input fields
         self.runNumberField = self._labeledField("Run Number")
+        self.runNumberField.setToolTip("Run number to be calibrated.")
         self.liteModeToggle = self._labeledToggle("Lite Mode", True)
         self.fieldConvergenceThreshold = self._labeledField("Convergence Threshold")
         self.fieldNBinsAcrossPeakWidth = self._labeledField("Bins Across Peak Width")
 
         # drop downs
         self.sampleDropdown = self._sampleDropDown("Sample", samples)
+        self.sampleDropdown.setToolTip("Samples available for this run number.")
         self.groupingFileDropdown = self._sampleDropDown("Grouping File", groups)
+        self.groupingFileDropdown.setToolTip("Grouping schemas available for this sample run number.")
         self.peakFunctionDropdown = self._sampleDropDown("Peak Function", [p.value for p in SymmetricPeakEnum])
+        self.peakFunctionDropdown.setToolTip("Peak function to be used for calibration.")
 
         # checkbox for removing background
         self.removeBackgroundToggle = self._labeledToggle("RemoveBackground", False)
@@ -43,23 +53,36 @@ class DiffCalRequestView(BackendRequestView):
         # skip pixel calibration toggle
         self.skipPixelCalToggle = self._labeledToggle("Skip Pixel Calibration", False)
 
+        # run number feedback fields
+        self.runFeedbackStateId = self._labeledField("State ID")
+        self.runFeedbackStateId.setToolTip("State ID of the run number.")
+        self.runFeedbackRunTitle = self._labeledField("Run Title")
+        self.runFeedbackRunTitle.setToolTip("Title of the run from PV file.")
+
+        # run feedback fields are read only
+        self.runFeedbackStateId.field.setReadOnly(True)
+        self.runFeedbackRunTitle.field.setReadOnly(True)
+
         # add all widgets to layout
         layout_ = self.layout()
         layout_.addWidget(self.runNumberField, 0, 0)
-        layout_.addWidget(self.liteModeToggle, 0, 1)
-        layout_.addWidget(self.skipPixelCalToggle, 0, 2)
-        layout_.addWidget(self.fieldConvergenceThreshold, 1, 0)
-        layout_.addWidget(self.fieldNBinsAcrossPeakWidth, 1, 1)
-        layout_.addWidget(self.removeBackgroundToggle, 1, 2)
-        layout_.addWidget(self.sampleDropdown, 2, 0)
-        layout_.addWidget(self.groupingFileDropdown, 2, 1)
-        layout_.addWidget(self.peakFunctionDropdown, 2, 2)
+        layout_.addWidget(self.liteModeToggle, 0, 2)
+        layout_.addWidget(self.runFeedbackStateId, 1, 0)
+        layout_.addWidget(self.runFeedbackRunTitle, 1, 1)
+        layout_.addWidget(self.skipPixelCalToggle, 1, 2)
+        layout_.addWidget(self.fieldConvergenceThreshold, 2, 0)
+        layout_.addWidget(self.fieldNBinsAcrossPeakWidth, 2, 1)
+        layout_.addWidget(self.removeBackgroundToggle, 2, 2)
+        layout_.addWidget(self.sampleDropdown, 3, 0)
+        layout_.addWidget(self.groupingFileDropdown, 3, 1)
+        layout_.addWidget(self.peakFunctionDropdown, 3, 2)
 
     def populateGroupingDropdown(self, groups):
         self.groupingFileDropdown.setItems(groups)
 
     def verify(self):
         if not self.runNumberField.text().isdigit():
+            self._setRunFeedback("", "")
             raise ValueError("Please enter a valid run number")
         if self.sampleDropdown.currentIndex() < 0:
             raise ValueError("Please select a sample")
@@ -99,3 +122,11 @@ class DiffCalRequestView(BackendRequestView):
 
     def enablePeakFunction(self):
         self.peakFunctionDropdown.setEnabled(True)
+
+    def updateRunFeedback(self, stateId: str, runTitle: str):
+        self.signalUpdateRunFeedback.emit(stateId, runTitle)
+
+    @Slot(str, str)
+    def _setRunFeedback(self, stateId: str, runTitle: str):
+        self.runFeedbackStateId.setText(stateId if stateId else "")
+        self.runFeedbackRunTitle.setText(runTitle if runTitle else "")

--- a/src/snapred/ui/view/reduction/ReductionRequestView.py
+++ b/src/snapred/ui/view/reduction/ReductionRequestView.py
@@ -213,7 +213,7 @@ class _RequestView(_RequestViewBase):
                 if self.retrieveRunFeedbackCallback:
                     for rn in runNumberList:
                         stateId, runTitle = self.retrieveRunFeedbackCallback(rn)
-                        lineText = f"{rn}, StateId={stateId}, Title={runTitle}"
+                        lineText = f"{rn},    StateId = {stateId},    Title = {runTitle}"
                         self.runNumberDisplay.addItem(lineText)
                 self.runNumberInput.clear()
                 self._populatePixelMaskDropdown(self.useLiteMode())

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -17,6 +17,7 @@ from snapred.backend.dao.request import (
     FocusSpectraRequest,
     HasStateRequest,
     OverrideRequest,
+    RunFeedbackRequest,
     SimpleDiffCalRequest,
 )
 from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
@@ -159,10 +160,27 @@ class DiffCalWorkflow(WorkflowImplementer):
         useLiteMode = self._requestView.liteModeToggle.getState()
 
         self.__setInteraction(False, "populateGroupDropdown")
+
+        def _onDropdownSuccess():
+            self.__setInteraction(True, "populateGroupDropdown")
+            self._populateRunFeedback(runNumber)
+
         self.workflow.presenter.handleAction(
             self.handleDropdown,
             args=(runNumber, useLiteMode),
-            onSuccess=lambda: self.__setInteraction(True, "populateGroupDropdown"),
+            onSuccess=_onDropdownSuccess,
+        )
+
+    @ExceptionToErrLog
+    @Slot()
+    def _populateRunFeedback(self, runNumber: str):
+        if not runNumber:
+            self._requestView.updateRunFeedback("", "")
+            return
+        self.workflow.presenter.handleAction(
+            self.handleRunFeedback,
+            args=(runNumber),
+            onSuccess=lambda: self.__setInteraction(False, "populateRunFeedback"),
         )
 
     @ExceptionToErrLog
@@ -193,6 +211,16 @@ class DiffCalWorkflow(WorkflowImplementer):
 
         # populate and re-enable the drop down
         self._requestView.populateGroupingDropdown(list(self.focusGroups.keys()))
+        return SNAPResponse(code=ResponseCode.OK)
+
+    def handleRunFeedback(self, runNumber):
+        payload = RunFeedbackRequest(
+            runId=runNumber,
+        )
+        response = self.request(path="calibration/runFeedback", payload=payload.json()).data
+        stateId, detectorState = response
+        runTitle = detectorState.title
+        self._requestView.updateRunFeedback(stateId, runTitle)
         return SNAPResponse(code=ResponseCode.OK)
 
     def handleOverride(self, sampleFile):

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -142,6 +142,8 @@ class NormalizationWorkflow(WorkflowImplementer):
         return SNAPResponse(code=ResponseCode.OK)
 
     def handleRunFeedback(self, runNumber):
+        if not RunNumberValidator.validateRunNumber(runNumber):
+            return SNAPResponse(code=ResponseCode.OK)
         payload = RunFeedbackRequest(
             runId=runNumber,
         )

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -10,6 +10,7 @@ from snapred.backend.dao.request import (
     MatchRunsRequest,
     ReductionExportRequest,
     ReductionRequest,
+    RunFeedbackRequest,
 )
 from snapred.backend.dao.response.ReductionResponse import ReductionResponse
 from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
@@ -66,6 +67,9 @@ class ReductionWorkflow(WorkflowImplementer):
             validateRunNumbers=self._validateRunNumbers,
             getLiveMetadata=self._getLiveMetadata,
         )
+
+        self._reductionRequestView._requestView.setRetrieveRunFeedbackCallback(self.handleRunFeedback)
+
         if not self._hasLiveDataConnection():
             # Only enable live-data mode if there is a connection to the listener.
             self._reductionRequestView.setLiveDataToggleEnabled(False)
@@ -173,6 +177,20 @@ class ReductionWorkflow(WorkflowImplementer):
         # Following `Qt` style, this is _not_ @<property>.setter!
         self._status = status
         self._statusUpdate.emit(status)
+
+    def handleRunFeedback(self, runNumber: str) -> tuple:
+        payload = RunFeedbackRequest(runId=runNumber)
+        response = self.request(path="calibration/runFeedback", payload=payload.json())
+        stateId = ""
+        runTitle = ""
+        if response.code == ResponseCode.OK:
+            data = response.data
+            if isinstance(data, tuple) and len(data) == 2:
+                stateId = data[0]
+                detectorState = data[1]
+                if hasattr(detectorState, "title"):
+                    runTitle = detectorState.title
+        return (stateId, runTitle)
 
     def _nothing(self, workflowPresenter: WorkflowPresenter):  # noqa: ARG002
         return SNAPResponse(code=200)

--- a/tests/integration/test_reduction.py
+++ b/tests/integration/test_reduction.py
@@ -258,7 +258,7 @@ class TestGUIPanels:
             _count = requestView._requestView.runNumberDisplay.count()
             _runNumbers = [requestView._requestView.runNumberDisplay.item(x).text() for x in range(_count)]
 
-            assert reductionRunNumber in _runNumbers
+            assert any(reductionRunNumber in item for item in _runNumbers)
             self.testSummary.SUCCESS()
 
             """

--- a/tests/integration/test_workflow_panels_happy_path.py
+++ b/tests/integration/test_workflow_panels_happy_path.py
@@ -440,7 +440,7 @@ class TestGUIPanels:
             _count = requestView.runNumberDisplay.count()
             _runNumbers = [requestView.runNumberDisplay.item(x).text() for x in range(_count)]
 
-            assert reductionRunNumber in _runNumbers
+            assert any(reductionRunNumber in item for item in _runNumbers)
 
             """
             request.liteModeToggle.setState(True);
@@ -1012,7 +1012,7 @@ class TestGUIPanels:
             _count = requestView._requestView.runNumberDisplay.count()
             _runNumbers = [requestView._requestView.runNumberDisplay.item(x).text() for x in range(_count)]
 
-            assert reductionRunNumber in _runNumbers
+            assert any(reductionRunNumber in item for item in _runNumbers)
             self.testSummary.SUCCESS()
             """
             request.liteModeToggle.setState(True);

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -102,6 +102,12 @@ def mockDetectorState(runId: str) -> DetectorState:
     return None
 
 
+def mockH5Dataset(value):
+    dset = mock.MagicMock(spec=h5py.Dataset)
+    dset.__getitem__.side_effect = lambda x: value  # noqa: ARG005
+    return dset
+
+
 def mockPVFile(detectorState: DetectorState) -> mock.Mock:
     # See also: `tests/unit/backend/data/util/test_PV_logs_util.py`.
 
@@ -110,32 +116,26 @@ def mockPVFile(detectorState: DetectorState) -> mock.Mock:
 
     # For the HDF5-file, each key requires the "/value" suffix.
     dict_ = {
-        "run_number/value": "123456",
-        "start_time/value": "2023-06-14T14:06:40.429048667",
-        "end_time/value": "2023-06-14T14:07:56.123123123",
-        "BL3:Chop:Skf1:WavelengthUserReq/value": [detectorState.wav],
-        "det_arc1/value": [detectorState.arc[0]],
-        "det_arc2/value": [detectorState.arc[1]],
-        "BL3:Det:TH:BL:Frequency/value": [detectorState.freq],
-        "BL3:Mot:OpticsPos:Pos/value": [detectorState.guideStat],
-        "det_lin1/value": [detectorState.lin[0]],
-        "det_lin2/value": [detectorState.lin[1]],
+        "run_number/value": np.array([123456], dtype=int),
+        "start_time/value": np.array(["2023-06-14T14:06:40.429048667"]),
+        "end_time/value": np.array(["2023-06-14T14:07:56.123123123"]),
+        "BL3:Chop:Skf1:WavelengthUserReq/value": mockH5Dataset(np.array([detectorState.wav])),
+        "det_arc1/value": np.array([detectorState.arc[0]]),
+        "det_arc2/value": np.array([detectorState.arc[1]]),
+        "BL3:Det:TH:BL:Frequency/value": np.array([detectorState.freq]),
+        "BL3:Mot:OpticsPos:Pos/value": np.array([detectorState.guideStat]),
+        "det_lin1/value": np.array([detectorState.lin[0]]),
+        "det_lin2/value": np.array([detectorState.lin[1]]),
     }
-
-    def del_item(key: str):
-        # bypass <class>.__delitem__
-        del dict_[key]
 
     mock_ = mock.MagicMock(spec=h5py.Group)
 
-    mock_.get = lambda key, default=None: dict_.get(key, default)
-    mock_.del_item = del_item
+    def side_effect_getitem(key: str):
+        if key == "entry/DASlogs":
+            return mock_
+        return dict_[key]
 
-    # Use of the h5py.File starts with access to the "entry/DASlogs" group:
-    mock_.__getitem__.side_effect = lambda key: mock_ if key == "entry/DASlogs" else dict_[key]
-
-    mock_.__contains__.side_effect = dict_.__contains__
-    mock_.keys.side_effect = dict_.keys
+    mock_.__getitem__.side_effect = side_effect_getitem
     return mock_
 
 

--- a/tests/unit/backend/data/util/test_PV_logs_util.py
+++ b/tests/unit/backend/data/util/test_PV_logs_util.py
@@ -217,31 +217,24 @@ class TestMappingFromRun(unittest.TestCase):
 
 class TestMappingFromNeXusLogs(unittest.TestCase):
     def _mockPVFile(self, detectorState: DetectorState) -> mock.Mock:
-        # Note: `PV_logs_util.mappingFromNeXusLogs` will open the 'entry/DASlogs' group,
-        #   so this `dict` mocks the HDF5 group, not the PV-file itself.
+        def _mockH5Dataset(array_value):
+            ds = mock.MagicMock(spec=h5py.Dataset)
+            ds.__getitem__.side_effect = lambda x: array_value  # noqa: ARG005
+            ds.shape = array_value.shape
+            ds.dtype = array_value.dtype
+            return ds
 
         dict_ = {
-            "BL3:Chop:Skf1:WavelengthUserReq/value": [detectorState.wav],
-            "det_arc1/value": [detectorState.arc[0]],
-            "det_arc2/value": [detectorState.arc[1]],
-            "BL3:Det:TH:BL:Frequency/value": [detectorState.freq],
-            "BL3:Mot:OpticsPos:Pos/value": [detectorState.guideStat],
-            "det_lin1/value": [detectorState.lin[0]],
-            "det_lin2/value": [detectorState.lin[1]],
+            "BL3:Chop:Skf1:WavelengthUserReq/value": _mockH5Dataset(np.array([detectorState.wav])),
+            "det_arc1/value": np.array([detectorState.arc[0]]),
+            "det_arc2/value": np.array([detectorState.arc[1]]),
+            "BL3:Det:TH:BL:Frequency/value": np.array([detectorState.freq]),
+            "BL3:Mot:OpticsPos:Pos/value": np.array([detectorState.guideStat]),
+            "det_lin1/value": np.array([detectorState.lin[0]]),
+            "det_lin2/value": np.array([detectorState.lin[1]]),
         }
-
-        def del_item(key: str):
-            # bypass <class>.__delitem__
-            del dict_[key]
-
         mock_ = mock.MagicMock(spec=h5py.Group)
-
-        mock_.get = lambda key, default=None: dict_.get(key, default)
-        mock_.del_item = del_item
-
-        # Use of the h5py.File starts with access to the "entry/DASlogs" group:
-        mock_.__getitem__.side_effect = lambda key: mock_ if key == "entry/DASlogs" else dict_[key]
-
+        mock_.__getitem__.side_effect = lambda key: (mock_ if key == "entry/DASlogs" else dict_[key])
         mock_.__setitem__.side_effect = dict_.__setitem__
         mock_.__contains__.side_effect = dict_.__contains__
         mock_.keys.side_effect = dict_.keys

--- a/tests/util_tests/test_state_helpers.py
+++ b/tests/util_tests/test_state_helpers.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from shutil import rmtree
 
 import h5py
+import numpy as np
 import pytest
 
 ##
@@ -31,39 +32,32 @@ def _cleanup_directories():
 
 
 def mockPVFile(detectorState: DetectorState) -> mock.Mock:
-    # See also: `tests/unit/backend/data/util/test_PV_logs_util.py`.
-
-    # Note: `PV_logs_util.mappingFromNeXusLogs` will open the 'entry/DASlogs' group,
-    #   so this `dict` mocks the HDF5 group, not the PV-file itself.
-
-    # For the HDF5-file, each key requires the "/value" suffix.
     dict_ = {
-        "run_number/value": "123456",
-        "start_time/value": "2023-06-14T14:06:40.429048667",
-        "end_time/value": "2023-06-14T14:07:56.123123123",
-        "BL3:Chop:Skf1:WavelengthUserReq/value": [detectorState.wav],
-        "det_arc1/value": [detectorState.arc[0]],
-        "det_arc2/value": [detectorState.arc[1]],
-        "BL3:Det:TH:BL:Frequency/value": [detectorState.freq],
-        "BL3:Mot:OpticsPos:Pos/value": [detectorState.guideStat],
-        "det_lin1/value": [detectorState.lin[0]],
-        "det_lin2/value": [detectorState.lin[1]],
+        "run_number/value": np.array(["123456"], dtype="S6"),
+        "start_time/value": np.array(["2023-06-14T14:06:40.429048667"], dtype="S30"),
+        "end_time/value": np.array(["2023-06-14T14:07:56.123123123"], dtype="S30"),
+        "BL3:Chop:Skf1:WavelengthUserReq/value": np.array([detectorState.wav]),
+        "det_arc1/value": np.array([detectorState.arc[0]]),
+        "det_arc2/value": np.array([detectorState.arc[1]]),
+        "BL3:Det:TH:BL:Frequency/value": np.array([detectorState.freq]),
+        "BL3:Mot:OpticsPos:Pos/value": np.array([detectorState.guideStat]),
+        "det_lin1/value": np.array([detectorState.lin[0]]),
+        "det_lin2/value": np.array([detectorState.lin[1]]),
     }
-
-    def del_item(key: str):
-        # bypass <class>.__delitem__
-        del dict_[key]
 
     mock_ = mock.MagicMock(spec=h5py.Group)
 
-    mock_.get = lambda key, default=None: dict_.get(key, default)
-    mock_.del_item = del_item
+    # Return either the mock group itself or the relevant dataset
+    def side_effect_getitem(key: str):
+        if key == "entry/DASlogs":
+            return mock_
+        return dict_[key]
 
-    # Use of the h5py.File starts with access to the "entry/DASlogs" group:
-    mock_.__getitem__.side_effect = lambda key: mock_ if key == "entry/DASlogs" else dict_[key]
-
+    mock_.__getitem__.side_effect = side_effect_getitem
+    # Typically you don’t need to override __setitem__ or .get unless your test calls them
     mock_.__contains__.side_effect = dict_.__contains__
     mock_.keys.side_effect = dict_.keys
+
     return mock_
 
 


### PR DESCRIPTION
## Description of work
This update introduces a **Run Feedback View** in SNAPRed, which provides real-time feedback about the selected run(s) in each workflow. The goal is to enhance user awareness by displaying key run metadata—such as State ID and Run Title—in an uneditable format within the first tab of each workflow. This ensures that users can verify their selections without needing to cross-reference external sources.

The feature is integrated into all primary workflows:

* **DiffCal Workflow**: Displays the State ID and Run Title for the selected run.
* **NormCal Workflow**: Displays the State ID and Run Title for the vanadium run only.
* **Reduction Workflow**: Displays the State ID and Run Title of the first run in the list.
<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work
The implementation consists of backend logic to retrieve and store run metadata, along with UI updates to display this information dynamically.

1. Data Retrieval & Storage
* Extracts State ID and Run Title from the selected run(s).
* Stores this information in a structured manner, ensuring consistency across workflows.

2. UI Integration
* In DiffCal and NormCal, the run information is displayed below the run entry field.
* In Reduction, it appears next to the entry in the run list.
* The fields are uneditable, ensuring the displayed information remains accurate and unchanged.
<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing
Please ensure all pytests and integration tests pass. In order to test, please manually regression test all of the workflows in order to insure this feature functions.
<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing
Same as above.
<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM # 8152](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8152)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] SNAPRed is fully functional as before
- [x] in diffcal (just one run selected): [show stateID and run title, To be displayed in the first tab, under run entry field upon entry of run number (uneditable)]
- [x] n normcal (two runs selected. must be from same state): [show stateID and run title from vanadium run only, To be displayed in the first tab, under run entry field upon entry of run number (uneditable)]
- [x]  in reduction (potentially many runs from different states): [show stateID and run title, To be displayed in the first tab, next to entry in run list (uneditable)]


