### PR TITLE
try to group workspaced before calling one savenexus

### DIFF
--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -754,7 +754,7 @@ class LocalDataService:
         else:
             workspaces = record.workspaceNames
             pixelMasks = [ws for ws in workspaces if ws.tokens("workspaceType") == wngt.REDUCTION_PIXEL_MASK]
-            workspaces = [ws for ws in workspaces if ws not in pixelMasks]
+            # workspaces = [ws for ws in workspaces if ws not in pixelMasks]
             self.mantidSnapper.GroupWorkspaces(
                 "Group workspaces for reduction output",
                 InputWorkspaces=workspaces,
@@ -797,8 +797,15 @@ class LocalDataService:
         # Read the workspaces, one by one;
         #   * as an alternative, these could be loaded into a group workspace with a single call to `readWorkspace`.
         pixelMaskKeyword = Config["mantid.workspace.nameTemplate.template.reduction.pixelMask"].split(",")[0]
+        # Find reduction_output_* file in filePath
+        reductionOutputFile = None
+        for file in os.listdir(filePath.parent):
+            # TODO: Better way of finding the reduced file
+            if file.startswith("_reduced_"):
+                reductionOutputFile = str(file)
+                break
+        self.readWorkspace(filePath.parent, Path(reductionOutputFile), "reduction_output")
         for n, ws in enumerate(record.workspaceNames):
-            self.readWorkspace(filePath.parent, Path(filePath.name), ws, entryNumber=n + 1)
             # ensure that any mask workspace is actually a `MaskWorkspace` instance
             if pixelMaskKeyword in ws:
                 self.mantidSnapper.ExtractMask(

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -753,6 +753,8 @@ class LocalDataService:
                     self.mantidSnapper.executeQueue()
         else:
             workspaces = record.workspaceNames
+            pixelMasks = [ws for ws in workspaces if ws.tokens("workspaceType") == wngt.REDUCTION_PIXEL_MASK]
+            workspaces = [ws for ws in workspaces if ws not in pixelMasks]
             self.mantidSnapper.GroupWorkspaces(
                 "Group workspaces for reduction output",
                 InputWorkspaces=workspaces,
@@ -765,6 +767,9 @@ class LocalDataService:
                 Append=False,
             )
             self.mantidSnapper.executeQueue()
+            for ws in pixelMasks:
+                maskFilename = ws + ".h5"
+                self.writePixelMask(filePath.parent, Path(maskFilename), ws)
         # Append the "metadata" group, containing the `ReductionRecord` metadata
         with h5py.File(filePath, "a") as h5:
             n5m.insertMetadataGroup(h5, record.dict(), "/metadata")

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -755,7 +755,7 @@ class LocalDataService:
             workspaces = record.workspaceNames
             pixelMasks = [ws for ws in workspaces if ws.tokens("workspaceType") == wngt.REDUCTION_PIXEL_MASK]
             reductionGroupWorkspace = wng.reductionOutputGroup().runNumber(runNumber).timestamp(timestamp).build()
-            # workspaces = [ws for ws in workspaces if ws not in pixelMasks]
+
             self.mantidSnapper.GroupWorkspaces(
                 "Group workspaces for reduction output",
                 InputWorkspaces=workspaces,

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -193,7 +193,7 @@ mantid:
           residual: "{unit},{runNumber},residual"
         reduction:
           output: "reduced,{unit},{group},{runNumber},{timestamp}"
-          outputGroup: "reduced,{runNumber},{timestamp}"
+          outputGroup: "reduced_output,{runNumber},{timestamp}"
           pixelMask: "pixelmask,{runNumber},{timestamp}"
           # the user pixel mask name token is case sensitive
           userPixelMask: "MaskWorkspace,{numberTag}"

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -630,7 +630,7 @@ class ReductionWorkflow(WorkflowImplementer):
             if ContinueWarning.Type.NO_WRITE_PERMISSIONS not in self.continueAnywayFlags:
                 self.request(path="reduction/save", payload=ReductionExportRequest(record=record))
             outputGroup = f"reduction_output_{record.timestamp}"
-            self.outputs.append(outputGroup)
+            self.outputs.add(outputGroup)
 
         # Retain the output workspaces after the workflow is complete.
         self.outputs.update(record.workspaceNames)

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -629,7 +629,7 @@ class ReductionWorkflow(WorkflowImplementer):
             self.savePath = self.request(path="reduction/getSavePath", payload=record.runNumber).data
             if ContinueWarning.Type.NO_WRITE_PERMISSIONS not in self.continueAnywayFlags:
                 self.request(path="reduction/save", payload=ReductionExportRequest(record=record))
-            outputGroup = wng.reductionOutput().runNumber(record.runNumber).timestamp(self.timestamp).build()
+            outputGroup = wng.reductionOutputGroup().runNumber(record.runNumber).timestamp(self.timestamp).build()
             self.outputs.add(outputGroup)
 
         # Retain the output workspaces after the workflow is complete.

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -630,7 +630,7 @@ class ReductionWorkflow(WorkflowImplementer):
             if ContinueWarning.Type.NO_WRITE_PERMISSIONS not in self.continueAnywayFlags:
                 self.request(path="reduction/save", payload=ReductionExportRequest(record=record))
             outputGroup = f"reduction_output_{record.timestamp}"
-            self.outputs.extend(outputGroup)
+            self.outputs.append(outputGroup)
 
         # Retain the output workspaces after the workflow is complete.
         self.outputs.update(record.workspaceNames)

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -629,6 +629,8 @@ class ReductionWorkflow(WorkflowImplementer):
             self.savePath = self.request(path="reduction/getSavePath", payload=record.runNumber).data
             if ContinueWarning.Type.NO_WRITE_PERMISSIONS not in self.continueAnywayFlags:
                 self.request(path="reduction/save", payload=ReductionExportRequest(record=record))
+            outputGroup = f"reduction_output_{record.timestamp}"
+            self.outputs.extend(outputGroup)
 
         # Retain the output workspaces after the workflow is complete.
         self.outputs.update(record.workspaceNames)

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -629,7 +629,7 @@ class ReductionWorkflow(WorkflowImplementer):
             self.savePath = self.request(path="reduction/getSavePath", payload=record.runNumber).data
             if ContinueWarning.Type.NO_WRITE_PERMISSIONS not in self.continueAnywayFlags:
                 self.request(path="reduction/save", payload=ReductionExportRequest(record=record))
-            outputGroup = f"reduction_output_{record.timestamp}"
+            outputGroup = wng.reductionOutput().runNumber(record.runNumber).timestamp(self.timestamp).build()
             self.outputs.add(outputGroup)
 
         # Retain the output workspaces after the workflow is complete.

--- a/tests/integration/test_reduction.py
+++ b/tests/integration/test_reduction.py
@@ -301,7 +301,7 @@ class TestGUIPanels:
                 contents = os.listdir(folderDir + "/" + timeStamp)
                 fullPath = folderDir + "/" + timeStamp
 
-                reduced = "_reduced_0" + reductionRunNumber + "_" + timeStamp + ".nxs"
+                reduced = "_reduced_output_0" + reductionRunNumber + "_" + timeStamp + ".nxs"
                 assert "ReductionRecord.json" in contents
                 assert reduced in contents
 

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -194,7 +194,7 @@ mantid:
             residual: "{unit},{runNumber},residual"
           reduction:
             output: "_reduced,{unit},{group},{runNumber},{timestamp}"
-            outputGroup: "_reduced,{runNumber},{timestamp}"
+            outputGroup: "_reduced_output,{runNumber},{timestamp}"
             pixelMask: "_pixelmask,{runNumber},{timestamp}"
             # the user pixel mask name token is case sensitive
             userPixelMask: "MaskWorkspace,{numberTag}"

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -243,17 +243,17 @@ logging:
     # IMPORTANT: "root" level determines override for message-pane level:
     #    do not set to *debug* for live-data usage!
     root:
-      level: 30
+      level: "DEBUG"
     stream:
-      level: 40
+      level: "DEBUG"
       format: 'MANTID %(levelname)s - %(message)s'
     file:
-      level: 40
+      level: "DEBUG"
       format: 'MANTID FILE %(levelname)s - %(message)s'
-      output: '/dev/null'
+      output: '/tmp/mantidlog.txt'
   SNAP:
     stream:
-      level: 40
+      level: "DEBUG"
       format: '%(asctime)s - %(levelname)-8s - %(name)s - %(message)s'
 
 samples:

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -2203,11 +2203,6 @@ def test_readWriteReductionData_pixel_mask(
                 if isinstance(mtd[ws], MaskWorkspace):
                     maskIsAppendedToData = True
 
-        workspaceTypes = []
-        for ws in actualRecord.workspaceNames:
-            workspaceTypes.append((ws, mtd[ws].__class__))
-
-        assert isinstance(mtd["_pixelmask_057514_2024-06-20T145831"], MaskWorkspace), workspaceTypes
         assert maskIsAppendedToData, mtd.getObjectNames()
 
 

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -2178,7 +2178,6 @@ def test_readWriteReductionData_pixel_mask(
 
         filePath = reductionRecordFilePath.parent / fileName
         assert filePath.exists()
-
         # 1) Verify that a pixel mask was separately written in `SaveDiffCal` format
         maskName = wng.reductionPixelMask().runNumber(runNumber).timestamp(timestamp).build()
         assert (reductionRecordFilePath.parent / (maskName + ".h5")).exists()
@@ -2203,7 +2202,13 @@ def test_readWriteReductionData_pixel_mask(
             if pixelMaskKeyword in ws:
                 if isinstance(mtd[ws], MaskWorkspace):
                     maskIsAppendedToData = True
-        assert maskIsAppendedToData
+
+        workspaceTypes = []
+        for ws in actualRecord.workspaceNames:
+            workspaceTypes.append((ws, mtd[ws].__class__))
+
+        assert isinstance(mtd["_pixelmask_057514_2024-06-20T145831"], MaskWorkspace), workspaceTypes
+        assert maskIsAppendedToData, mtd.getObjectNames()
 
 
 def test__constructReductionDataFilePath():

--- a/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
+++ b/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
@@ -131,10 +131,10 @@ def testReductionOutputName():
 
 def testReductionOutputGroupName():
     assert (  # "reduced_data,{stateId},{timestamp}"
-        f"_reduced_{fRunNumber}" == wng.reductionOutputGroup().runNumber(runNumber).build()
+        f"_reduced_output_{fRunNumber}" == wng.reductionOutputGroup().runNumber(runNumber).build()
     )
     assert (
-        f"_reduced_{fRunNumber}_{fTimestamp}"
+        f"_reduced_output_{fRunNumber}_{fTimestamp}"
         == wng.reductionOutputGroup().runNumber(runNumber).timestamp(timestamp).build()
     )
 


### PR DESCRIPTION
## Description of work

This pr groups the reduction output before save in an attempt to remedy the segfault at reduction save.


## To test

Regression of reduction workflow, tests pass.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

### Verification

- [ ] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] acceptance criterion 1
- [ ] acceptance criterion 2
