### PR TITLE
Add side-by-side-view-locations

### DIFF
--- a/docs/source/developer/feature/workflow/calibrationWorkflow.rst
+++ b/docs/source/developer/feature/workflow/calibrationWorkflow.rst
@@ -12,6 +12,7 @@ Steps
 -----
 
 The high-level steps are:
+
 1. Trigger Calibration Creation
 2. Assess Calibration Quality
 3. Accept or Reject Calibration

--- a/src/snapred/resources/SNAPLite_Definition.xml
+++ b/src/snapred/resources/SNAPLite_Definition.xml
@@ -111,18 +111,22 @@
     </component>
   </type>
 
+  <!-- East -->
   <type name="Column1">
     <component type="panel"   idstart="2048" idfillbyfirst="y" idstepbyrow="32" >
+      <side-by-side-view-location x="-0.44" y="0.17"/>
       <location name="bank13">  <!-- was bank1 - 720896 -->
         <trans x="-0.167548" y="0.167548" />
       </location>
     </component>
     <component type="panel"   idstart="1024" idfillbyfirst="y" idstepbyrow="32" >
+      <side-by-side-view-location x="-0.44" y="0"/>
       <location name="bank12">  <!-- was bank4 - 655360 -->
         <trans x="-0.167548" y="0.0" />
       </location>
     </component>
     <component type="panel"   idstart="0" idfillbyfirst="y" idstepbyrow="32" >
+      <side-by-side-view-location x="-0.44" y="-0.17"/>
       <location name="bank11">  <!-- was bank7 - 589824 -->
         <trans x="-0.167548" y="-0.167548" />
       </location>
@@ -130,16 +134,19 @@
   </type>
   <type name="Column2">
     <component type="panel"   idstart="5120" idfillbyfirst="y" idstepbyrow="32" >
+      <side-by-side-view-location x="-0.27" y="0.17"/>
       <location name="bank23">  <!-- was bank2 - 917504 -->
         <trans x="0.0" y="0.167548" />
       </location>
     </component>
     <component type="panel"  idstart="4096" idfillbyfirst="y" idstepbyrow="32" >
+      <side-by-side-view-location x="-0.27" y="0"/>
       <location name="bank22">  <!-- was bank5 - 851968 -->
         <trans x="0.0" y="0.0" />
       </location>
     </component>
     <component type="panel"   idstart="3072" idfillbyfirst="y" idstepbyrow="32" >
+      <side-by-side-view-location x="-0.27" y="-0.17"/>
       <location name="bank21">  <!-- was bank8 - 786432 -->
         <trans x="0.0" y="-0.167548" />
       </location>
@@ -147,33 +154,40 @@
   </type>
   <type name="Column3">
     <component type="panel"   idstart="8192" idfillbyfirst="y" idstepbyrow="32" >
+      <side-by-side-view-location x="-0.1" y="0.17"/>
       <location name="bank33">  <!-- was bank3 - 1114112 -->
         <trans x="0.167548" y="0.167548" />
       </location>
     </component>
     <component type="panel"   idstart="7168" idfillbyfirst="y" idstepbyrow="32" >
+      <side-by-side-view-location x="-0.1" y="0"/>
       <location name="bank32">  <!-- was bank6 - 1048576 -->
         <trans x="0.167548" y="0.0" />
       </location>
     </component>
     <component type="panel"   idstart="6144" idfillbyfirst="y" idstepbyrow="32" >
+      <side-by-side-view-location x="-0.1" y="-0.17"/>
       <location name="bank31">  <!-- was bank9 - 983040 -->
         <trans x="0.167548" y="-0.167548" />
       </location>
     </component>
   </type>
+  <!-- West -->
   <type name="Column4">
     <component type="panel"   idstart="17408" idfillbyfirst="y" idstepbyrow="32" >
+      <side-by-side-view-location x="0.1" y="0.17"/>
       <location name="bank63">  <!-- was bank10 - 524288 -->
         <trans x="0.167548" y="0.167548" />
       </location>
     </component>
     <component type="panel"   idstart="16384" idfillbyfirst="y" idstepbyrow="32" >
+      <side-by-side-view-location x="0.1" y="0"/>
       <location name="bank62">  <!-- was bank13 - 458752 -->
         <trans x="0.167548" y="0.0" />
       </location>
     </component>
     <component type="panel"   idstart="15360" idfillbyfirst="y" idstepbyrow="32" >
+      <side-by-side-view-location x="0.1" y="-0.17"/>
       <location name="bank61">  <!-- was bank16 - 393216 -->
         <trans x="0.167548" y="-0.167548" />
       </location>
@@ -181,16 +195,19 @@
   </type>
   <type name="Column5">
     <component type="panel"   idstart="14336" idfillbyfirst="y" idstepbyrow="32" >
+      <side-by-side-view-location x="0.27" y="0.17"/>
       <location name="bank53">  <!-- was bank11 - 327680 -->
         <trans x="0.0" y="0.167548" />
       </location>
     </component>
     <component type="panel"   idstart="13312" idfillbyfirst="y" idstepbyrow="32" >
+      <side-by-side-view-location x="0.27" y="0"/>
       <location name="bank52">  <!-- was bank14 - 262144 -->
         <trans x="0.0" y="0.0" />
       </location>
     </component>
     <component type="panel"   idstart="12288" idfillbyfirst="y" idstepbyrow="32" >
+      <side-by-side-view-location x="0.27" y="-0.17"/>
       <location name="bank51">  <!-- was bank17 - 196608 -->
         <trans x="0.0" y="-0.167548" />
       </location>
@@ -198,16 +215,19 @@
   </type>
   <type name="Column6">
     <component type="panel"   idstart="11264" idfillbyfirst="y" idstepbyrow="32" >
+      <side-by-side-view-location x="0.44" y="0.17"/>
       <location name="bank43">  <!-- was bank12 - 131072 -->
         <trans x="-0.167548" y="0.167548" />
       </location>
     </component>
     <component type="panel"   idstart="10240" idfillbyfirst="y" idstepbyrow="32" >
+      <side-by-side-view-location x="0.44" y="0"/>
       <location name="bank42">  <!-- was bank15 - 65536 -->
         <trans x="-0.167548" y="0.0" />
       </location>
     </component>
     <component type="panel"  idstart="9216" idfillbyfirst="y" idstepbyrow="32" >
+      <side-by-side-view-location x="0.44" y="-0.17"/>
       <location name="bank41">  <!-- was bank18 - 0 -->
         <trans x="-0.167548" y="-0.167548" />
       </location>

--- a/src/snapred/resources/SNAP_Definition.xml
+++ b/src/snapred/resources/SNAP_Definition.xml
@@ -111,18 +111,22 @@
     </component>
   </type>
 
+  <!-- East -->
   <type name="Column1">
     <component type="panel"   idstart="131072" idfillbyfirst="y" idstepbyrow="256" >
+      <side-by-side-view-location x="-0.44" y="0.17"/>
       <location name="bank13">  <!-- was bank1 - 720896 -->
         <trans x="-0.167548" y="0.167548" />
       </location>
     </component>
     <component type="panel"   idstart="65536" idfillbyfirst="y" idstepbyrow="256" >
+      <side-by-side-view-location x="-0.44" y="0"/>
       <location name="bank12">  <!-- was bank4 - 655360 -->
         <trans x="-0.167548" y="0.0" />
       </location>
     </component>
     <component type="panel"   idstart="0" idfillbyfirst="y" idstepbyrow="256" >
+      <side-by-side-view-location x="-0.44" y="-0.17"/>
       <location name="bank11">  <!-- was bank7 - 589824 -->
         <trans x="-0.167548" y="-0.167548" />
       </location>
@@ -130,16 +134,19 @@
   </type>
   <type name="Column2">
     <component type="panel"   idstart="327680" idfillbyfirst="y" idstepbyrow="256" >
+      <side-by-side-view-location x="-0.27" y="0.17"/>
       <location name="bank23">  <!-- was bank2 - 917504 -->
         <trans x="0.0" y="0.167548" />
       </location>
     </component>
     <component type="panel"  idstart="262144" idfillbyfirst="y" idstepbyrow="256" >
+      <side-by-side-view-location x="-0.27" y="0"/>
       <location name="bank22">  <!-- was bank5 - 851968 -->
         <trans x="0.0" y="0.0" />
       </location>
     </component>
     <component type="panel"   idstart="196608" idfillbyfirst="y" idstepbyrow="256" >
+      <side-by-side-view-location x="-0.27" y="-0.17"/>
       <location name="bank21">  <!-- was bank8 - 786432 -->
         <trans x="0.0" y="-0.167548" />
       </location>
@@ -147,33 +154,40 @@
   </type>
   <type name="Column3">
     <component type="panel"   idstart="524288" idfillbyfirst="y" idstepbyrow="256" >
+      <side-by-side-view-location x="-0.1" y="0.17"/>
       <location name="bank33">  <!-- was bank3 - 1114112 -->
         <trans x="0.167548" y="0.167548" />
       </location>
     </component>
     <component type="panel"   idstart="458752" idfillbyfirst="y" idstepbyrow="256" >
+      <side-by-side-view-location x="-0.1" y="0"/>
       <location name="bank32">  <!-- was bank6 - 1048576 -->
         <trans x="0.167548" y="0.0" />
       </location>
     </component>
     <component type="panel"   idstart="393216" idfillbyfirst="y" idstepbyrow="256" >
+      <side-by-side-view-location x="-0.1" y="-0.17"/>
       <location name="bank31">  <!-- was bank9 - 983040 -->
         <trans x="0.167548" y="-0.167548" />
       </location>
     </component>
   </type>
+  <!-- West -->
   <type name="Column4">
     <component type="panel"   idstart="1114112" idfillbyfirst="y" idstepbyrow="256" >
+      <side-by-side-view-location x="0.1" y="0.17"/>
       <location name="bank63">  <!-- was bank10 - 524288 -->
         <trans x="0.167548" y="0.167548" />
       </location>
     </component>
     <component type="panel"   idstart="1048576" idfillbyfirst="y" idstepbyrow="256" >
+      <side-by-side-view-location x="0.1" y="0"/>
       <location name="bank62">  <!-- was bank13 - 458752 -->
         <trans x="0.167548" y="0.0" />
       </location>
     </component>
     <component type="panel"   idstart="983040" idfillbyfirst="y" idstepbyrow="256" >
+      <side-by-side-view-location x="0.1" y="-0.17"/>
       <location name="bank61">  <!-- was bank16 - 393216 -->
         <trans x="0.167548" y="-0.167548" />
       </location>
@@ -181,16 +195,19 @@
   </type>
   <type name="Column5">
     <component type="panel"   idstart="917504" idfillbyfirst="y" idstepbyrow="256" >
+      <side-by-side-view-location x="0.27" y="0.17"/>
       <location name="bank53">  <!-- was bank11 - 327680 -->
         <trans x="0.0" y="0.167548" />
       </location>
     </component>
     <component type="panel"   idstart="851968" idfillbyfirst="y" idstepbyrow="256" >
+      <side-by-side-view-location x="0.27" y="0"/>
       <location name="bank52">  <!-- was bank14 - 262144 -->
         <trans x="0.0" y="0.0" />
       </location>
     </component>
     <component type="panel"   idstart="786432" idfillbyfirst="y" idstepbyrow="256" >
+      <side-by-side-view-location x="0.27" y="-0.17"/>
       <location name="bank51">  <!-- was bank17 - 196608 -->
         <trans x="0.0" y="-0.167548" />
       </location>
@@ -198,16 +215,19 @@
   </type>
   <type name="Column6">
     <component type="panel"   idstart="720896" idfillbyfirst="y" idstepbyrow="256" >
+      <side-by-side-view-location x="0.44" y="0.17"/>
       <location name="bank43">  <!-- was bank12 - 131072 -->
         <trans x="-0.167548" y="0.167548" />
       </location>
     </component>
     <component type="panel"   idstart="655360" idfillbyfirst="y" idstepbyrow="256" >
+      <side-by-side-view-location x="0.44" y="0"/>
       <location name="bank42">  <!-- was bank15 - 65536 -->
         <trans x="-0.167548" y="0.0" />
       </location>
     </component>
     <component type="panel"  idstart="589824" idfillbyfirst="y" idstepbyrow="256" >
+      <side-by-side-view-location x="0.44" y="-0.17"/>
       <location name="bank41">  <!-- was bank18 - 0 -->
         <trans x="-0.167548" y="-0.167548" />
       </location>


### PR DESCRIPTION
## Description of work

Add `side-by-side-view-location`s to the detector panels in SNAP_ and SNAPLite_Definition.xml files to fix side by side view in mantid instrument viewer.

## To test

Open either IDF in Mantid, open instrument viewer, and select side by side view. 

## Link to EWM item


[EWM#9534](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9534)

### Verification

- [ ] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] acceptance criterion 1
- [ ] acceptance criterion 2
