### PR TITLE
Ewm9391 make cis mode a subsection

### DIFF
--- a/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
+++ b/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
@@ -19,12 +19,11 @@ class MakeDirtyDish(PythonAlgorithm):
         self.declareProperty("OutputWorkspace", defaultValue="", direction=Direction.Output)  # noqa: F821
         self.setRethrows(True)
 
-        cisModeConfig = Config["cis_mode"]
-        self.enabled: bool = cisModeConfig.get("enabled")
-        self.preserve: bool = cisModeConfig.get("preserveDiagnosticWorkspaces")
+        self.cis_enabled: bool = Config["cis_mode.enabled"]
+        self.cis_preserve: bool = Config["cis_mode.preserveDiagnosticWorkspaces"]
 
     def PyExec(self) -> None:
-        if self.enabled and self.preserve:
+        if self.cis_enabled and self.cis_preserve:
             inWS = self.getProperty("InputWorkspace").value
             outWS = self.getProperty("OutputWorkspace").value
             self.log().debug(f"Dirtying up dish {inWS} --> {outWS}")

--- a/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
+++ b/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
@@ -18,7 +18,7 @@ class MakeDirtyDish(PythonAlgorithm):
         self.declareProperty("InputWorkspace", defaultValue="", direction=Direction.Input)  # noqa: F821
         self.declareProperty("OutputWorkspace", defaultValue="", direction=Direction.Output)  # noqa: F821
         self.setRethrows(True)
-        self._CISmode: bool = Config["cis_mode"]
+        self._CISmode: bool = Config["cis_mode.enabled"]
 
     def PyExec(self) -> None:
         if self._CISmode:

--- a/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
+++ b/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
@@ -19,9 +19,10 @@ class MakeDirtyDish(PythonAlgorithm):
         self.declareProperty("OutputWorkspace", defaultValue="", direction=Direction.Output)  # noqa: F821
         self.setRethrows(True)
         self._CISmode: bool = Config["cis_mode.enabled"]
+        self._preserveDiagnosticWorkspaces: bool = Config["cis_mode.preserveDiagnosticWorkspaces"]
 
     def PyExec(self) -> None:
-        if self._CISmode:
+        if self._preserveDiagnosticWorkspaces:
             inWS = self.getProperty("InputWorkspace").value
             outWS = self.getProperty("OutputWorkspace").value
             self.log().debug(f"Dirtying up dish {inWS} --> {outWS}")

--- a/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
+++ b/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
@@ -23,12 +23,6 @@ class MakeDirtyDish(PythonAlgorithm):
         self.enabled: bool = cisModeConfig.get("enabled")
         self.preserve: bool = cisModeConfig.get("preserveDiagnosticWorkspaces")
 
-        if self.enabled != self.preserve:
-            self.log().warning(
-                f"Mismatch in config: cis_mode.enabled={self.enabled}, "
-                f"cis_mode.preserveDiagnosticWorkspaces={self.preserve}."
-            )
-
     def PyExec(self) -> None:
         if self.enabled and self.preserve:
             inWS = self.getProperty("InputWorkspace").value

--- a/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
+++ b/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
@@ -24,7 +24,7 @@ class MakeDirtyDish(PythonAlgorithm):
         self.preserve: bool = cisModeConfig.get("preserveDiagnosticWorkspaces")
 
         if self.enabled != self.preserve:
-            self.log().notice(
+            self.log().warning(
                 f"Mismatch in config: cis_mode.enabled={self.enabled}, "
                 f"cis_mode.preserveDiagnosticWorkspaces={self.preserve}."
             )

--- a/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
+++ b/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
@@ -18,11 +18,19 @@ class MakeDirtyDish(PythonAlgorithm):
         self.declareProperty("InputWorkspace", defaultValue="", direction=Direction.Input)  # noqa: F821
         self.declareProperty("OutputWorkspace", defaultValue="", direction=Direction.Output)  # noqa: F821
         self.setRethrows(True)
-        self._CISmode: bool = Config["cis_mode.enabled"]
-        self._preserveDiagnosticWorkspaces: bool = Config["cis_mode.preserveDiagnosticWorkspaces"]
+
+        cisModeConfig = Config["cis_mode"]
+        self.enabled: bool = cisModeConfig.get("enabled")
+        self.preserve: bool = cisModeConfig.get("preserveDiagnosticWorkspaces")
+
+        if self.enabled != self.preserve:
+            self.log().notice(
+                f"Mismatch in config: cis_mode.enabled={self.enabled}, "
+                f"cis_mode.preserveDiagnosticWorkspaces={self.preserve}."
+            )
 
     def PyExec(self) -> None:
-        if self._preserveDiagnosticWorkspaces:
+        if self.enabled and self.preserve:
             inWS = self.getProperty("InputWorkspace").value
             outWS = self.getProperty("OutputWorkspace").value
             self.log().debug(f"Dirtying up dish {inWS} --> {outWS}")

--- a/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
+++ b/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
@@ -18,7 +18,7 @@ class MakeDirtyDish(PythonAlgorithm):
         self.declareProperty("InputWorkspace", defaultValue="", direction=Direction.Input)  # noqa: F821
         self.declareProperty("OutputWorkspace", defaultValue="", direction=Direction.Output)  # noqa: F821
         self.setRethrows(True)
-        self._CISmode: bool = Config["cis_mode"]["enabled"]
+        self._CISmode: bool = Config["cis_mode.enabled"]
 
     def PyExec(self) -> None:
         if self._CISmode:

--- a/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
+++ b/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
@@ -18,7 +18,7 @@ class MakeDirtyDish(PythonAlgorithm):
         self.declareProperty("InputWorkspace", defaultValue="", direction=Direction.Input)  # noqa: F821
         self.declareProperty("OutputWorkspace", defaultValue="", direction=Direction.Output)  # noqa: F821
         self.setRethrows(True)
-        self._CISmode: bool = Config["cis_mode.enabled"]
+        self._CISmode: bool = Config["cis_mode"]["enabled"]
 
     def PyExec(self) -> None:
         if self._CISmode:

--- a/src/snapred/backend/recipe/algorithm/WashDishes.py
+++ b/src/snapred/backend/recipe/algorithm/WashDishes.py
@@ -20,8 +20,14 @@ class WashDishes(PythonAlgorithm):
         self.declareProperty(StringArrayProperty(name="WorkspaceList", values=[], direction=Direction.Input))
 
         cisModeConfig = Config["cis_mode"]
-        self._CISmode: bool = cisModeConfig.get("enabled")
-        self._preserveDiagnosticWorkspaces: bool = cisModeConfig.get("preserveDiagnosticWorkspaces")
+        self.enabled: bool = cisModeConfig.get("enabled")
+        self.preserve: bool = cisModeConfig.get("preserveDiagnosticWorkspaces")
+
+        if self.enabled != self.preserve:
+            self.log().notice(
+                f"Mismatch in config: cis_mode.enabled={self.enabled}, "
+                f"cis_mode.preserveDiagnosticWorkspaces={self.preserve}."
+            )
 
         self.setRethrows(True)
 
@@ -30,14 +36,16 @@ class WashDishes(PythonAlgorithm):
 
         workspace = self.getProperty("Workspace").value
         if workspace and mtd.doesExist(workspace):
-            if not self._CISmode:
-                DeleteWorkspace(Workspace=workspace)
+            if not self.enabled:
+                if not self.preserve:
+                    DeleteWorkspace(Workspace=workspace)
 
         workspaces = self.getProperty("WorkspaceList").value
         workspaces = [w for w in workspaces if mtd.doesExist(w)]
         if workspaces:
-            if not self._CISmode:
-                DeleteWorkspaces(WorkspaceList=workspaces)
+            if not self.enabled:
+                if not self.preserve:
+                    DeleteWorkspaces(WorkspaceList=workspaces)
 
 
 # Register algorithm

--- a/src/snapred/backend/recipe/algorithm/WashDishes.py
+++ b/src/snapred/backend/recipe/algorithm/WashDishes.py
@@ -19,9 +19,8 @@ class WashDishes(PythonAlgorithm):
         self.declareProperty("Workspace", defaultValue="", direction=Direction.Input)  # noqa: F821
         self.declareProperty(StringArrayProperty(name="WorkspaceList", values=[], direction=Direction.Input))
 
-        cisModeConfig = Config["cis_mode"]
-        self.enabled: bool = cisModeConfig.get("enabled")
-        self.preserve: bool = cisModeConfig.get("preserveDiagnosticWorkspaces")
+        self.cis_enabled: bool = Config["cis_mode.enabled"]
+        self.cis_preserve: bool = Config["cis_mode.preserveDiagnosticWorkspaces"]
 
         self.setRethrows(True)
 
@@ -30,16 +29,14 @@ class WashDishes(PythonAlgorithm):
 
         workspace = self.getProperty("Workspace").value
         if workspace and mtd.doesExist(workspace):
-            if not self.enabled:
-                if not self.preserve:
-                    DeleteWorkspace(Workspace=workspace)
+            if not self.cis_enabled and not self.cis_preserve:
+                DeleteWorkspace(Workspace=workspace)
 
         workspaces = self.getProperty("WorkspaceList").value
         workspaces = [w for w in workspaces if mtd.doesExist(w)]
         if workspaces:
-            if not self.enabled:
-                if not self.preserve:
-                    DeleteWorkspaces(WorkspaceList=workspaces)
+            if not self.cis_enabled and not self.cis_preserve:
+                DeleteWorkspaces(WorkspaceList=workspaces)
 
 
 # Register algorithm

--- a/src/snapred/backend/recipe/algorithm/WashDishes.py
+++ b/src/snapred/backend/recipe/algorithm/WashDishes.py
@@ -20,8 +20,8 @@ class WashDishes(PythonAlgorithm):
         self.declareProperty(StringArrayProperty(name="WorkspaceList", values=[], direction=Direction.Input))
 
         cisModeConfig = Config._config.get("cis_mode", {})
-        self._CISmode = cisModeConfig.get("enabled", False)
-        self._preserveDiagnosticWorkspaces = cisModeConfig.get("preserveDiagnosticWorkspaces", False)
+        self._CISmode: bool = cisModeConfig.get("enabled", False)
+        self._preserveDiagnosticWorkspaces: bool = cisModeConfig.get("preserveDiagnosticWorkspaces", False)
 
         self.setRethrows(True)
 

--- a/src/snapred/backend/recipe/algorithm/WashDishes.py
+++ b/src/snapred/backend/recipe/algorithm/WashDishes.py
@@ -19,7 +19,7 @@ class WashDishes(PythonAlgorithm):
         self.declareProperty("Workspace", defaultValue="", direction=Direction.Input)  # noqa: F821
         self.declareProperty(StringArrayProperty(name="WorkspaceList", values=[], direction=Direction.Input))
 
-        cisModeConfig = Config._config.get("cis_mode", {})
+        cisModeConfig = Config["cis_mode"]
         self._CISmode: bool = cisModeConfig.get("enabled", False)
         self._preserveDiagnosticWorkspaces: bool = cisModeConfig.get("preserveDiagnosticWorkspaces", False)
 

--- a/src/snapred/backend/recipe/algorithm/WashDishes.py
+++ b/src/snapred/backend/recipe/algorithm/WashDishes.py
@@ -23,12 +23,6 @@ class WashDishes(PythonAlgorithm):
         self.enabled: bool = cisModeConfig.get("enabled")
         self.preserve: bool = cisModeConfig.get("preserveDiagnosticWorkspaces")
 
-        if self.enabled != self.preserve:
-            self.log().warning(
-                f"Mismatch in config: cis_mode.enabled={self.enabled}, "
-                f"cis_mode.preserveDiagnosticWorkspaces={self.preserve}."
-            )
-
         self.setRethrows(True)
 
     def PyExec(self) -> None:

--- a/src/snapred/backend/recipe/algorithm/WashDishes.py
+++ b/src/snapred/backend/recipe/algorithm/WashDishes.py
@@ -20,8 +20,8 @@ class WashDishes(PythonAlgorithm):
         self.declareProperty(StringArrayProperty(name="WorkspaceList", values=[], direction=Direction.Input))
 
         cisModeConfig = Config["cis_mode"]
-        self._CISmode: bool = cisModeConfig.get("enabled", False)
-        self._preserveDiagnosticWorkspaces: bool = cisModeConfig.get("preserveDiagnosticWorkspaces", False)
+        self._CISmode: bool = cisModeConfig.get("enabled")
+        self._preserveDiagnosticWorkspaces: bool = cisModeConfig.get("preserveDiagnosticWorkspaces")
 
         self.setRethrows(True)
 

--- a/src/snapred/backend/recipe/algorithm/WashDishes.py
+++ b/src/snapred/backend/recipe/algorithm/WashDishes.py
@@ -18,24 +18,23 @@ class WashDishes(PythonAlgorithm):
         # declare properties
         self.declareProperty("Workspace", defaultValue="", direction=Direction.Input)  # noqa: F821
         self.declareProperty(StringArrayProperty(name="WorkspaceList", values=[], direction=Direction.Input))
+        self.setRethrows(True)
 
         self.cis_enabled: bool = Config["cis_mode.enabled"]
         self.cis_preserve: bool = Config["cis_mode.preserveDiagnosticWorkspaces"]
-
-        self.setRethrows(True)
 
     def PyExec(self) -> None:
         self.log().notice("Washing the dishes...")
 
         workspace = self.getProperty("Workspace").value
         if workspace and mtd.doesExist(workspace):
-            if not self.cis_enabled and not self.cis_preserve:
+            if (not self.cis_enabled) or (not self.cis_preserve):
                 DeleteWorkspace(Workspace=workspace)
 
         workspaces = self.getProperty("WorkspaceList").value
         workspaces = [w for w in workspaces if mtd.doesExist(w)]
         if workspaces:
-            if not self.cis_enabled and not self.cis_preserve:
+            if (not self.cis_enabled) or (not self.cis_preserve):
                 DeleteWorkspaces(WorkspaceList=workspaces)
 
 

--- a/src/snapred/backend/recipe/algorithm/WashDishes.py
+++ b/src/snapred/backend/recipe/algorithm/WashDishes.py
@@ -24,7 +24,7 @@ class WashDishes(PythonAlgorithm):
         self.preserve: bool = cisModeConfig.get("preserveDiagnosticWorkspaces")
 
         if self.enabled != self.preserve:
-            self.log().notice(
+            self.log().warning(
                 f"Mismatch in config: cis_mode.enabled={self.enabled}, "
                 f"cis_mode.preserveDiagnosticWorkspaces={self.preserve}."
             )

--- a/src/snapred/backend/recipe/algorithm/WashDishes.py
+++ b/src/snapred/backend/recipe/algorithm/WashDishes.py
@@ -18,19 +18,27 @@ class WashDishes(PythonAlgorithm):
         # declare properties
         self.declareProperty("Workspace", defaultValue="", direction=Direction.Input)  # noqa: F821
         self.declareProperty(StringArrayProperty(name="WorkspaceList", values=[], direction=Direction.Input))
+
+        cisModeConfig = Config._config.get("cis_mode", {})
+        self._CISmode = cisModeConfig.get("enabled", False)
+        self._preserveDiagnosticWorkspaces = cisModeConfig.get("preserveDiagnosticWorkspaces", False)
+
         self.setRethrows(True)
-        self._CISmode: bool = Config._config.get("cis_mode", False)
 
     def PyExec(self) -> None:
         self.log().notice("Washing the dishes...")
+
         workspace = self.getProperty("Workspace").value
-        if workspace != "" and mtd.doesExist(workspace) and not self._CISmode:
-            DeleteWorkspace(Workspace=workspace)
+        if workspace and mtd.doesExist(workspace):
+            if not self._CISmode:
+                DeleteWorkspace(Workspace=workspace)
+
         workspaces = self.getProperty("WorkspaceList").value
         workspaces = [w for w in workspaces if mtd.doesExist(w)]
-        if workspaces != [] and not self._CISmode:
-            DeleteWorkspaces(workspaces)
+        if workspaces:
+            if not self._CISmode:
+                DeleteWorkspaces(WorkspaceList=workspaces)
 
 
-# Register algorithm with Mantid
+# Register algorithm
 AlgorithmFactory.subscribe(WashDishes)

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -245,7 +245,9 @@ version:
     default: 0 # alphanumeric
   start: 0   # MUST be nonnegative integer
 
-cis_mode: false
+cis_mode:
+  enabled: false
+  preserveDiagnosticWorkspaces: false
 
 constants:
   millisecondsPerSecond: 1000

--- a/tests/cis_tests/artificial_norm_script.py
+++ b/tests/cis_tests/artificial_norm_script.py
@@ -34,7 +34,7 @@ calibrantSamplePath = "Silicon_NIST_640D_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._config["cis_mode"] = False
+Config._Config["cis_mode.enabled"] = False
 #######################################
 
 ### PREP INGREDIENTS ################
@@ -140,7 +140,7 @@ groceryService = GroceryService()
 #User input ###########################
 runNumber = "46680" #"57482"
 isLite = True
-Config._config["cis_mode"] = True
+Config._Config["cis_mode.enabled"] = True
 version=(1, None)
 grouping = "Column"
 

--- a/tests/cis_tests/artificial_norm_script.py
+++ b/tests/cis_tests/artificial_norm_script.py
@@ -35,6 +35,7 @@ peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
 Config._config["cis_mode.enabled"] = False
+Config._config["cis_mode.preserveDiagnosticWorkspaces"] = False
 #######################################
 
 ### PREP INGREDIENTS ################
@@ -141,6 +142,7 @@ groceryService = GroceryService()
 runNumber = "46680" #"57482"
 isLite = True
 Config._config["cis_mode.enabled"] = True
+Config._config["cis_mode.preserveDiagnosticWorkspaces"] = True
 version=(1, None)
 grouping = "Column"
 

--- a/tests/cis_tests/artificial_norm_script.py
+++ b/tests/cis_tests/artificial_norm_script.py
@@ -34,7 +34,7 @@ calibrantSamplePath = "Silicon_NIST_640D_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._Config["cis_mode.enabled"] = False
+Config._Config["cis_mode"]["enabled"] = False
 #######################################
 
 ### PREP INGREDIENTS ################
@@ -140,7 +140,7 @@ groceryService = GroceryService()
 #User input ###########################
 runNumber = "46680" #"57482"
 isLite = True
-Config._Config["cis_mode.enabled"] = True
+Config._Config["cis_mode"]["enabled"] = True
 version=(1, None)
 grouping = "Column"
 

--- a/tests/cis_tests/artificial_norm_script.py
+++ b/tests/cis_tests/artificial_norm_script.py
@@ -34,7 +34,7 @@ calibrantSamplePath = "Silicon_NIST_640D_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._Config["cis_mode"]["enabled"] = False
+Config._config["cis_mode"]["enabled"] = False
 #######################################
 
 ### PREP INGREDIENTS ################
@@ -140,7 +140,7 @@ groceryService = GroceryService()
 #User input ###########################
 runNumber = "46680" #"57482"
 isLite = True
-Config._Config["cis_mode"]["enabled"] = True
+Config._config["cis_mode"]["enabled"] = True
 version=(1, None)
 grouping = "Column"
 

--- a/tests/cis_tests/artificial_norm_script.py
+++ b/tests/cis_tests/artificial_norm_script.py
@@ -34,7 +34,7 @@ calibrantSamplePath = "Silicon_NIST_640D_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._config["cis_mode"]["enabled"] = False
+Config._config["cis_mode.enabled"] = False
 #######################################
 
 ### PREP INGREDIENTS ################
@@ -140,7 +140,7 @@ groceryService = GroceryService()
 #User input ###########################
 runNumber = "46680" #"57482"
 isLite = True
-Config._config["cis_mode"]["enabled"] = True
+Config._config["cis_mode.enabled"] = True
 version=(1, None)
 grouping = "Column"
 

--- a/tests/cis_tests/cc-and-smooth.py
+++ b/tests/cis_tests/cc-and-smooth.py
@@ -23,7 +23,7 @@ calibrantSamplePath = "Silicon_NIST_640D_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._Config["cis_mode"]["enabled"] = True
+Config._config["cis_mode"]["enabled"] = True
 #######################################
 
 ### PREP INGREDIENTS ################

--- a/tests/cis_tests/cc-and-smooth.py
+++ b/tests/cis_tests/cc-and-smooth.py
@@ -23,7 +23,7 @@ calibrantSamplePath = "Silicon_NIST_640D_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._config["cis_mode"] = True
+Config._Config["cis_mode.enabled"] = True
 #######################################
 
 ### PREP INGREDIENTS ################

--- a/tests/cis_tests/cc-and-smooth.py
+++ b/tests/cis_tests/cc-and-smooth.py
@@ -23,7 +23,7 @@ calibrantSamplePath = "Silicon_NIST_640D_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._config["cis_mode"]["enabled"] = True
+Config._config["cis_mode.enabled"] = True
 #######################################
 
 ### PREP INGREDIENTS ################

--- a/tests/cis_tests/cc-and-smooth.py
+++ b/tests/cis_tests/cc-and-smooth.py
@@ -24,6 +24,7 @@ peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
 Config._config["cis_mode.enabled"] = True
+Config._config["cis_mode.preserveDiagnosticWorkspaces"] = True
 #######################################
 
 ### PREP INGREDIENTS ################

--- a/tests/cis_tests/cc-and-smooth.py
+++ b/tests/cis_tests/cc-and-smooth.py
@@ -23,7 +23,7 @@ calibrantSamplePath = "Silicon_NIST_640D_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._Config["cis_mode.enabled"] = True
+Config._Config["cis_mode"]["enabled"] = True
 #######################################
 
 ### PREP INGREDIENTS ################

--- a/tests/cis_tests/check_remove.py
+++ b/tests/cis_tests/check_remove.py
@@ -25,6 +25,7 @@ peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
 Config._config["cis_mode.enabled"] = True
+Config._config["cis_mode.preserveDiagnosticWorkspaces"] = True
 #######################################
 
 ### PREP INGREDIENTS ################

--- a/tests/cis_tests/check_remove.py
+++ b/tests/cis_tests/check_remove.py
@@ -24,7 +24,7 @@ calibrantSamplePath = "Silicon_NIST_640D_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._Config["cis_mode.enabled"] = True
+Config._Config["cis_mode"]["enabled"] = True
 #######################################
 
 ### PREP INGREDIENTS ################

--- a/tests/cis_tests/check_remove.py
+++ b/tests/cis_tests/check_remove.py
@@ -24,7 +24,7 @@ calibrantSamplePath = "Silicon_NIST_640D_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._config["cis_mode"]["enabled"] = True
+Config._config["cis_mode.enabled"] = True
 #######################################
 
 ### PREP INGREDIENTS ################

--- a/tests/cis_tests/check_remove.py
+++ b/tests/cis_tests/check_remove.py
@@ -24,7 +24,7 @@ calibrantSamplePath = "Silicon_NIST_640D_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._Config["cis_mode"]["enabled"] = True
+Config._config["cis_mode"]["enabled"] = True
 #######################################
 
 ### PREP INGREDIENTS ################

--- a/tests/cis_tests/check_remove.py
+++ b/tests/cis_tests/check_remove.py
@@ -24,7 +24,7 @@ calibrantSamplePath = "Silicon_NIST_640D_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._config["cis_mode"] = True
+Config._Config["cis_mode.enabled"] = True
 #######################################
 
 ### PREP INGREDIENTS ################

--- a/tests/cis_tests/diffcal_integration_test_script.py
+++ b/tests/cis_tests/diffcal_integration_test_script.py
@@ -63,6 +63,7 @@ def script(goldenData):
     offsetConvergenceLimit = 0.1
     isLite = True
     Config._config["cis_mode.enabled"] = False
+    Config._config["cis_mode.preserveDiagnosticWorkspaces"] = False
     #######################################
 
     ### OVERRIDE IPTS location (optional), re-initialize STATE ###         

--- a/tests/cis_tests/diffcal_integration_test_script.py
+++ b/tests/cis_tests/diffcal_integration_test_script.py
@@ -62,7 +62,7 @@ def script(goldenData):
     peakThreshold = 0.05
     offsetConvergenceLimit = 0.1
     isLite = True
-    Config._config["cis_mode"]["enabled"] = False
+    Config._config["cis_mode.enabled"] = False
     #######################################
 
     ### OVERRIDE IPTS location (optional), re-initialize STATE ###         

--- a/tests/cis_tests/diffcal_integration_test_script.py
+++ b/tests/cis_tests/diffcal_integration_test_script.py
@@ -62,7 +62,7 @@ def script(goldenData):
     peakThreshold = 0.05
     offsetConvergenceLimit = 0.1
     isLite = True
-    Config._config["cis_mode"] = False
+    Config._Config["cis_mode.enabled"] = False
     #######################################
 
     ### OVERRIDE IPTS location (optional), re-initialize STATE ###         

--- a/tests/cis_tests/diffcal_integration_test_script.py
+++ b/tests/cis_tests/diffcal_integration_test_script.py
@@ -62,7 +62,7 @@ def script(goldenData):
     peakThreshold = 0.05
     offsetConvergenceLimit = 0.1
     isLite = True
-    Config._Config["cis_mode"]["enabled"] = False
+    Config._config["cis_mode"]["enabled"] = False
     #######################################
 
     ### OVERRIDE IPTS location (optional), re-initialize STATE ###         

--- a/tests/cis_tests/diffcal_integration_test_script.py
+++ b/tests/cis_tests/diffcal_integration_test_script.py
@@ -62,7 +62,7 @@ def script(goldenData):
     peakThreshold = 0.05
     offsetConvergenceLimit = 0.1
     isLite = True
-    Config._Config["cis_mode.enabled"] = False
+    Config._Config["cis_mode"]["enabled"] = False
     #######################################
 
     ### OVERRIDE IPTS location (optional), re-initialize STATE ###         

--- a/tests/cis_tests/diffcal_masking_script.py
+++ b/tests/cis_tests/diffcal_masking_script.py
@@ -92,7 +92,7 @@ peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
 instrumentFilePath = SNAPLiteInstrumentFilePath if isLite else SNAPInstrumentFilePath
-Config._Config["cis_mode.enabled"] = False
+Config._Config["cis_mode"]["enabled"] = False
 #######################################
 
 ### PREP INGREDIENTS ##################

--- a/tests/cis_tests/diffcal_masking_script.py
+++ b/tests/cis_tests/diffcal_masking_script.py
@@ -92,7 +92,7 @@ peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
 instrumentFilePath = SNAPLiteInstrumentFilePath if isLite else SNAPInstrumentFilePath
-Config._config["cis_mode"] = False
+Config._Config["cis_mode.enabled"] = False
 #######################################
 
 ### PREP INGREDIENTS ##################

--- a/tests/cis_tests/diffcal_masking_script.py
+++ b/tests/cis_tests/diffcal_masking_script.py
@@ -93,6 +93,7 @@ offsetConvergenceLimit = 0.1
 isLite = True
 instrumentFilePath = SNAPLiteInstrumentFilePath if isLite else SNAPInstrumentFilePath
 Config._config["cis_mode.enabled"] = False
+Config._config["cis_mode.preserveDiagnosticWorkspaces"] = False
 #######################################
 
 ### PREP INGREDIENTS ##################

--- a/tests/cis_tests/diffcal_masking_script.py
+++ b/tests/cis_tests/diffcal_masking_script.py
@@ -92,7 +92,7 @@ peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
 instrumentFilePath = SNAPLiteInstrumentFilePath if isLite else SNAPInstrumentFilePath
-Config._Config["cis_mode"]["enabled"] = False
+Config._config["cis_mode"]["enabled"] = False
 #######################################
 
 ### PREP INGREDIENTS ##################

--- a/tests/cis_tests/diffcal_masking_script.py
+++ b/tests/cis_tests/diffcal_masking_script.py
@@ -92,7 +92,7 @@ peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
 instrumentFilePath = SNAPLiteInstrumentFilePath if isLite else SNAPInstrumentFilePath
-Config._config["cis_mode"]["enabled"] = False
+Config._config["cis_mode.enabled"] = False
 #######################################
 
 ### PREP INGREDIENTS ##################

--- a/tests/cis_tests/diffcal_pixel_diffraction_background_subtraction_script.py
+++ b/tests/cis_tests/diffcal_pixel_diffraction_background_subtraction_script.py
@@ -30,7 +30,7 @@ peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
 removeBackground = True
-Config._config["cis_mode"] = True
+Config._Config["cis_mode.enabled"] = True
 Config._config["diffraction.smoothingParameter"] = 0.5  #This is the smoothing parameter to be set.
 #######################################
 

--- a/tests/cis_tests/diffcal_pixel_diffraction_background_subtraction_script.py
+++ b/tests/cis_tests/diffcal_pixel_diffraction_background_subtraction_script.py
@@ -31,6 +31,7 @@ offsetConvergenceLimit = 0.1
 isLite = True
 removeBackground = True
 Config._config["cis_mode.enabled"] = True
+Config._config["cis_mode.preserveDiagnosticWorkspaces"] = True
 Config._config["diffraction.smoothingParameter"] = 0.5  #This is the smoothing parameter to be set.
 #######################################
 

--- a/tests/cis_tests/diffcal_pixel_diffraction_background_subtraction_script.py
+++ b/tests/cis_tests/diffcal_pixel_diffraction_background_subtraction_script.py
@@ -30,7 +30,7 @@ peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
 removeBackground = True
-Config._Config["cis_mode.enabled"] = True
+Config._Config["cis_mode"]["enabled"] = True
 Config._config["diffraction.smoothingParameter"] = 0.5  #This is the smoothing parameter to be set.
 #######################################
 

--- a/tests/cis_tests/diffcal_pixel_diffraction_background_subtraction_script.py
+++ b/tests/cis_tests/diffcal_pixel_diffraction_background_subtraction_script.py
@@ -30,7 +30,7 @@ peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
 removeBackground = True
-Config._config["cis_mode"]["enabled"] = True
+Config._config["cis_mode.enabled"] = True
 Config._config["diffraction.smoothingParameter"] = 0.5  #This is the smoothing parameter to be set.
 #######################################
 

--- a/tests/cis_tests/diffcal_pixel_diffraction_background_subtraction_script.py
+++ b/tests/cis_tests/diffcal_pixel_diffraction_background_subtraction_script.py
@@ -30,7 +30,7 @@ peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
 removeBackground = True
-Config._Config["cis_mode"]["enabled"] = True
+Config._config["cis_mode"]["enabled"] = True
 Config._config["diffraction.smoothingParameter"] = 0.5  #This is the smoothing parameter to be set.
 #######################################
 

--- a/tests/cis_tests/lite_data_creation.py
+++ b/tests/cis_tests/lite_data_creation.py
@@ -8,6 +8,7 @@ from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
 
 from snapred.meta.Config import Config
 Config._config["cis_mode.enabled"] = False
+Config._config["cis_mode.preserveDiagnosticWorkspaces"] = False
 
 #User input ###########################
 runNumber = "46680"

--- a/tests/cis_tests/lite_data_creation.py
+++ b/tests/cis_tests/lite_data_creation.py
@@ -7,7 +7,7 @@ from snapred.backend.data.GroceryService import GroceryService
 from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
 
 from snapred.meta.Config import Config
-Config._config["cis_mode"]["enabled"] = False
+Config._config["cis_mode.enabled"] = False
 
 #User input ###########################
 runNumber = "46680"

--- a/tests/cis_tests/lite_data_creation.py
+++ b/tests/cis_tests/lite_data_creation.py
@@ -7,7 +7,7 @@ from snapred.backend.data.GroceryService import GroceryService
 from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
 
 from snapred.meta.Config import Config
-Config._Config["cis_mode"]["enabled"] = False
+Config._config["cis_mode"]["enabled"] = False
 
 #User input ###########################
 runNumber = "46680"

--- a/tests/cis_tests/lite_data_creation.py
+++ b/tests/cis_tests/lite_data_creation.py
@@ -7,7 +7,7 @@ from snapred.backend.data.GroceryService import GroceryService
 from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
 
 from snapred.meta.Config import Config
-Config._Config["cis_mode.enabled"] = False
+Config._Config["cis_mode"]["enabled"] = False
 
 #User input ###########################
 runNumber = "46680"

--- a/tests/cis_tests/lite_data_creation.py
+++ b/tests/cis_tests/lite_data_creation.py
@@ -7,7 +7,7 @@ from snapred.backend.data.GroceryService import GroceryService
 from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
 
 from snapred.meta.Config import Config
-Config._config["cis_mode"] = False
+Config._Config["cis_mode.enabled"] = False
 
 #User input ###########################
 runNumber = "46680"

--- a/tests/cis_tests/new_diffcal_script.py
+++ b/tests/cis_tests/new_diffcal_script.py
@@ -32,7 +32,7 @@ calibrantSamplePath = "Silicon_NIST_640D_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._config["cis_mode"] = False
+Config._Config["cis_mode.enabled"] = False
 #######################################
 
 ### PREP INGREDIENTS ################

--- a/tests/cis_tests/new_diffcal_script.py
+++ b/tests/cis_tests/new_diffcal_script.py
@@ -32,7 +32,7 @@ calibrantSamplePath = "Silicon_NIST_640D_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._config["cis_mode"]["enabled"] = False
+Config._config["cis_mode.enabled"] = False
 #######################################
 
 ### PREP INGREDIENTS ################

--- a/tests/cis_tests/new_diffcal_script.py
+++ b/tests/cis_tests/new_diffcal_script.py
@@ -32,7 +32,7 @@ calibrantSamplePath = "Silicon_NIST_640D_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._Config["cis_mode.enabled"] = False
+Config._Config["cis_mode"]["enabled"] = False
 #######################################
 
 ### PREP INGREDIENTS ################

--- a/tests/cis_tests/new_diffcal_script.py
+++ b/tests/cis_tests/new_diffcal_script.py
@@ -33,6 +33,7 @@ peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
 Config._config["cis_mode.enabled"] = False
+Config._config["cis_mode.preserveDiagnosticWorkspaces"] = False
 #######################################
 
 ### PREP INGREDIENTS ################

--- a/tests/cis_tests/new_diffcal_script.py
+++ b/tests/cis_tests/new_diffcal_script.py
@@ -32,7 +32,7 @@ calibrantSamplePath = "Silicon_NIST_640D_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._Config["cis_mode"]["enabled"] = False
+Config._config["cis_mode"]["enabled"] = False
 #######################################
 
 ### PREP INGREDIENTS ################

--- a/tests/cis_tests/pixel_grouping_parameters_script.py
+++ b/tests/cis_tests/pixel_grouping_parameters_script.py
@@ -84,7 +84,7 @@ runNumber = "58882"
 groupingScheme = 'Column'
 isLite = True
 instrumentFilePath = SNAPLiteInstrumentFilePath
-Config._Config["cis_mode"]["enabled"] = False
+Config._config["cis_mode"]["enabled"] = False
 #######################################
 
 ## PREP INGREDIENTS ###################

--- a/tests/cis_tests/pixel_grouping_parameters_script.py
+++ b/tests/cis_tests/pixel_grouping_parameters_script.py
@@ -84,7 +84,7 @@ runNumber = "58882"
 groupingScheme = 'Column'
 isLite = True
 instrumentFilePath = SNAPLiteInstrumentFilePath
-Config._config["cis_mode"] = False
+Config._Config["cis_mode.enabled"] = False
 #######################################
 
 ## PREP INGREDIENTS ###################

--- a/tests/cis_tests/pixel_grouping_parameters_script.py
+++ b/tests/cis_tests/pixel_grouping_parameters_script.py
@@ -84,7 +84,7 @@ runNumber = "58882"
 groupingScheme = 'Column'
 isLite = True
 instrumentFilePath = SNAPLiteInstrumentFilePath
-Config._config["cis_mode"]["enabled"] = False
+Config._config["cis_mode.enabled"] = False
 #######################################
 
 ## PREP INGREDIENTS ###################

--- a/tests/cis_tests/pixel_grouping_parameters_script.py
+++ b/tests/cis_tests/pixel_grouping_parameters_script.py
@@ -85,6 +85,7 @@ groupingScheme = 'Column'
 isLite = True
 instrumentFilePath = SNAPLiteInstrumentFilePath
 Config._config["cis_mode.enabled"] = False
+Config._config["cis_mode.preserveDiagnosticWorkspaces"] = False
 #######################################
 
 ## PREP INGREDIENTS ###################

--- a/tests/cis_tests/pixel_grouping_parameters_script.py
+++ b/tests/cis_tests/pixel_grouping_parameters_script.py
@@ -84,7 +84,7 @@ runNumber = "58882"
 groupingScheme = 'Column'
 isLite = True
 instrumentFilePath = SNAPLiteInstrumentFilePath
-Config._Config["cis_mode.enabled"] = False
+Config._Config["cis_mode"]["enabled"] = False
 #######################################
 
 ## PREP INGREDIENTS ###################

--- a/tests/cis_tests/reduction_recipe_script.py
+++ b/tests/cis_tests/reduction_recipe_script.py
@@ -24,7 +24,7 @@ groceryService = GroceryService()
 #User input ###########################
 runNumber = "46680" #"57482"
 isLite = True
-Config._Config["cis_mode"]["enabled"] = True
+Config._config["cis_mode"]["enabled"] = True
 version=None
 
 

--- a/tests/cis_tests/reduction_recipe_script.py
+++ b/tests/cis_tests/reduction_recipe_script.py
@@ -25,6 +25,7 @@ groceryService = GroceryService()
 runNumber = "46680" #"57482"
 isLite = True
 Config._config["cis_mode.enabled"] = True
+Config._config["cis_mode.preserveDiagnosticWorkspaces"] = True
 version=None
 
 

--- a/tests/cis_tests/reduction_recipe_script.py
+++ b/tests/cis_tests/reduction_recipe_script.py
@@ -24,7 +24,7 @@ groceryService = GroceryService()
 #User input ###########################
 runNumber = "46680" #"57482"
 isLite = True
-Config._config["cis_mode"]["enabled"] = True
+Config._config["cis_mode.enabled"] = True
 version=None
 
 

--- a/tests/cis_tests/reduction_recipe_script.py
+++ b/tests/cis_tests/reduction_recipe_script.py
@@ -24,7 +24,7 @@ groceryService = GroceryService()
 #User input ###########################
 runNumber = "46680" #"57482"
 isLite = True
-Config._Config["cis_mode.enabled"] = True
+Config._Config["cis_mode"]["enabled"] = True
 version=None
 
 

--- a/tests/cis_tests/reduction_recipe_script.py
+++ b/tests/cis_tests/reduction_recipe_script.py
@@ -24,7 +24,7 @@ groceryService = GroceryService()
 #User input ###########################
 runNumber = "46680" #"57482"
 isLite = True
-Config._config["cis_mode"] = True
+Config._Config["cis_mode.enabled"] = True
 version=None
 
 

--- a/tests/cis_tests/reorder_proto.py
+++ b/tests/cis_tests/reorder_proto.py
@@ -37,7 +37,7 @@ calibrantSamplePath = "Diamond_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._config["cis_mode"]["enabled"] = False
+Config._config["cis_mode.enabled"] = False
 #######################################
 
 focusGroup = {"name": groupingScheme, "definition": ""}

--- a/tests/cis_tests/reorder_proto.py
+++ b/tests/cis_tests/reorder_proto.py
@@ -37,7 +37,7 @@ calibrantSamplePath = "Diamond_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._Config["cis_mode.enabled"] = False
+Config._Config["cis_mode"]["enabled"] = False
 #######################################
 
 focusGroup = {"name": groupingScheme, "definition": ""}

--- a/tests/cis_tests/reorder_proto.py
+++ b/tests/cis_tests/reorder_proto.py
@@ -38,6 +38,7 @@ peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
 Config._config["cis_mode.enabled"] = False
+Config._config["cis_mode.preserveDiagnosticWorkspaces"] = False
 #######################################
 
 focusGroup = {"name": groupingScheme, "definition": ""}

--- a/tests/cis_tests/reorder_proto.py
+++ b/tests/cis_tests/reorder_proto.py
@@ -37,7 +37,7 @@ calibrantSamplePath = "Diamond_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._config["cis_mode"] = False
+Config._Config["cis_mode.enabled"] = False
 #######################################
 
 focusGroup = {"name": groupingScheme, "definition": ""}

--- a/tests/cis_tests/reorder_proto.py
+++ b/tests/cis_tests/reorder_proto.py
@@ -37,7 +37,7 @@ calibrantSamplePath = "Diamond_001.json"
 peakThreshold = 0.05
 offsetConvergenceLimit = 0.1
 isLite = True
-Config._Config["cis_mode"]["enabled"] = False
+Config._config["cis_mode"]["enabled"] = False
 #######################################
 
 focusGroup = {"name": groupingScheme, "definition": ""}

--- a/tests/cis_tests/save_grouping_definition_with_xml.py
+++ b/tests/cis_tests/save_grouping_definition_with_xml.py
@@ -33,7 +33,7 @@ LoadEmptyInstrument(
 )
 assert mtd.doesExist(instrumentDonor)
 
-Config._Config["cis_mode"]["enabled"] = True
+Config._config["cis_mode"]["enabled"] = True
 
 grwsXML = "gr_ws_from_XML"
 grwsHDF = "gr_ws_from_HDF"

--- a/tests/cis_tests/save_grouping_definition_with_xml.py
+++ b/tests/cis_tests/save_grouping_definition_with_xml.py
@@ -34,6 +34,7 @@ LoadEmptyInstrument(
 assert mtd.doesExist(instrumentDonor)
 
 Config._config["cis_mode.enabled"] = True
+Config._config["cis_mode.preserveDiagnosticWorkspaces"] = True
 
 grwsXML = "gr_ws_from_XML"
 grwsHDF = "gr_ws_from_HDF"

--- a/tests/cis_tests/save_grouping_definition_with_xml.py
+++ b/tests/cis_tests/save_grouping_definition_with_xml.py
@@ -33,7 +33,7 @@ LoadEmptyInstrument(
 )
 assert mtd.doesExist(instrumentDonor)
 
-Config._config["cis_mode"] = True
+Config._Config["cis_mode.enabled"] = True
 
 grwsXML = "gr_ws_from_XML"
 grwsHDF = "gr_ws_from_HDF"

--- a/tests/cis_tests/save_grouping_definition_with_xml.py
+++ b/tests/cis_tests/save_grouping_definition_with_xml.py
@@ -33,7 +33,7 @@ LoadEmptyInstrument(
 )
 assert mtd.doesExist(instrumentDonor)
 
-Config._config["cis_mode"]["enabled"] = True
+Config._config["cis_mode.enabled"] = True
 
 grwsXML = "gr_ws_from_XML"
 grwsHDF = "gr_ws_from_HDF"

--- a/tests/cis_tests/save_grouping_definition_with_xml.py
+++ b/tests/cis_tests/save_grouping_definition_with_xml.py
@@ -33,7 +33,7 @@ LoadEmptyInstrument(
 )
 assert mtd.doesExist(instrumentDonor)
 
-Config._Config["cis_mode.enabled"] = True
+Config._Config["cis_mode"]["enabled"] = True
 
 grwsXML = "gr_ws_from_XML"
 grwsHDF = "gr_ws_from_HDF"

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -251,7 +251,9 @@ test:
   data:
     home: ${test.persistence}/data/${test.config.name}
 
-cis_mode: false
+cis_mode:
+  enabled: false
+  preserveDiagnosticWorkspaces: false
 
 version:
   friendlyName:

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -312,7 +312,7 @@ class TestDataFactoryService(unittest.TestCase):
         assert self.instance.groceryService.fetchNeutronDataSingleUse.called
 
     def test_deleteWorkspace(self):
-        from snapred.meta.Config import Config
+        from util.Config_helpers import Config_override
 
         wsname = mtd.unique_name()
         assert not self.instance.workspaceDoesExist(wsname)
@@ -321,14 +321,14 @@ class TestDataFactoryService(unittest.TestCase):
         assert self.instance.workspaceDoesExist(wsname)
 
         # won't delete in cis mode
-        Config._config["cis_mode"]["enabled"] = True
-        self.instance.deleteWorkspace(wsname)
-        assert self.instance.workspaceDoesExist(wsname)
+        with Config_override("cis_mode.enabled", True):
+            self.instance.deleteWorkspace(wsname)
+            assert self.instance.workspaceDoesExist(wsname)
 
         # will delete otherwise
-        Config._config["cis_mode"]["enabled"] = False
-        self.instance.deleteWorkspace(wsname)
-        assert not self.instance.workspaceDoesExist(wsname)
+        with Config_override("cis_mode.enabled", False):
+            self.instance.deleteWorkspace(wsname)
+            assert not self.instance.workspaceDoesExist(wsname)
 
     def test_deleteWorkspaceUnconditional(self):
         wsname = mtd.unique_name()

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -322,13 +322,15 @@ class TestDataFactoryService(unittest.TestCase):
 
         # won't delete in cis mode
         with Config_override("cis_mode.enabled", True):
-            self.instance.deleteWorkspace(wsname)
-            assert self.instance.workspaceDoesExist(wsname)
+            with Config_override("cis_mode.preserveDiagnosticWorkspaces", True):
+                self.instance.deleteWorkspace(wsname)
+                assert self.instance.workspaceDoesExist(wsname)
 
         # will delete otherwise
         with Config_override("cis_mode.enabled", False):
-            self.instance.deleteWorkspace(wsname)
-            assert not self.instance.workspaceDoesExist(wsname)
+            with Config_override("cis_mode.preserveDiagnosticWorkspaces", False):
+                self.instance.deleteWorkspace(wsname)
+                assert not self.instance.workspaceDoesExist(wsname)
 
     def test_deleteWorkspaceUnconditional(self):
         wsname = mtd.unique_name()

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -321,12 +321,12 @@ class TestDataFactoryService(unittest.TestCase):
         assert self.instance.workspaceDoesExist(wsname)
 
         # won't delete in cis mode
-        Config._config["cis_mode.enabled"] = True
+        Config._config["cis_mode"]["enabled"] = True
         self.instance.deleteWorkspace(wsname)
         assert self.instance.workspaceDoesExist(wsname)
 
         # will delete otherwise
-        Config._config["cis_mode.enabled"] = False
+        Config._config["cis_mode"]["enabled"] = False
         self.instance.deleteWorkspace(wsname)
         assert not self.instance.workspaceDoesExist(wsname)
 

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -321,12 +321,12 @@ class TestDataFactoryService(unittest.TestCase):
         assert self.instance.workspaceDoesExist(wsname)
 
         # won't delete in cis mode
-        Config._config["cis_mode"] = True
+        Config._config["cis_mode.enabled"] = True
         self.instance.deleteWorkspace(wsname)
         assert self.instance.workspaceDoesExist(wsname)
 
         # will delete otherwise
-        Config._config["cis_mode"] = False
+        Config._config["cis_mode.enabled"] = False
         self.instance.deleteWorkspace(wsname)
         assert not self.instance.workspaceDoesExist(wsname)
 

--- a/tests/unit/backend/recipe/algorithm/test_WashDishes.py
+++ b/tests/unit/backend/recipe/algorithm/test_WashDishes.py
@@ -50,7 +50,7 @@ class TestWashDishes(unittest.TestCase):
     def test_wash_dish_using_yaml(self):
         # verify that the algorithm will behave as expected with the config key
         wsname = "_test_wash_one_dish"
-        cismode = Config["cis_mode"]["enabled"]
+        cismode = Config["cis_mode.enabled"]
         CreateWorkspace(OutputWorkspace=wsname, DataX=1, DataY=1)
         assert wsname in mtd
         algo = WashDishes()

--- a/tests/unit/backend/recipe/algorithm/test_WashDishes.py
+++ b/tests/unit/backend/recipe/algorithm/test_WashDishes.py
@@ -17,11 +17,11 @@ class TestWashDishes(unittest.TestCase):
         algo.initialize()
         algo.setProperty("Workspace", wsname)
         # verify workspace not deleted when in CIS mode
-        algo._CISmode = True
+        algo.enabled = True
         algo.execute()
         assert wsname in mtd
         # verify workspace deleted when not in CIS mode
-        algo._CISmode = False
+        algo.enabled = False
         algo.execute()
         assert wsname not in mtd
 
@@ -37,12 +37,12 @@ class TestWashDishes(unittest.TestCase):
         algo.initialize()
         algo.setProperty("WorkspaceList", wsnames)
         # verify no workapces deleted when in CIS mode
-        algo._CISmode = True
+        algo.enabled = True
         algo.execute()
         for wsname in wsnames:
             assert wsname in mtd
         # verify all workspaces deleted when not in CIS mode
-        algo._CISmode = False
+        algo.enabled = False
         algo.execute()
         for wsname in wsnames:
             assert wsname not in mtd

--- a/tests/unit/backend/recipe/algorithm/test_WashDishes.py
+++ b/tests/unit/backend/recipe/algorithm/test_WashDishes.py
@@ -50,7 +50,7 @@ class TestWashDishes(unittest.TestCase):
     def test_wash_dish_using_yaml(self):
         # verify that the algorithm will behave as expected with the config key
         wsname = "_test_wash_one_dish"
-        cismode = Config["cis_mode"]
+        cismode = Config["cis_mode.enabled"]
         CreateWorkspace(OutputWorkspace=wsname, DataX=1, DataY=1)
         assert wsname in mtd
         algo = WashDishes()

--- a/tests/unit/backend/recipe/algorithm/test_WashDishes.py
+++ b/tests/unit/backend/recipe/algorithm/test_WashDishes.py
@@ -17,11 +17,14 @@ class TestWashDishes(unittest.TestCase):
         algo.initialize()
         algo.setProperty("Workspace", wsname)
         # verify workspace not deleted when in CIS mode
-        algo.enabled = True
+        algo.cis_enabled = True
+        algo.cis_preserve = True
+
         algo.execute()
         assert wsname in mtd
         # verify workspace deleted when not in CIS mode
-        algo.enabled = False
+        algo.cis_enabled = False
+        algo.cis_preserve = False
         algo.execute()
         assert wsname not in mtd
 
@@ -37,12 +40,14 @@ class TestWashDishes(unittest.TestCase):
         algo.initialize()
         algo.setProperty("WorkspaceList", wsnames)
         # verify no workapces deleted when in CIS mode
-        algo.enabled = True
+        algo.cis_enabled = True
+        algo.cis_preserve = True
         algo.execute()
         for wsname in wsnames:
             assert wsname in mtd
         # verify all workspaces deleted when not in CIS mode
-        algo.enabled = False
+        algo.cis_enabled = False
+        algo.cis_preserve = False
         algo.execute()
         for wsname in wsnames:
             assert wsname not in mtd
@@ -74,7 +79,6 @@ class TestWashDishes(unittest.TestCase):
         algo.setProperty("Workspace", wsname)
 
         with Config_override("cis_mode.enabled", True):
-            with Config_override("cis_mode.preserveDiagnosticWorkspaces", False):
-                algo.execute()
+            algo.execute()
 
         assert wsname not in mtd

--- a/tests/unit/backend/recipe/algorithm/test_WashDishes.py
+++ b/tests/unit/backend/recipe/algorithm/test_WashDishes.py
@@ -61,3 +61,20 @@ class TestWashDishes(unittest.TestCase):
             assert wsname in mtd
         elif not cismode:
             assert wsname not in mtd
+
+    def test_wash_dish_with_improper_flags(self):
+        from util.Config_helpers import Config_override
+
+        wsname = "_test_wash_one_dish"
+        CreateWorkspace(OutputWorkspace=wsname, DataX=1, DataY=1)
+        assert wsname in mtd
+
+        algo = WashDishes()
+        algo.initialize()
+        algo.setProperty("Workspace", wsname)
+
+        with Config_override("cis_mode.enabled", True):
+            with Config_override("cis_mode.preserveDiagnosticWorkspaces", False):
+                algo.execute()
+
+        assert wsname not in mtd

--- a/tests/unit/backend/recipe/algorithm/test_WashDishes.py
+++ b/tests/unit/backend/recipe/algorithm/test_WashDishes.py
@@ -50,7 +50,7 @@ class TestWashDishes(unittest.TestCase):
     def test_wash_dish_using_yaml(self):
         # verify that the algorithm will behave as expected with the config key
         wsname = "_test_wash_one_dish"
-        cismode = Config["cis_mode.enabled"]
+        cismode = Config["cis_mode"]["enabled"]
         CreateWorkspace(OutputWorkspace=wsname, DataX=1, DataY=1)
         assert wsname in mtd
         algo = WashDishes()


### PR DESCRIPTION
## Description of work
This work updates `application.yml` so that the old single-boolean key cis_mode: false is replaced by a subsection:
```yml
cis_mode:
   enabled: false
   preserveDiagnosticWorkspaces: false
```
This allows us to attach additional parameters under `cis_mode`, not just a single on/off switch. For instance, `preserveDiagnosticWorkspaces` can now specify whether diagnostic or intermediate workspaces should be retained even in CIS investigations.
<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work
1. Sub-key approach: Instead of `cis_mode: [True/False]`, the YAML now contains `cis_mode.enabled` and `cis_mode.preserveDiagnosticWorkspaces`. This allows an extensible config block while retaining backward-compatible usage (by reading `cis_mode` in Python).
2. Dynamic reading in algorithms: Updated `WashDishes.py` to read `cis_mode.enabled` and `cis_mode.preserveDiagnosticWorkspaces` at execution time, ensuring changes to the config are recognized.
<!-- EXPLAIN, as it seems necessary
 - the techniques used
 - new algos/classes/variables and how were they implemented
 - the particular coding choices you made, especially where others were possible

As needed, use
  ``` python
    x
  ```
to paste code blocks.
-->

## To test

### Dev testing
Ensure all pytests are functional as well as integration tests. Use any workflow to insure that the lite mode toggle is still functional.
<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing
N/A
<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM # 9391](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9391)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] cis_mode is now a functional subsection
- [ ] SNAPRed is fully functional
