### PR TITLE
Ewm9401 force use of mantidsnapper

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,6 @@ dependencies:
 - pytest-qt
 - pytest-cov
 - flake8
-- flake8-tidy-imports
 - erdantic>=1.0.3
 - versioningit
 - anaconda-client

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
 - pytest-qt
 - pytest-cov
 - flake8
+- flake8-tidy-imports
 - erdantic>=1.0.3
 - versioningit
 - anaconda-client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,11 +72,6 @@ extend-exclude = ["conftest.py"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "mantid.simpleapi".msg = "In the SNAPRed backend, any calls to 'mantid.simpleapi' algorithms should be routed through 'MantidSnapper'."
-exclude = [
-"tests/",
-"src/snapred/backend/recipe/algorithm",
-"src/snapred/resources/ultralite"
-]
 
 [tool.mypy]
 plugins = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,13 +65,18 @@ addopts = "-m 'not (integration or datarepo)'"
 [tool.ruff]
 line-length = 120
 # https://beta.ruff.rs/docs/rules/
-select = ["A", "ARG", "BLE", "E", "F", "I", "PT"]
+select = ["A", "ARG", "BLE", "E", "F", "I", "PT", "TID251"]
 ignore = ["F403", "F405", # wild imports and  unknown names
 ]
 extend-exclude = ["conftest.py"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "mantid.simpleapi".msg = "In the SNAPRed backend, any calls to 'mantid.simpleapi' algorithms should be routed through 'MantidSnapper'."
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["TID251"]
+"src/snapred/backend/recipe/algorithm*" = ["TID251"]
+"src/snapred/resources/ultralite*" = ["TID251"]
 
 [tool.mypy]
 plugins = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,6 @@ select = ["A", "ARG", "BLE", "E", "F", "I", "PT"]
 ignore = ["F403", "F405", # wild imports and  unknown names
 ]
 extend-exclude = ["conftest.py"]
-
-[tool.flake8]
 banned-modules =
 mantid.simpleapi = In the SNAPRed backend, any calls to 'mantid.simpleapi' algorithms should be routed through 'MantidSnapper'.
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,9 @@ select = ["A", "ARG", "BLE", "E", "F", "I", "PT"]
 ignore = ["F403", "F405", # wild imports and  unknown names
 ]
 extend-exclude = ["conftest.py"]
-banned-modules =
-mantid.simpleapi = In the SNAPRed backend, any calls to 'mantid.simpleapi' algorithms should be routed through 'MantidSnapper'.
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"mantid.simpleapi".msg = "In the SNAPRed backend, any calls to 'mantid.simpleapi' algorithms should be routed through 'MantidSnapper'."
 exclude = [
 "tests/",
 "src/snapred/backend/recipe/algorithm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,14 @@ ignore = ["F403", "F405", # wild imports and  unknown names
 ]
 extend-exclude = ["conftest.py"]
 
-[tool.ruff.lint.flake8-tidy-imports.banned-api]
-"mantid.simpleapi".msg = "In the SNAPRed backend, any calls to 'mantid.simpleapi' algorithms should be routed through 'MantidSnapper'."[tool.ruff.lint.flake8-tidy-imports.banned-api]
+[tool.flake8]
+banned-modules =
+mantid.simpleapi = In the SNAPRed backend, any calls to 'mantid.simpleapi' algorithms should be routed through 'MantidSnapper'.
+exclude = [
+"tests/",
+"src/snapred/backend/recipe/algorithm",
+"src/snapred/resources/ultralite"
+]
 
 [tool.mypy]
 plugins = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ ignore = ["F403", "F405", # wild imports and  unknown names
 ]
 extend-exclude = ["conftest.py"]
 
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"mantid.simpleapi".msg = "In the SNAPRed backend, any calls to 'mantid.simpleapi' algorithms should be routed through 'MantidSnapper'."[tool.ruff.lint.flake8-tidy-imports.banned-api]
+
 [tool.mypy]
 plugins = [
   "pydantic.mypy"

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -7,7 +7,9 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 from mantid.dataobjects import MaskWorkspace
-from mantid.simpleapi import (
+
+# TODO Replace the use of the import(s) below with MantidSnapper in EWM 9909
+from mantid.simpleapi import (  # noqa : TID251
     mtd,
 )
 from pydantic import validate_call
@@ -456,7 +458,7 @@ class GroceryService:
         :return: a pointer to the cloned workspace in the ADS
         :rtype: a python wrapped, C++ shared pointer to a Workspace
         """
-        from mantid.simpleapi import CloneWorkspace
+        from mantid.simpleapi import CloneWorkspace  # noqa : TID251
 
         if self.workspaceDoesExist(name):
             ws = CloneWorkspace(InputWorkspace=name, OutputWorkspace=copy)

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -17,7 +17,9 @@ import h5py
 from mantid.api import Run
 from mantid.dataobjects import MaskWorkspace
 from mantid.kernel import ConfigService, PhysicalConstants
-from mantid.simpleapi import GetIPTS, mtd
+
+# TODO Replace the use of the import(s) below with MantidSnapper in EWM 9909
+from mantid.simpleapi import GetIPTS, mtd  # noqa : TID251
 from pydantic import ValidationError
 
 from snapred.backend.dao import (

--- a/src/snapred/backend/data/util/PV_logs_util.py
+++ b/src/snapred/backend/data/util/PV_logs_util.py
@@ -10,7 +10,9 @@ from typing import Any
 import h5py
 import numpy as np
 from mantid.api import Run
-from mantid.simpleapi import AddSampleLog, mtd
+
+# TODO Replace the use of the import(s) below with MantidSnapper in EWM 9909
+from mantid.simpleapi import AddSampleLog, mtd  # noqa : TID251
 
 from snapred.meta.Config import Config
 

--- a/src/snapred/backend/recipe/GenerateCalibrationMetricsWorkspaceRecipe.py
+++ b/src/snapred/backend/recipe/GenerateCalibrationMetricsWorkspaceRecipe.py
@@ -1,4 +1,5 @@
-from mantid.simpleapi import (
+# TODO Replace the use of the import(s) below with MantidSnapper in EWM 9909
+from mantid.simpleapi import (  # noqa : TID251
     DeleteWorkspace,
 )
 

--- a/src/snapred/backend/recipe/GenericRecipe.py
+++ b/src/snapred/backend/recipe/GenericRecipe.py
@@ -1,7 +1,8 @@
 import json
 from typing import Generic, TypeVar, get_args
 
-from mantid.simpleapi import ConvertTableToMatrixWorkspace, Minus
+# TODO Replace the use of the import(s) below with MantidSnapper in EWM 9909
+from mantid.simpleapi import ConvertTableToMatrixWorkspace, Minus  # noqa : TID251
 from pydantic import BaseModel
 
 from snapred.backend.log.logger import snapredLogger

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -3,7 +3,9 @@ from typing import List
 import matplotlib.pyplot as plt
 import pydantic
 from mantid.plots.datafunctions import get_spectrum
-from mantid.simpleapi import mtd
+
+# TODO Replace the use of the import(s) below with MantidSnapper in EWM 9909
+from mantid.simpleapi import mtd  # noqa : TID251
 from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import (
     QHBoxLayout,

--- a/src/snapred/ui/view/NormalizationTweakPeakView.py
+++ b/src/snapred/ui/view/NormalizationTweakPeakView.py
@@ -3,7 +3,9 @@ from typing import List
 import matplotlib.pyplot as plt
 import pydantic
 from mantid.plots.datafunctions import get_spectrum
-from mantid.simpleapi import mtd
+
+# TODO Replace the use of the import(s) below with MantidSnapper in EWM 9909
+from mantid.simpleapi import mtd  # noqa : TID251
 from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import (
     QHBoxLayout,

--- a/src/snapred/ui/view/reduction/ArtificialNormalizationView.py
+++ b/src/snapred/ui/view/reduction/ArtificialNormalizationView.py
@@ -1,6 +1,8 @@
 import matplotlib.pyplot as plt
 from mantid.plots.datafunctions import get_spectrum
-from mantid.simpleapi import mtd
+
+# TODO Replace the use of the import(s) below with MantidSnapper in EWM 9909
+from mantid.simpleapi import mtd  # noqa : TID251
 from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import (
     QFrame,

--- a/src/snapred/ui/widget/FitPeaksPlot.py
+++ b/src/snapred/ui/widget/FitPeaksPlot.py
@@ -1,7 +1,9 @@
 import matplotlib.pyplot as plt
 import numpy as np
 from mantid.api import mtd
-from mantid.simpleapi import Minus
+
+# TODO Replace the use of the import(s) below with MantidSnapper in EWM 9909
+from mantid.simpleapi import Minus  # noqa : TID251
 
 
 def FitPeaksPlot(wsName):

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -1,4 +1,5 @@
-from mantid.simpleapi import mtd
+# TODO Replace the use of the import(s) below with MantidSnapper in EWM 9909
+from mantid.simpleapi import mtd  # noqa : TID251
 from qtpy.QtCore import Slot
 
 from snapred.backend.dao import RunConfig


### PR DESCRIPTION
## Description of work

This adds a rule to ruff that checks if mantid.simpleapi is being used where it shouldn't. MantidSnapper should be used instead going forward.

## Explanation of work

The rule checks all src directories except algortihm and makes sure `mantid.simpleapi` is not in the import list. If it is, the error will state to use MantidSnapper instead.

## To test

### Dev testing

Pull the branch and run `pre-commit run --all-files`. You should see about 11 files that break this rule

### CIS testing

None, this is for developers only.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#9401](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9401)

### Verification

- [ ] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] rule works and does not affect files in algorithm directory
