### PR TITLE
Ewm10274 event managment during difcal

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -116,6 +116,8 @@ jobs:
             - conda-forge
             - default
             - mantid/label/nightly
+            - mantid-ornl
+            - mantid-ornl/label/rc
         cache-environment-key: ${{ runner.os }}-env-${{ hashFiles('**/environment.yml') }}
         cache-downloads-key: ${{ runner.os }}-downloads-${{ hashFiles('**/environment.yml') }}
     - name: Build conda libraray

--- a/src/snapred/backend/dao/calibration/CalibrationDefaultRecord.py
+++ b/src/snapred/backend/dao/calibration/CalibrationDefaultRecord.py
@@ -7,7 +7,7 @@ from snapred.backend.dao.indexing.Record import Record
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName, WorkspaceType
 
 
-class CalibrationDefaultRecord(Record, extra="ignore"):
+class CalibrationDefaultRecord(Record, extra="ignore", strict=False):
     """
 
     The refer to the CalibrationRecord class for a more in-depth explanation of Calibration Records.

--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -90,7 +90,7 @@ class GroceryListItem(BaseModel):
 
     # if set to False, neutron data will not be loaded in a clean, cached way
     # this is faster and uses less memory, if you know you only need one copy
-    keepItClean: bool = True
+    keepItClean: bool = False
 
     # name the property the workspace will be used for
     propertyName: Optional[str] = None

--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -90,7 +90,7 @@ class GroceryListItem(BaseModel):
 
     # if set to False, neutron data will not be loaded in a clean, cached way
     # this is faster and uses less memory, if you know you only need one copy
-    keepItClean: bool = False
+    keepItClean: bool = True
 
     # name the property the workspace will be used for
     propertyName: Optional[str] = None

--- a/src/snapred/backend/dao/request/CreateCalibrationRecordRequest.py
+++ b/src/snapred/backend/dao/request/CreateCalibrationRecordRequest.py
@@ -10,7 +10,7 @@ from snapred.backend.dao.state.PixelGroup import PixelGroup
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName, WorkspaceType
 
 
-class CreateCalibrationRecordRequest(BaseModel, extra="forbid"):
+class CreateCalibrationRecordRequest(BaseModel, extra="forbid", strict=False):
     """
 
     The information needed to create a calibration record.

--- a/src/snapred/backend/recipe/GroupDiffCalRecipe.py
+++ b/src/snapred/backend/recipe/GroupDiffCalRecipe.py
@@ -108,7 +108,7 @@ class GroupDiffCalRecipe(Recipe[Ingredients]):
         """
         Process input neutron data
         """
-
+        logger.debug(f"Groceries: {groceries}")
         self.diagnosticSuffix = FIT_PEAK_DIAG_SUFFIX.copy()
 
         self.originalWStof = groceries["inputWorkspace"]

--- a/src/snapred/backend/recipe/PixelDiffCalRecipe.py
+++ b/src/snapred/backend/recipe/PixelDiffCalRecipe.py
@@ -18,6 +18,7 @@ class PixelDiffCalServing(BaseModel):
     medianOffsets: List[float]
     maskWorkspace: str
     calibrationTable: str
+    outputWorkspace: str
 
 
 class PixelDiffCalRecipe(Recipe[Ingredients]):
@@ -330,7 +331,12 @@ class PixelDiffCalRecipe(Recipe[Ingredients]):
         logger.info(f"Pixel calibration converged.  Offsets: {self.medianOffsets}")
 
         # create for inspection
-        self.convertUnitsAndRebin(self.wsTOF, f"{self.wsDSP}_afterCrossCor")
+        outputWorkspace = f"{self.wsDSP}_afterCrossCor"
+        self.convertUnitsAndRebin(self.wsTOF, outputWorkspace)
+        self.mantidSnapper.DeleteWorkspace(
+            "Deleting tof workspace",
+            Workspace=self.wsTOF,
+        )
         self.mantidSnapper.executeQueue()
 
         return PixelDiffCalServing(
@@ -338,4 +344,5 @@ class PixelDiffCalRecipe(Recipe[Ingredients]):
             medianOffsets=self.medianOffsets,
             calibrationTable=self.DIFCpixel,
             maskWorkspace=self.maskWS,
+            outputWorkspace=outputWorkspace,
         )

--- a/src/snapred/backend/recipe/algorithm/FocusSpectraAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FocusSpectraAlgorithm.py
@@ -30,7 +30,10 @@ class FocusSpectraAlgorithm(PythonAlgorithm):
         # declare properties
         self.declareProperty(
             MatrixWorkspaceProperty(
-                "InputWorkspace", "", Direction.Input, PropertyMode.Mandatory, validator=WorkspaceUnitValidator("TOF")
+                "InputWorkspace",
+                "",
+                Direction.Input,
+                PropertyMode.Mandatory,
             ),
             doc="Workspace containing values at each pixel",
         )
@@ -93,6 +96,12 @@ class FocusSpectraAlgorithm(PythonAlgorithm):
                 """
             errors["InputWorkspace"] = msg
             errors["GroupingWorkspace"] = msg
+
+        if inWS.getAxis(0).getUnit().unitID() != "dSpacing" and inWS.getAxis(0).getUnit().unitID() != "TOF":
+            errors["InputWorkspace"] = (
+                f"Input workspace must be in dSpacing or TOF units, found {inWS.getAxis(0).getUnit().unitID()}"
+            )
+
         return errors
 
     def PyExec(self):

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -147,13 +147,15 @@ class CalibrationService(Service):
         if request.startingTableVersion == VersionState.DEFAULT:
             request.startingTableVersion = VERSION_START
 
-        self.groceryClerk.name("inputWorkspace").neutron(request.runNumber).useLiteMode(request.useLiteMode).add()
+        self.groceryClerk.name("inputWorkspace").neutron(request.runNumber).useLiteMode(
+            request.useLiteMode
+        ).dirty().add()
         self.groceryClerk.name("groupingWorkspace").fromRun(request.runNumber).grouping(
             request.focusGroup.name
-        ).useLiteMode(request.useLiteMode).add()
+        ).useLiteMode(request.useLiteMode).dirty().add()
         self.groceryClerk.name("previousCalibration").diffcal_table(
             request.runNumber, request.startingTableVersion
-        ).useLiteMode(request.useLiteMode).add()
+        ).useLiteMode(request.useLiteMode).dirty().add()
         # names
         diffcalOutputName = (
             wng.diffCalOutput().unit(wng.Units.DSP).runNumber(request.runNumber).group(request.focusGroup.name).build()

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -188,6 +188,7 @@ class CalibrationService(Service):
             raise RuntimeError("Pixel Calibration failed")
 
         payload.groceries["previousCalibration"] = pixelRes.calibrationTable
+        payload.groceries["inputWorkspace"] = pixelRes.outputWorkspace
         groupRes = self.groupCalibration(payload)
         if not groupRes.result:
             raise RuntimeError("Group Calibration failed")

--- a/src/snapred/resources/SNAPLite_Definition.xml
+++ b/src/snapred/resources/SNAPLite_Definition.xml
@@ -111,21 +111,20 @@
     </component>
   </type>
 
-  <!-- East -->
   <type name="Column1">
-    <component type="panel"   idstart="131072" idfillbyfirst="y" idstepbyrow="256" >
+    <component type="panel"   idstart="2048" idfillbyfirst="y" idstepbyrow="32" >
       <side-by-side-view-location x="0.1" y="0.17"/>
       <location name="bank13">  <!-- was bank1 - 720896 -->
         <trans x="-0.167548" y="0.167548" />
       </location>
     </component>
-    <component type="panel"   idstart="65536" idfillbyfirst="y" idstepbyrow="256" >
+    <component type="panel"   idstart="1024" idfillbyfirst="y" idstepbyrow="32" >
       <side-by-side-view-location x="0.1" y="0"/>
       <location name="bank12">  <!-- was bank4 - 655360 -->
         <trans x="-0.167548" y="0.0" />
       </location>
     </component>
-    <component type="panel"   idstart="0" idfillbyfirst="y" idstepbyrow="256" >
+    <component type="panel"   idstart="0" idfillbyfirst="y" idstepbyrow="32" >
       <side-by-side-view-location x="0.1" y="-0.17"/>
       <location name="bank11">  <!-- was bank7 - 589824 -->
         <trans x="-0.167548" y="-0.167548" />
@@ -133,19 +132,19 @@
     </component>
   </type>
   <type name="Column2">
-    <component type="panel"   idstart="327680" idfillbyfirst="y" idstepbyrow="256" >
+    <component type="panel"   idstart="5120" idfillbyfirst="y" idstepbyrow="32" >
       <side-by-side-view-location x="0.27" y="0.17"/>
       <location name="bank23">  <!-- was bank2 - 917504 -->
         <trans x="0.0" y="0.167548" />
       </location>
     </component>
-    <component type="panel"  idstart="262144" idfillbyfirst="y" idstepbyrow="256" >
+    <component type="panel"  idstart="4096" idfillbyfirst="y" idstepbyrow="32" >
       <side-by-side-view-location x="0.27" y="0"/>
       <location name="bank22">  <!-- was bank5 - 851968 -->
         <trans x="0.0" y="0.0" />
       </location>
     </component>
-    <component type="panel"   idstart="196608" idfillbyfirst="y" idstepbyrow="256" >
+    <component type="panel"   idstart="3072" idfillbyfirst="y" idstepbyrow="32" >
       <side-by-side-view-location x="0.27" y="-0.17"/>
       <location name="bank21">  <!-- was bank8 - 786432 -->
         <trans x="0.0" y="-0.167548" />
@@ -153,40 +152,39 @@
     </component>
   </type>
   <type name="Column3">
-    <component type="panel"   idstart="524288" idfillbyfirst="y" idstepbyrow="256" >
+    <component type="panel"   idstart="8192" idfillbyfirst="y" idstepbyrow="32" >
       <side-by-side-view-location x="0.44" y="0.17"/>
       <location name="bank33">  <!-- was bank3 - 1114112 -->
         <trans x="0.167548" y="0.167548" />
       </location>
     </component>
-    <component type="panel"   idstart="458752" idfillbyfirst="y" idstepbyrow="256" >
+    <component type="panel"   idstart="7168" idfillbyfirst="y" idstepbyrow="32" >
       <side-by-side-view-location x="0.44" y="0"/>
       <location name="bank32">  <!-- was bank6 - 1048576 -->
         <trans x="0.167548" y="0.0" />
       </location>
     </component>
-    <component type="panel"   idstart="393216" idfillbyfirst="y" idstepbyrow="256" >
+    <component type="panel"   idstart="6144" idfillbyfirst="y" idstepbyrow="32" >
       <side-by-side-view-location x="0.44" y="-0.17"/>
       <location name="bank31">  <!-- was bank9 - 983040 -->
         <trans x="0.167548" y="-0.167548" />
       </location>
     </component>
   </type>
-  <!-- West -->
   <type name="Column4">
-    <component type="panel"   idstart="1114112" idfillbyfirst="y" idstepbyrow="256" >
+    <component type="panel"   idstart="17408" idfillbyfirst="y" idstepbyrow="32" >
       <side-by-side-view-location x="-0.44" y="0.17"/>
       <location name="bank63">  <!-- was bank10 - 524288 -->
         <trans x="0.167548" y="0.167548" />
       </location>
     </component>
-    <component type="panel"   idstart="1048576" idfillbyfirst="y" idstepbyrow="256" >
+    <component type="panel"   idstart="16384" idfillbyfirst="y" idstepbyrow="32" >
       <side-by-side-view-location x="-0.44" y="0"/>
       <location name="bank62">  <!-- was bank13 - 458752 -->
         <trans x="0.167548" y="0.0" />
       </location>
     </component>
-    <component type="panel"   idstart="983040" idfillbyfirst="y" idstepbyrow="256" >
+    <component type="panel"   idstart="15360" idfillbyfirst="y" idstepbyrow="32" >
       <side-by-side-view-location x="-0.44" y="-0.17"/>
       <location name="bank61">  <!-- was bank16 - 393216 -->
         <trans x="0.167548" y="-0.167548" />
@@ -194,19 +192,19 @@
     </component>
   </type>
   <type name="Column5">
-    <component type="panel"   idstart="917504" idfillbyfirst="y" idstepbyrow="256" >
+    <component type="panel"   idstart="14336" idfillbyfirst="y" idstepbyrow="32" >
       <side-by-side-view-location x="-0.27" y="0.17"/>
       <location name="bank53">  <!-- was bank11 - 327680 -->
         <trans x="0.0" y="0.167548" />
       </location>
     </component>
-    <component type="panel"   idstart="851968" idfillbyfirst="y" idstepbyrow="256" >
+    <component type="panel"   idstart="13312" idfillbyfirst="y" idstepbyrow="32" >
       <side-by-side-view-location x="-0.27" y="0"/>
       <location name="bank52">  <!-- was bank14 - 262144 -->
         <trans x="0.0" y="0.0" />
       </location>
     </component>
-    <component type="panel"   idstart="786432" idfillbyfirst="y" idstepbyrow="256" >
+    <component type="panel"   idstart="12288" idfillbyfirst="y" idstepbyrow="32" >
       <side-by-side-view-location x="-0.27" y="-0.17"/>
       <location name="bank51">  <!-- was bank17 - 196608 -->
         <trans x="0.0" y="-0.167548" />
@@ -214,19 +212,19 @@
     </component>
   </type>
   <type name="Column6">
-    <component type="panel"   idstart="720896" idfillbyfirst="y" idstepbyrow="256" >
+    <component type="panel"   idstart="11264" idfillbyfirst="y" idstepbyrow="32" >
       <side-by-side-view-location x="-0.1" y="0.17"/>
       <location name="bank43">  <!-- was bank12 - 131072 -->
         <trans x="-0.167548" y="0.167548" />
       </location>
     </component>
-    <component type="panel"   idstart="655360" idfillbyfirst="y" idstepbyrow="256" >
+    <component type="panel"   idstart="10240" idfillbyfirst="y" idstepbyrow="32" >
       <side-by-side-view-location x="-0.1" y="0"/>
       <location name="bank42">  <!-- was bank15 - 65536 -->
         <trans x="-0.167548" y="0.0" />
       </location>
     </component>
-    <component type="panel"  idstart="589824" idfillbyfirst="y" idstepbyrow="256" >
+    <component type="panel"  idstart="9216" idfillbyfirst="y" idstepbyrow="32" >
       <side-by-side-view-location x="-0.1" y="-0.17"/>
       <location name="bank41">  <!-- was bank18 - 0 -->
         <trans x="-0.167548" y="-0.167548" />


### PR DESCRIPTION
## Description of work

This story pertains to what workspaces we load and when to trash them through the workflow.

## Explanation of work

Eventually we want to load most sample data as "dirty" but this is being done piecemeal as opposed to setting the default.
as for the deletion of the workspace, its probably safe to delete anything that isnt immediately required by the next step's groceries, which covers the "before" workspace we need to trash.

## To test

run diffcal and observe the AC is met.


## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#10274](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=10274)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] Remove copy/clone paradigm, only keep 1 workspace of sample data on load (dirty)
- [x] The above initial workspace is consumed and should not exist in the tweak peaks view
- [x] the only unfocussed workspaces in tweak peak should be dsp_064413_raw_beforeCrossCor and dsp_064413_raw_afterCrossCor
- [x] dsp_064413_raw_beforeCrossCor should be deleted before group diffcal proceeds, i.e. immediately after continue is clicked on tweak peak.
- [x] The story mentions pixelcalibration being reran but we (Malcolm and I) could not recreate this once I began working on the story.
