### PR TITLE
Stability fixups for live-data mode

### DIFF
--- a/src/snapred/backend/dao/LiveMetadata.py
+++ b/src/snapred/backend/dao/LiveMetadata.py
@@ -17,6 +17,13 @@ class LiveMetadata(BaseModel):
     #     For this reason, in most cases this DAO should never be cached.
     #
 
+    ## Special Live-listener <start time> strings in ISO8601 format:
+    #  Return data from _now_ (<epoch zero>):
+    FROM_NOW_ISO8601: ClassVar[str] = "1990-01-01T00:00:00"
+
+    #  Return data from start of run (<epoch +1 second>):
+    FROM_START_ISO8601: ClassVar[str] = "1990-01-01T00:00:01"
+
     INACTIVE_RUN: ClassVar[int] = 0
 
     runNumber: str
@@ -24,7 +31,7 @@ class LiveMetadata(BaseModel):
     startTime: datetime
     endTime: datetime
 
-    detectorState: DetectorState
+    detectorState: DetectorState | None
 
     protonCharge: float
 

--- a/src/snapred/backend/data/util/PV_logs_util.py
+++ b/src/snapred/backend/data/util/PV_logs_util.py
@@ -4,14 +4,38 @@ Python `Mapping`-interface adapters and utility-methods relating to Mantid works
 """
 
 import datetime
+import logging
 from collections.abc import Iterable, Mapping
-from typing import Any
+from typing import Any, Dict
 
 import h5py
 import numpy as np
-from mantid.api import Run
+from mantid.api import Run, WorkspaceGroup
+from mantid.dataobjects import TableWorkspace
 
+from snapred.backend.log.logger import snapredLogger
 from snapred.meta.Config import Config
+
+logger = snapredLogger.getLogger(__name__)
+
+_snapper = None  # Prevent circular import.
+
+
+def allInstrumentPVLogKeys(keysWithAlternates: Iterable[str | Iterable[str]]):
+    # Flatten a list of keys, where each list item is either a single key,
+    #   or a list of alternative keys.
+    keys = []
+
+    for ks in keysWithAlternates:
+        if isinstance(ks, str):
+            # append a single key
+            keys.append(ks)
+        elif isinstance(ks, Iterable) and all([isinstance(k, str) for k in ks]):
+            # append several alternate keys
+            keys.extend(ks)
+        else:
+            raise RuntimeError("unexpected format: list of keys with alternates")
+    return keys
 
 
 def transferInstrumentPVLogs(dest: Run, src: Run, keys: Iterable[str]):
@@ -21,33 +45,47 @@ def transferInstrumentPVLogs(dest: Run, src: Run, keys: Iterable[str]):
     # Placed here for use by various `FetchGroceriesAlgorithm` loaders.
     for key in keys:
         if src.hasProperty(key):
-            # WARNING: known Mantid defect: `addPropery` 'name' arg will not be used.
-            #   'name' of new property will be taken from the source property.
             dest.addProperty(key, src.getProperty(key), True)
     # REMINDER: the instrument-parameter update still needs to be explicitly triggered!
 
 
 def populateInstrumentParameters(wsName: str):
-    from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
+    global _snapper
+    if _snapper is None:
+        # Prevent circular import.
+        from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 
-    mantidSnapper = MantidSnapper(None, "Utensils")
+        _snapper = MantidSnapper(parentAlgorithm=None, name=__name__)
+
     # This utility function is a "stand in" until Mantid PR #38684 can be merged.
     # (see https://github.com/mantidproject/mantid/pull/38684)
     # After that, `mtd[wsName].populateInstrumentParameters()` should be used instead.
 
     # Any PV-log key will do, so long as it is one that always exists in the logs.
     pvLogKey = "run_title"
-    pvLogValue = mantidSnapper.mtd[wsName].run().getProperty(pvLogKey).value
 
-    mantidSnapper.AddSampleLog(
-        "Adding sample log",
-        Workspace=wsName,
-        LogName=pvLogKey,
-        logText=pvLogValue,
-        logType="String",
-        UpdateInstrumentParameters=True,
+    # In case it's a workspace group: call `populateInstrumentParameters` for each workspace separately.
+    names = (
+        [
+            wsName,
+        ]
+        if not isinstance(_snapper.mtd[wsName], WorkspaceGroup)
+        else _snapper.mtd[wsName].getNames()
     )
-    mantidSnapper.executeQueue()
+    for name in names:
+        ws = _snapper.mtd[name]
+        if isinstance(ws, TableWorkspace):
+            continue
+        pvLogValue = ws.run().getProperty(pvLogKey).value
+        _snapper.AddSampleLog(
+            f"populating instrument parameters for '{name}'",
+            Workspace=name,
+            LogName=pvLogKey,
+            logText=pvLogValue,
+            logType="String",
+            UpdateInstrumentParameters=True,
+        )
+    _snapper.executeQueue()
 
 
 def datetimeFromLogTime(logTime: np.datetime64) -> datetime.datetime:
@@ -66,9 +104,27 @@ def datetimeFromLogTime(logTime: np.datetime64) -> datetime.datetime:
 def mappingFromRun(run: Run) -> Mapping:
     # Normalize `mantid.api.run` to a standard Python Mapping.
 
+    # TODO: a possible alternative implementation would be to just construct a `dict` from the `Run` instance.
+    #   It was an optimization choice NOT to use this approach, although once alternative PV-log keys are considered,
+    #   the code would probably be much simpler.
+
     class _Mapping(Mapping):
         def __init__(self, run: Run):
             self._run = run
+
+            # Save a self-consistent value for "now": this allows the fallback case for 'start_time' and 'end_time'
+            #  to return the same value, regardless of calling order.
+            self._now = np.datetime64(datetime.datetime.utcnow().isoformat(), "ns")
+
+            # A primary key may be used to reference values at an alternative key, if they exist.
+            self._alternateKeys: Dict[str, str] = {}
+            for ks in Config["instrument.PVLogs.instrumentKeys"]:
+                if isinstance(ks, str):
+                    continue
+                for k in ks[1:]:
+                    if run.hasProperty(k):
+                        self._alternateKeys[ks[0]] = k
+                        break
 
         def __getitem__(self, key: str) -> Any:
             # Deal with PV-logs special cases:
@@ -80,39 +136,76 @@ def mappingFromRun(run: Run) -> Mapping:
                 #   see the `datetimeFromLogTime` method above.
 
                 case "end_time":
-                    value = self._run.endTime().to_datetime64()
+                    try:
+                        value = self._run.endTime().to_datetime64()
+                    except RuntimeError as e:
+                        # Any exception => no run is active
+                        if logger.isEnabledFor(logging.DEBUG):
+                            logger.warning(str(e))
+                        value = self._now
 
                 case "start_time":
-                    value = self._run.startTime().to_datetime64()
+                    try:
+                        value = self._run.startTime().to_datetime64()
+                    except RuntimeError as e:
+                        # Any exception => no run is active
+                        if logger.isEnabledFor(logging.DEBUG):
+                            logger.warning(str(e))
+                        value = self._now
 
                 case "proton_charge":
-                    value = self._run.getProtonCharge()
+                    try:
+                        value = self._run.getProtonCharge()
+                    except RuntimeError as e:
+                        # Any exception => no run is active.
+                        if logger.isEnabledFor(logging.DEBUG):
+                            logger.warning(str(e))
+                        value = 0.0
 
                 case "run_number":
+                    # TODO: this case does not normalize 'run_number' value to `string`,
+                    #   because Mantid itself does not do that:
+                    #   probably that should be fixed here, and in Mantid.
                     value = self._run.getProperty("run_number").value if self._run.hasProperty("run_number") else 0
 
                 case _:
                     try:
                         value = self._run.getProperty(key).value
                     except RuntimeError as e:
+                        # A primary PV-log key may be used to reference a value at an alternative key.
                         if "Unknown property search object" in str(e):
-                            raise KeyError(key) from e
-                        raise
+                            if key in self._alternateKeys:
+                                value = self._run.getProperty(self._alternateKeys[key]).value
+                            else:
+                                raise KeyError(key) from e
+                        else:
+                            raise
             return value
 
         def __iter__(self):
-            return self._run.keys().__iter__()
+            return self.keys().__iter__()
 
         def __len__(
             self,
         ):
-            return len(self._run.keys())
+            return len(self.keys())
 
         def __contains__(self, key: str):
-            return self._run.hasProperty(key)
+            if self._run.hasProperty(key):
+                return True
+            # Check for special cases:
+            if key in ("end_time", "start_time", "proton_charge", "run_number"):
+                return True
+            # Check for _alternate_ instrument PV-log keys:
+            if key in self._alternateKeys:
+                return True
+            return False
 
         def keys(self):
-            return self._run.keys()
+            keys_ = set(self._run.keys())
+            keys_.update(["end_time", "start_time", "proton_charge", "run_number"])
+            keys_.update(self._alternateKeys.keys())
+            return list(keys_)
 
     return _Mapping(run)
 

--- a/src/snapred/backend/recipe/algorithm/LoadCalibrationWorkspaces.py
+++ b/src/snapred/backend/recipe/algorithm/LoadCalibrationWorkspaces.py
@@ -14,7 +14,11 @@ from mantid.api import (
 from mantid.dataobjects import MaskWorkspaceProperty
 from mantid.kernel import Direction
 
-from snapred.backend.data.util.PV_logs_util import populateInstrumentParameters, transferInstrumentPVLogs
+from snapred.backend.data.util.PV_logs_util import (
+    allInstrumentPVLogKeys,
+    populateInstrumentParameters,
+    transferInstrumentPVLogs,
+)
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
@@ -142,14 +146,14 @@ class LoadCalibrationWorkspaces(PythonAlgorithm):
             transferInstrumentPVLogs(
                 self.mantidSnapper.mtd[self.maskWorkspace].mutableRun(),
                 self.mantidSnapper.mtd[self.getPropertyValue("InstrumentDonor")].run(),
-                Config["instrument.PVLogs.instrumentKeys"],
+                allInstrumentPVLogKeys(Config["instrument.PVLogs.instrumentKeys"]),
             )
             populateInstrumentParameters(self.maskWorkspace)
         if self.groupingWorkspace:
             transferInstrumentPVLogs(
                 self.mantidSnapper.mtd[self.groupingWorkspace].mutableRun(),
                 self.mantidSnapper.mtd[self.getPropertyValue("InstrumentDonor")].run(),
-                Config["instrument.PVLogs.instrumentKeys"],
+                allInstrumentPVLogKeys(Config["instrument.PVLogs.instrumentKeys"]),
             )
             populateInstrumentParameters(self.groupingWorkspace)
 

--- a/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
+++ b/src/snapred/backend/recipe/algorithm/LoadGroupingDefinition.py
@@ -12,7 +12,11 @@ from mantid.api import (
 )
 from mantid.kernel import Direction
 
-from snapred.backend.data.util.PV_logs_util import populateInstrumentParameters, transferInstrumentPVLogs
+from snapred.backend.data.util.PV_logs_util import (
+    allInstrumentPVLogKeys,
+    populateInstrumentParameters,
+    transferInstrumentPVLogs,
+)
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
@@ -152,7 +156,7 @@ class LoadGroupingDefinition(PythonAlgorithm):
                 transferInstrumentPVLogs(
                     self.mantidSnapper.mtd[self.outputWorkspaceName].mutableRun(),
                     self.mantidSnapper.mtd[self.getPropertyValue("InstrumentDonor")].run(),
-                    Config["instrument.PVLogs.instrumentKeys"],
+                    allInstrumentPVLogKeys(Config["instrument.PVLogs.instrumentKeys"]),
                 )
                 populateInstrumentParameters(self.outputWorkspaceName)
         elif self.groupingFileExt in self.supported_xml_file_extensions:

--- a/src/snapred/backend/service/ReductionService.py
+++ b/src/snapred/backend/service/ReductionService.py
@@ -154,7 +154,8 @@ class ReductionService(Service):
         continueFlags = ContinueWarning.Type.UNSET
 
         # Check that the user has write permissions to the save directory
-        if not self.checkReductionWritePermissions(request.runNumber):
+        # (In live-data mode, this check should not apply.)
+        if not request.liveDataMode and not self.checkReductionWritePermissions(request.runNumber):
             continueFlags |= ContinueWarning.Type.NO_WRITE_PERMISSIONS
 
         # Remove any continue flags that are present in the request by XOR-ing with the flags

--- a/src/snapred/meta/Callback.py
+++ b/src/snapred/meta/Callback.py
@@ -60,7 +60,7 @@ def callback(clazz):
         def __subclasscheck__(cls, subclass):
             return clazz.__subclasscheck__(subclass)
 
-    # Forwared all methods to the _value, throw if not populated
+    # Forward all methods to the _value, throw if not populated
     for name in dir(clazz):
         if name not in ignore:
             delegate(Callback, "_value", name)

--- a/src/snapred/meta/Config.py
+++ b/src/snapred/meta/Config.py
@@ -34,7 +34,7 @@ class _Resource:
     _resourcesPath: str
     _logger = logging.getLogger(__name__ + ".Resource")
 
-    def __init__(self):            
+    def __init__(self):
         # where the location of resources are depends on whether or not this is in package mode
         self._packageMode = not self._existsInPackage("application.yml")
         if self._packageMode:
@@ -129,7 +129,6 @@ class _Config:
             self._config["samples"]["home"] = expandhome(self._config["samples"]["home"])
 
     def refresh(self, env_name: str, clearPrevious: bool = False) -> None:
- 
         if clearPrevious:
             self._config.clear()
 
@@ -223,17 +222,18 @@ class _Config:
 
     def validate(self):
         # Warn the user about any issues with `Config` settings.
-        
+
         # Implementation notes:
-        # 
+        #
         #   * Do not prevent the user from doing something that won't outright "break" SNAPRed.
         #   Where at all possible, this method should WARN, otherwise it should throw `RuntimeError`.
         #
-    
+
         # Use SNAPRed's logger for any warnings:
-        from snapred.backend.log.logger import snapredLogger # prevent circular import
+        from snapred.backend.log.logger import snapredLogger  # prevent circular import
+
         logger = snapredLogger.getLogger(__name__ + ".Config")
-        
+
         if self["liveData.enabled"] and self["mantid.workspace.normalizeByBeamMonitor"]:
             logger.warning(
                 "Both 'mantid.workspace.normalizeByBeamMonitor' and 'liveData.enabled'\n"
@@ -241,7 +241,8 @@ class _Config:
                 + "This type of normalization is not yet implemented for live-data mode.  "
                 + "Live-data mode will not function correctly!"
             )
-        
+
+
 Config = _Config()
 
 

--- a/src/snapred/meta/Config.py
+++ b/src/snapred/meta/Config.py
@@ -32,9 +32,9 @@ def _find_root_dir():
 class _Resource:
     _packageMode: bool
     _resourcesPath: str
-    _logger = logging.getLogger("snapred.meta.Config.Resource")
+    _logger = logging.getLogger(__name__ + ".Resource")
 
-    def __init__(self):
+    def __init__(self):            
         # where the location of resources are depends on whether or not this is in package mode
         self._packageMode = not self._existsInPackage("application.yml")
         if self._packageMode:
@@ -91,7 +91,7 @@ def deep_update(mapping: Dict[KeyType, Any], *updating_mappings: Dict[KeyType, A
 @Singleton
 class _Config:
     _config: Dict[str, Any] = {}
-    _logger = logging.getLogger("snapred.meta.Config.Config")
+    _logger = logging.getLogger(__name__ + ".Config")
 
     def __init__(self):
         # use refresh to do initial load, clearing shouldn't matter
@@ -129,6 +129,7 @@ class _Config:
             self._config["samples"]["home"] = expandhome(self._config["samples"]["home"])
 
     def refresh(self, env_name: str, clearPrevious: bool = False) -> None:
+ 
         if clearPrevious:
             self._config.clear()
 
@@ -220,7 +221,27 @@ class _Config:
             raise KeyError(f"Key '{key}' not found in configuration")
         return val
 
-
+    def validate(self):
+        # Warn the user about any issues with `Config` settings.
+        
+        # Implementation notes:
+        # 
+        #   * Do not prevent the user from doing something that won't outright "break" SNAPRed.
+        #   Where at all possible, this method should WARN, otherwise it should throw `RuntimeError`.
+        #
+    
+        # Use SNAPRed's logger for any warnings:
+        from snapred.backend.log.logger import snapredLogger # prevent circular import
+        logger = snapredLogger.getLogger(__name__ + ".Config")
+        
+        if self["liveData.enabled"] and self["mantid.workspace.normalizeByBeamMonitor"]:
+            logger.warning(
+                "Both 'mantid.workspace.normalizeByBeamMonitor' and 'liveData.enabled'\n"
+                + "  are set in your 'application.yml'.  "
+                + "This type of normalization is not yet implemented for live-data mode.  "
+                + "Live-data mode will not function correctly!"
+            )
+        
 Config = _Config()
 
 
@@ -235,6 +256,29 @@ def datasearch_directories(instrumentHome: Path) -> List[str]:
     return dirs
 
 
+# `Logging.Level` is not an `Enum`.
+_pythonLoggingLevelFromString = {
+    "notset": logging.NOTSET,
+    "critical": logging.CRITICAL,
+    "error": logging.ERROR,
+    "warning": logging.WARNING,
+    "info": logging.INFO,
+    "debug": logging.DEBUG,
+}
+
+_pythonLoggingLevelFromMantid = {
+    "none": logging.NOTSET,
+    "fatal": logging.CRITICAL + 5,  # exists only as a POCO level
+    "critical": logging.CRITICAL,
+    "error": logging.ERROR,
+    "warning": logging.WARNING,
+    "notice": logging.INFO + 5,  # exists only as a POCO level
+    "information": logging.INFO,
+    "debug": logging.DEBUG,
+    "trace": logging.DEBUG - 5,  # exists only as a POCO level
+}
+
+
 def fromMantidLoggingLevel(level: str) -> int:
     # Python logging level from Mantid logging level
 
@@ -246,25 +290,18 @@ def fromMantidLoggingLevel(level: str) -> int:
     # 'none': , 'fatal', 'critical', 'error', 'warning', 'notice', 'information', 'debug', 'trace'
 
     pythonLevel = logging.NOTSET
-    match level.lower():
-        case "none":
-            pythonLevel = logging.NOTSET
-        case "fatal":
-            # this level doesn't really exist in python
-            pythonLevel = logging.CRITICAL + 5
-        case "critical":
-            pythonLevel = logging.CRITICAL
-        case "error":
-            pythonLevel = logging.ERROR
-        case "warning":
-            pythonLevel = logging.WARNING
-        case "notice":
-            pythonLevel = logging.INFO
-        case "debug":
-            pythonLevel = logging.DEBUG
-        case "trace":
-            # this level doesn't really exist in python
-            pythonLevel = logging.DEBUG - 5
-        case _:
-            raise RuntimeError(f"can't convert '{level}' to a Python logging level")
+    try:
+        pythonLevel = _pythonLoggingLevelFromMantid[level.lower()]
+    except KeyError as e:
+        raise RuntimeError(f"can't convert '{e}' to a Python logging level")
     return pythonLevel
+
+
+def fromPythonLoggingLevel(level: int | str) -> str:
+    # Mantid logging level from Python logging level
+    try:
+        level = level if isinstance(level, int) else _pythonLoggingLevelFromString[level.lower()]
+        mantidLevel = {v: k for k, v in _pythonLoggingLevelFromMantid.items()}[level]
+    except KeyError as e:
+        raise RuntimeError(f"can't convert '{e}' to a Mantid logging level")
+    return mantidLevel

--- a/src/snapred/meta/decorators/ExceptionToErrLog.py
+++ b/src/snapred/meta/decorators/ExceptionToErrLog.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 from typing import Any, Callable
 
 from snapred.backend.log.logger import snapredLogger
@@ -12,9 +13,11 @@ def ExceptionToErrLog(func: Callable[..., Any]):
         try:
             return func(*args, **kwargs)
         except Exception as e:  # noqa BLE001
-            import traceback
-
             logger.error(e)
-            traceback.print_exc()
+            if logger.isEnabledFor(logging.DEBUG):
+                # print stacktrace
+                import traceback
+
+                traceback.print_exc()
 
     return inner

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -58,13 +58,19 @@ instrument:
     # rootGroup: "mantid_workspace_1/logs"
 
     # PV-log keys relating to instrument settings:
+    #   - for alternative log keys, the preferred value is the first,
+    #     and that key is also what will be used in SNAPRed.
     instrumentKeys:
-    - "BL3:Chop:Gbl:WavelengthReq"
-    - "BL3:Chop:Skf1:WavelengthUserReq"
+    -
+      - "BL3:Chop:Skf1:WavelengthUserReq"
+      - "BL3:Chop:Gbl:WavelengthReq"
+      - "BL3:Det:TH:BL:Lambda"
     - "det_arc1"
     - "det_arc2"
     - "BL3:Det:TH:BL:Frequency"
-    - "BL3:Mot:OpticsPos:Pos"
+    -
+      - "BL3:Mot:OpticsPos:Pos"
+      - "optics"
     - "det_lin1"
     - "det_lin2"
 
@@ -83,7 +89,11 @@ liveData:
   instrument:
     name: ${instrument.name}
     # name: ADARA_FileReader
+
+  # The ONLY supported mode right now is 'REPLACE':
+  #   any other mode requires stay-resident `LoadLiveData` treatment.
   accumulationMethod: Replace
+
   testInput:
     inputFilename: SNAP_46680.nxs.h5
     # WARNING: "chunks" seems a bit glitchy:
@@ -157,6 +167,8 @@ reduction:
 
 mantid:
   workspace:
+    # WARNING: 'normalizeByBeamMonitor' and 'liveData.enabled' should not be set at the same time.
+    #   This type of normalization is not yet implemented for live-data mode.  Live-data mode will not function correctly!
     normalizeByBeamMonitor: false
     normMonitorID: 0
     nameTemplate:
@@ -227,6 +239,10 @@ localdataservice:
 logging:
   # log levels are NOTSET, DEBUG, INFO, WARNING, ERROR, CRITICAL
   mantid:
+    # IMPORTANT: "root" level determines override for message-pane level:
+    #    do not set to *debug* for live-data usage!
+    root:
+      level: "WARNING"
     stream:
       level: "WARNING"
       format: 'MANTID %(levelname)-8s - %(asctime)s - %(message)s'

--- a/src/snapred/ui/handler/SNAPResponseHandler.py
+++ b/src/snapred/ui/handler/SNAPResponseHandler.py
@@ -104,9 +104,9 @@ class SNAPResponseHandler(QWidget):
 
     def _handleContinueWarning(self, continueInfo: ContinueWarning.Model):
         if logger.isEnabledFor(logging.DEBUG):
+            # print stacktrace
             import traceback
 
-            # print stacktrace
             logger.debug(f"`_handleContinueWarning`: `continueInfo`: {continueInfo}")
             traceback.print_stack()
 

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -21,7 +21,7 @@ from qtpy.QtWidgets import (
 from workbench.plugins.workspacewidget import WorkspaceWidget
 
 from snapred.backend.log.logger import CustomFormatter, snapredLogger
-from snapred.meta.Config import Config, Resource, datasearch_directories, fromMantidLoggingLevel
+from snapred.meta.Config import Config, Resource, datasearch_directories, fromMantidLoggingLevel, fromPythonLoggingLevel
 from snapred.ui.widget.LogTable import LogTable
 from snapred.ui.widget.TestPanel import TestPanel
 from snapred.ui.widget.ToolBar import ToolBar
@@ -116,6 +116,9 @@ class SNAPRedGUI(QMainWindow):
             splitter.addWidget(self.userDocButton)
         else:
             print("UserDocsButton is not available. Skipping its initialization.")
+            
+        # Check for incompatible `Config` settings.
+        Config.validate()
 
     @Slot()
     def openCalibrationPanel(self):
@@ -202,9 +205,19 @@ class SNAPRedGUI(QMainWindow):
         self._savedMantidConfigEntries[LOGGERCLASSKEY] = self._mantidConfig[LOGGERCLASSKEY]
         self._savedMantidConfigEntries[LOGGERLEVELKEY] = self._mantidConfig[LOGGERLEVELKEY]
 
-        # Configure Mantid to send messages to Python
-        log_to_python()
         logger = logging.getLogger("Mantid")
+        if ConfigService.getLogLevel().lower() == "debug" and _within_mantid():
+            logger.warning(
+                "WARNING: 'messages' pane is set to 'DEBUG' logging level: this may cause LOCK UP in live-data mode!"
+            )
+
+        # Configure Mantid to send messages to Python.
+
+        # Despite what the documentation says:
+        #   the level passed in here _only_ controls the log-level in the "messages" panel.
+        #     For live-data, it's recommended _not_ to set this to *debug*!
+        log_to_python(level=fromPythonLoggingLevel(Config["logging.mantid.root.level"]))
+
         # NOTE it is necessary to set the log to a nonzero level before adding handlers
         logger.setLevel(logging.DEBUG)
 
@@ -234,6 +247,9 @@ class SNAPRedGUI(QMainWindow):
         logger.handlers.clear()
 
 
+# ------ Duplicate `mantidqt.gui_helper.get_qapplication`, but as two separate methods: ------
+
+
 # Be careful here: the _key_ pytest-qt fixture is named `qapp`!
 def _qapp():
     if QApplication.instance():
@@ -241,6 +257,13 @@ def _qapp():
     else:
         _app = QApplication(sys.argv)
     return _app
+
+
+def _within_mantid():
+    return _qapp().applicationName().lower().startswith("mantid")
+
+
+# ------
 
 
 def start(options=None):

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -116,7 +116,7 @@ class SNAPRedGUI(QMainWindow):
             splitter.addWidget(self.userDocButton)
         else:
             print("UserDocsButton is not available. Skipping its initialization.")
-            
+
         # Check for incompatible `Config` settings.
         Config.validate()
 

--- a/src/snapred/ui/presenter/WorkflowPresenter.py
+++ b/src/snapred/ui/presenter/WorkflowPresenter.py
@@ -347,7 +347,6 @@ class WorkflowPresenter(QObject):
         QMessageBox.information(self.view, "Live Data:", liveDataInfo.message)
         # Any live-data transition resets the workflow:
         #   at which point the live-data part of the request view should display the new live-data status.
-        self.reset()
 
     @Slot()
     def requestCancellation(self):

--- a/src/snapred/ui/threading/worker_pool.py
+++ b/src/snapred/ui/threading/worker_pool.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Dict, List
 
 from qtpy.QtCore import QObject, QThread, Signal, Slot
@@ -49,11 +50,12 @@ class Worker(QObject):
         except RecoverableException as e:
             results = SNAPResponse(code=ResponseCode.RECOVERABLE, message=e.model.json())
         except Exception as e:  # noqa: BLE001
-            # print stacktrace
-            import traceback
+            logger.error(e)
+            if logger.isEnabledFor(logging.DEBUG):
+                # print stacktrace
+                import traceback
 
-            print(e)
-            traceback.print_exc()
+                traceback.print_exc()
 
             results = SNAPResponse(code=ResponseCode.ERROR, message=str(e))
 

--- a/src/snapred/ui/view/WorkflowNodeView.py
+++ b/src/snapred/ui/view/WorkflowNodeView.py
@@ -1,3 +1,4 @@
+from qtpy.QtCore import Slot
 from qtpy.QtWidgets import QGridLayout, QPushButton, QWidget
 
 
@@ -36,9 +37,11 @@ class WorkflowNodeView(QWidget):
         self.cancelButton = QPushButton("Cancel \U0000274c", self)
         layout_.addWidget(self.cancelButton, 2, 1)
 
+    @Slot()
     def reset(self):
         self.view.reset()
 
+    @Slot()
     def enableSkip(self):
         layout_ = self.layout()
         layout_.removeWidget(self.continueButton)
@@ -48,6 +51,7 @@ class WorkflowNodeView(QWidget):
         layout_.addWidget(self.cancelButton, 2, 2)
         self.skipButton.setVisible(True)
 
+    @Slot()
     def enableIterate(self):
         layout_ = self.layout()
         layout_.removeWidget(self.continueButton)

--- a/src/snapred/ui/view/reduction/ReductionRequestView.py
+++ b/src/snapred/ui/view/reduction/ReductionRequestView.py
@@ -397,7 +397,7 @@ class _LiveDataView(_RequestViewBase):
         elif not data.hasActiveRun():
             status = ReductionStatus.NO_ACTIVE_RUN
         elif not data.beamState():
-            status = ReductionStatus.NO_BEAM
+            status = ReductionStatus.ZERO_PROTON_CHARGE
 
         # Keep track of the displayed status, so that the flash sequences aren't constantly restarted.
         statusChange = status != self._lastDisplayedStatus
@@ -439,7 +439,7 @@ class _LiveDataView(_RequestViewBase):
                     self.liveDataIndicator.setFlashSequence(((QColor(255, 255, 0),), (0.4, 0.6)))
                     self.liveDataIndicator.setFlash(True)
 
-            case ReductionStatus.NO_BEAM:
+            case ReductionStatus.ZERO_PROTON_CHARGE:
                 self.runNumbers = []
                 self.liveDataStatus.setText(
                     "<p><font size = 4><b>Live data:</b></font>"
@@ -451,7 +451,7 @@ class _LiveDataView(_RequestViewBase):
                     + f"<p><font size = 4><b>{str(status).upper()}.</b></font></p>"
                 )
 
-                # ERROR flash -- beam is down with a run active.
+                # ERROR flash -- proton charge is zero, with a run active.
                 if statusChange:
                     self.liveDataIndicator.setFlashSequence(((QColor(255, 0, 0),), (0.1, 0.4)))
                     self.liveDataIndicator.setFlash(True)
@@ -571,9 +571,9 @@ class _LiveDataView(_RequestViewBase):
 
         # -- For completeness, these checks should also be here, but they are redundant: --
         if not self._liveMetadata.hasActiveRun():
-            raise ValueError("No live-data run is active.")
+            raise ValueError("No run is active.")
         if not self._liveMetadata.beamState():
-            raise ValueError("The beam is down")
+            raise ValueError("The proton charge is zero")
         # -- end: redundant checks --
 
         if self.keepUnfocused():

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -599,9 +599,9 @@ class DiffCalWorkflow(WorkflowImplementer):
         assessmentResponse = response.data
         self.calibrationRecord = assessmentResponse.record
 
-        self.outputs.extend(assessmentResponse.metricWorkspaces)
+        self.outputs.update(assessmentResponse.metricWorkspaces)
         for calibrationWorkspaces in self.calibrationRecord.workspaces.values():
-            self.outputs.extend(calibrationWorkspaces)
+            self.outputs.update(calibrationWorkspaces)
         self._assessmentView.updateRunNumber(self.runNumber, self.useLiteMode)
         return response
 

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
-from qtpy.QtCore import Qt, QTimer, Signal, Slot
+from qtpy.QtCore import QMetaObject, Qt, QTimer, Signal, Slot
 
 from snapred.backend.dao.ingredients import ArtificialNormalizationIngredients
 from snapred.backend.dao.LiveMetadata import LiveMetadata
@@ -51,7 +51,7 @@ class ReductionStatus(StrEnum):
     CONNECTING = "Connecting to listener"
     WAITING_TO_LOAD = "Waiting to load next chunk"
     NO_ACTIVE_RUN = "No run is active"
-    NO_BEAM = "Beam is down"
+    ZERO_PROTON_CHARGE = "Proton charge is zero"
 
 
 class ReductionWorkflow(WorkflowImplementer):
@@ -69,10 +69,6 @@ class ReductionWorkflow(WorkflowImplementer):
         )
 
         self._reductionRequestView._requestView.setRetrieveRunFeedbackCallback(self.handleRunFeedback)
-
-        if not self._hasLiveDataConnection():
-            # Only enable live-data mode if there is a connection to the listener.
-            self._reductionRequestView.setLiveDataToggleEnabled(False)
 
         self._compatibleMasks: Dict[str, WorkspaceName] = {}
 
@@ -107,7 +103,7 @@ class ReductionWorkflow(WorkflowImplementer):
 
         self.setStatus(ReductionStatus.READY)
 
-        # Quite a few of these attributes are also at `self._triggerReduction`
+        # Quite a few of these attributes are also set at `self._triggerReduction`
         #   using the current settings from `ReductionRequestView`.
 
         self._keeps: Set[WorkspaceName] = set()
@@ -125,10 +121,19 @@ class ReductionWorkflow(WorkflowImplementer):
         self._liveDataUpdateTimer.setInterval(Config["liveData.updateIntervalDefault"] * 1000)
         self._liveDataUpdateTimer.timeout.connect(self.updateLiveMetadata)
 
-        self.addResetHook(
-            # Note: when _not_ in live-data mode, this controls the live-data toggle enable.
-            #   In live-data mode, the toggle is enabled when the workflow is not cycling.
-            lambda: self._reductionRequestView.setLiveDataToggleEnabled(True) if not self.liveDataMode else None
+        # Only enable live-data mode if there is a connection to the listener.
+        self._reductionRequestView.setLiveDataToggleEnabled(self._hasLiveDataConnection())
+        self.workflow.presenter.resetCompleted.connect(
+            # Notes:
+            # -- When _not_ in live-data mode, this controls the live-data toggle enable;
+            # -- When in live-data mode, the toggle is enabled when the workflow is not cycling;
+            # -- This hook overrides the normal reset behavior of re-enabling all of the toggles,
+            #    for this reason it must be executed _after_ all of the other reset hooks!
+            lambda: (
+                self._reductionRequestView.setLiveDataToggleEnabled(self._hasLiveDataConnection())
+                if not self.liveDataMode
+                else None
+            )
         )
 
         # Initialize a separate timer for the control of the live-data reduction-workflow loop.
@@ -157,7 +162,7 @@ class ReductionWorkflow(WorkflowImplementer):
         # Presenter signals the live-data view that a reduction is in progress:
         self.workflow.presenter.workflowInProgressChange.connect(self._reductionRequestView.setReductionInProgress)
 
-        # Status summary shows "CANCELLING WORKFLOW" on any cancellatioin request:
+        # Status summary shows "CANCELLING WORKFLOW" on any cancellation request:
         self.workflow.presenter.cancellationRequest.connect(lambda: self.setStatus(ReductionStatus.USER_CANCELLATION))
 
         # Status summary is updated to "READY" at the completion of reset:
@@ -239,8 +244,8 @@ class ReductionWorkflow(WorkflowImplementer):
     @Slot(bool)
     def _cycleLiveData(self, success: bool):
         # Prepare the next live-data reduction request, and start its submission timer.
-        status = success
-        if status:
+        cycleStatus = success
+        if cycleStatus:
             try:
                 # Retain the last completed `ReductionRequest`,
                 #   and its `ReductionResponse` before any `reset` is called.
@@ -264,6 +269,11 @@ class ReductionWorkflow(WorkflowImplementer):
                 # Calling `presenter.resetSoft()` gets us back to the live-data summary panel.
                 self.workflow.presenter.resetSoft()
 
+                # Since they are replaced only at the end of the reduction process,
+                #   and the first reduction cycle has been completed and has produced valid outputs:
+                #   do _not_ delete output workspaces in case of error.
+                self.outputs.update(self._lastReductionResponse.record.workspaceNames)
+
                 updateInterval = self._liveDataUpdateInterval()
 
                 # If the user has set the updateInterval to too small a value, we just do the best we can.
@@ -282,8 +292,8 @@ class ReductionWorkflow(WorkflowImplementer):
                 self._workflowTimer.start()
             except (AttributeError, IndexError) as e:
                 logger.error(f"_cycleLiveData: unexpected: {e}")
-                status = False
-        if not status:
+                cycleStatus = False
+        if not cycleStatus:
             if self.status != ReductionStatus.READY:
                 # "READY" indicates that this `reset` would be redundant.
                 # (e.g. User cancellation has its own `reset` pathway.)
@@ -451,6 +461,8 @@ class ReductionWorkflow(WorkflowImplementer):
         # All runs are from the same state, use the first run to load groupings.
         request_ = self._createReductionRequest(self.runNumbers[0])
         response = self.request(path="reduction/groupings", payload=request_)
+
+        # Set of workspaces to retain is INITIALIZED here: after this point, we add to the set.
         self._keeps = set(response.data["groupingWorkspaces"])
 
         # Reload the lite-grouping-map only when necessary.
@@ -464,6 +476,8 @@ class ReductionWorkflow(WorkflowImplementer):
         matchRequest = MatchRunsRequest(runNumbers=self.runNumbers, useLiteMode=self.useLiteMode)
         loadedCalibrations, calVersions = self.request(path="calibration/fetchMatches", payload=matchRequest).data
         loadedNormalizations, normVersions = self.request(path="normalization/fetchMatches", payload=matchRequest).data
+
+        # Add loaded calibrations, calibration-masks, and normalizations to the list of workspaces to retain.
         self._keeps.update(loadedCalibrations)
         self._keeps.update(loadedNormalizations)
 
@@ -505,7 +519,8 @@ class ReductionWorkflow(WorkflowImplementer):
                 self._keeps.update(self.outputs)
                 self._clearWorkspaces(exclude=self._keeps, clearCachedWorkspaces=True)
 
-            workflowPresenter.advanceWorkflow()
+            # Here we are probably not on the GUI thread, so we cannot call `advanceWorkflow` directly.
+            QMetaObject.invokeMethod(workflowPresenter, "advanceWorkflow", Qt.QueuedConnection)
 
         return self.responses[-1]
 
@@ -614,13 +629,13 @@ class ReductionWorkflow(WorkflowImplementer):
                 self.request(path="reduction/save", payload=ReductionExportRequest(record=record))
 
         # Retain the output workspaces after the workflow is complete.
-        self.outputs.extend(record.workspaceNames)
+        self.outputs.update(record.workspaceNames)
 
         # Also retain the unfocused data after the workflow is complete (if the box was checked),
         #   but do not actually save it as part of the reduction-data file.
         # The unfocused data does not get added to the response.workspaces list.
         if unfocusedData:
-            self.outputs.append(unfocusedData)
+            self.outputs.add(unfocusedData)
             # Note that the run number is deliberately not deleted from the run numbers list.
             # Almost certainly it should be moved to a "completed run numbers" list.
 

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -58,13 +58,19 @@ instrument:
     # rootGroup: "mantid_workspace_1/logs"
 
     # PV-log keys relating to instrument settings:
+    #   - for alternative log keys, the preferred value is the first,
+    #     and that key is also what will be used in SNAPRed.
     instrumentKeys:
-    - "BL3:Chop:Gbl:WavelengthReq"
-    - "BL3:Chop:Skf1:WavelengthUserReq"
+    -
+      - "BL3:Chop:Skf1:WavelengthUserReq"
+      - "BL3:Chop:Gbl:WavelengthReq"
+      - "BL3:Det:TH:BL:Lambda"
     - "det_arc1"
     - "det_arc2"
     - "BL3:Det:TH:BL:Frequency"
-    - "BL3:Mot:OpticsPos:Pos"
+    -
+      - "BL3:Mot:OpticsPos:Pos"
+      - "optics"
     - "det_lin1"
     - "det_lin2"
 
@@ -73,7 +79,7 @@ instrument:
   maxNumberOfRuns: 10
 
 liveData:
-  enabled: true
+  enabled: false
   # Override 'liveData.facility' and 'liveData.instrument'
   #   in order to use the mock listener for testing
   #   without overriding the real instrument.
@@ -83,7 +89,11 @@ liveData:
   instrument:
     name: ${instrument.name}
     # name: ADARA_FileReader
+
+  # The ONLY supported mode right now is 'REPLACE':
+  #   any other mode requires stay-resident `LoadLiveData` treatment.
   accumulationMethod: Replace
+
   testInput:
     inputFilename: SNAP_46680.nxs.h5
     # WARNING: "chunks" seems a bit glitchy:
@@ -158,6 +168,8 @@ reduction:
 
 mantid:
     workspace:
+      # WARNING: 'normalizeByBeamMonitor' and 'liveData.enabled' should not be set at the same time.
+      #   This type of normalization is not yet implemented for live-data mode.  Live-data mode will not function correctly!
       normalizeByBeamMonitor: false
       normMonitorID: 0
       nameTemplate:
@@ -227,11 +239,11 @@ localdataservice:
 
 logging:
   # logging.NOTSET: 0, logging.DEBUG: 10, logging.INFO: 20, logging:WARNING: 30, logging.ERROR: 40, logging.CRITICAL: 50
-  SNAP:
-    stream:
-      level: 40
-      format: '%(asctime)s - %(levelname)-8s - %(name)s - %(message)s'
   mantid:
+    # IMPORTANT: "root" level determines override for message-pane level:
+    #    do not set to *debug* for live-data usage!
+    root:
+      level: 30
     stream:
       level: 40
       format: 'MANTID %(levelname)s - %(message)s'
@@ -239,6 +251,10 @@ logging:
       level: 40
       format: 'MANTID FILE %(levelname)s - %(message)s'
       output: '/dev/null'
+  SNAP:
+    stream:
+      level: 40
+      format: '%(asctime)s - %(levelname)-8s - %(name)s - %(message)s'
 
 samples:
   home: ${instrument.calibration.sample.home}

--- a/tests/unit/backend/data/util/test_PV_logs_util.py
+++ b/tests/unit/backend/data/util/test_PV_logs_util.py
@@ -1,12 +1,18 @@
+import logging
+
 ##
 ## In order to keep the rest of the import sequence unmodified: any test-related imports are added at the end.
 ##
 import unittest
 from collections.abc import Iterable
+from typing import Any, Dict, List
 from unittest import mock
 
 import numpy as np
 import pytest
+from mantid.api import MatrixWorkspace, WorkspaceGroup
+from mantid.dataobjects import TableWorkspace
+from mantid.kernel import DateAndTime
 from mantid.simpleapi import (
     CreateSampleWorkspace,
     DeleteWorkspace,
@@ -20,6 +26,139 @@ from util.instrument_helpers import addInstrumentLogs, getInstrumentLogDescripto
 from snapred.backend.dao.state import DetectorState
 from snapred.backend.data.util.PV_logs_util import *
 from snapred.meta.Config import Config, Resource
+
+
+def test_allInstrumentPVLogKeys():
+    keysWithAlternates = ["one", ["two", "three", "four"], "five", ["six", "seven"], "eight"]
+    expected = []
+    for ks in keysWithAlternates:
+        if isinstance(ks, str):
+            expected.append(ks)
+        else:
+            expected.extend(ks)
+    # We do not care about the ordering, just that all keys are present.
+    assert set(allInstrumentPVLogKeys(keysWithAlternates)) == set(expected)
+
+
+def test_allInstrumentPVLogKeys_format_error():
+    keysWithAlternates = ["one", [["two", "three", "four"], "one"], "five", ["six", "seven"], "eight"]
+    with pytest.raises(RuntimeError, match="unexpected format: list of keys with alternates"):
+        keys = allInstrumentPVLogKeys(keysWithAlternates)  # noqa: F841
+
+
+class TestPopulateInstrumentParameters(unittest.TestCase):
+    class _MockMtd:
+        # In order to test flow-of-control, the only thing that matters is
+        #   the _type_ of the workspace.
+
+        @classmethod
+        def _mockWorkspace(cls, wsClass, wsName, wsNames):
+            # return a mock where `isinstance(mock, wsClass) == True`
+            #   and <mock>.getTitle() == wsName
+            _mock = mock.Mock(spec=wsClass, getTitle=mock.Mock(return_value=wsName), run=mock.Mock())
+            if wsClass is WorkspaceGroup:
+                assert wsNames is not None
+                _mock.getNames = mock.Mock(return_value=wsNames)
+            assert isinstance(_mock, wsClass)
+            return _mock
+
+        def __init__(self, wsNames=None):
+            self._wsNames = wsNames
+
+        def __getitem__(self, name):
+            ws = None
+            if "group" in name:
+                ws = self._mockWorkspace(WorkspaceGroup, name, self._wsNames)
+            elif "table" in name:
+                ws = self._mockWorkspace(TableWorkspace, name, self._wsNames)
+            else:
+                ws = self._mockWorkspace(MatrixWorkspace, name, self._wsNames)
+            return ws
+
+    def test_single_workspace(self):
+        # test `populateInstrumentParameters` with a single `MatrixWorkspace`.
+        mockSnapper_ = mock.Mock()
+        mockSnapper_.mtd = TestPopulateInstrumentParameters._MockMtd()
+        assert isinstance(mockSnapper_.mtd["test_workspace"], MatrixWorkspace)
+
+        with (
+            mock.patch("snapred.backend.data.util.PV_logs_util._snapper", mockSnapper_) as mockSnapper,
+        ):
+            populateInstrumentParameters("test_workspace")
+            mockSnapper.AddSampleLog.assert_called_once()
+            mockSnapper.executeQueue.assert_called_once()
+            # Verify that `ExperimentInfo::populateInstrumentParameters` was triggered.
+            assert mockSnapper.AddSampleLog.mock_calls[0].kwargs["UpdateInstrumentParameters"]
+
+    @pytest.mark.skip(reason="TODO: Breaks 'TestTransferInstrumentPVLogs.test_instrument_update'?!")
+    def test_snapper_import(self):
+        # test `populateInstrumentParameters` import of `MantidSnapper`.
+        mockSnapper_ = mock.Mock()
+        mockSnapper_.mtd = TestPopulateInstrumentParameters._MockMtd()
+        assert isinstance(mockSnapper_.mtd["test_workspace"], MatrixWorkspace)
+
+        with mock.patch.dict(
+            "snapred.backend.recipe.algorithm.MantidSnapper.MantidSnapper", mock.Mock(return_value=mockSnapper_)
+        ) as mockSnapperClass:
+            populateInstrumentParameters("test_workspace")
+            mockSnapperClass.assert_called_once()
+
+    def test_single_table_workspace(self):
+        # test `AddSampleLog` is not called on a single `TableWorkspace`.
+        mockSnapper_ = mock.Mock()
+        mockSnapper_.mtd = TestPopulateInstrumentParameters._MockMtd()
+        assert isinstance(mockSnapper_.mtd["test_table"], TableWorkspace)
+
+        with (
+            mock.patch("snapred.backend.data.util.PV_logs_util._snapper", mockSnapper_) as mockSnapper,
+        ):
+            populateInstrumentParameters("test_table")
+            mockSnapper.AddSampleLog.assert_not_called()
+
+    def test_group_workspace(self):
+        # test `populateInstrumentParameters` is called on each workspace in a `WorkspaceGroup`.
+        mockSnapper_ = mock.Mock()
+        mockSnapper_.mtd = TestPopulateInstrumentParameters._MockMtd(wsNames=["ws1", "ws2", "ws3", "ws4", "ws5"])
+        assert isinstance(mockSnapper_.mtd["test_group"], WorkspaceGroup)
+        N_wss = len(mockSnapper_.mtd["test_group"].getNames())
+
+        with (
+            mock.patch("snapred.backend.data.util.PV_logs_util._snapper", mockSnapper_) as mockSnapper,
+        ):
+            populateInstrumentParameters("test_group")
+            # Verify that `AddSampleLog` is called for every workspace in the group.
+            mockSnapper.AddSampleLog.call_count == N_wss
+            for n in range(len(mockSnapper.AddSampleLog.mock_calls)):
+                # Verify that `populateInstrumentParameters` is triggered for each call.
+                assert mockSnapper.AddSampleLog.mock_calls[n].kwargs["UpdateInstrumentParameters"]
+
+    def test_group_workspace_with_table(self):
+        # test `AddSampleLog` is not called for any `TableWorkspace` in a `WorkspaceGroup`.
+        mockSnapper_ = mock.Mock()
+        mockSnapper_.mtd = TestPopulateInstrumentParameters._MockMtd(wsNames=["ws1", "ws2", "table_ws3", "ws4", "ws5"])
+        assert isinstance(mockSnapper_.mtd["test_group"], WorkspaceGroup)
+
+        with (
+            mock.patch("snapred.backend.data.util.PV_logs_util._snapper", mockSnapper_) as mockSnapper,
+        ):
+            populateInstrumentParameters("test_group")
+            mockSnapper.AddSampleLog.call_count == len(
+                [ws for ws in mockSnapper_.mtd["test_group"].getNames() if "table" not in ws]
+            )
+
+    def test_group_workspace_all_tables(self):
+        # test `AddSampleLog` is not called at all for a group consisting of all `TableWorkspace`.
+        mockSnapper_ = mock.Mock()
+        mockSnapper_.mtd = TestPopulateInstrumentParameters._MockMtd(
+            wsNames=["table_ws1", "table_ws2", "table_ws3", "table_ws4", "table_ws5"]
+        )
+        assert isinstance(mockSnapper_.mtd["test_group"], WorkspaceGroup)
+
+        with (
+            mock.patch("snapred.backend.data.util.PV_logs_util._snapper", mockSnapper_) as mockSnapper,
+        ):
+            populateInstrumentParameters("test_group")
+            mockSnapper.AddSampleLog.assert_not_called()
 
 
 class TestTransferInstrumentPVLogs(unittest.TestCase):
@@ -51,7 +190,7 @@ class TestTransferInstrumentPVLogs(unittest.TestCase):
         # Add the standard instrument PV-logs to the workspace's `Run` attribute.
         self.detectorState = DAOFactory.real_detector_state
         self.instrumentKeys = [
-            k for k in Config["instrument.PVLogs.instrumentKeys"] if k != "BL3:Chop:Gbl:WavelengthReq"
+            k if not isinstance(k, List) else k[0] for k in Config["instrument.PVLogs.instrumentKeys"]
         ]
         logsDescriptors = getInstrumentLogDescriptors(self.detectorState)
         addInstrumentLogs(self.wsWithStandardLogs, **logsDescriptors)
@@ -60,7 +199,7 @@ class TestTransferInstrumentPVLogs(unittest.TestCase):
         # Add the alterate instrument PV-logs.
         self.wsWithAlternateLogs = self.createSampleWorkspace()
         self.alternateInstrumentKeys = [
-            k for k in Config["instrument.PVLogs.instrumentKeys"] if k != "BL3:Chop:Skf1:WavelengthUserReq"
+            k if k != "BL3:Chop:Skf1:WavelengthUserReq" else "BL3:Chop:Gbl:WavelengthReq" for k in self.instrumentKeys
         ]
         logsDescriptors["logNames"] = [
             k if k != "BL3:Chop:Skf1:WavelengthUserReq" else "BL3:Chop:Gbl:WavelengthReq"
@@ -76,17 +215,13 @@ class TestTransferInstrumentPVLogs(unittest.TestCase):
         # Verify that the standard instrument PV-logs have been attached to the test workspace.
         # (This test additionally verifies that the `addInstrumentLogs` interface is using the keys from `Config`.)
         run = mtd[self.wsWithStandardLogs].run()
-        for key in Config["instrument.PVLogs.instrumentKeys"]:
-            if key == "BL3:Chop:Gbl:WavelengthReq":
-                continue
+        for key in self.instrumentKeys:
             assert run.hasProperty(key)
             assert f"{run.getProperty(key).value[0]:.16f}" == self.standardLogs[key]
 
         # Verify the test workspace with the alternate instrument PV-logs.
         run = mtd[self.wsWithAlternateLogs].run()
-        for key in Config["instrument.PVLogs.instrumentKeys"]:
-            if key == "BL3:Chop:Skf1:WavelengthUserReq":
-                continue
+        for key in self.alternateInstrumentKeys:
             assert run.hasProperty(key)
             assert f"{run.getProperty(key).value[0]:.16f}" == self.alternateLogs[key]
 
@@ -182,6 +317,49 @@ class TestMappingFromRun(unittest.TestCase):
     def tearDown(self):
         DeleteWorkspace(self.wsName)
 
+    class _mockProperty:
+        def __init__(self, value):
+            self.value = value
+
+    class _MockRun:
+        def __init__(
+            self,
+            dict_: Dict[str, Any],
+            end_time: DateAndTime = None,
+            start_time: DateAndTime = None,
+            proton_charge: float = None,
+        ):
+            self._dict = dict_
+            self._end_time = end_time
+            self._start_time = start_time
+            self._proton_charge = proton_charge
+
+        def endTime(self) -> DateAndTime:
+            if self._end_time is None:
+                raise RuntimeError("no end time has been set for this run")
+            return self._end_time
+
+        def startTime(self) -> DateAndTime:
+            if self._start_time is None:
+                raise RuntimeError("no start time has been set for this run")
+            return self._start_time
+
+        def getProtonCharge(self) -> float:
+            if self._proton_charge is None:
+                raise RuntimeError("proton charge log is empty")
+            return self._proton_charge
+
+        def hasProperty(self, key: str) -> bool:
+            return key in self._dict
+
+        def getProperty(self, key: str) -> "TestMappingFromRun._mockProperty":
+            if key not in self._dict:
+                raise RuntimeError(f"Unknown property search object {key}")
+            return TestMappingFromRun._mockProperty(self._dict[key])
+
+        def keys(self):
+            return self._dict.keys()
+
     def test_init(self):
         map_ = mappingFromRun(self.ws.getRun())  # noqa: F841
 
@@ -194,24 +372,434 @@ class TestMappingFromRun(unittest.TestCase):
 
     def test_iter(self):
         map_ = mappingFromRun(self.ws.getRun())
-        assert [k for k in map_] == ["run_title", "start_time", "end_time", "run_start", "run_end"]
+        expectedKeys = ["run_title", "start_time", "end_time", "proton_charge", "run_number", "run_start", "run_end"]
+        for k in map_:
+            assert k in expectedKeys
 
     def test_len(self):
         map_ = mappingFromRun(self.ws.getRun())
-        assert len(map_) == 5
+        print([k for k in self.ws.getRun().keys()])
+        print(map_.keys())
+        assert len(map_) == 7
 
     @mock.patch("mantid.api.Run.hasProperty")
-    def test_contains(self, mockHasProperty):
+    def test_contains_direct(self, mockHasProperty):
         mockHasProperty.return_value = True
         map_ = mappingFromRun(self.ws.getRun())
+
+        # NOTE: `<run>.hasProperty()` is also called during `mappingFromRun.__init__()`.
+        mockHasProperty.reset_mock()
         assert "anything" in map_
         mockHasProperty.assert_called_once_with("anything")
+
+    def test_contains_indirect_special_cases(self):
+        map_ = mappingFromRun(self.ws.getRun())
+        assert "start_time" in map_
+        assert "end_time" in map_
+        assert "proton_charge" in map_
+        assert "run_number" in map_
+
+    def test_contains_primary(self):
+        # Test that any '__contains__' with a primary key references the primary-key only.
+        """
+        EXAMPLE: 'instrument.PVLogs.instrumentKeys' section from 'application.yml':
+         -
+           - "BL3:Chop:Skf1:WavelengthUserReq"
+           - "BL3:Chop:Gbl:WavelengthReq"
+           - "BL3:Det:TH:BL:Lambda"
+         - "det_arc1"
+         - "det_arc2"
+         - "BL3:Det:TH:BL:Frequency"
+         -
+           - "BL3:Mot:OpticsPos:Pos"
+           - "optics"
+         - "det_lin1"
+         - "det_lin2"
+        """
+        _MockRun = TestMappingFromRun._MockRun
+        _run = _MockRun(
+            {
+                "BL3:Chop:Skf1:WavelengthUserReq": [24.0],
+                "det_arc1": [1.25],
+                "det_arc2": [2.26],
+                "BL3:Det:TH:BL:Frequency": [35.0],
+                "BL3:Mot:OpticsPos:Pos": [10.0],
+                "det_lin1": [1.0],
+                "det_lin2": [2.0],
+            },
+            start_time="2010-01-01T00:00:00",
+            end_time="2010-01-01T01:00:00",
+            proton_charge=1000.0,
+        )
+        mockRun = mock.Mock(wraps=_MockRun, return_value=_run)
+        map_ = mappingFromRun(mockRun())
+        for ks in Config["instrument.PVLogs.instrumentKeys"]:
+            if isinstance(ks, str):
+                # make sure keys have been initialized for this test
+                assert ks in _run._dict
+                # make sure all keys are in the mapping
+                assert ks in map_
+            else:
+                # make sure that only the primary key is referencable
+                assert ks[0] in _run._dict
+                assert ks[0] in map_
+                for k in ks[1:]:
+                    assert k not in map_
+
+    def test_contains_alternatives(self):
+        # Test that any '__contains__' with a primary key references the alternative-key.
+        """
+        EXAMPLE: 'instrument.PVLogs.instrumentKeys' section from 'application.yml':
+         -
+           - "BL3:Chop:Skf1:WavelengthUserReq"
+           - "BL3:Chop:Gbl:WavelengthReq"
+           - "BL3:Det:TH:BL:Lambda"
+         - "det_arc1"
+         - "det_arc2"
+         - "BL3:Det:TH:BL:Frequency"
+         -
+           - "BL3:Mot:OpticsPos:Pos"
+           - "optics"
+         - "det_lin1"
+         - "det_lin2"
+        """
+        _MockRun = TestMappingFromRun._MockRun
+        _run = _MockRun(
+            {
+                "BL3:Chop:Gbl:WavelengthReq": [24.0],
+                "det_arc1": [1.25],
+                "det_arc2": [2.26],
+                "BL3:Det:TH:BL:Frequency": [35.0],
+                "optics": [10.0],
+                "det_lin1": [1.0],
+                "det_lin2": [2.0],
+            },
+            start_time="2010-01-01T00:00:00",
+            end_time="2010-01-01T01:00:00",
+            proton_charge=1000.0,
+        )
+        mockRun = mock.Mock(wraps=_MockRun, return_value=_run)
+        map_ = mappingFromRun(mockRun())
+        for ks in Config["instrument.PVLogs.instrumentKeys"]:
+            if isinstance(ks, str):
+                # make sure keys have been initialized for this test
+                assert ks in _run._dict
+                # make sure all keys are in the mapping
+                assert ks in map_
+            else:
+                # primary key references alternative key
+                assert ks[0] not in _run._dict
+                assert ks[0] in map_
+                # alternative key continues to reference itself
+                assert ks[1] in map_
+
+    def test_keys_special_cases(self):
+        map_ = mappingFromRun(self.ws.getRun())
+        keys_ = map_.keys()
+        assert "start_time" in keys_
+        assert "end_time" in keys_
+        assert "proton_charge" in keys_
+        assert "run_number" in keys_
+
+    def test_keys_alternatives(self):
+        # Test that both primary keys and any existing altarnative-keys show up in the 'keys()' return value.
+        """
+        EXAMPLE: 'instrument.PVLogs.instrumentKeys' section from 'application.yml':
+         -
+           - "BL3:Chop:Skf1:WavelengthUserReq"
+           - "BL3:Chop:Gbl:WavelengthReq"
+           - "BL3:Det:TH:BL:Lambda"
+         - "det_arc1"
+         - "det_arc2"
+         - "BL3:Det:TH:BL:Frequency"
+         -
+           - "BL3:Mot:OpticsPos:Pos"
+           - "optics"
+         - "det_lin1"
+         - "det_lin2"
+        """
+        _MockRun = TestMappingFromRun._MockRun
+        _run = _MockRun(
+            {
+                "BL3:Chop:Gbl:WavelengthReq": [24.0],
+                "det_arc1": [1.25],
+                "det_arc2": [2.26],
+                "BL3:Det:TH:BL:Frequency": [35.0],
+                "optics": [10.0],
+                "det_lin1": [1.0],
+                "det_lin2": [2.0],
+            },
+            start_time="2010-01-01T00:00:00",
+            end_time="2010-01-01T01:00:00",
+            proton_charge=1000.0,
+        )
+        mockRun = mock.Mock(wraps=_MockRun, return_value=_run)
+        map_ = mappingFromRun(mockRun())
+        keys_ = map_.keys()
+        for ks in Config["instrument.PVLogs.instrumentKeys"]:
+            if isinstance(ks, str):
+                # make sure keys have been initialized for this test
+                assert ks in _run._dict
+                # make sure all keys are in the mapping
+                assert ks in keys_
+            else:
+                # primary key references alternative key
+                assert ks[0] not in _run._dict
+                assert ks[0] in keys_
+                # alternative key continues to reference itself
+                assert ks[1] in keys_
+
+    def test_get_alternatives(self):
+        # Test that any 'get' with a primary key references the altarnative-key value.
+        """
+        EXAMPLE: 'instrument.PVLogs.instrumentKeys' section from 'application.yml':
+         -
+           - "BL3:Chop:Skf1:WavelengthUserReq"
+           - "BL3:Chop:Gbl:WavelengthReq"
+           - "BL3:Det:TH:BL:Lambda"
+         - "det_arc1"
+         - "det_arc2"
+         - "BL3:Det:TH:BL:Frequency"
+         -
+           - "BL3:Mot:OpticsPos:Pos"
+           - "optics"
+         - "det_lin1"
+         - "det_lin2"
+        """
+        _MockRun = TestMappingFromRun._MockRun
+        _run = _MockRun(
+            {
+                "BL3:Chop:Gbl:WavelengthReq": [24.0],
+                "det_arc1": [1.25],
+                "det_arc2": [2.26],
+                "BL3:Det:TH:BL:Frequency": [35.0],
+                "optics": [10.0],
+                "det_lin1": [1.0],
+                "det_lin2": [2.0],
+            },
+            start_time="2010-01-01T00:00:00",
+            end_time="2010-01-01T01:00:00",
+            proton_charge=1000.0,
+        )
+        mockRun = mock.Mock(wraps=_MockRun, return_value=_run)
+        map_ = mappingFromRun(mockRun())
+        for ks in Config["instrument.PVLogs.instrumentKeys"]:
+            if isinstance(ks, str):
+                assert map_[ks] == _run._dict[ks]
+            else:
+                # primary key references alternative key
+                assert map_[ks[0]] == _run._dict[ks[1]]
+                # alternative key continues to reference itself
+                assert map_[ks[1]] == _run._dict[ks[1]]
+
+    def test_get_key_error(self):
+        # Test that "Unknown property search object" is converted to `KeyError`.
+        """
+        EXAMPLE: 'instrument.PVLogs.instrumentKeys' section from 'application.yml':
+         -
+           - "BL3:Chop:Skf1:WavelengthUserReq"
+           - "BL3:Chop:Gbl:WavelengthReq"
+           - "BL3:Det:TH:BL:Lambda"
+         - "det_arc1"
+         - "det_arc2"
+         - "BL3:Det:TH:BL:Frequency"
+         -
+           - "BL3:Mot:OpticsPos:Pos"
+           - "optics"
+         - "det_lin1"
+         - "det_lin2"
+        """
+        _MockRun = TestMappingFromRun._MockRun
+        _run = _MockRun(
+            {
+                "BL3:Chop:Gbl:WavelengthReq": [24.0],
+                "det_arc1": [1.25],
+                "det_arc2": [2.26],
+                "BL3:Det:TH:BL:Frequency": [35.0],
+                "optics": [10.0],
+                "det_lin1": [1.0],
+                "det_lin2": [2.0],
+            },
+            start_time="2010-01-01T00:00:00",
+            end_time="2010-01-01T01:00:00",
+            proton_charge=1000.0,
+        )
+        mockRun = mock.Mock(wraps=_MockRun, return_value=_run)
+        mockRun.return_value.getProperty = mock.Mock(side_effect=RuntimeError("Unknown property search object"))
+        map_ = mappingFromRun(mockRun())
+        with pytest.raises(KeyError, match="lah_dee_dah"):
+            value = map_["lah_dee_dah"]  # noqa: F841
+
+    def test_get_not_key_error(self):
+        # Test that only "property not found" is converted to `KeyError`.
+        """
+        EXAMPLE: 'instrument.PVLogs.instrumentKeys' section from 'application.yml':
+         -
+           - "BL3:Chop:Skf1:WavelengthUserReq"
+           - "BL3:Chop:Gbl:WavelengthReq"
+           - "BL3:Det:TH:BL:Lambda"
+         - "det_arc1"
+         - "det_arc2"
+         - "BL3:Det:TH:BL:Frequency"
+         -
+           - "BL3:Mot:OpticsPos:Pos"
+           - "optics"
+         - "det_lin1"
+         - "det_lin2"
+        """
+        _MockRun = TestMappingFromRun._MockRun
+        _run = _MockRun(
+            {
+                "BL3:Chop:Gbl:WavelengthReq": [24.0],
+                "det_arc1": [1.25],
+                "det_arc2": [2.26],
+                "BL3:Det:TH:BL:Frequency": [35.0],
+                "optics": [10.0],
+                "det_lin1": [1.0],
+                "det_lin2": [2.0],
+            },
+            start_time="2010-01-01T00:00:00",
+            end_time="2010-01-01T01:00:00",
+            proton_charge=1000.0,
+        )
+        mockRun = mock.Mock(wraps=_MockRun, return_value=_run)
+        mockRun.return_value.getProperty = mock.Mock(side_effect=RuntimeError("something bad happened"))
+        map_ = mappingFromRun(mockRun())
+        with pytest.raises(RuntimeError, match="something bad happened"):
+            value = map_["lah_dee_dah"]  # noqa: F841
+
+    def test_default_start_and_end_times(self):
+        # test that default start and end times are "now"
+        _MockRun = TestMappingFromRun._MockRun
+        _run = _MockRun(
+            {
+                "BL3:Chop:Skf1:WavelengthUserReq": [24.0],
+                "det_arc1": [1.25],
+                "det_arc2": [2.26],
+                "BL3:Det:TH:BL:Frequency": [35.0],
+                "BL3:Mot:OpticsPos:Pos": [10.0],
+                "det_lin1": [1.0],
+                "det_lin2": [2.0],
+                "run_number": "12345",
+            },
+            start_time=None,
+            end_time=None,
+            proton_charge=1000.0,
+        )
+        mockRun = mock.Mock(wraps=_MockRun, return_value=_run)
+        map_ = mappingFromRun(mockRun())
+        assert "start_time" in map_
+        assert map_["start_time"] == map_._now
+        assert "end_time" in map_
+        assert map_["end_time"] == map_._now
+
+    def test_default_proton_charge(self):
+        # test that proton charge is zero
+        _MockRun = TestMappingFromRun._MockRun
+        _run = _MockRun(
+            {
+                "BL3:Chop:Skf1:WavelengthUserReq": [24.0],
+                "det_arc1": [1.25],
+                "det_arc2": [2.26],
+                "BL3:Det:TH:BL:Frequency": [35.0],
+                "BL3:Mot:OpticsPos:Pos": [10.0],
+                "det_lin1": [1.0],
+                "det_lin2": [2.0],
+                "run_number": "12345",
+            },
+            start_time="2010-01-01T00:00:00",
+            end_time="2010-01-01T01:00:00",
+            proton_charge=None,
+        )
+        mockRun = mock.Mock(wraps=_MockRun, return_value=_run)
+        map_ = mappingFromRun(mockRun())
+        assert "proton_charge" in map_
+        assert map_["proton_charge"] == 0.0
+
+    def test_default_run_number(self):
+        # test that default 'run_number' is int(0)
+        _MockRun = TestMappingFromRun._MockRun
+        _run = _MockRun(
+            {
+                "BL3:Chop:Skf1:WavelengthUserReq": [24.0],
+                "det_arc1": [1.25],
+                "det_arc2": [2.26],
+                "BL3:Det:TH:BL:Frequency": [35.0],
+                "BL3:Mot:OpticsPos:Pos": [10.0],
+                "det_lin1": [1.0],
+                "det_lin2": [2.0],
+            },
+            start_time="2010-01-01T00:00:00",
+            end_time="2010-01-01T01:00:00",
+            proton_charge=1000.0,
+        )
+        mockRun = mock.Mock(wraps=_MockRun, return_value=_run)
+        map_ = mappingFromRun(mockRun())
+        assert "run_number" in map_
+        assert map_["run_number"] == 0
+
+    def test_defaults_warning(self):
+        # test that default 'run_number' is int(0)
+        _MockRun = TestMappingFromRun._MockRun
+        _run = _MockRun(
+            {
+                "BL3:Chop:Skf1:WavelengthUserReq": [24.0],
+                "det_arc1": [1.25],
+                "det_arc2": [2.26],
+                "BL3:Det:TH:BL:Frequency": [35.0],
+                "BL3:Mot:OpticsPos:Pos": [10.0],
+                "det_lin1": [1.0],
+                "det_lin2": [2.0],
+            },
+            start_time=None,
+            end_time=None,
+            proton_charge=None,
+        )
+        mockRun = mock.Mock(wraps=_MockRun, return_value=_run)
+        mockLogger_ = mock.Mock(isEnabledFor=mock.Mock(return_value=True))
+        with mock.patch("snapred.backend.data.util.PV_logs_util.logger", mockLogger_) as mockLogger:
+            map_ = mappingFromRun(mockRun())
+            startTime = map_["start_time"]  # noqa: F841
+            endTime = map_["end_time"]  # noqa: F841
+            protonCharge = map_["proton_charge"]  # noqa: F841
+            assert mockLogger.isEnabledFor.call_count == 3
+            mockLogger.isEnabledFor.assert_any_call(logging.DEBUG)
+            assert mockLogger.warning.call_count == 3
+            assert "start time" in mockLogger.warning.mock_calls[0].args[0]
+            assert "end time" in mockLogger.warning.mock_calls[1].args[0]
+            assert "proton charge" in mockLogger.warning.mock_calls[2].args[0]
+
+    def test_run_number(self):
+        # test that 'run_number' is recognized correctly
+        runNumber = "12345"
+        _MockRun = TestMappingFromRun._MockRun
+        _run = _MockRun(
+            {
+                "BL3:Chop:Skf1:WavelengthUserReq": [24.0],
+                "det_arc1": [1.25],
+                "det_arc2": [2.26],
+                "BL3:Det:TH:BL:Frequency": [35.0],
+                "BL3:Mot:OpticsPos:Pos": [10.0],
+                "det_lin1": [1.0],
+                "det_lin2": [2.0],
+                "run_number": runNumber,
+            },
+            start_time="2010-01-01T00:00:00",
+            end_time="2010-01-01T01:00:00",
+            proton_charge=1000.0,
+        )
+        mockRun = mock.Mock(wraps=_MockRun, return_value=_run)
+        map_ = mappingFromRun(mockRun())
+        assert "run_number" in map_
+        assert map_["run_number"] == runNumber
 
     @mock.patch("mantid.api.Run.keys")
     def test_keys(self, mockKeys):
         mockKeys.return_value = ["we", "are", "the", "keys"]
         map_ = mappingFromRun(self.ws.getRun())
-        assert map_.keys() == mockKeys.return_value
+        expectedKeys = set(mockKeys.return_value)
+        expectedKeys.update(["start_time", "end_time", "proton_charge", "run_number"])
+        assert set(map_.keys()) == expectedKeys
         mockKeys.assert_called_once()
 
 

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -1057,7 +1057,14 @@ class TestCalibrationServiceMethods(unittest.TestCase):
             mock.sentinel.run2: mock.sentinel.version2,
             mock.sentinel.run3: mock.sentinel.version2,
         }
-        mockGroceries = [mock.sentinel.grocery1, mock.sentinel.grocery2, mock.sentinel.grocery2]
+        mockGroceries = [
+            mock.sentinel.grocery1_table,
+            mock.sentinel.grocery1_mask,
+            mock.sentinel.grocery2_table,
+            mock.sentinel.grocery2_mask,
+            mock.sentinel.grocery2_table,
+            mock.sentinel.grocery2_mask,
+        ]
         self.instance.matchRunsToCalibrationVersions = mock.Mock(return_value=mockCalibrations)
         self.instance.groceryService.fetchGroceryList = mock.Mock(return_value=mockGroceries)
         self.instance.groceryClerk = mock.Mock()
@@ -1065,14 +1072,15 @@ class TestCalibrationServiceMethods(unittest.TestCase):
         with mock.patch.object(NameBuilder, "build", autospec=True) as mockNameBuilder_build:
             mockNameBuilder_build.side_effect = lambda self_: tuple(self_.props.values())
 
-            request = mock.Mock(runNumbers=[mock.sentinel.run1, mock.sentinel.run2], useLiteMode=True)
-            groceries, cal = self.instance.fetchMatchingCalibrations(request)
-            assert groceries == {
-                mock.sentinel.grocery1,  # diffcal-table #1
-                mock.sentinel.grocery2,  # diffcal-table #2
-                # Be careful here: there's some implicit ordering going on in the 'values' tuples.
-                (mock.sentinel.version1, WorkspaceType.DIFFCAL_MASK, False, mock.sentinel.run1),  # diffcal-mask #1
-                (mock.sentinel.version2, WorkspaceType.DIFFCAL_MASK, False, mock.sentinel.run2),  # diffcal-mask #2
+            request = mock.Mock(
+                runNumbers=[mock.sentinel.run1, mock.sentinel.run2, mock.sentinel.run3], useLiteMode=True
+            )
+            workspaces, cal = self.instance.fetchMatchingCalibrations(request)
+            assert workspaces == {
+                mock.sentinel.grocery1_table,  # diffcal-table #1
+                mock.sentinel.grocery2_table,  # diffcal-table #2
+                mock.sentinel.grocery1_mask,  # diffcal-mask #1
+                mock.sentinel.grocery2_mask,  # diffcal-mask #2
             }
             assert cal == mockCalibrations
 

--- a/tests/unit/ui/workflow/test_WorkflowImplementer.py
+++ b/tests/unit/ui/workflow/test_WorkflowImplementer.py
@@ -10,7 +10,7 @@ from snapred.ui.workflow.WorkflowImplementer import WorkflowImplementer
 @pytest.mark.ui
 def test_rename_on_iterate_list(qtbot):  # noqa: ARG001
     """
-    Test that on iteration, a list of workspaces will be renamed according to the iteration template.
+    Test that on iteration, a set of workspaces will be renamed according to the iteration template.
     """
     # setup a list of workspaces to be renamed
     oldNames = ["old1", "old2"]
@@ -21,9 +21,9 @@ def test_rename_on_iterate_list(qtbot):  # noqa: ARG001
 
     instance = WorkflowImplementer()
     newNames = [instance.renameTemplate.format(workspaceName=ws, iteration=mockPresenter.iteration) for ws in oldNames]
-    instance.outputs = oldNames
+    instance.outputs = set(oldNames)
     instance.iterate(mockPresenter)
-    assert instance.collectedOutputs == newNames
+    assert instance.collectedOutputs == set(newNames)
 
 
 @pytest.mark.ui
@@ -45,9 +45,9 @@ def test_rename_on_iterate_group(qtbot):  # noqa: ARG001
         assert mtd.doesExist(old)
         assert not mtd.doesExist(new)
 
-    instance.outputs = [oldNames[0]]
+    instance.outputs = set([oldNames[0]])
     instance.iterate(mockPresenter)
-    assert instance.collectedOutputs == [newNames[0]]
+    assert instance.collectedOutputs == set([newNames[0]])
     for old, new in zip(oldNames, newNames):
         assert not mtd.doesExist(old)
         assert mtd.doesExist(new)


### PR DESCRIPTION
## Description of work

The majority of the changes implementing SNAPRed's live-data capability were merged at the PR for EWM#7436 (SNAPRed PR#541). This commit deals with additional required changes discovered during testing with the actual live-data listener.

## Explanation of work

**This commit includes the following changes:**

  * During testing it was found that almost always the instrument-parameter related PV-logs of the live-data input workspaces have been incompletely initialized.  The utility method `PV_logs_util.mappingFromRun` has been modified to optionally use a list of alternative keys in order to more reliably obtain several of the instrument-parameter values.  These keys are specified in a new nested-list structure in `application.yml` stored at the compound key `instrument.PVLogs.instrumentKeys`;

  * Log a warning when the live-data fallback has been triggered -- this warning is only logged during the fallback case.

  * Allow for the possibility that no IPTS directory exists at all -- this seems to be a common live-data case when diagnostic runs are being made with the instrument;  (Note that Mantid `GetIPTS` sometimes locks up when this case occurs.  This will be reported as a separate DEFECT.)

  * Modifications to `LocalDataService.getIPTS` to allow full caching of both IPTS-directories, and also the case when "no IPTS directory exists";

  * Full caching of both `LocalDataService.generateStateId`, and `LocalDataService.readDetectorState` methods, allowing far fewer calles to `GetIPTS`.  (Primarily this is a work around to the `GetIPTS` lock-up issue.)

  * Allow `LocalDataService.readDetectorState` to return `None` when no run is active.

  * Reduce logging output during live-data mode as much as possible.  This includes both silencing the `LoadLiveData` and `GetIPTS` algorithm by declaring them as "quiet algorithms` (in `MantidSnapper`), but also modifying some traceback logging so that it only occurs at the `debug` logging level;  (A major issue when running live-data mode when `debug` logging is enabled has been that Mantid's logging system locks up, due to excessive output to the "messages" panel.  In addition, the `LoadLiveData` algorithm does not correctly initialize the logging level of it's live-data listener.  Both of these issues will also be written up as separate DEFECTs.)

  * Log a `WARNING` if the "messages" panel logging level is set to `DEBUG` in MantidWorkbench when SNAPRed is initialized.  Although SNAPRed's live data mode will run correctly in this case, when the user exits SNAPRed, and the "messages" panel is reset to this `DEBUG` level, the log messages from the live-data listener will lock-up Mantid's logging system;

  * Change all of the reduction-workflow "exclude" workspaces lists to `set`.  This is more consistent with how this information is actually used within the workflow;

  * More robust treatment of `LiveMetadata` load, adding reasonable default values when some values are not present in the logs.  Primarily this allows the "PROTON CHARGE IS ZERO" case to be identified more successfully;

  * In all cases, substitute "PROTON CHARGE IS ZERO" for "BEAM IS DOWN".  Although in this case the beam may indeed be down, only the assertion about proton charge can be made accurately.

**Defects that have been fixed as part of this commit:**

  * The live-data toggle is no longer re-enabled after a normal reduction workflow, when the `application.yml` has `liveData.enabled: false`;

  * In live-data mode, in case of any error, reduction output workspaces are no longer deleted if they have valid content from a previous reduction cycle that _has_ completed successfully;

  * Several required fixes to what happens during an end-of-run transition.  This transition should now be working correctly, and displays a `warning` messagebox;

  * In the diffraction-calibration assessment panel: fix a defect that prevented the "load" function from working correctly.  This involved enabling the 'populateInstrumentParameters' method to successfully take a  workspace group as input;

  * In `GroceryService`: do not assume the diffraction-calibration mask is loaded just because the table is loaded. This caused errors in any successive reduction workflow, due to the _next_ defect;

  * When multiple workflows are being run _successfully_ add the diffraction-calibration mask to the "_keeps" list.  It was being added before, but was not using its correct workspace name;

  * Send the correct <start time> values to `LoadLiveData`.  These values are <EPOCH ZERO>, and <EPOCH + 1 second> which correspond to <now> and <all available data for the run> respectively.  The correct  behavior is that a _zero_ duration setting in the duration slider corresponds to <load all available data>, and due to this issue, this case was not being treated correctly;

**New DEFECTS found that have NOT been fixed:**

  * Race condition in Mantid `GetIPTS`;

  * Race conditions in Mantid's logging system;

  * The live-data listener does not shut down correctly when its calling algorithm has exited.  This is actually a high-priority defect as it has been associated with Mantidworkbench shut-down issues.  In this regard I've added all of the possible work arounds that I could think of.  However, it would be better to actually solve this problem within the Mantid code.  Almost certainly, this might require slight modifications to the live-listener interface, which at present is woefully inadequate for the requirements of the present usage;

  * The possibility of running `LoadLiveData` as a stay-resident algorithm was explored.  It was decided that although this functionality might be necessary in live-data "Accumulate" mode, it would actually generate erroneous output from `LoadLiveData` when run in `Replace` mode.  As a result of this, this stay-resident mode is not used and `Replace` mode is now the only mode that is supported.  (There's a note to this effect in `application.yml`, but there isn't an actual error check at initialization.  Solving the previously mentioned defect with the live listener should fix this issue.)


## To test
 
For "by hand" testing with the live listener, one needs to be patient, as there seem to be long periods where only very short runs occur, or only runs separated by long "PAUSED" intervals.  I have quite a few suggestions here, but I am in progress of drafting this section.

**In order to save time use `monitor.sns.gov` to determine the current \< _run_ _state_ \> for the SNAP instrument.  Also, it's important to modify your \< instrument parameters: appliesTo \> values so that the current run-numbers are included.**

When you run live-data sometimes there seem to be "drop outs", that is input-data workspaces that don't have their run number set correctly.  In this case SNAPRed will mistakenly identify this as an end-of-run condition, so you still need to keep track of what's actually going on at [monitor.sns.gov](http://monitor.sns.gov/).  In this case, just hit \<cancel\> then \<continue\> again, and things usually fix themselves.

### Dev testing
New unit tests have been implemented to cover most of the substantive changes.

### CIS testing


## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#9504](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=9504)

