### PR TITLE
Ewm2142 allow selection of alt diffcal

### DIFF
--- a/src/snapred/backend/dao/WorkspaceMetadata.py
+++ b/src/snapred/backend/dao/WorkspaceMetadata.py
@@ -40,6 +40,7 @@ class WorkspaceMetadata(BaseModel):
     """Class to hold tags related to a workspace"""
 
     diffcalState: DiffcalStateMetadata = UNSET
+    altDiffcalPath: Union[str, Literal["unset"]] = UNSET
     normalizationState: NormalizationStateMetadata = UNSET
     # NOTE: variables not allowed in type declarations
     liteDataCompressionTolerance: Union[float, Literal["unset"]] = UNSET

--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -95,6 +95,8 @@ class GroceryListItem(BaseModel):
     # name the property the workspace will be used for
     propertyName: Optional[str] = None
 
+    alternativeState: Optional[str] = None
+
     def builder():
         # NOTE this import is here to avoid circular dependencies -- don't bother trying to move it
         from snapred.meta.builder.GroceryListBuilder import GroceryListBuilder

--- a/src/snapred/backend/dao/request/FarmFreshIngredients.py
+++ b/src/snapred/backend/dao/request/FarmFreshIngredients.py
@@ -66,6 +66,8 @@ class FarmFreshIngredients(BaseModel):
 
     focusGroups: Optional[List[FocusGroup]] = None
 
+    alternativeState: Optional[str] = None
+
     # Allow 'focusGroups' to be accessed as a single 'focusGroup'
     @property
     def focusGroup(self) -> FocusGroup:

--- a/src/snapred/backend/dao/request/ReductionRequest.py
+++ b/src/snapred/backend/dao/request/ReductionRequest.py
@@ -34,6 +34,8 @@ class ReductionRequest(BaseModel):
     # TODO: Move to SNAPRequest
     continueFlags: Optional[ContinueWarning.Type] = ContinueWarning.Type.UNSET
 
+    alternativeState: Optional[str] = None
+
     @field_validator("versions")
     @classmethod
     def validate_versions(cls, v) -> Versions:

--- a/src/snapred/backend/data/DataExportService.py
+++ b/src/snapred/backend/data/DataExportService.py
@@ -7,6 +7,7 @@ from pydantic import validate_call
 from snapred.backend.dao.calibration.Calibration import Calibration
 from snapred.backend.dao.calibration.CalibrationRecord import CalibrationRecord
 from snapred.backend.dao.indexing.IndexEntry import IndexEntry
+from snapred.backend.dao.indexing.Versioning import Version, VersionState
 from snapred.backend.dao.normalization.Normalization import Normalization
 from snapred.backend.dao.normalization.NormalizationRecord import NormalizationRecord
 from snapred.backend.dao.reduction import ReductionRecord
@@ -53,6 +54,15 @@ class DataExportService:
         return self.dataService.checkWritePermissions(path)
 
     ##### CALIBRATION METHODS #####
+
+    def copyCalibration(
+        self,
+        sourceStateID: str,
+        targetStateID: str,
+        targetIndexEntry: IndexEntry,
+        sourceVersion: Version = VersionState.LATEST,
+    ):
+        return self.dataService.copyCalibration(sourceStateID, targetStateID, targetIndexEntry, sourceVersion)
 
     @validate_call
     def initializeState(self, runId: str, useLiteMode: bool, name: str):

--- a/src/snapred/backend/error/ContinueWarning.py
+++ b/src/snapred/backend/error/ContinueWarning.py
@@ -12,6 +12,7 @@ class ContinueWarning(Exception):
     class Type(Flag):
         UNSET = 0
         MISSING_DIFFRACTION_CALIBRATION = auto()
+        ALTERNATE_DIFFRACTION_CALIBRATION = auto()
         DEFAULT_DIFFRACTION_CALIBRATION = auto()
         MISSING_NORMALIZATION = auto()
         LOW_PEAK_COUNT = auto()

--- a/src/snapred/meta/builder/GroceryListBuilder.py
+++ b/src/snapred/meta/builder/GroceryListBuilder.py
@@ -48,16 +48,18 @@ class GroceryListBuilder:
         self._tokens["version"] = version
         return self
 
-    def diffcal_table(self, runId: str, version: int):
+    def diffcal_table(self, runId: str, version: int, alternativeState: str = None):
         self._tokens["workspaceType"] = "diffcal_table"
         self._tokens["runNumber"] = runId
         self._tokens["version"] = version
+        self._tokens["alternativeState"] = alternativeState
         return self
 
-    def diffcal_mask(self, runId: str, version: int):
+    def diffcal_mask(self, runId: str, version: int, alternativeState: str = None):
         self._tokens["workspaceType"] = "diffcal_mask"
         self._tokens["runNumber"] = runId
         self._tokens["version"] = version
+        self._tokens["alternativeState"] = alternativeState
         return self
 
     def normalization(self, runId: str, version: int):

--- a/tests/cis_tests/alternative_calibration_in_reduction_script.py
+++ b/tests/cis_tests/alternative_calibration_in_reduction_script.py
@@ -1,0 +1,64 @@
+
+
+from os import path
+from snapred.backend.api.InterfaceController import InterfaceController
+from snapred.backend.dao.SNAPRequest import SNAPRequest
+from snapred.backend.dao.request.CreateIndexEntryRequest import CreateIndexEntryRequest
+from snapred.backend.dao.request.ReductionRequest import ReductionRequest
+from snapred.backend.data.DataExportService import DataExportService
+from snapred.backend.data.DataFactoryService import DataFactoryService
+from snapred.backend.service.ReductionService import ReductionService
+
+import time
+
+runId="59039"
+useLiteMode=True
+altStateId = "myAltState"
+
+dataService = DataFactoryService()
+dataExportService = DataExportService()
+
+compatibleStates = dataService.getCompatibleStates(runId, useLiteMode)
+print(compatibleStates)
+assert altStateId in compatibleStates
+
+
+reductionService = ReductionService()
+groups = reductionService.loadAllGroupings(runId, useLiteMode)
+# find column group
+columnGroup = next((group for group in groups["focusGroups"] if "column" in group.name.lower()), None)
+
+requestPayload = ReductionRequest(
+    runNumber=runId,
+    useLiteMode=useLiteMode,
+    timestamp=time.time(),
+    focusGroups=[columnGroup],
+    alternativeState=altStateId
+)
+
+request = SNAPRequest(path="reduction", payload=requestPayload.model_dump_json())
+
+interface = InterfaceController()
+
+# interface.executeRequest(request)
+
+
+
+request = {
+    "runNumber": runId,
+    "useLiteMode": useLiteMode,
+    "version": "next",
+    "comments": "test",
+    "author": "test",
+    "appliesTo": f">={runId}"
+}
+indexEntryRequest = CreateIndexEntryRequest(
+    **request
+)
+entry = dataService.createCalibrationIndexEntry(indexEntryRequest)
+
+sourceStateId = altStateId
+targetStateId, _ = dataService.constructStateId(runId)
+print(f"Copying calibration from {sourceStateId} to {targetStateId}")
+dataExportService.copyCalibration(sourceStateId, targetStateId, entry)
+

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -3535,7 +3535,7 @@ class TestReductionPixelMasks:
         with Config_override("instrument.reduction.home", "a.string.with.{IPTS}.in.it"):
             with pytest.raises(RuntimeError, match="Some other runtime error"):
                 self.service._reducedRuns(self.runNumber6, True)  # noqa: F841
-                
+
     @mock.patch(ThisService + "Path")
     def test_findCompatibleStates(self, mockPath):
         compatibleDetectorState1 = DetectorState(arc=(1.0, 2.0), wav=3.0, freq=4.0, guideStat=1, lin=(5.0, 6.0))

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -101,6 +101,7 @@ class TestSousChef(unittest.TestCase):
         self.instance.dataFactoryService.getCalibrationState.assert_called_once_with(
             self.ingredients.runNumber,
             self.ingredients.useLiteMode,
+            None,
         )
         assert res == self.instance.dataFactoryService.getCalibrationState.return_value
         assert res.instrumentState.fwhmMultipliers.dict() == Config["calibration.parameters.default.FWHMMultiplier"]
@@ -121,6 +122,7 @@ class TestSousChef(unittest.TestCase):
         self.instance.dataFactoryService.getCalibrationState.assert_called_once_with(
             self.ingredients.runNumber,
             self.ingredients.useLiteMode,
+            None,
         )
         assert res == self.instance.dataFactoryService.getCalibrationState.return_value
         assert res.instrumentState.fwhmMultipliers == self.ingredients.fwhmMultipliers
@@ -142,6 +144,7 @@ class TestSousChef(unittest.TestCase):
             spec=FarmFreshIngredients,
             runNumber="12345",
             useLiteMode=True,
+            alternativeState=None,
         )
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=False)
         self.instance.dataFactoryService.getDefaultInstrumentState = mock.Mock(return_value=mock.Mock())
@@ -149,6 +152,7 @@ class TestSousChef(unittest.TestCase):
         self.instance.dataFactoryService.calibrationExists.assert_called_once_with(
             ingredients.runNumber,
             ingredients.useLiteMode,
+            None,
         )
         self.instance.dataFactoryService.getDefaultInstrumentState.assert_called_once_with(
             ingredients.runNumber,

--- a/tests/util/WhateversInTheFridge.py
+++ b/tests/util/WhateversInTheFridge.py
@@ -87,7 +87,9 @@ class WhateversInTheFridge(LocalDataService):
         )
 
     @validate_call
-    def readCalibrationRecord(self, runId: str, useLiteMode: bool, version: Optional[int] = None):
+    def readCalibrationRecord(
+        self, runId: str, useLiteMode: bool, version: Optional[int] = None, alternativeState: Optional[str] = None
+    ):
         version = version if version is not None else self.latestVersion
         record = CalibrationRecord.model_construct(
             runNumber=runId,


### PR DESCRIPTION
## Description of work
NOTE: This is distinct from: 	
[Story 8194: [Story] Allow user to specify a path to a non-SNAPRed h5 calibration file.](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=8194)
In that this is enabling the reduction workflow to proceed with a calibration from another valid state that is deemed compatible.

NOTE: After discussion with Malcolm the ui orchestration portion of this ticket was cut, as he will be using SNAPBlue's reduction script. 

This story adds an additional request parameter to the ReductionRequest.
This parameter tells the backend which if any alternate state to use for the diffraction calibration.
Valid alternate states can be looked up via the new DataService method.

## Explanation of work

Besides the additional parameter to the request above, this alt state param had to be propagated throughout quite a few methods.  I feel like having to do this is a flaw in the design but Im not up for another refactor!  

This param had to be added to anywhere that created and used the calibration indexer in order for it to refer to the correct alternative state.

## To test

First, setup your local calibration home with a state of your choosing, calibrate it/normalize it.
Copy said state, and give its folder a different name of your choosing.

Run the provided cis_test script in mantidworkbench substituting in the name of this alt state you created.
Confirm that the alt state you created shows up in the [print out](https://github.com/neutrons/SNAPRed/pull/562/files#diff-ddf3e517805d702ce600141fe3edab628ab3527fa1e3c4e1efa490cd58388987R17-R18)

Confirm reduction completes, confirm the reduced data looks decent, review the logs and confirm that it referred to the alternate state for the diffcal table load.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#2142](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2142)

### Verification

- [ ] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] User can apply compatible diffcal from alternative state
- [ ] snapred can propagate this alternative state's calibration
- [ ] Snapred can find compatible alternative states
