### PR TITLE
Ewm9909 replace simpleapi with mantid snapper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,9 @@ extend-exclude = ["conftest.py"]
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["TID251"]
 "src/snapred/backend/recipe/algorithm*" = ["TID251"]
+"src/snapred/backend/recipe/GenericRecipe.py" = ["TID251"]
 "src/snapred/resources/ultralite*" = ["TID251"]
+
 
 [tool.mypy]
 plugins = [

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -1149,7 +1149,6 @@ class LocalDataService:
 
         # Next: add compatible user-created masks that are already resident in the ADS
         mantidMaskName = re.compile(r"MaskWorkspace(_([0-9]+))?")
-        # add function to snapper
         wsNames = self.mantidSnapper.mtd.getObjectNames()
         for ws in wsNames:
             match_ = mantidMaskName.match(ws)

--- a/src/snapred/backend/data/util/PV_logs_util.py
+++ b/src/snapred/backend/data/util/PV_logs_util.py
@@ -11,9 +11,6 @@ import h5py
 import numpy as np
 from mantid.api import Run
 
-# TODO Replace the use of the import(s) below with MantidSnapper in EWM 9909
-from mantid.simpleapi import AddSampleLog, mtd  # noqa : TID251
-
 from snapred.meta.Config import Config
 
 
@@ -31,21 +28,35 @@ def transferInstrumentPVLogs(dest: Run, src: Run, keys: Iterable[str]):
 
 
 def populateInstrumentParameters(wsName: str):
+    from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
+
+    mantidSnapper = MantidSnapper(None, "Utensils")
     # This utility function is a "stand in" until Mantid PR #38684 can be merged.
     # (see https://github.com/mantidproject/mantid/pull/38684)
     # After that, `mtd[wsName].populateInstrumentParameters()` should be used instead.
 
     # Any PV-log key will do, so long as it is one that always exists in the logs.
     pvLogKey = "run_title"
-    pvLogValue = mtd[wsName].run().getProperty(pvLogKey).value
+    pvLogValue = mantidSnapper.mtd[wsName].run().getProperty(pvLogKey).value
+    # pvLogValue = mtd[wsName].run().getProperty(pvLogKey).value
 
-    AddSampleLog(
+    # AddSampleLog(
+    #     "Adding sample log",
+    #     Workspace=wsName,
+    #     LogName=pvLogKey,
+    #     logText=pvLogValue,
+    #     logType="String",
+    #     UpdateInstrumentParameters=True,
+    # )
+    mantidSnapper.AddSampleLog(
+        "Adding sample log",
         Workspace=wsName,
         LogName=pvLogKey,
         logText=pvLogValue,
         logType="String",
         UpdateInstrumentParameters=True,
     )
+    mantidSnapper.executeQueue()
 
 
 def datetimeFromLogTime(logTime: np.datetime64) -> datetime.datetime:

--- a/src/snapred/backend/data/util/PV_logs_util.py
+++ b/src/snapred/backend/data/util/PV_logs_util.py
@@ -38,16 +38,7 @@ def populateInstrumentParameters(wsName: str):
     # Any PV-log key will do, so long as it is one that always exists in the logs.
     pvLogKey = "run_title"
     pvLogValue = mantidSnapper.mtd[wsName].run().getProperty(pvLogKey).value
-    # pvLogValue = mtd[wsName].run().getProperty(pvLogKey).value
 
-    # AddSampleLog(
-    #     "Adding sample log",
-    #     Workspace=wsName,
-    #     LogName=pvLogKey,
-    #     logText=pvLogValue,
-    #     logType="String",
-    #     UpdateInstrumentParameters=True,
-    # )
     mantidSnapper.AddSampleLog(
         "Adding sample log",
         Workspace=wsName,

--- a/src/snapred/backend/recipe/GenerateCalibrationMetricsWorkspaceRecipe.py
+++ b/src/snapred/backend/recipe/GenerateCalibrationMetricsWorkspaceRecipe.py
@@ -3,7 +3,6 @@ from snapred.backend.error.AlgorithmException import AlgorithmException
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.backend.recipe.GenericRecipe import (
-    ConvertTableToMatrixWorkspaceRecipe,
     GenerateTableWorkspaceFromListOfDictRecipe,
 )
 from snapred.meta.decorators.Singleton import Singleton
@@ -62,13 +61,15 @@ class GenerateCalibrationMetricsWorkspaceRecipe:
                     )
                 else:
                     ws_metric = wng.diffCalMetric().metricName(metric).runNumber(runId).version(version).build()
-                ConvertTableToMatrixWorkspaceRecipe().executeRecipe(
+                self.mantidSnapper.ConvertTableToMatrixWorkspace(
+                    "Converting table to matrix workspace",
                     InputWorkspace=ws_table,
                     ColumnX="twoThetaAverage",
                     ColumnY=metric + "Average",
                     ColumnE=metric + "StandardDeviation",
                     OutputWorkspace=ws_metric,
                 )
+                self.mantidSnapper.executeQueue()
                 outputs.append(ws_metric)
 
             self.mantidSnapper.DeleteWorkspace(

--- a/src/snapred/backend/recipe/GenerateCalibrationMetricsWorkspaceRecipe.py
+++ b/src/snapred/backend/recipe/GenerateCalibrationMetricsWorkspaceRecipe.py
@@ -1,8 +1,3 @@
-# TODO Replace the use of the import(s) below with MantidSnapper in EWM 9909
-from mantid.simpleapi import (  # noqa : TID251
-    DeleteWorkspace,
-)
-
 from snapred.backend.dao.ingredients import CalibrationMetricsWorkspaceIngredients as Ingredients
 from snapred.backend.error.AlgorithmException import AlgorithmException
 from snapred.backend.log.logger import snapredLogger
@@ -38,7 +33,7 @@ class GenerateCalibrationMetricsWorkspaceRecipe:
     """
 
     def __init__(self):
-        self.mantidSnapper = MantidSnapper(self, self.__class__.__name__)
+        self.mantidSnapper = MantidSnapper(None, self.__class__.__name__)
 
     def executeRecipe(self, ingredients: Ingredients):
         runId = ingredients.calibrationRecord.runNumber
@@ -75,7 +70,12 @@ class GenerateCalibrationMetricsWorkspaceRecipe:
                     OutputWorkspace=ws_metric,
                 )
                 outputs.append(ws_metric)
-            DeleteWorkspace(Workspace=ws_table)
+
+            self.mantidSnapper.DeleteWorkspace(
+                message="Deleting workspace",
+                Workspace=ws_table,
+            )
+            self.mantidSnapper.executeQueue()
             logger.info("Finished generating calibration metrics workspace.")
             return outputs
         except (RuntimeError, AlgorithmException) as e:

--- a/src/snapred/backend/recipe/GenericRecipe.py
+++ b/src/snapred/backend/recipe/GenericRecipe.py
@@ -1,6 +1,7 @@
 import json
 from typing import Generic, TypeVar, get_args
 
+from mantid.simpleapi import Minus
 from pydantic import BaseModel
 
 from snapred.backend.log.logger import snapredLogger
@@ -103,4 +104,8 @@ class BufferMissingColumnsRecipe(GenericRecipe[BufferMissingColumnsAlgo]):
 
 
 class ArtificialNormalizationRecipe(GenericRecipe[CreateArtificialNormalizationAlgo]):
+    pass
+
+
+class MinusRecipe(GenericRecipe[Minus]):
     pass

--- a/src/snapred/backend/recipe/GenericRecipe.py
+++ b/src/snapred/backend/recipe/GenericRecipe.py
@@ -1,8 +1,6 @@
 import json
 from typing import Generic, TypeVar, get_args
 
-# TODO Replace the use of the import(s) below with MantidSnapper in EWM 9909
-from mantid.simpleapi import ConvertTableToMatrixWorkspace, Minus  # noqa : TID251
 from pydantic import BaseModel
 
 from snapred.backend.log.logger import snapredLogger
@@ -100,17 +98,9 @@ class FocusSpectraRecipe(GenericRecipe[FocusSpectraAlgorithm]):
     pass
 
 
-class ConvertTableToMatrixWorkspaceRecipe(GenericRecipe[ConvertTableToMatrixWorkspace]):
-    pass
-
-
 class BufferMissingColumnsRecipe(GenericRecipe[BufferMissingColumnsAlgo]):
     pass
 
 
 class ArtificialNormalizationRecipe(GenericRecipe[CreateArtificialNormalizationAlgo]):
-    pass
-
-
-class MinusRecipe(GenericRecipe[Minus]):
     pass

--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -44,6 +44,9 @@ class _CustomMtd:
                 raise KeyError(f"SNAPRed log {realLogName} not found in {wsName}")
             raise
 
+    def getObjectNames(self):
+        return mtd.getObjectNames()
+
 
 class MantidSnapper:
     ##

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -29,9 +29,9 @@ from snapred.backend.data.DataFactoryService import DataFactoryService
 from snapred.backend.data.GroceryService import GroceryService
 from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.log.logger import snapredLogger
-from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.backend.recipe.GenericRecipe import (
     FocusSpectraRecipe,
+    MinusRecipe,
     RawVanadiumCorrectionRecipe,
     SmoothDataExcludingPeaksRecipe,
 )
@@ -71,7 +71,6 @@ class NormalizationService(Service):
         self.groceryClerk = GroceryListItem.builder()
         self.diffractionCalibrationService = CalibrationService()
         self.sousChef = SousChef()
-        self.mantidSnapper = MantidSnapper(None, "Utensils")
         return
 
     @staticmethod
@@ -418,11 +417,9 @@ class NormalizationService(Service):
     @Register("calculateResidual")
     def calculateResidual(self, request: CalculateNormalizationResidualRequest):
         outputWorkspace = wng.normCalResidual().runNumber(request.runNumber).unit(wng.Units.DSP).build()
-        self.mantidSnapper.Minus(
-            "Subtracting calculation from data workspace",
+        MinusRecipe().executeRecipe(
             LHSWorkspace=request.dataWorkspace,
             RHSWorkspace=request.calculationWorkspace,
             OutputWorkspace=outputWorkspace,
         )
-        self.mantidSnapper.executeQueue()
         return outputWorkspace

--- a/src/snapred/ui/view/NormalizationTweakPeakView.py
+++ b/src/snapred/ui/view/NormalizationTweakPeakView.py
@@ -3,9 +3,6 @@ from typing import List
 import matplotlib.pyplot as plt
 import pydantic
 from mantid.plots.datafunctions import get_spectrum
-
-# TODO Replace the use of the import(s) below with MantidSnapper in EWM 9909
-from mantid.simpleapi import mtd  # noqa : TID251
 from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import (
     QHBoxLayout,
@@ -16,6 +13,7 @@ from workbench.plotting.figuremanager import MantidFigureCanvas
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
 
 from snapred.backend.dao import GroupPeakList
+from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.plotting.Factory import mantidAxisFactory
@@ -51,6 +49,8 @@ class NormalizationTweakPeakView(BackendRequestView):
 
     def __init__(self, samples=[], groups=[], parent=None):
         super().__init__(parent=parent)
+
+        self.mantidSnapper = MantidSnapper(None, "Utensils")
 
         # create the run number fields
         self.fieldRunNumber = self._labeledField("Run Number")
@@ -173,9 +173,9 @@ class NormalizationTweakPeakView(BackendRequestView):
 
     def _updateGraphs(self, peaks):
         # get the updated workspaces and optimal graph grid
-        focusedWorkspace = mtd[self.focusWorkspace]
-        smoothedWorkspace = mtd[self.smoothedWorkspace]
-        residualWorkspace = mtd[self.residualWorkspace]
+        focusedWorkspace = self.mantidSnapper.mtd[self.focusWorkspace]
+        smoothedWorkspace = self.mantidSnapper.mtd[self.smoothedWorkspace]
+        residualWorkspace = self.mantidSnapper.mtd[self.residualWorkspace]
         peaks = pydantic.TypeAdapter(List[GroupPeakList]).validate_python(peaks)
         numGraphs = focusedWorkspace.getNumberHistograms()
         nrows, ncols = self._optimizeRowsAndCols(numGraphs)

--- a/src/snapred/ui/view/reduction/ArtificialNormalizationView.py
+++ b/src/snapred/ui/view/reduction/ArtificialNormalizationView.py
@@ -1,8 +1,5 @@
 import matplotlib.pyplot as plt
 from mantid.plots.datafunctions import get_spectrum
-
-# TODO Replace the use of the import(s) below with MantidSnapper in EWM 9909
-from mantid.simpleapi import mtd  # noqa : TID251
 from qtpy.QtCore import Signal, Slot
 from qtpy.QtWidgets import (
     QFrame,
@@ -15,6 +12,7 @@ from qtpy.QtWidgets import (
 from workbench.plotting.figuremanager import MantidFigureCanvas
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
 
+from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.plotting.Factory import mantidAxisFactory
@@ -30,6 +28,8 @@ class ArtificialNormalizationView(BackendRequestView):
 
     def __init__(self, parent=None):
         super().__init__(parent=parent)
+
+        self.mantidSnapper = MantidSnapper(None, "Utensils")
 
         # create the run number field
         self.fieldRunNumber = self._labeledField("Run Number", QLineEdit())
@@ -127,8 +127,8 @@ class ArtificialNormalizationView(BackendRequestView):
 
     def _updateGraphs(self):
         # get the updated workspaces and optimal graph grid
-        diffractionWorkspace = mtd[self.diffractionWorkspace]
-        artificialNormWorkspace = mtd[self.artificialNormWorkspace]
+        diffractionWorkspace = self.mantidSnapper.mtd[self.diffractionWorkspace]
+        artificialNormWorkspace = self.mantidSnapper.mtd[self.artificialNormWorkspace]
         numGraphs = diffractionWorkspace.getNumberHistograms()
         nrows, ncols = self._optimizeRowsAndCols(numGraphs)
 

--- a/src/snapred/ui/widget/FitPeaksPlot.py
+++ b/src/snapred/ui/widget/FitPeaksPlot.py
@@ -1,14 +1,13 @@
 import matplotlib.pyplot as plt
 import numpy as np
-from mantid.api import mtd
 
-# TODO Replace the use of the import(s) below with MantidSnapper in EWM 9909
-from mantid.simpleapi import Minus  # noqa : TID251
+from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 
 
 def FitPeaksPlot(wsName):
-    ws = mtd[wsName]
-    wsGroup = mtd["fitPeaksWSGroup"]
+    mantidSnapper = MantidSnapper(None, "Utensils")
+    ws = mantidSnapper.mtd[wsName]
+    wsGroup = mantidSnapper.mtd["fitPeaksWSGroup"]
     numSpec = ws.getNumberHistograms()
     sqrtSize = int(np.sqrt(numSpec))
     # Get best size for layout
@@ -25,9 +24,12 @@ def FitPeaksPlot(wsName):
     fig = plt.figure()
     plts = []
     for index in range(numSpec):
-        fitWS = mtd[f"{wsName}_fitted_{index}"]
-        Minus(ws, fitWS, AllowDifferentNumberSpectra=True, OutputWorkspace=f"res_{index}")
-        res = mtd[f"res_{index}"]
+        fitWS = mantidSnapper.mtd[f"{wsName}_fitted_{index}"]
+        mantidSnapper.Minus(
+            "Subtracting fitted workspace", ws, fitWS, AllowDifferentNumberSpectra=True, OutputWorkspace=f"res_{index}"
+        )
+        mantidSnapper.executeQueue()
+        res = mantidSnapper.mtd[f"res_{index}"]
         wsGroup.add(f"res_{index}")
         ax = fig.add_subplot(rowSize, colSize, index + 1, projection="mantid")
         ax.plot(res, specNum=res.getSpectrum(index).getSpectrumNo(), label="Residual")

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -1,5 +1,3 @@
-# TODO Replace the use of the import(s) below with MantidSnapper in EWM 9909
-from mantid.simpleapi import mtd  # noqa : TID251
 from qtpy.QtCore import Slot
 
 from snapred.backend.dao import RunConfig
@@ -24,6 +22,7 @@ from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.FitMultiplePeaksAlgorithm import FitOutputEnum
+from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
 from snapred.meta.decorators.ExceptionToErrLog import ExceptionToErrLog
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
@@ -60,6 +59,8 @@ class DiffCalWorkflow(WorkflowImplementer):
 
     def __init__(self, parent=None):
         super().__init__(parent)
+
+        self.mantidSnapper = MantidSnapper(None, "Utensils")
         # create a tree of flows for the user to successfully execute diffraction calibration
         # DiffCal Request ->
         # Check Peaks     ->
@@ -495,7 +496,7 @@ class DiffCalWorkflow(WorkflowImplementer):
         # update the max chi sq
         self.maxChiSq = maxChiSq
         allPeaks = self.ingredients.groupedPeakLists
-        param_table = mtd[self.fitPeaksDiagnostic].getItem(FitOutputEnum.Parameters.value).toDict()
+        param_table = self.mantidSnapper.mtd[self.fitPeaksDiagnostic].getItem(FitOutputEnum.Parameters.value).toDict()
         index = param_table["wsindex"]
         allChi2 = param_table["chi2"]
         goodPeaks = []

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -872,6 +872,7 @@ class TestGroceryService(unittest.TestCase):
         self.instance.dataService.generateInstrumentState = mock.MagicMock(
             return_value=testCalibrationData.instrumentState
         )
+        self.instance.mantidSnapper.mtd = mtd
 
         # mock out _createNeutronFilePath so that only a native version exists on disk
         nonExistentPath = Path("does/not/exist.nxs")
@@ -973,6 +974,7 @@ class TestGroceryService(unittest.TestCase):
         self.instance.mantidSnapper.RenameWorkspace = mock.MagicMock(
             side_effect=lambda _, **kwargs: RenameWorkspace(**kwargs)
         )
+        self.instance.mantidSnapper.mtd = mtd
 
         testCalibrationData = DAOFactory.calibrationParameters()
         self.instance.dataService.generateInstrumentState = mock.MagicMock(
@@ -1065,6 +1067,7 @@ class TestGroceryService(unittest.TestCase):
         self.instance.mantidSnapper.RenameWorkspace = mock.MagicMock(
             side_effect=lambda _, **kwargs: RenameWorkspace(**kwargs)
         )
+        self.instance.mantidSnapper.mtd = mtd
 
         testCalibrationData = DAOFactory.calibrationParameters()
         self.instance.dataService.generateInstrumentState = mock.MagicMock(
@@ -3068,10 +3071,9 @@ class TestGroceryService(unittest.TestCase):
             # Mask shall be blank.
             assert mtd[maskWsName].getNumberMasked() == 0
 
-    @mock.patch(ThisService + "mtd")
-    def test_unique_hidden_name(self, mockADS):
+    def test_unique_hidden_name(self):
         testWSName = "not_any_workspace"
-        mockADS.unique_hidden_name.return_value = testWSName
+        self.instance.mantidSnapper.mtd.unique_hidden_name = mock.Mock(return_value=testWSName)
         wsName = self.instance.uniqueHiddenName()
         assert wsName == testWSName
 

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -325,13 +325,16 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         )
         assert metric == FocusGroupMetric.return_value
 
+    @mock.patch("snapred.backend.recipe.algorithm.MantidSnapper")
     @mock.patch(thisService + "FarmFreshIngredients")
     @mock.patch(thisService + "FitMultiplePeaksRecipe")
-    def test_assessQuality(
-        self,
-        FitMultiplePeaksRecipe,
-        FarmFreshIngredients,
-    ):
+    def test_assessQuality(self, FitMultiplePeaksRecipe, FarmFreshIngredients, mockGCMWRecipe):
+        mockGCMWRecipe.MantidSnapper = mock.Mock()
+        # mockGCMWRecipe.return_value.MantidSnapepr.return_value.DeleteWorkspace.return_value = True
+        # self.instance.GenerateCalibrationMetricsWorkspaceRecipe.mantidSnapper = mock.Mock()
+        # mockGCMWRecipe.mantidSnapper.DeleteWorkspace = mock.MagicMock(
+        #     side_effect=lambda _, **kwargs: DeleteWorkspace(**kwargs)
+        # )
         # Mock input data
         timestamp = time.time()
         mockFarmFreshIngredients = mock.Mock(

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -325,16 +325,9 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         )
         assert metric == FocusGroupMetric.return_value
 
-    @mock.patch("snapred.backend.recipe.algorithm.MantidSnapper")
     @mock.patch(thisService + "FarmFreshIngredients")
     @mock.patch(thisService + "FitMultiplePeaksRecipe")
-    def test_assessQuality(self, FitMultiplePeaksRecipe, FarmFreshIngredients, mockGCMWRecipe):
-        mockGCMWRecipe.MantidSnapper = mock.Mock()
-        # mockGCMWRecipe.return_value.MantidSnapepr.return_value.DeleteWorkspace.return_value = True
-        # self.instance.GenerateCalibrationMetricsWorkspaceRecipe.mantidSnapper = mock.Mock()
-        # mockGCMWRecipe.mantidSnapper.DeleteWorkspace = mock.MagicMock(
-        #     side_effect=lambda _, **kwargs: DeleteWorkspace(**kwargs)
-        # )
+    def test_assessQuality(self, FitMultiplePeaksRecipe, FarmFreshIngredients):
         # Mock input data
         timestamp = time.time()
         mockFarmFreshIngredients = mock.Mock(


### PR DESCRIPTION
## Description of work

This replaces all calls of simpleapi, directly calling mantid algos, with using MantidSnapper instead.

## Explanation of work

Main code was updated to use MantidSnapper, and tests were updated accordingly. 

## To test

### Dev testing

Make sure tests pass and run through all 3 workflows to make sure they still work.

### CIS testing

None, this affects internals only.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#9909](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9909)

### Verification

- [ ] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] simpleapi is now replaced with MantidSnapper in main code
