### PR TITLE
fix for the application of cropping factors to pgp's

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -116,6 +116,8 @@ jobs:
             - conda-forge
             - default
             - mantid/label/nightly
+            - mantid-ornl
+            - mantid-ornl/label/rc
         cache-environment-key: ${{ runner.os }}-env-${{ hashFiles('**/environment.yml') }}
         cache-downloads-key: ${{ runner.os }}-downloads-${{ hashFiles('**/environment.yml') }}
     - name: Build conda libraray

--- a/src/snapred/backend/dao/calibration/CalibrationDefaultRecord.py
+++ b/src/snapred/backend/dao/calibration/CalibrationDefaultRecord.py
@@ -7,7 +7,7 @@ from snapred.backend.dao.indexing.Record import Record
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName, WorkspaceType
 
 
-class CalibrationDefaultRecord(Record, extra="ignore"):
+class CalibrationDefaultRecord(Record, extra="ignore", strict=False):
     """
 
     The refer to the CalibrationRecord class for a more in-depth explanation of Calibration Records.

--- a/src/snapred/backend/dao/request/CreateCalibrationRecordRequest.py
+++ b/src/snapred/backend/dao/request/CreateCalibrationRecordRequest.py
@@ -10,7 +10,7 @@ from snapred.backend.dao.state.PixelGroup import PixelGroup
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName, WorkspaceType
 
 
-class CreateCalibrationRecordRequest(BaseModel, extra="forbid"):
+class CreateCalibrationRecordRequest(BaseModel, extra="forbid", strict=False):
     """
 
     The information needed to create a calibration record.

--- a/src/snapred/backend/dao/state/PixelGroup.py
+++ b/src/snapred/backend/dao/state/PixelGroup.py
@@ -82,7 +82,7 @@ class PixelGroup(BaseModel):
         #   different Mantid algorithms use either "0.0" or "NaN" to indicate an unspecified value,
         #   so these values may need to be filtered.
         return [
-            self.pixelGroupingParameters[gid].dResolution.maximum - Config["constants.CropFactors.highdSpacingCrop"]
+            self.pixelGroupingParameters[gid].dResolution.maximum
             if not self.pixelGroupingParameters[gid].isMasked
             else default
             for gid in self.groupIDs
@@ -93,7 +93,7 @@ class PixelGroup(BaseModel):
         #   different Mantid algorithms use either "0.0" or "NaN" to indicate an unspecified value,
         #   so these values may need to be filtered.
         return [
-            self.pixelGroupingParameters[gid].dResolution.minimum + Config["constants.CropFactors.lowdSpacingCrop"]
+            self.pixelGroupingParameters[gid].dResolution.minimum
             if not self.pixelGroupingParameters[gid].isMasked
             else default
             for gid in self.groupIDs

--- a/src/snapred/backend/recipe/RebinFocussedGroupDataRecipe.py
+++ b/src/snapred/backend/recipe/RebinFocussedGroupDataRecipe.py
@@ -28,16 +28,6 @@ class RebinFocussedGroupDataRecipe(Recipe[Ingredients]):
         Chops off the needed elements of the ingredients.
         We are mostly concerned about the drange for a ResampleX operation.
         """
-        lowdSpacingCrop = Config["constants.CropFactors.lowdSpacingCrop"]
-        highdSpacingCrop = Config["constants.CropFactors.highdSpacingCrop"]
-
-        if lowdSpacingCrop < 0:
-            raise ValueError("Low d-spacing crop factor must be positive")
-        if highdSpacingCrop < 0:
-            raise ValueError("High d-spacing crop factor must be positive")
-
-        if (lowdSpacingCrop > 100) or (highdSpacingCrop > 100):
-            raise ValueError("d-spacing crop factors are too large")
 
         self.pixelGroup = ingredients.pixelGroup
         dMin = self.pixelGroup.dMin()

--- a/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
+++ b/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
@@ -37,6 +37,9 @@ class ReductionGroupProcessingRecipe(Recipe[Ingredients]):
 
     def chopIngredients(self, ingredients):
         self.pixelGroup = ingredients.pixelGroup
+        logger.debug(f"dMin: {self.pixelGroup.dMin()}")
+        logger.debug(f"dMax: {self.pixelGroup.dMax()}")
+        logger.debug(f"dBin: {self.pixelGroup.dBin()}")
 
     def queueAlgos(self):
         """

--- a/tests/cis_tests/xarray_test_spectral_edges.py
+++ b/tests/cis_tests/xarray_test_spectral_edges.py
@@ -1,0 +1,70 @@
+# import mantid algorithms, numpy and matplotlib
+from mantid.simpleapi import *
+import matplotlib.pyplot as plt
+import numpy as np
+
+# a class for analysing bin edges in mantid workspaces
+
+# import mantid algorithms, numpy and matplotlib
+from mantid.simpleapi import *
+import matplotlib.pyplot as plt
+import numpy as np
+
+class xarray:
+
+    def __init__(self,wsName,specIndex):
+
+        self.wsName = wsName
+        self.specIndex = int(specIndex)
+
+
+        ws = mtd[wsName]
+        x = ws.readX(self.specIndex)
+
+        self.nEdges = len(x)
+
+        self.x = x
+        self.min = min(x)
+        self.max = max(x)
+
+        self.binWidths = x[1:]-x[0:-1]
+        #check that x-array is monotonically increasing
+        if np.all(self.binWidths > 0):
+            print("x-array is monotonically increasing")
+            self.monotonic = True
+        else:
+            print("x-array is NOT monotonically increasing")
+            self.monotonic = False
+
+        nEdges = len(x)
+        if self.binWidths[0] == self.binWidths[-2]:
+            self.binType = "lin"
+            self.delta = x[1]-x[0]
+        else:
+            self.binType = "log"
+            self.delta= (x[1]/x[0]-1)
+
+    def binInfo(self):
+
+        print(f"I think this workspace is {self.binType} binned with Delta = {self.delta:.12f}")
+        print(f"It has {self.nEdges} bin edges, with min: {self.min} and max: {self.max}")
+        print(f"It's largest bin is {max(self.binWidths):.5f}")
+        
+
+    def makeBinWS(self):
+        
+        indices = np.arange(len(self.binWidths))
+        CreateWorkspace(DataX=indices,
+                        DataY=self.binWidths,
+                        OutputWorkspace=f"{self.wsName}_bins")
+        
+        print(f"bin sizes have been saved to workspace: {self.wsName}_bins")
+        
+normX = xarray("tof_column_s+f-vanadium_059039", 5)
+redX = xarray("reduced_dsp_column_059039_2025-04-03T105140", 5)
+
+normX.binInfo()
+redX.binInfo()
+
+normX.makeBinWS()
+redX.makeBinWS()

--- a/tests/unit/backend/recipe/test_RebinFocussedGroupDataRecipe.py
+++ b/tests/unit/backend/recipe/test_RebinFocussedGroupDataRecipe.py
@@ -1,6 +1,5 @@
 import unittest
 
-import pytest
 from mantid.api import MatrixWorkspace
 from mantid.simpleapi import (
     CreateSampleWorkspace,
@@ -8,11 +7,9 @@ from mantid.simpleapi import (
     GroupDetectors,
     mtd,
 )
-from util.Config_helpers import Config_override
 from util.dao import DAOFactory
 from util.SculleryBoy import SculleryBoy
 
-from snapred.backend.dao.Limit import Limit
 from snapred.backend.recipe.RebinFocussedGroupDataRecipe import RebinFocussedGroupDataRecipe as Recipe
 
 ThisRecipe: str = "snapred.backend.recipe.RebinFocussedGroupDataRecipe"
@@ -51,21 +48,3 @@ class TestRebinFocussedGroupDataRecipe(unittest.TestCase):
         outputWs = mtd[self.sampleWorkspace]
         assert isinstance(outputWs, MatrixWorkspace)
         assert outputWs.isRaggedWorkspace()
-
-    def test_bad_dspacing_range(self):
-        pixel_group = self.sculleryBoy.prepPixelGroup()
-
-        first_group_id = list(pixel_group.pixelGroupingParameters.keys())[0]
-        group_params = pixel_group.pixelGroupingParameters[first_group_id]
-
-        group_params.dResolution = Limit[float](minimum=0.1, maximum=2.0)
-
-        ingredients = Recipe.Ingredients(pixelGroup=pixel_group, preserveEvents=True)
-        recipe = Recipe()
-
-        with (
-            Config_override("constants.CropFactors.lowdSpacingCrop", 3.0),
-            Config_override("constants.CropFactors.highdSpacingCrop", 0.0),
-            pytest.raises(ValueError, match="Invalid d-spacing range detected: some dMax <= dMin."),
-        ):
-            recipe.chopIngredients(ingredients)

--- a/tests/unit/backend/recipe/test_RebinFocussedGroupDataRecipe.py
+++ b/tests/unit/backend/recipe/test_RebinFocussedGroupDataRecipe.py
@@ -52,28 +52,6 @@ class TestRebinFocussedGroupDataRecipe(unittest.TestCase):
         assert isinstance(outputWs, MatrixWorkspace)
         assert outputWs.isRaggedWorkspace()
 
-    def test_badChopIngredients(self):
-        ingredients = Recipe.Ingredients(pixelGroup=self.sculleryBoy.prepPixelGroup())
-        recipe = Recipe()
-        with (
-            Config_override("constants.CropFactors.lowdSpacingCrop", 500.0),
-            Config_override("constants.CropFactors.highdSpacingCrop", 1000.0),
-            pytest.raises(ValueError, match="d-spacing crop factors are too large"),
-        ):
-            recipe.chopIngredients(ingredients)
-        #
-        with (
-            Config_override("constants.CropFactors.lowdSpacingCrop", -10.0),
-            pytest.raises(ValueError, match="Low d-spacing crop factor must be positive"),
-        ):
-            recipe.chopIngredients(ingredients)
-        #
-        with (
-            Config_override("constants.CropFactors.highdSpacingCrop", -10.0),
-            pytest.raises(ValueError, match="High d-spacing crop factor must be positive"),
-        ):
-            recipe.chopIngredients(ingredients)
-
     def test_bad_dspacing_range(self):
         pixel_group = self.sculleryBoy.prepPixelGroup()
 


### PR DESCRIPTION
## Description of work

**NOTE:** There is a potential defect/deviation between the workflows involving masking.  In `SousChef#L132`, set maskWorkspace to none for the sake of this test.  This should be covered in future work.  Otherwise you will likely observe differences due to masking.

This is a fix that enables snapred to uniformly apply its cropping factor and subsequently record the actual pgp values in each workflow.

Previously this was just applied in PixelGroup, which for some reason did not uniformly apply this to both the reduction workflow and normalization workflow.  Incidentally, because it was applied through a method call and wasnt flattened into the data it was not recorded on disk either.

## Explanation of work

I just moved where the cropping factor was applied.

## To test

1. Run reduction on a given run (e.g. 59039)
2. Run Normalization on the same run, with some other bg run (58810) and the column grouping, but stop at the tweak peak view
3. Run the cist test script included in the pr, comparing the log output and workspaces for each spectra in the referenced workspaces 

a favorable result should look something like this:
![image](https://github.com/user-attachments/assets/2ae19830-b609-4bce-a12c-e402db4b1d12)


## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#10466](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=10466)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] x values match for each spectra (cis test script)
- [ ] binnings match for each workspace (cis test script)
