### PR TITLE
EWM 9435 Discarding events

### DIFF
--- a/src/snapred/backend/recipe/ApplyNormalizationRecipe.py
+++ b/src/snapred/backend/recipe/ApplyNormalizationRecipe.py
@@ -93,9 +93,9 @@ class ApplyNormalizationRecipe(Recipe[Ingredients]):
         Final step in a recipe, executes the queued algorithms.
         Requires: queued algorithms.
         """
-        self._rebinSample(preserveEvents=True)
+        self._rebinSample(preserveEvents=False)  # This is now false
         self.mantidSnapper.executeQueue()
-        self._rebinSample(preserveEvents=False)
+        # self._rebinSample(preserveEvents=False) remove this
         return True
 
     def cater(self, shipment: List[Pallet]) -> List[WorkspaceName]:

--- a/src/snapred/backend/recipe/ApplyNormalizationRecipe.py
+++ b/src/snapred/backend/recipe/ApplyNormalizationRecipe.py
@@ -93,9 +93,8 @@ class ApplyNormalizationRecipe(Recipe[Ingredients]):
         Final step in a recipe, executes the queued algorithms.
         Requires: queued algorithms.
         """
-        self._rebinSample(preserveEvents=False)  # This is now false
+        self._rebinSample(preserveEvents=False)
         self.mantidSnapper.executeQueue()
-        # self._rebinSample(preserveEvents=False) remove this
         return True
 
     def cater(self, shipment: List[Pallet]) -> List[WorkspaceName]:

--- a/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
+++ b/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
@@ -56,7 +56,7 @@ class ReductionGroupProcessingRecipe(Recipe[Ingredients]):
             OutputWorkspace=self.outputWS,
             GroupingWorkspace=self.groupingWS,
             Ingredients=self.pixelGroup.json(),
-            RebinOutput=True,  # updated to true
+            RebinOutput=True,
         )
 
         normalizeArgs = {

--- a/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
+++ b/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
@@ -56,7 +56,7 @@ class ReductionGroupProcessingRecipe(Recipe[Ingredients]):
             OutputWorkspace=self.outputWS,
             GroupingWorkspace=self.groupingWS,
             Ingredients=self.pixelGroup.json(),
-            RebinOutput=False,
+            RebinOutput=True,  # updated to true
         )
 
         normalizeArgs = {

--- a/tests/integration/test_reduction.py
+++ b/tests/integration/test_reduction.py
@@ -28,8 +28,13 @@ class InterruptWithBlock(BaseException):
     pass
 
 
+# TODO: Remove mantid import and skipif mark when mantid version is higher than skipif
+import mantid  # noqa: E402
+
+
 @pytest.mark.datarepo
 @pytest.mark.integration
+@pytest.mark.skipif(mantid.__version__ <= "6.12.0.2", reason="Needs mantid version that has fix for segfault")
 class TestGUIPanels:
     @pytest.fixture(scope="function", autouse=True)  # noqa: PT003
     def _setup_gui(self, qapp):


### PR DESCRIPTION
## Description of work

The purpose of this was to get rid of events where possible and to just keep histograms. I went through the code with Malcolm and added just a few fixes, more work will be covered by later stories.

## Explanation of work

This is just setting the keepEvents flag in RebinRagged calls where possible.

## To test

### Dev testing

Run reduction and diffcal workflows and make sure they still work.

### CIS testing

Run diffcal and reduction workflows, and make sure that there are more workspaces that are set as histograms instead of event workspaces.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#9435](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9435)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] reduction works as expected
- [x] diffcal works as expected
