### PR TITLE
remove sample and bg workspaces after RawVanadiumCorrection, do not r…

### DIFF
--- a/src/snapred/backend/dao/request/NormalizationRequest.py
+++ b/src/snapred/backend/dao/request/NormalizationRequest.py
@@ -32,3 +32,4 @@ class NormalizationRequest(BaseModel, extra="forbid"):
     fwhmMultipliers: Pair[float] = Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
 
     continueFlags: Optional[ContinueWarning.Type] = ContinueWarning.Type.UNSET
+    renew: bool = False

--- a/src/snapred/backend/dao/request/NormalizationRequest.py
+++ b/src/snapred/backend/dao/request/NormalizationRequest.py
@@ -6,9 +6,10 @@ from snapred.backend.dao.Limit import Limit, Pair
 from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.meta.Config import Config
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
 
-class NormalizationRequest(BaseModel, extra="forbid"):
+class NormalizationRequest(BaseModel, extra="forbid", arbitrary_types_allowed=True):
     """
 
     This class encapsulates all the necessary parameters to request a normalization process,
@@ -32,4 +33,4 @@ class NormalizationRequest(BaseModel, extra="forbid"):
     fwhmMultipliers: Pair[float] = Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
 
     continueFlags: Optional[ContinueWarning.Type] = ContinueWarning.Type.UNSET
-    renew: bool = False
+    correctedVanadiumWs: Optional[WorkspaceName] = None

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -121,6 +121,11 @@ class NormalizationService(Service):
             self.groceryClerk.name("backgroundWorkspace").neutron(request.backgroundRunNumber).useLiteMode(
                 request.useLiteMode
             ).dirty().add()
+        else:
+            # check that the corrected vanadium workspaces exist already
+            if not self.groceryService.workspaceDoesExist(correctedVanadium):
+                raise RuntimeError(f"Workspace {correctedVanadium} does not exist. Renew flag incorrectly applied.")
+
         self.groceryClerk.name("groupingWorkspace").fromRun(request.runNumber).grouping(groupingScheme).useLiteMode(
             request.useLiteMode
         ).add()

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -114,7 +114,7 @@ class NormalizationService(Service):
             ).dict()
 
         # gather needed groceries and ingredients
-        if not request.renew:
+        if request.correctedVanadiumWs is None:
             self.groceryClerk.name("inputWorkspace").neutron(request.runNumber).useLiteMode(
                 request.useLiteMode
             ).dirty().add()
@@ -123,6 +123,13 @@ class NormalizationService(Service):
             ).dirty().add()
         else:
             # check that the corrected vanadium workspaces exist already
+            if request.correctedVanadiumWs != correctedVanadium:
+                raise RuntimeError(
+                    (
+                        "Corrected vanadium of unexpected name provided. Is this workspace still compatible?"
+                        f"{request.correctedVanadiumWs} vs {correctedVanadium}"
+                    )
+                )
             if not self.groceryService.workspaceDoesExist(correctedVanadium):
                 raise RuntimeError(f"Workspace {correctedVanadium} does not exist. Renew flag incorrectly applied.")
 
@@ -148,7 +155,7 @@ class NormalizationService(Service):
             self.groceryClerk.buildDict(),
         )
 
-        if not request.renew:
+        if request.correctedVanadiumWs is None:
             self._markWorkspaceMetadata(request, groceries["inputWorkspace"])
             # NOTE: This used to point at other methods in this service to accomplish the same thing
             #       It looks like it got reverted accidentally?

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -131,7 +131,7 @@ class NormalizationService(Service):
                     )
                 )
             if not self.groceryService.workspaceDoesExist(correctedVanadium):
-                raise RuntimeError(f"Workspace {correctedVanadium} does not exist. Renew flag incorrectly applied.")
+                raise RuntimeError(f"Supplied corrected vanadium {correctedVanadium} does not exist.")
 
         self.groceryClerk.name("groupingWorkspace").fromRun(request.runNumber).grouping(groupingScheme).useLiteMode(
             request.useLiteMode

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -319,7 +319,7 @@ class NormalizationWorkflow(WorkflowImplementer):
         return response
 
     @EntryExitLogger(logger=logger)
-    def callNormalization(self, index, smoothingParameter, xtalDMin, xtalDMax):
+    def callNormalization(self, index, smoothingParameter, xtalDMin, xtalDMax, renew=False):
         payload = NormalizationRequest(
             runNumber=self.runNumber,
             useLiteMode=self.useLiteMode,
@@ -329,6 +329,7 @@ class NormalizationWorkflow(WorkflowImplementer):
             smoothingParameter=smoothingParameter,
             crystalDBounds={"minimum": xtalDMin, "maximum": xtalDMax},
             continueFlags=self.continueAnywayFlags,
+            renew=renew,
         )
         self.normalizationResponse = self.request(path="normalization", payload=payload.json())
 
@@ -388,7 +389,7 @@ class NormalizationWorkflow(WorkflowImplementer):
 
         # check the case, apply correct update
         if groupingFileChanged:
-            self.callNormalization(index, smoothingValue, xtalDMin, xtalDMax)
+            self.callNormalization(index, smoothingValue, xtalDMin, xtalDMax, renew=True)
         elif peakListWillChange:
             self.applySmoothingUpdate(index, smoothingValue, xtalDMin, xtalDMax)
         elif "focusedVanadium" in self.responses[-1].data and "smoothedVanadium" in self.responses[-1].data:

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -241,6 +241,7 @@ class NormalizationWorkflow(WorkflowImplementer):
         self.normalizationResponse = self.request(path="normalization", payload=payload.json())
         focusWorkspace = self.normalizationResponse.data["focusedVanadium"]
         smoothWorkspace = self.normalizationResponse.data["smoothedVanadium"]
+        self.correctedVanadiumWorkspace = self.normalizationResponse.data["correctedVanadium"]
         peaks = self.normalizationResponse.data["detectorPeaks"]
         self.calibrationRunNumber = self.normalizationResponse.data["calibrationRunNumber"]
         # calculate residual
@@ -319,7 +320,7 @@ class NormalizationWorkflow(WorkflowImplementer):
         return response
 
     @EntryExitLogger(logger=logger)
-    def callNormalization(self, index, smoothingParameter, xtalDMin, xtalDMax, renew=False):
+    def callNormalization(self, index, smoothingParameter, xtalDMin, xtalDMax, correctedVanadiumWs=None):
         payload = NormalizationRequest(
             runNumber=self.runNumber,
             useLiteMode=self.useLiteMode,
@@ -329,12 +330,13 @@ class NormalizationWorkflow(WorkflowImplementer):
             smoothingParameter=smoothingParameter,
             crystalDBounds={"minimum": xtalDMin, "maximum": xtalDMax},
             continueFlags=self.continueAnywayFlags,
-            renew=renew,
+            correctedVanadiumWs=correctedVanadiumWs,
         )
         self.normalizationResponse = self.request(path="normalization", payload=payload.json())
 
         focusWorkspace = self.normalizationResponse.data["focusedVanadium"]
         smoothWorkspace = self.normalizationResponse.data["smoothedVanadium"]
+        self.correctedVanadiumWorkspace = self.normalizationResponse.data["correctedVanadium"]
         peaks = self.normalizationResponse.data["detectorPeaks"]
 
         residualWorkspace = self._calcResidual(focusWorkspace, smoothWorkspace)
@@ -389,7 +391,9 @@ class NormalizationWorkflow(WorkflowImplementer):
 
         # check the case, apply correct update
         if groupingFileChanged:
-            self.callNormalization(index, smoothingValue, xtalDMin, xtalDMax, renew=True)
+            self.callNormalization(
+                index, smoothingValue, xtalDMin, xtalDMax, correctedVanadiumWs=self.correctedVanadiumWorkspace
+            )
         elif peakListWillChange:
             self.applySmoothingUpdate(index, smoothingValue, xtalDMin, xtalDMax)
         elif "focusedVanadium" in self.responses[-1].data and "smoothedVanadium" in self.responses[-1].data:


### PR DESCRIPTION
## Description of work

This is more work regarding the data management of sample data.
Largely repeated workflows with the same sample data dont seem to be a prime use case, and thus it is more beneficial to not cache them. 
This pr removes the sample data and background sample data cache for the normalization workflow.
In addition it also fixes the unnecessary recalculating of the RawVanadiumCorrectionAlgo and skips this on continue since it is already done for the preview.

## To test

Run the normalization workflow and observe the workspaces present at each stage as well as the algorithms executed with each action.
Confirm the AC.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#10276](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=10276)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] There are no `raw` and `copy` pairs of initial sample data workspaces
- [x] After the first step, there should only be one unfocussed even workspace `raw_van_corr`
- [x] RawVanadiumCorrection algo is only ever executed once in the entire workflow, even recalcs.
- [x] The final output is not to be converted to histograms at this time due to logistical difficulties in managing native vs lite cases
