### PR TITLE
prototype that applies any swiss cheese mask found in the ADS

### DIFF
--- a/src/snapred/backend/recipe/PreprocessReductionRecipe.py
+++ b/src/snapred/backend/recipe/PreprocessReductionRecipe.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Set, Tuple
+from mantid.simpleapi import mtd
 
 from snapred.backend.dao.ingredients import PreprocessReductionIngredients as Ingredients
 from snapred.backend.log.logger import snapredLogger
@@ -32,6 +33,21 @@ class PreprocessReductionRecipe(Recipe[Ingredients]):
         self.diffcalWs = groceries.get("diffcalWorkspace", "")
         self.outputWs = groceries.get("outputWorkspace", groceries["inputWorkspace"])
 
+    def findMaskBinsTableWorkspaces(self):
+        """
+        Locates bin Mask workspaces on the basis of their names and creates a list of these
+        """
+
+        self.binMasks = []
+        for ws in mtd.getObjectNames():
+            if "maskBins_" in ws:
+                self.binMasks.append(ws)
+        print(f"{len(self.binMasks)} binMasks were found in ADS")
+        if len(self.binMasks) >= 1:
+            self.hasBinMasks = True
+        else:
+            self.hasBinMasks = False
+    
     def queueAlgos(self):
         """
         Queues up the processing algorithms for the recipe.
@@ -51,6 +67,36 @@ class PreprocessReductionRecipe(Recipe[Ingredients]):
                 InstrumentWorkspace=self.outputWs,
                 CalibrationWorkspace=self.diffcalWs,
             )
+
+        #check if any bin masks exist
+        self.findMaskBinsTableWorkspaces()
+        #apply bin Masks if they were found
+        if self.hasBinMasks:
+            for mask in self.binMasks:
+                #extract units from ws name (table workspaces don't have logs)
+                maskUnits = mask.split('_')[-1]
+                #ensure units of workspace match
+                self.mantidSnapper.ConvertUnits(
+                    f"Converting units to match Bin Mask with units of {maskUnits}",
+                    InputWorkspace=self.outputWs,
+                    Target = maskUnits,
+                    OutputWorkspace=self.outputWs
+                )
+                #mask bins
+                self.mantidSnapper.MaskBinsFromTable(
+                    "Masking bins...",
+                    InputWorkspace=self.outputWs,
+                    MaskingInformation=mask,
+                    OutputWorkspace=self.outputWs
+                )
+
+        # convert to tof if needed
+        self.mantidSnapper.ConvertUnits(
+            "Converting to TOF...",
+            InputWorkspace=self.outputWs,
+            Target="TOF",
+            OutputWorkspace=self.outputWs,
+        )
 
     def cook(self, ingredients: Ingredients, groceries: Dict[str, str]) -> Dict[str, Any]:
         """


### PR DESCRIPTION
## Description of work

This is a very primitive implementation of prototype swiss cheese mask. External to SNAPRed, I have machinery to make the swiss cheese masks and to save these to a mantid BinMaskTableWorkspace with the names: 

```maskBins_{units}```

Where units are recognised mantid units such as dSpacing, Wavelength, TOF

I then modified SNAPRed to check if _any_ of these are present in the ADS and, if it finds these, apply them by looping through all bin_mask ws it finds, then

1. converting units to match those of the maskBins ws
2. running `MaskBinsFromTable`

finally, it converts units back to TOF.

<!-- ANSWER
 - What is this for?
 - What purpose does it serve within data reduction?
 - How does it relate to other parts of the code, or improve the code?
 - How is it supposed to work?
-->

## Explanation of work

This is obviously not the best way to handle the operation. 

I would like to make a list of BinMaskTableWorkspaces a reduction ingredient _identical_ to pixel masks. I'd then like these to be saved the same as pixel masks. 

Any advice on how to go about this appreciated!

(the machinery to make the mask can stay outside of SNAPRed and live in SNAPBlue)

## To test

### Dev testing

<!-- ANSWER
 - What unit tests were added to cover this work?
 - Where are they, how do they work, and how do they cover the work done?
 - What parts are you uncertain about? E.g. language features used, new functions defined, etc.
-->

### CIS testing

<!-- SCRIPT
Include enough of a script that could be called from workbench to allow the CIS to ensure this works as intended.
See the existent scripts in tests/cis_tests/ for examples to get started.
Your PR is not complete until this section is filled in.
-->

``` python
# replace with your test script below
```

<!-- GUI
If testing should instead be done from the GUI, explain
 - how to access the feature in the GUI
 - what buttons to click
 - what output should be generated in both test and fail.  state the SPECIFIC text
 - what will the CIS see?  link to screenshots of both success and failure, if possible
-->

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#<ticket_number>](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=<ticket_number>)

### Verification

- [ ] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] acceptance criterion 1
- [ ] acceptance criterion 2
