### PR TITLE
Ewm2990 reload application yml

### DIFF
--- a/src/snapred/backend/dao/InstrumentConfig.py
+++ b/src/snapred/backend/dao/InstrumentConfig.py
@@ -1,3 +1,5 @@
+from pydantic import Field
+
 from snapred.backend.dao.indexing.Versioning import VersionedObject
 from snapred.meta.Config import Config
 
@@ -27,4 +29,4 @@ class InstrumentConfig(VersionedObject):
     delThWithGuide: float
     width: float
     frequency: float
-    lowWavelengthCrop: float = Config["constants.CropFactors.lowWavelengthCrop"]
+    lowWavelengthCrop: float = Field(default_factory = lambda: Config["constants.CropFactors.lowWavelengthCrop"])

--- a/src/snapred/backend/dao/InstrumentConfig.py
+++ b/src/snapred/backend/dao/InstrumentConfig.py
@@ -29,4 +29,4 @@ class InstrumentConfig(VersionedObject):
     delThWithGuide: float
     width: float
     frequency: float
-    lowWavelengthCrop: float = Field(default_factory = lambda: Config["constants.CropFactors.lowWavelengthCrop"])
+    lowWavelengthCrop: float = Field(default_factory=lambda: Config["constants.CropFactors.lowWavelengthCrop"])

--- a/src/snapred/backend/dao/__init__.py
+++ b/src/snapred/backend/dao/__init__.py
@@ -1,16 +1,6 @@
-from snapred import _pullAllModules, pullModuleMembers
+from snapred import pullModuleMembers
 
 # Pull members from current package modules, respecting __all__.
 __all__, localz = pullModuleMembers(__file__, __name__)
 # update locals such that module members can be accessed directly
 locals().update(localz)
-
-
-def reload():
-    import importlib
-    import sys
-
-    for moduleName in _pullAllModules(__file__):
-        module = importlib.import_module(f"{__name__}.{moduleName}", moduleName)
-        if module.__name__ in sys.modules:
-            importlib.reload(module)

--- a/src/snapred/backend/dao/__init__.py
+++ b/src/snapred/backend/dao/__init__.py
@@ -1,8 +1,16 @@
-from snapred import pullModuleMembers
+from snapred import _pullAllModules, pullModuleMembers
 
 # Pull members from current package modules, respecting __all__.
 __all__, localz = pullModuleMembers(__file__, __name__)
 # update locals such that module members can be accessed directly
 locals().update(localz)
-# cleanup
-del pullModuleMembers
+
+
+def reload():
+    import importlib
+    import sys
+
+    for moduleName in _pullAllModules(__file__):
+        module = importlib.import_module(f"{__name__}.{moduleName}", moduleName)
+        if module.__name__ in sys.modules:
+            importlib.reload(module)

--- a/src/snapred/backend/dao/indexing/Versioning.py
+++ b/src/snapred/backend/dao/indexing/Versioning.py
@@ -1,16 +1,15 @@
-from enum import Enum
 import numpy
 from pydantic import BaseModel, ConfigDict, field_validator
 
 from snapred.meta.Config import Config
 from snapred.meta.Enum import StrEnum
 
-# TODO: Wrap in class so that default values may be overridden  
+# NOTE: This should probably not be reconfigurable at runtime.
+#       This would be liable to only cause indexing issues.
 VERSION_START = Config["version.start"]
 
 
 class VersionState(StrEnum):
-    START = Config["version.start"]
     DEFAULT = Config["version.friendlyName.default"]
     LATEST = "latest"
     NEXT = "next"

--- a/src/snapred/backend/dao/indexing/Versioning.py
+++ b/src/snapred/backend/dao/indexing/Versioning.py
@@ -1,14 +1,16 @@
+from enum import Enum
 import numpy
 from pydantic import BaseModel, ConfigDict, field_validator
 
 from snapred.meta.Config import Config
 from snapred.meta.Enum import StrEnum
 
+# TODO: Wrap in class so that default values may be overridden  
 VERSION_START = Config["version.start"]
-VERSION_NONE_NAME = Config["version.friendlyName.error"]
 
 
 class VersionState(StrEnum):
+    START = Config["version.start"]
     DEFAULT = Config["version.friendlyName.default"]
     LATEST = "latest"
     NEXT = "next"

--- a/src/snapred/backend/dao/indexing/Versioning.py
+++ b/src/snapred/backend/dao/indexing/Versioning.py
@@ -46,8 +46,8 @@ class VersionedObject(BaseModel):
             # Conversion from HDF5 metadata.
             value = int(value)
 
-        if value < VERSION_START:
-            raise ValueError(f"Version must be greater than {VERSION_START}")
+        if value < VERSION_START():
+            raise ValueError(f"Version must be greater than {VERSION_START()}")
 
         return value
 

--- a/src/snapred/backend/dao/indexing/Versioning.py
+++ b/src/snapred/backend/dao/indexing/Versioning.py
@@ -4,9 +4,11 @@ from pydantic import BaseModel, ConfigDict, field_validator
 from snapred.meta.Config import Config
 from snapred.meta.Enum import StrEnum
 
+
 # NOTE: This should probably not be reconfigurable at runtime.
 #       This would be liable to only cause indexing issues.
-VERSION_START = Config["version.start"]
+def VERSION_START():
+    return Config["version.start"]
 
 
 class VersionState(StrEnum):

--- a/src/snapred/backend/dao/ingredients/ArtificialNormalizationIngredients.py
+++ b/src/snapred/backend/dao/ingredients/ArtificialNormalizationIngredients.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from snapred.meta.Config import Config
 
@@ -8,7 +8,7 @@ class ArtificialNormalizationIngredients(BaseModel):
     Class to hold ingredients for the creation of artificial normalization data.
     """
 
-    peakWindowClippingSize: int = Config["constants.ArtificialNormalization.peakWindowClippingSize"]
+    peakWindowClippingSize: int = Field(default_factory = lambda: Config["constants.ArtificialNormalization.peakWindowClippingSize"])
     smoothingParameter: float
     decreaseParameter: bool = True
     lss: bool = True

--- a/src/snapred/backend/dao/ingredients/ArtificialNormalizationIngredients.py
+++ b/src/snapred/backend/dao/ingredients/ArtificialNormalizationIngredients.py
@@ -8,7 +8,9 @@ class ArtificialNormalizationIngredients(BaseModel):
     Class to hold ingredients for the creation of artificial normalization data.
     """
 
-    peakWindowClippingSize: int = Field(default_factory = lambda: Config["constants.ArtificialNormalization.peakWindowClippingSize"])
+    peakWindowClippingSize: int = Field(
+        default_factory=lambda: Config["constants.ArtificialNormalization.peakWindowClippingSize"]
+    )
     smoothingParameter: float
     decreaseParameter: bool = True
     lss: bool = True

--- a/src/snapred/backend/dao/ingredients/DiffractionCalibrationIngredients.py
+++ b/src/snapred/backend/dao/ingredients/DiffractionCalibrationIngredients.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.RunConfig import RunConfig
@@ -24,8 +24,8 @@ class DiffractionCalibrationIngredients(BaseModel, extra="forbid"):
     runConfig: RunConfig
     pixelGroup: PixelGroup
     groupedPeakLists: List[GroupPeakList]
-    convergenceThreshold: float = float(Config["calibration.diffraction.convergenceThreshold"])
-    peakFunction: SymmetricPeakEnum = SymmetricPeakEnum[Config["calibration.diffraction.peakFunction"]]
-    maxOffset: float = Config["calibration.diffraction.maximumOffset"]
-    maxChiSq: float = Config["constants.GroupDiffractionCalibration.MaxChiSq"]
+    convergenceThreshold: float = Field(default_factory = lambda: float(Config["calibration.diffraction.convergenceThreshold"]))
+    peakFunction: SymmetricPeakEnum = Field(default_factory = lambda: SymmetricPeakEnum[Config["calibration.diffraction.peakFunction"]])
+    maxOffset: float = Field(default_factory = lambda: Config["calibration.diffraction.maximumOffset"])
+    maxChiSq: float = Field(default_factory = lambda: Config["constants.GroupDiffractionCalibration.MaxChiSq"])
     removeBackground: bool = False

--- a/src/snapred/backend/dao/ingredients/DiffractionCalibrationIngredients.py
+++ b/src/snapred/backend/dao/ingredients/DiffractionCalibrationIngredients.py
@@ -24,8 +24,12 @@ class DiffractionCalibrationIngredients(BaseModel, extra="forbid"):
     runConfig: RunConfig
     pixelGroup: PixelGroup
     groupedPeakLists: List[GroupPeakList]
-    convergenceThreshold: float = Field(default_factory = lambda: float(Config["calibration.diffraction.convergenceThreshold"]))
-    peakFunction: SymmetricPeakEnum = Field(default_factory = lambda: SymmetricPeakEnum[Config["calibration.diffraction.peakFunction"]])
-    maxOffset: float = Field(default_factory = lambda: Config["calibration.diffraction.maximumOffset"])
-    maxChiSq: float = Field(default_factory = lambda: Config["constants.GroupDiffractionCalibration.MaxChiSq"])
+    convergenceThreshold: float = Field(
+        default_factory=lambda: float(Config["calibration.diffraction.convergenceThreshold"])
+    )
+    peakFunction: SymmetricPeakEnum = Field(
+        default_factory=lambda: SymmetricPeakEnum[Config["calibration.diffraction.peakFunction"]]
+    )
+    maxOffset: float = Field(default_factory=lambda: Config["calibration.diffraction.maximumOffset"])
+    maxChiSq: float = Field(default_factory=lambda: Config["constants.GroupDiffractionCalibration.MaxChiSq"])
     removeBackground: bool = False

--- a/src/snapred/backend/dao/ingredients/GenerateFocussedVanadiumIngredients.py
+++ b/src/snapred/backend/dao/ingredients/GenerateFocussedVanadiumIngredients.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.ingredients.ArtificialNormalizationIngredients import ArtificialNormalizationIngredients
@@ -11,7 +11,7 @@ from snapred.meta.Config import Config
 class GenerateFocussedVanadiumIngredients(BaseModel):
     """Class to hold the ingredients for smoothing preprocessed vanadium data"""
 
-    smoothingParameter: float = Config["calibration.parameters.default.smoothing"]
+    smoothingParameter: float = Field(default_factory = lambda: Config["calibration.parameters.default.smoothing"])
     pixelGroup: PixelGroup
     # This can be None if we lack a calibration
     detectorPeaks: Optional[list[GroupPeakList]] = None

--- a/src/snapred/backend/dao/ingredients/GenerateFocussedVanadiumIngredients.py
+++ b/src/snapred/backend/dao/ingredients/GenerateFocussedVanadiumIngredients.py
@@ -11,7 +11,7 @@ from snapred.meta.Config import Config
 class GenerateFocussedVanadiumIngredients(BaseModel):
     """Class to hold the ingredients for smoothing preprocessed vanadium data"""
 
-    smoothingParameter: float = Field(default_factory = lambda: Config["calibration.parameters.default.smoothing"])
+    smoothingParameter: float = Field(default_factory=lambda: Config["calibration.parameters.default.smoothing"])
     pixelGroup: PixelGroup
     # This can be None if we lack a calibration
     detectorPeaks: Optional[list[GroupPeakList]] = None

--- a/src/snapred/backend/dao/ingredients/PixelGroupingIngredients.py
+++ b/src/snapred/backend/dao/ingredients/PixelGroupingIngredients.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from snapred.backend.dao.state.InstrumentState import InstrumentState
 from snapred.meta.Config import Config
@@ -13,4 +13,4 @@ class PixelGroupingIngredients(BaseModel):
 
     groupingScheme: Optional[str] = None
 
-    nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]
+    nBinsAcrossPeakWidth: int = Field(default_factory = lambda: Config["calibration.diffraction.nBinsAcrossPeakWidth"])

--- a/src/snapred/backend/dao/ingredients/PixelGroupingIngredients.py
+++ b/src/snapred/backend/dao/ingredients/PixelGroupingIngredients.py
@@ -13,4 +13,4 @@ class PixelGroupingIngredients(BaseModel):
 
     groupingScheme: Optional[str] = None
 
-    nBinsAcrossPeakWidth: int = Field(default_factory = lambda: Config["calibration.diffraction.nBinsAcrossPeakWidth"])
+    nBinsAcrossPeakWidth: int = Field(default_factory=lambda: Config["calibration.diffraction.nBinsAcrossPeakWidth"])

--- a/src/snapred/backend/dao/normalization/NormalizationRecord.py
+++ b/src/snapred/backend/dao/normalization/NormalizationRecord.py
@@ -1,6 +1,6 @@
 from typing import Any, List
 
-from pydantic import field_validator
+from pydantic import Field, field_validator
 
 from snapred.backend.dao.indexing.Record import Record
 from snapred.backend.dao.indexing.Versioning import VERSION_START, Version, VersionedObject
@@ -31,7 +31,7 @@ class NormalizationRecord(Record, extra="ignore"):
     smoothingParameter: float
     # detectorPeaks: List[DetectorPeak] # TODO: need to save this for reference during reduction
     workspaceNames: List[WorkspaceName] = []
-    calibrationVersionUsed: Version = VERSION_START
+    calibrationVersionUsed: Version = Field(default_factory=VERSION_START)
     crystalDBounds: Limit[float]
     normalizationCalibrantSamplePath: str
 

--- a/src/snapred/backend/dao/request/CalibrationAssessmentRequest.py
+++ b/src/snapred/backend/dao/request/CalibrationAssessmentRequest.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator, Field
 
 from snapred.backend.dao.Limit import Pair
 from snapred.backend.dao.RunConfig import RunConfig
@@ -33,8 +33,8 @@ class CalibrationAssessmentRequest(BaseModel, extra="forbid"):
     crystalDMin: float
     crystalDMax: float
     nBinsAcrossPeakWidth: int
-    fwhmMultipliers: Pair[float] = Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
-    maxChiSq: float = Config["constants.GroupDiffractionCalibration.MaxChiSq"]
+    fwhmMultipliers: Pair[float] = Field(default_factory = lambda: Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"]))
+    maxChiSq: float = Field(default_factory = lambda: Config["constants.GroupDiffractionCalibration.MaxChiSq"])
 
     @field_validator("fwhmMultipliers", mode="before")
     @classmethod

--- a/src/snapred/backend/dao/request/CalibrationAssessmentRequest.py
+++ b/src/snapred/backend/dao/request/CalibrationAssessmentRequest.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List
 
-from pydantic import BaseModel, ConfigDict, field_validator, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from snapred.backend.dao.Limit import Pair
 from snapred.backend.dao.RunConfig import RunConfig
@@ -33,8 +33,10 @@ class CalibrationAssessmentRequest(BaseModel, extra="forbid"):
     crystalDMin: float
     crystalDMax: float
     nBinsAcrossPeakWidth: int
-    fwhmMultipliers: Pair[float] = Field(default_factory = lambda: Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"]))
-    maxChiSq: float = Field(default_factory = lambda: Config["constants.GroupDiffractionCalibration.MaxChiSq"])
+    fwhmMultipliers: Pair[float] = Field(
+        default_factory=lambda: Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
+    )
+    maxChiSq: float = Field(default_factory=lambda: Config["constants.GroupDiffractionCalibration.MaxChiSq"])
 
     @field_validator("fwhmMultipliers", mode="before")
     @classmethod

--- a/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
+++ b/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
@@ -1,7 +1,7 @@
 # TODO this can probably be relaced in the code with FarmFreshIngredients
 from typing import Any, Optional
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, Field
 
 from snapred.backend.dao.indexing.Versioning import Version, VersionState
 from snapred.backend.dao.Limit import Pair
@@ -28,14 +28,14 @@ class DiffractionCalibrationRequest(BaseModel, extra="forbid"):
     calibrantSamplePath: str
     focusGroup: FocusGroup
     useLiteMode: bool
-    crystalDMin: float = Config["constants.CrystallographicInfo.crystalDMin"]
-    crystalDMax: float = Config["constants.CrystallographicInfo.crystalDMax"]
-    peakFunction: SymmetricPeakEnum = SymmetricPeakEnum[Config["calibration.diffraction.peakFunction"]]
-    convergenceThreshold: float = Config["calibration.diffraction.convergenceThreshold"]
-    nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]
-    maximumOffset: float = Config["calibration.diffraction.maximumOffset"]
-    fwhmMultipliers: Pair[float] = Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
-    maxChiSq: float = Config["constants.GroupDiffractionCalibration.MaxChiSq"]
+    crystalDMin: float = Field(default_factory = lambda: Config["constants.CrystallographicInfo.crystalDMin"])
+    crystalDMax: float = Field(default_factory = lambda: Config["constants.CrystallographicInfo.crystalDMax"])
+    peakFunction: SymmetricPeakEnum = Field(default_factory = lambda: SymmetricPeakEnum[Config["calibration.diffraction.peakFunction"]])
+    convergenceThreshold: float = Field(default_factory = lambda: Config["calibration.diffraction.convergenceThreshold"])
+    nBinsAcrossPeakWidth: int = Field(default_factory = lambda: Config["calibration.diffraction.nBinsAcrossPeakWidth"])
+    maximumOffset: float = Field(default_factory = lambda: Config["calibration.diffraction.maximumOffset"])
+    fwhmMultipliers: Pair[float] = Field(default_factory = lambda: Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"]))
+    maxChiSq: float = Field(default_factory = lambda: Config["constants.GroupDiffractionCalibration.MaxChiSq"])
     removeBackground: bool = False
 
     continueFlags: Optional[ContinueWarning.Type] = ContinueWarning.Type.UNSET

--- a/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
+++ b/src/snapred/backend/dao/request/DiffractionCalibrationRequest.py
@@ -1,7 +1,7 @@
 # TODO this can probably be relaced in the code with FarmFreshIngredients
 from typing import Any, Optional
 
-from pydantic import BaseModel, field_validator, Field
+from pydantic import BaseModel, Field, field_validator
 
 from snapred.backend.dao.indexing.Versioning import Version, VersionState
 from snapred.backend.dao.Limit import Pair
@@ -28,14 +28,18 @@ class DiffractionCalibrationRequest(BaseModel, extra="forbid"):
     calibrantSamplePath: str
     focusGroup: FocusGroup
     useLiteMode: bool
-    crystalDMin: float = Field(default_factory = lambda: Config["constants.CrystallographicInfo.crystalDMin"])
-    crystalDMax: float = Field(default_factory = lambda: Config["constants.CrystallographicInfo.crystalDMax"])
-    peakFunction: SymmetricPeakEnum = Field(default_factory = lambda: SymmetricPeakEnum[Config["calibration.diffraction.peakFunction"]])
-    convergenceThreshold: float = Field(default_factory = lambda: Config["calibration.diffraction.convergenceThreshold"])
-    nBinsAcrossPeakWidth: int = Field(default_factory = lambda: Config["calibration.diffraction.nBinsAcrossPeakWidth"])
-    maximumOffset: float = Field(default_factory = lambda: Config["calibration.diffraction.maximumOffset"])
-    fwhmMultipliers: Pair[float] = Field(default_factory = lambda: Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"]))
-    maxChiSq: float = Field(default_factory = lambda: Config["constants.GroupDiffractionCalibration.MaxChiSq"])
+    crystalDMin: float = Field(default_factory=lambda: Config["constants.CrystallographicInfo.crystalDMin"])
+    crystalDMax: float = Field(default_factory=lambda: Config["constants.CrystallographicInfo.crystalDMax"])
+    peakFunction: SymmetricPeakEnum = Field(
+        default_factory=lambda: SymmetricPeakEnum[Config["calibration.diffraction.peakFunction"]]
+    )
+    convergenceThreshold: float = Field(default_factory=lambda: Config["calibration.diffraction.convergenceThreshold"])
+    nBinsAcrossPeakWidth: int = Field(default_factory=lambda: Config["calibration.diffraction.nBinsAcrossPeakWidth"])
+    maximumOffset: float = Field(default_factory=lambda: Config["calibration.diffraction.maximumOffset"])
+    fwhmMultipliers: Pair[float] = Field(
+        default_factory=lambda: Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
+    )
+    maxChiSq: float = Field(default_factory=lambda: Config["constants.GroupDiffractionCalibration.MaxChiSq"])
     removeBackground: bool = False
 
     continueFlags: Optional[ContinueWarning.Type] = ContinueWarning.Type.UNSET

--- a/src/snapred/backend/dao/request/FarmFreshIngredients.py
+++ b/src/snapred/backend/dao/request/FarmFreshIngredients.py
@@ -1,6 +1,6 @@
 from typing import Any, List, NamedTuple, Optional
 
-from pydantic import BaseModel, ConfigDict, ValidationError, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator, model_validator, Field
 
 from snapred.backend.dao.indexing.Versioning import Version, VersionState
 from snapred.backend.dao.Limit import Limit, Pair
@@ -52,17 +52,17 @@ class FarmFreshIngredients(BaseModel):
     convertUnitsTo: Optional[str] = None
 
     ## the below are not-so-fresh, being fiddly optional parameters with defaults
-    convergenceThreshold: float = Config["calibration.diffraction.convergenceThreshold"]
-    nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]
+    convergenceThreshold: float = Field(default_factory = lambda: Config["calibration.diffraction.convergenceThreshold"])
+    nBinsAcrossPeakWidth: int = Field(default_factory = lambda: Config["calibration.diffraction.nBinsAcrossPeakWidth"])
     peakIntensityThreshold: Optional[float] = None
-    peakFunction: SymmetricPeakEnum = SymmetricPeakEnum[Config["calibration.diffraction.peakFunction"]]
-    maxOffset: float = Config["calibration.diffraction.maximumOffset"]
-    crystalDBounds: Limit[float] = Limit(
+    peakFunction: SymmetricPeakEnum = Field(default_factory = lambda: SymmetricPeakEnum[Config["calibration.diffraction.peakFunction"]])
+    maxOffset: float = Field(default_factory = lambda: Config["calibration.diffraction.maximumOffset"])
+    crystalDBounds: Limit[float] = Field(default_factory = lambda: Limit(
         minimum=Config["constants.CrystallographicInfo.crystalDMin"],
         maximum=Config["constants.CrystallographicInfo.crystalDMax"],
-    )
-    fwhmMultipliers: Pair[float] = Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
-    maxChiSq: Optional[float] = Config["constants.GroupDiffractionCalibration.MaxChiSq"]
+    ))
+    fwhmMultipliers: Pair[float] = Field(default_factory = lambda: Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"]))
+    maxChiSq: Optional[float] = Field(default_factory = lambda: Config["constants.GroupDiffractionCalibration.MaxChiSq"])
 
     focusGroups: Optional[List[FocusGroup]] = None
 

--- a/src/snapred/backend/dao/request/FarmFreshIngredients.py
+++ b/src/snapred/backend/dao/request/FarmFreshIngredients.py
@@ -1,6 +1,6 @@
 from typing import Any, List, NamedTuple, Optional
 
-from pydantic import BaseModel, ConfigDict, ValidationError, field_validator, model_validator, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 from snapred.backend.dao.indexing.Versioning import Version, VersionState
 from snapred.backend.dao.Limit import Limit, Pair
@@ -52,17 +52,23 @@ class FarmFreshIngredients(BaseModel):
     convertUnitsTo: Optional[str] = None
 
     ## the below are not-so-fresh, being fiddly optional parameters with defaults
-    convergenceThreshold: float = Field(default_factory = lambda: Config["calibration.diffraction.convergenceThreshold"])
-    nBinsAcrossPeakWidth: int = Field(default_factory = lambda: Config["calibration.diffraction.nBinsAcrossPeakWidth"])
+    convergenceThreshold: float = Field(default_factory=lambda: Config["calibration.diffraction.convergenceThreshold"])
+    nBinsAcrossPeakWidth: int = Field(default_factory=lambda: Config["calibration.diffraction.nBinsAcrossPeakWidth"])
     peakIntensityThreshold: Optional[float] = None
-    peakFunction: SymmetricPeakEnum = Field(default_factory = lambda: SymmetricPeakEnum[Config["calibration.diffraction.peakFunction"]])
-    maxOffset: float = Field(default_factory = lambda: Config["calibration.diffraction.maximumOffset"])
-    crystalDBounds: Limit[float] = Field(default_factory = lambda: Limit(
-        minimum=Config["constants.CrystallographicInfo.crystalDMin"],
-        maximum=Config["constants.CrystallographicInfo.crystalDMax"],
-    ))
-    fwhmMultipliers: Pair[float] = Field(default_factory = lambda: Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"]))
-    maxChiSq: Optional[float] = Field(default_factory = lambda: Config["constants.GroupDiffractionCalibration.MaxChiSq"])
+    peakFunction: SymmetricPeakEnum = Field(
+        default_factory=lambda: SymmetricPeakEnum[Config["calibration.diffraction.peakFunction"]]
+    )
+    maxOffset: float = Field(default_factory=lambda: Config["calibration.diffraction.maximumOffset"])
+    crystalDBounds: Limit[float] = Field(
+        default_factory=lambda: Limit(
+            minimum=Config["constants.CrystallographicInfo.crystalDMin"],
+            maximum=Config["constants.CrystallographicInfo.crystalDMax"],
+        )
+    )
+    fwhmMultipliers: Pair[float] = Field(
+        default_factory=lambda: Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
+    )
+    maxChiSq: Optional[float] = Field(default_factory=lambda: Config["constants.GroupDiffractionCalibration.MaxChiSq"])
 
     focusGroups: Optional[List[FocusGroup]] = None
 

--- a/src/snapred/backend/dao/request/FitMultiplePeaksRequest.py
+++ b/src/snapred/backend/dao/request/FitMultiplePeaksRequest.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.meta.Config import Config
@@ -12,7 +12,7 @@ class FitMultiplePeaksRequest(BaseModel):
     inputWorkspace: WorkspaceName
     outputWorkspaceGroup: WorkspaceName
     detectorPeaks: List[GroupPeakList]
-    peakFunction: SymmetricPeakEnum = SymmetricPeakEnum[Config["calibration.diffraction.peakFunction"]]
+    peakFunction: SymmetricPeakEnum = Field(default_factory = lambda: SymmetricPeakEnum[Config["calibration.diffraction.peakFunction"]])
 
     model_config = ConfigDict(
         # required in order to use 'WorkspaceName'

--- a/src/snapred/backend/dao/request/FitMultiplePeaksRequest.py
+++ b/src/snapred/backend/dao/request/FitMultiplePeaksRequest.py
@@ -12,7 +12,9 @@ class FitMultiplePeaksRequest(BaseModel):
     inputWorkspace: WorkspaceName
     outputWorkspaceGroup: WorkspaceName
     detectorPeaks: List[GroupPeakList]
-    peakFunction: SymmetricPeakEnum = Field(default_factory = lambda: SymmetricPeakEnum[Config["calibration.diffraction.peakFunction"]])
+    peakFunction: SymmetricPeakEnum = Field(
+        default_factory=lambda: SymmetricPeakEnum[Config["calibration.diffraction.peakFunction"]]
+    )
 
     model_config = ConfigDict(
         # required in order to use 'WorkspaceName'

--- a/src/snapred/backend/dao/request/NormalizationRequest.py
+++ b/src/snapred/backend/dao/request/NormalizationRequest.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from snapred.backend.dao.Limit import Limit, Pair
 from snapred.backend.dao.state.FocusGroup import FocusGroup
@@ -24,13 +24,13 @@ class NormalizationRequest(BaseModel, extra="forbid", arbitrary_types_allowed=Tr
     useLiteMode: bool
     focusGroup: FocusGroup
     calibrantSamplePath: str
-    smoothingParameter: float = Config["calibration.parameters.default.smoothing"]
-    crystalDBounds: Limit[float] = Limit(
+    smoothingParameter: float = Field(default_factory = lambda: Config["calibration.parameters.default.smoothing"])
+    crystalDBounds: Limit[float] = Field(default_factory = lambda: Limit(
         minimum=Config["constants.CrystallographicInfo.crystalDMin"],
         maximum=Config["constants.CrystallographicInfo.crystalDMax"],
-    )
-    nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]
-    fwhmMultipliers: Pair[float] = Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
+    ))
+    nBinsAcrossPeakWidth: int = Field(default_factory = lambda: Config["calibration.diffraction.nBinsAcrossPeakWidth"])
+    fwhmMultipliers: Pair[float] = Field(default_factory = lambda: Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"]))
 
     continueFlags: Optional[ContinueWarning.Type] = ContinueWarning.Type.UNSET
     correctedVanadiumWs: Optional[WorkspaceName] = None

--- a/src/snapred/backend/dao/request/NormalizationRequest.py
+++ b/src/snapred/backend/dao/request/NormalizationRequest.py
@@ -24,13 +24,17 @@ class NormalizationRequest(BaseModel, extra="forbid", arbitrary_types_allowed=Tr
     useLiteMode: bool
     focusGroup: FocusGroup
     calibrantSamplePath: str
-    smoothingParameter: float = Field(default_factory = lambda: Config["calibration.parameters.default.smoothing"])
-    crystalDBounds: Limit[float] = Field(default_factory = lambda: Limit(
-        minimum=Config["constants.CrystallographicInfo.crystalDMin"],
-        maximum=Config["constants.CrystallographicInfo.crystalDMax"],
-    ))
-    nBinsAcrossPeakWidth: int = Field(default_factory = lambda: Config["calibration.diffraction.nBinsAcrossPeakWidth"])
-    fwhmMultipliers: Pair[float] = Field(default_factory = lambda: Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"]))
+    smoothingParameter: float = Field(default_factory=lambda: Config["calibration.parameters.default.smoothing"])
+    crystalDBounds: Limit[float] = Field(
+        default_factory=lambda: Limit(
+            minimum=Config["constants.CrystallographicInfo.crystalDMin"],
+            maximum=Config["constants.CrystallographicInfo.crystalDMax"],
+        )
+    )
+    nBinsAcrossPeakWidth: int = Field(default_factory=lambda: Config["calibration.diffraction.nBinsAcrossPeakWidth"])
+    fwhmMultipliers: Pair[float] = Field(
+        default_factory=lambda: Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
+    )
 
     continueFlags: Optional[ContinueWarning.Type] = ContinueWarning.Type.UNSET
     correctedVanadiumWs: Optional[WorkspaceName] = None

--- a/src/snapred/backend/dao/request/SmoothDataExcludingPeaksRequest.py
+++ b/src/snapred/backend/dao/request/SmoothDataExcludingPeaksRequest.py
@@ -20,6 +20,6 @@ class SmoothDataExcludingPeaksRequest(BaseModel):
     calibrantSamplePath: str
     inputWorkspace: str
     outputWorkspace: str
-    smoothingParameter: float = Field(default_factory = lambda: Config["calibration.parameters.default.smoothing"])
-    crystalDMin: float = Field(default_factory = lambda: Config["constants.CrystallographicInfo.crystalDMin"])
-    crystalDMax: float = Field(default_factory = lambda: Config["constants.CrystallographicInfo.crystalDMax"])
+    smoothingParameter: float = Field(default_factory=lambda: Config["calibration.parameters.default.smoothing"])
+    crystalDMin: float = Field(default_factory=lambda: Config["constants.CrystallographicInfo.crystalDMin"])
+    crystalDMax: float = Field(default_factory=lambda: Config["constants.CrystallographicInfo.crystalDMax"])

--- a/src/snapred/backend/dao/request/SmoothDataExcludingPeaksRequest.py
+++ b/src/snapred/backend/dao/request/SmoothDataExcludingPeaksRequest.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.meta.Config import Config
@@ -20,6 +20,6 @@ class SmoothDataExcludingPeaksRequest(BaseModel):
     calibrantSamplePath: str
     inputWorkspace: str
     outputWorkspace: str
-    smoothingParameter: float = Config["calibration.parameters.default.smoothing"]
-    crystalDMin: float = Config["constants.CrystallographicInfo.crystalDMin"]
-    crystalDMax: float = Config["constants.CrystallographicInfo.crystalDMax"]
+    smoothingParameter: float = Field(default_factory = lambda: Config["calibration.parameters.default.smoothing"])
+    crystalDMin: float = Field(default_factory = lambda: Config["constants.CrystallographicInfo.crystalDMin"])
+    crystalDMax: float = Field(default_factory = lambda: Config["constants.CrystallographicInfo.crystalDMax"])

--- a/src/snapred/backend/dao/request/VanadiumCorrectionRequest.py
+++ b/src/snapred/backend/dao/request/VanadiumCorrectionRequest.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from snapred.backend.dao.state.FocusGroup import FocusGroup
 from snapred.meta.Config import Config
@@ -15,5 +15,5 @@ class VanadiumCorrectionRequest(BaseModel):
     backgroundWorkspace: str
     outputWorkspace: str
 
-    crystalDMin: float = Config["constants.CrystallographicInfo.crystalDMin"]
-    crystalDMax: float = Config["constants.CrystallographicInfo.crystalDMax"]
+    crystalDMin: float = Field(default_factory = lambda: Config["constants.CrystallographicInfo.crystalDMin"])
+    crystalDMax: float = Field(default_factory = lambda: Config["constants.CrystallographicInfo.crystalDMax"])

--- a/src/snapred/backend/dao/request/VanadiumCorrectionRequest.py
+++ b/src/snapred/backend/dao/request/VanadiumCorrectionRequest.py
@@ -15,5 +15,5 @@ class VanadiumCorrectionRequest(BaseModel):
     backgroundWorkspace: str
     outputWorkspace: str
 
-    crystalDMin: float = Field(default_factory = lambda: Config["constants.CrystallographicInfo.crystalDMin"])
-    crystalDMax: float = Field(default_factory = lambda: Config["constants.CrystallographicInfo.crystalDMax"])
+    crystalDMin: float = Field(default_factory=lambda: Config["constants.CrystallographicInfo.crystalDMin"])
+    crystalDMax: float = Field(default_factory=lambda: Config["constants.CrystallographicInfo.crystalDMax"])

--- a/src/snapred/backend/dao/state/CalibrantSample/CalibrantSample.py
+++ b/src/snapred/backend/dao/state/CalibrantSample/CalibrantSample.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, Field
 
 from snapred.backend.dao.state.CalibrantSample.Crystallography import Crystallography
 from snapred.backend.dao.state.CalibrantSample.Geometry import Geometry
@@ -18,7 +18,7 @@ class CalibrantSample(BaseModel):
     geometry: Geometry
     material: Material
     crystallography: Optional[Crystallography] = None
-    peakIntensityFractionThreshold: Optional[float] = Config["constants.PeakIntensityFractionThreshold"]
+    peakIntensityFractionThreshold: Optional[float] = Field(default_factory = lambda: Config["constants.PeakIntensityFractionThreshold"])
     overrides: Optional[Dict[str, Any]] = None
 
     # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.

--- a/src/snapred/backend/dao/state/CalibrantSample/CalibrantSample.py
+++ b/src/snapred/backend/dao/state/CalibrantSample/CalibrantSample.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, field_validator, Field
+from pydantic import BaseModel, Field, field_validator
 
 from snapred.backend.dao.state.CalibrantSample.Crystallography import Crystallography
 from snapred.backend.dao.state.CalibrantSample.Geometry import Geometry
@@ -18,7 +18,9 @@ class CalibrantSample(BaseModel):
     geometry: Geometry
     material: Material
     crystallography: Optional[Crystallography] = None
-    peakIntensityFractionThreshold: Optional[float] = Field(default_factory = lambda: Config["constants.PeakIntensityFractionThreshold"])
+    peakIntensityFractionThreshold: Optional[float] = Field(
+        default_factory=lambda: Config["constants.PeakIntensityFractionThreshold"]
+    )
     overrides: Optional[Dict[str, Any]] = None
 
     # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.

--- a/src/snapred/backend/dao/state/PixelGroup.py
+++ b/src/snapred/backend/dao/state/PixelGroup.py
@@ -1,7 +1,7 @@
 from enum import IntEnum
 from typing import Dict, List
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, Field
 
 from snapred.backend.dao.Limit import BinnedValue, Limit
 from snapred.backend.dao.state.FocusGroup import FocusGroup
@@ -13,7 +13,7 @@ class PixelGroup(BaseModel):
     # allow initialization from either a dictionary or list
     pixelGroupingParameters: List[PixelGroupingParameters] | Dict[int, PixelGroupingParameters] = {}
 
-    nBinsAcrossPeakWidth: int = Config["calibration.diffraction.nBinsAcrossPeakWidth"]
+    nBinsAcrossPeakWidth: int = Field(default_factory = lambda: Config["calibration.diffraction.nBinsAcrossPeakWidth"])
     focusGroup: FocusGroup
     timeOfFlight: BinnedValue[float]
 

--- a/src/snapred/backend/dao/state/PixelGroup.py
+++ b/src/snapred/backend/dao/state/PixelGroup.py
@@ -1,7 +1,7 @@
 from enum import IntEnum
 from typing import Dict, List
 
-from pydantic import BaseModel, field_validator, Field
+from pydantic import BaseModel, Field, field_validator
 
 from snapred.backend.dao.Limit import BinnedValue, Limit
 from snapred.backend.dao.state.FocusGroup import FocusGroup
@@ -13,7 +13,7 @@ class PixelGroup(BaseModel):
     # allow initialization from either a dictionary or list
     pixelGroupingParameters: List[PixelGroupingParameters] | Dict[int, PixelGroupingParameters] = {}
 
-    nBinsAcrossPeakWidth: int = Field(default_factory = lambda: Config["calibration.diffraction.nBinsAcrossPeakWidth"])
+    nBinsAcrossPeakWidth: int = Field(default_factory=lambda: Config["calibration.diffraction.nBinsAcrossPeakWidth"])
     focusGroup: FocusGroup
     timeOfFlight: BinnedValue[float]
 

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -22,6 +22,7 @@ from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.backend.recipe.FetchGroceriesRecipe import FetchGroceriesRecipe
 from snapred.backend.service.WorkspaceMetadataService import WorkspaceMetadataService
 from snapred.meta.Config import Config
+from snapred.meta.decorators.ConfigDefault import ConfigDefault, ConfigValue
 from snapred.meta.decorators.Singleton import Singleton
 from snapred.meta.InternalConstants import ReservedRunNumber
 from snapred.meta.mantid.WorkspaceNameGenerator import (
@@ -185,8 +186,8 @@ class GroceryService:
                 del self._loadedInstruments[key]
 
     ## FILENAME METHODS
-
-    def getIPTS(self, runNumber: str, instrumentName: str = Config["instrument.name"]) -> str:
+    @ConfigDefault
+    def getIPTS(self, runNumber: str, instrumentName: str = ConfigValue("instrument.name")) -> str:
         """
         Find the approprate IPTS folder for a run number.
 

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -359,7 +359,7 @@ class GroceryService:
         NOTE: This method will IGNORE runNumber if the provided version is VersionState.DEFAULT
         """
         wsName = wng.diffCalTable().runNumber(runNumber).version(version).build()
-        if version in [VersionState.DEFAULT, VERSION_START]:
+        if version in [VersionState.DEFAULT, VERSION_START()]:
             wsName = wng.diffCalTable().runNumber("default").version(VersionState.DEFAULT).build()
         return wsName
 

--- a/src/snapred/backend/data/Indexer.py
+++ b/src/snapred/backend/data/Indexer.py
@@ -162,7 +162,7 @@ class Indexer:
         """
         The version number to use for default states.
         """
-        return VERSION_START
+        return VERSION_START()
 
     def currentVersion(self) -> int:
         """

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -92,6 +92,7 @@ class LocalDataService:
     # conversion factor from microsecond/Angstrom to meters
     # (TODO: FIX THIS COMMENT! Obviously `m2cm` doesn't convert from 1.0 / Angstrom to 1.0 / meters.)
     CONVERSION_FACTOR = Config["constants.m2cm"] * PhysicalConstants.h / PhysicalConstants.NeutronMass
+    _verifyPaths = None
 
     def __init__(self) -> None:
         self.mantidSnapper = MantidSnapper(None, "Utensils")

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -55,6 +55,7 @@ from snapred.backend.error.StateValidationException import StateValidationExcept
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
+from snapred.meta.decorators.ConfigDefault import ConfigDefault, ConfigValue
 from snapred.meta.decorators.ExceptionHandler import ExceptionHandler
 from snapred.meta.decorators.Singleton import Singleton
 from snapred.meta.InternalConstants import ReservedRunNumber, ReservedStateId
@@ -93,10 +94,13 @@ class LocalDataService:
     CONVERSION_FACTOR = Config["constants.m2cm"] * PhysicalConstants.h / PhysicalConstants.NeutronMass
 
     def __init__(self) -> None:
-        self.verifyPaths = Config["localdataservice.config.verifypaths"]
         self.mantidSnapper = MantidSnapper(None, "Utensils")
 
     ##### MISCELLANEOUS METHODS #####
+
+    @property
+    def verifyPaths(self) -> bool:
+        return Config["localdataservice.config.verifypaths"]
 
     def fileExists(self, path):
         return os.path.isfile(path)
@@ -189,7 +193,8 @@ class LocalDataService:
         return nextTimestamp
 
     @lru_cache
-    def _getIPTS(self, runNumber: str, instrumentName: str = Config["instrument.name"]) -> str | None:
+    @ConfigDefault
+    def _getIPTS(self, runNumber: str, instrumentName: str = ConfigValue("instrument.name")) -> str | None:
         # Fully cached version of `GetIPTS`:
         #   returns the IPTS-directory for the run or None if no IPTS directory exists.
 
@@ -215,7 +220,8 @@ class LocalDataService:
 
         return None
 
-    def getIPTS(self, runNumber: str, instrumentName: str = Config["instrument.name"]) -> str:
+    @ConfigDefault
+    def getIPTS(self, runNumber: str, instrumentName: str = ConfigValue("instrument.name")) -> str:
         IPTS = self._getIPTS(runNumber, instrumentName)
         if IPTS is None:
             raise RuntimeError(f"Cannot find IPTS directory for run '{runNumber}'")

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -55,6 +55,7 @@ from snapred.backend.error.StateValidationException import StateValidationExcept
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 from snapred.meta.decorators.ConfigDefault import ConfigDefault, ConfigValue
 from snapred.meta.decorators.ExceptionHandler import ExceptionHandler
 from snapred.meta.decorators.Singleton import Singleton
@@ -99,8 +100,8 @@ class LocalDataService:
 
     ##### MISCELLANEOUS METHODS #####
 
-    @property
-    def verifyPaths(self) -> bool:
+    @classproperty
+    def verifyPaths(cls) -> bool:
         return Config["localdataservice.config.verifypaths"]
 
     def fileExists(self, path):

--- a/src/snapred/backend/log/logger.py
+++ b/src/snapred/backend/log/logger.py
@@ -19,8 +19,7 @@ class CustomFormatter(logging.Formatter):
     _host = socket.gethostname().split(".")[0]
 
     def __init__(self, name="SNAP.stream"):
-        self._format = self._host + " - " + Config[f"logging.{name}.format"]
-
+        self._name = name
         self.FORMATS = {
             logging.DEBUG: self._grey + self._format + self._reset,
             logging.INFO: self._grey + self._format + self._reset,
@@ -28,6 +27,10 @@ class CustomFormatter(logging.Formatter):
             logging.ERROR: self._red + self._format + self._reset,
             logging.CRITICAL: self._bold_red + self._format + self._reset,
         }
+
+    @property
+    def _format(self):
+        return self._host + " - " + Config[f"logging.{self._name}.format"]
 
     def _colorCodeFormat(self, rawFormat):
         fields = rawFormat.split("-")
@@ -45,11 +48,14 @@ class CustomFormatter(logging.Formatter):
 
 @Singleton
 class _SnapRedLogger:
-    _level = Config["logging.SNAP.stream.level"]
     _warnings = []
 
     def __init__(self):
         self.resetProgress(0, 1.0, 100)
+
+    @property
+    def _level(self):
+        return Config["logging.SNAP.stream.level"]
 
     def _setFormatter(self, logger):
         ch = logging.StreamHandler(sys.stdout)

--- a/src/snapred/backend/recipe/ApplyNormalizationRecipe.py
+++ b/src/snapred/backend/recipe/ApplyNormalizationRecipe.py
@@ -13,8 +13,11 @@ Pallet = Tuple[Ingredients, Dict[str, str]]
 
 
 class ApplyNormalizationRecipe(Recipe[Ingredients]):
-    NUM_BINS = Config["constants.ResampleX.NumberBins"]
     LOG_BINNING = True
+
+    @property
+    def NUM_BINS(self) -> int:
+        return Config["constants.ResampleX.NumberBins"]
 
     def allGroceryKeys(self) -> Set[str]:
         return {"inputWorkspace", "normalizationWorkspace", "backgroundWorkspace"}

--- a/src/snapred/backend/recipe/CrystallographicInfoRecipe.py
+++ b/src/snapred/backend/recipe/CrystallographicInfoRecipe.py
@@ -10,8 +10,13 @@ logger = snapredLogger.getLogger(__name__)
 
 
 class CrystallographicInfoRecipe:
-    D_MIN = Config["constants.CrystallographicInfo.crystalDMin"]
-    D_MAX = Config["constants.CrystallographicInfo.crystalDMax"]
+    @property
+    def D_MIN(self):
+        return Config["constants.CrystallographicInfo.crystalDMin"]
+
+    @property
+    def D_MAX(self):
+        return Config["constants.CrystallographicInfo.crystalDMax"]
 
     def __init__(self):
         # NOTE: workaround, we just add an empty host algorithm.

--- a/src/snapred/backend/recipe/GroupDiffCalRecipe.py
+++ b/src/snapred/backend/recipe/GroupDiffCalRecipe.py
@@ -27,15 +27,20 @@ class GroupDiffCalRecipe(Recipe[Ingredients]):
     One part of diffraction calibration.
     """
 
-    NOYZE_2_MIN = Config["calibration.fitting.minSignal2Noise"]
-    MAX_CHI_SQ = Config["constants.GroupDiffractionCalibration.MaxChiSq"]
-
     def __init__(self, utensils: Utensils = None):
         if utensils is None:
             utensils = Utensils()
             utensils.PyInit()
         self.mantidSnapper = utensils.mantidSnapper
         self._counts = 0
+
+    @property
+    def NOYZE_2_MIN(self):
+        return Config["calibration.fitting.minSignal2Noise"]
+
+    @property
+    def MAX_CHI_SQ(self):
+        return Config["constants.GroupDiffractionCalibration.MaxChiSq"]
 
     def logger(self):
         return logger

--- a/src/snapred/backend/recipe/GroupDiffCalRecipe.py
+++ b/src/snapred/backend/recipe/GroupDiffCalRecipe.py
@@ -7,6 +7,7 @@ from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.Utensils import Utensils
 from snapred.backend.recipe.Recipe import Recipe, WorkspaceName
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 from snapred.meta.mantid.FitPeaksOutput import FIT_PEAK_DIAG_SUFFIX, FitOutputEnum
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 
@@ -34,12 +35,12 @@ class GroupDiffCalRecipe(Recipe[Ingredients]):
         self.mantidSnapper = utensils.mantidSnapper
         self._counts = 0
 
-    @property
-    def NOYZE_2_MIN(self):
+    @classproperty
+    def NOYZE_2_MIN(cls):
         return Config["calibration.fitting.minSignal2Noise"]
 
-    @property
-    def MAX_CHI_SQ(self):
+    @classproperty
+    def MAX_CHI_SQ(cls):
         return Config["constants.GroupDiffractionCalibration.MaxChiSq"]
 
     def logger(self):

--- a/src/snapred/backend/recipe/PixelDiffCalRecipe.py
+++ b/src/snapred/backend/recipe/PixelDiffCalRecipe.py
@@ -8,6 +8,7 @@ from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.Utensils import Utensils
 from snapred.backend.recipe.Recipe import Recipe, WorkspaceName
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceNameGenerator as wng
 
 logger = snapredLogger.getLogger(__name__)
@@ -39,8 +40,8 @@ class PixelDiffCalRecipe(Recipe[Ingredients]):
         self.mantidSnapper = utensils.mantidSnapper
         self._counts = 0
 
-    @property
-    def MAX_DSPACE_SHIFT_FACTOR(self) -> float:
+    @classproperty
+    def MAX_DSPACE_SHIFT_FACTOR(cls) -> float:
         return Config["calibration.diffraction.maxDSpaceShiftFactor"]
 
     def logger(self):

--- a/src/snapred/backend/recipe/PixelDiffCalRecipe.py
+++ b/src/snapred/backend/recipe/PixelDiffCalRecipe.py
@@ -32,14 +32,16 @@ class PixelDiffCalRecipe(Recipe[Ingredients]):
     # therefore there is no reason not to deform the input workspace to this algorithm
     # instead, the original clean file is preserved in a separate location
 
-    MAX_DSPACE_SHIFT_FACTOR = Config["calibration.diffraction.maxDSpaceShiftFactor"]
-
     def __init__(self, utensils: Utensils = None):
         if utensils is None:
             utensils = Utensils()
             utensils.PyInit()
         self.mantidSnapper = utensils.mantidSnapper
         self._counts = 0
+
+    @property
+    def MAX_DSPACE_SHIFT_FACTOR(self) -> float:
+        return Config["calibration.diffraction.maxDSpaceShiftFactor"]
 
     def logger(self):
         return logger

--- a/src/snapred/backend/recipe/ReadWorkspaceMetadata.py
+++ b/src/snapred/backend/recipe/ReadWorkspaceMetadata.py
@@ -4,6 +4,7 @@ from snapred.backend.dao.WorkspaceMetadata import UNSET, WorkspaceMetadata
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.Recipe import Recipe
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 from snapred.meta.decorators.Singleton import Singleton
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
@@ -14,8 +15,8 @@ Pallet = Tuple[WorkspaceMetadata, Dict[str, WorkspaceName]]
 
 @Singleton
 class ReadWorkspaceMetadata(Recipe[WorkspaceMetadata]):
-    @property
-    def TAG_PREFIX(self):
+    @classproperty
+    def TAG_PREFIX(cls):
         return Config["metadata.tagPrefix"]
 
     def allGroceryKeys(self) -> Set[str]:

--- a/src/snapred/backend/recipe/ReadWorkspaceMetadata.py
+++ b/src/snapred/backend/recipe/ReadWorkspaceMetadata.py
@@ -14,7 +14,9 @@ Pallet = Tuple[WorkspaceMetadata, Dict[str, WorkspaceName]]
 
 @Singleton
 class ReadWorkspaceMetadata(Recipe[WorkspaceMetadata]):
-    TAG_PREFIX = Config["metadata.tagPrefix"]
+    @property
+    def TAG_PREFIX(self):
+        return Config["metadata.tagPrefix"]
 
     def allGroceryKeys(self) -> Set[str]:
         return {"workspace"}

--- a/src/snapred/backend/recipe/RebinFocussedGroupDataRecipe.py
+++ b/src/snapred/backend/recipe/RebinFocussedGroupDataRecipe.py
@@ -12,8 +12,11 @@ Pallet = Tuple[Ingredients, Dict[str, str]]
 
 
 class RebinFocussedGroupDataRecipe(Recipe[Ingredients]):
-    NUM_BINS = Config["constants.ResampleX.NumberBins"]
     LOG_BINNING = True
+
+    @property
+    def NUM_BINS(self) -> int:
+        return Config["constants.ResampleX.NumberBins"]
 
     def allGroceryKeys(self) -> Set[str]:
         return {"inputWorkspace"}

--- a/src/snapred/backend/recipe/RebinFocussedGroupDataRecipe.py
+++ b/src/snapred/backend/recipe/RebinFocussedGroupDataRecipe.py
@@ -4,6 +4,7 @@ from snapred.backend.dao.ingredients import RebinFocussedGroupDataIngredients as
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.Recipe import Recipe
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
 logger = snapredLogger.getLogger(__name__)
@@ -14,8 +15,8 @@ Pallet = Tuple[Ingredients, Dict[str, str]]
 class RebinFocussedGroupDataRecipe(Recipe[Ingredients]):
     LOG_BINNING = True
 
-    @property
-    def NUM_BINS(self) -> int:
+    @classproperty
+    def NUM_BINS(cls) -> int:
         return Config["constants.ResampleX.NumberBins"]
 
     def allGroceryKeys(self) -> Set[str]:

--- a/src/snapred/backend/recipe/WriteWorkspaceMetadata.py
+++ b/src/snapred/backend/recipe/WriteWorkspaceMetadata.py
@@ -5,6 +5,7 @@ from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.ReadWorkspaceMetadata import ReadWorkspaceMetadata
 from snapred.backend.recipe.Recipe import Recipe
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
 
 logger = snapredLogger.getLogger(__name__)
@@ -13,8 +14,8 @@ Pallet = Tuple[WorkspaceMetadata, Dict[str, str]]
 
 
 class WriteWorkspaceMetadata(Recipe[WorkspaceMetadata]):
-    @property
-    def TAG_PREFIX(self):
+    @classproperty
+    def TAG_PREFIX(cls):
         return Config["metadata.tagPrefix"]
 
     def allGroceryKeys(self):

--- a/src/snapred/backend/recipe/WriteWorkspaceMetadata.py
+++ b/src/snapred/backend/recipe/WriteWorkspaceMetadata.py
@@ -13,7 +13,9 @@ Pallet = Tuple[WorkspaceMetadata, Dict[str, str]]
 
 
 class WriteWorkspaceMetadata(Recipe[WorkspaceMetadata]):
-    TAG_PREFIX = Config["metadata.tagPrefix"]
+    @property
+    def TAG_PREFIX(self):
+        return Config["metadata.tagPrefix"]
 
     def allGroceryKeys(self):
         return {"workspace"}

--- a/src/snapred/backend/recipe/algorithm/CrystallographicInfoAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/CrystallographicInfoAlgorithm.py
@@ -10,15 +10,16 @@ from snapred.backend.dao.CrystallographicInfo import CrystallographicInfo
 from snapred.backend.dao.state.CalibrantSample.Crystallography import Crystallography
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 
 
 class CrystallographicInfoAlgorithm(PythonAlgorithm):
-    @property
-    def D_MIN(self):
+    @classproperty
+    def D_MIN(cls):
         return Config["constants.CrystallographicInfo.crystalDMin"]
 
-    @property
-    def D_MAX(self):
+    @classproperty
+    def D_MAX(cls):
         return Config["constants.CrystallographicInfo.crystalDMax"]
 
     def category(self):

--- a/src/snapred/backend/recipe/algorithm/CrystallographicInfoAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/CrystallographicInfoAlgorithm.py
@@ -13,8 +13,13 @@ from snapred.meta.Config import Config
 
 
 class CrystallographicInfoAlgorithm(PythonAlgorithm):
-    D_MIN = Config["constants.CrystallographicInfo.crystalDMin"]
-    D_MAX = Config["constants.CrystallographicInfo.crystalDMax"]
+    @property
+    def D_MIN(self):
+        return Config["constants.CrystallographicInfo.crystalDMin"]
+
+    @property
+    def D_MAX(self):
+        return Config["constants.CrystallographicInfo.crystalDMax"]
 
     def category(self):
         return "SNAPRed Sample Data"

--- a/src/snapred/backend/recipe/algorithm/DetectorPeakPredictor.py
+++ b/src/snapred/backend/recipe/algorithm/DetectorPeakPredictor.py
@@ -15,8 +15,14 @@ class DetectorPeakPredictor(PythonAlgorithm):
     # BETA_D_COEFFICIENT = PhysicalConstants.h / (2 * PhysicalConstants.NeutronMass * 1e10)
     # also the equation below that uses the coefficient should be changed to
     # beta_d = BETA_D_COEFFICIENT*beta_T/(L*np.sin(tTheta/2))
-    BETA_D_COEFFICIENT = 1 / (PhysicalConstants.h / (2 * PhysicalConstants.NeutronMass) * Config["constants.m2cm"])
-    FWHM = Config["constants.DetectorPeakPredictor.fwhm"]
+
+    @property
+    def BETA_D_COEFFICIENT(self):
+        return 1 / (PhysicalConstants.h / (2 * PhysicalConstants.NeutronMass) * Config["constants.m2cm"])
+
+    @property
+    def FWHM(self):
+        return Config["constants.DetectorPeakPredictor.fwhm"]
 
     def category(self):
         return "SNAPRed Data Processing"

--- a/src/snapred/backend/recipe/algorithm/DetectorPeakPredictor.py
+++ b/src/snapred/backend/recipe/algorithm/DetectorPeakPredictor.py
@@ -7,6 +7,7 @@ from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.dao.ingredients import PeakIngredients
 from snapred.backend.dao.Limit import LimitedValue
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 from snapred.meta.redantic import list_to_raw
 
 
@@ -16,12 +17,12 @@ class DetectorPeakPredictor(PythonAlgorithm):
     # also the equation below that uses the coefficient should be changed to
     # beta_d = BETA_D_COEFFICIENT*beta_T/(L*np.sin(tTheta/2))
 
-    @property
-    def BETA_D_COEFFICIENT(self):
+    @classproperty
+    def BETA_D_COEFFICIENT(cls):
         return 1 / (PhysicalConstants.h / (2 * PhysicalConstants.NeutronMass) * Config["constants.m2cm"])
 
-    @property
-    def FWHM(self):
+    @classproperty
+    def FWHM(cls):
         return Config["constants.DetectorPeakPredictor.fwhm"]
 
     def category(self):

--- a/src/snapred/backend/recipe/algorithm/FitMultiplePeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FitMultiplePeaksAlgorithm.py
@@ -16,6 +16,7 @@ from snapred.backend.dao.GroupPeakList import GroupPeakList
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 from snapred.meta.mantid.AllowedPeakTypes import allowed_peak_type_list
 from snapred.meta.mantid.FitPeaksOutput import FIT_PEAK_DIAG_SUFFIX, FitOutputEnum
 
@@ -23,8 +24,8 @@ logger = snapredLogger.getLogger(__name__)
 
 
 class FitMultiplePeaksAlgorithm(PythonAlgorithm):
-    @property
-    def NOYZE_2_MIN(self):
+    @classproperty
+    def NOYZE_2_MIN(cls):
         return Config["calibration.fitting.minSignal2Noise"]
 
     def category(self):

--- a/src/snapred/backend/recipe/algorithm/FitMultiplePeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FitMultiplePeaksAlgorithm.py
@@ -23,7 +23,9 @@ logger = snapredLogger.getLogger(__name__)
 
 
 class FitMultiplePeaksAlgorithm(PythonAlgorithm):
-    NOYZE_2_MIN = Config["calibration.fitting.minSignal2Noise"]
+    @property
+    def NOYZE_2_MIN(self):
+        return Config["calibration.fitting.minSignal2Noise"]
 
     def category(self):
         return "SNAPRed Data Processing"

--- a/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
@@ -49,7 +49,7 @@ class LiteDataCreationAlgo(PythonAlgorithm):
         # TODO this is needed by LoadInstrument, which needs to be removed
         self.declareProperty(
             "LiteInstrumentDefinitionFile",
-            str(Config["instrument.lite.definition.file"]),
+            "instrument.lite.definition.file",
             Direction.Input,
         )
         self.declareProperty("AutoDeleteNonLiteWS", defaultValue=False, direction=Direction.Input)
@@ -85,6 +85,11 @@ class LiteDataCreationAlgo(PythonAlgorithm):
 
     def PyExec(self):
         self.log().notice("Lite Data Creation START!")
+
+        if self.getProperty("LiteInstrumentDefinitionFile").isDefault:
+            liteInstrumentDefinitionFileKey = self.getPropertyValue("LiteInstrumentDefinitionFile")
+            self.setPropertyValue("LiteInstrumentDefinitionFile", Config[liteInstrumentDefinitionFileKey])
+
         ingredients = InstrumentState.model_validate_json(self.getProperty("Ingredients").value)
         self.chopIngredients(ingredients)
         # load input workspace

--- a/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
+++ b/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
@@ -19,8 +19,19 @@ class MakeDirtyDish(PythonAlgorithm):
         self.declareProperty("OutputWorkspace", defaultValue="", direction=Direction.Output)  # noqa: F821
         self.setRethrows(True)
 
-        self.cis_enabled: bool = Config["cis_mode.enabled"]
-        self.cis_preserve: bool = Config["cis_mode.preserveDiagnosticWorkspaces"]
+    @property
+    def cis_enabled(self) -> bool:
+        """
+        Check if CIS mode is enabled
+        """
+        return Config["cis_mode.enabled"]
+
+    @property
+    def cis_preserve(self) -> bool:
+        """
+        Check if CIS mode is enabled
+        """
+        return Config["cis_mode.preserveDiagnosticWorkspaces"]
 
     def PyExec(self) -> None:
         if self.cis_enabled and self.cis_preserve:

--- a/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
+++ b/src/snapred/backend/recipe/algorithm/MakeDirtyDish.py
@@ -3,6 +3,7 @@ from mantid.kernel import Direction
 from mantid.simpleapi import CloneWorkspace
 
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 
 
 class MakeDirtyDish(PythonAlgorithm):
@@ -19,15 +20,15 @@ class MakeDirtyDish(PythonAlgorithm):
         self.declareProperty("OutputWorkspace", defaultValue="", direction=Direction.Output)  # noqa: F821
         self.setRethrows(True)
 
-    @property
-    def cis_enabled(self) -> bool:
+    @classproperty
+    def cis_enabled(cls) -> bool:
         """
         Check if CIS mode is enabled
         """
         return Config["cis_mode.enabled"]
 
-    @property
-    def cis_preserve(self) -> bool:
+    @classproperty
+    def cis_preserve(cls) -> bool:
         """
         Check if CIS mode is enabled
         """

--- a/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculation.py
+++ b/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculation.py
@@ -17,6 +17,7 @@ from snapred.backend.dao.state.PixelGroupingParameters import PixelGroupingParam
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 from snapred.meta.redantic import list_to_raw
 
 logger = snapredLogger.getLogger(__name__)
@@ -25,8 +26,8 @@ logger = snapredLogger.getLogger(__name__)
 class PixelGroupingParametersCalculation(PythonAlgorithm):
     # conversion factor from microsecond/Angstrom to meters
 
-    @property
-    def CONVERSION_FACTOR(self):
+    @classproperty
+    def CONVERSION_FACTOR(cls):
         return Config["constants.m2cm"] * PhysicalConstants.h / PhysicalConstants.NeutronMass
 
     def category(self):

--- a/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculation.py
+++ b/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculation.py
@@ -24,7 +24,10 @@ logger = snapredLogger.getLogger(__name__)
 
 class PixelGroupingParametersCalculation(PythonAlgorithm):
     # conversion factor from microsecond/Angstrom to meters
-    CONVERSION_FACTOR = Config["constants.m2cm"] * PhysicalConstants.h / PhysicalConstants.NeutronMass
+
+    @property
+    def CONVERSION_FACTOR(self):
+        return Config["constants.m2cm"] * PhysicalConstants.h / PhysicalConstants.NeutronMass
 
     def category(self):
         return "SNAPRed Internal"

--- a/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
@@ -10,18 +10,19 @@ from snapred.backend.dao.ingredients import PeakIngredients
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 from snapred.meta.redantic import list_to_raw
 
 logger = snapredLogger.getLogger(__name__)
 
 
 class PurgeOverlappingPeaksAlgorithm(PythonAlgorithm):
-    @property
-    def D_MIN(self):
+    @classproperty
+    def D_MIN(cls):
         return Config["constants.CrystallographicInfo.crystalDMin"]
 
-    @property
-    def D_MAX(self):
+    @classproperty
+    def D_MAX(cls):
         return Config["constants.CrystallographicInfo.crystalDMax"]
 
     def category(self):

--- a/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/PurgeOverlappingPeaksAlgorithm.py
@@ -16,8 +16,13 @@ logger = snapredLogger.getLogger(__name__)
 
 
 class PurgeOverlappingPeaksAlgorithm(PythonAlgorithm):
-    D_MIN = Config["constants.CrystallographicInfo.crystalDMin"]
-    D_MAX = Config["constants.CrystallographicInfo.crystalDMax"]
+    @property
+    def D_MIN(self):
+        return Config["constants.CrystallographicInfo.crystalDMin"]
+
+    @property
+    def D_MAX(self):
+        return Config["constants.CrystallographicInfo.crystalDMax"]
 
     def category(self):
         return "SNAPRed Data Processing"

--- a/src/snapred/backend/recipe/algorithm/RemoveSmoothedBackground.py
+++ b/src/snapred/backend/recipe/algorithm/RemoveSmoothedBackground.py
@@ -68,7 +68,7 @@ class RemoveSmoothedBackground(PythonAlgorithm):
         )
         self.declareProperty(
             "SmoothingParameter",
-            defaultValue=Config["calibration.diffraction.smoothingParameter"],
+            defaultValue=0.0,
             validator=FloatBoundedValidator(lower=0.0),
         )
         self.setRethrows(True)
@@ -103,6 +103,9 @@ class RemoveSmoothedBackground(PythonAlgorithm):
         This background can later be subtracted from the main data.
         """
         self.log().notice("Extracting background")
+
+        if self.getProperty("SmpoothingParameter").isDefault:
+            self.setProperty("SmoothingParameter", Config["calibration.diffraction.smoothingParameter"])
 
         # get the peak predictions from user input
         peak_ptr: PointerProperty = self.getProperty("DetectorPeaks").value

--- a/src/snapred/backend/recipe/algorithm/RemoveSmoothedBackground.py
+++ b/src/snapred/backend/recipe/algorithm/RemoveSmoothedBackground.py
@@ -104,7 +104,7 @@ class RemoveSmoothedBackground(PythonAlgorithm):
         """
         self.log().notice("Extracting background")
 
-        if self.getProperty("SmpoothingParameter").isDefault:
+        if self.getProperty("SmoothingParameter").isDefault:
             self.setProperty("SmoothingParameter", Config["calibration.diffraction.smoothingParameter"])
 
         # get the peak predictions from user input

--- a/src/snapred/backend/recipe/algorithm/WashDishes.py
+++ b/src/snapred/backend/recipe/algorithm/WashDishes.py
@@ -20,8 +20,19 @@ class WashDishes(PythonAlgorithm):
         self.declareProperty(StringArrayProperty(name="WorkspaceList", values=[], direction=Direction.Input))
         self.setRethrows(True)
 
-        self.cis_enabled: bool = Config["cis_mode.enabled"]
-        self.cis_preserve: bool = Config["cis_mode.preserveDiagnosticWorkspaces"]
+    @property
+    def cis_enabled(self) -> bool:
+        """
+        Check if CIS mode is enabled
+        """
+        return Config["cis_mode.enabled"]
+
+    @property
+    def cis_preserve(self) -> bool:
+        """
+        Check if CIS mode is enabled
+        """
+        return Config["cis_mode.preserveDiagnosticWorkspaces"]
 
     def PyExec(self) -> None:
         self.log().notice("Washing the dishes...")

--- a/src/snapred/backend/recipe/algorithm/WashDishes.py
+++ b/src/snapred/backend/recipe/algorithm/WashDishes.py
@@ -31,7 +31,7 @@ class WashDishes(PythonAlgorithm):
     @classproperty
     def cis_preserve(cls) -> bool:
         """
-        Check if CIS mode is enabled
+        Check if diagonostic workspaces should be preserved
         """
         return Config["cis_mode.preserveDiagnosticWorkspaces"]
 

--- a/src/snapred/backend/recipe/algorithm/WashDishes.py
+++ b/src/snapred/backend/recipe/algorithm/WashDishes.py
@@ -3,6 +3,7 @@ from mantid.kernel import Direction, StringArrayProperty
 from mantid.simpleapi import DeleteWorkspace, DeleteWorkspaces, mtd
 
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 
 
 class WashDishes(PythonAlgorithm):
@@ -20,15 +21,15 @@ class WashDishes(PythonAlgorithm):
         self.declareProperty(StringArrayProperty(name="WorkspaceList", values=[], direction=Direction.Input))
         self.setRethrows(True)
 
-    @property
-    def cis_enabled(self) -> bool:
+    @classproperty
+    def cis_enabled(cls) -> bool:
         """
         Check if CIS mode is enabled
         """
         return Config["cis_mode.enabled"]
 
-    @property
-    def cis_preserve(self) -> bool:
+    @classproperty
+    def cis_preserve(cls) -> bool:
         """
         Check if CIS mode is enabled
         """

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -53,6 +53,7 @@ from snapred.backend.recipe.PixelDiffCalRecipe import PixelDiffCalRecipe, PixelD
 from snapred.backend.service.Service import Service
 from snapred.backend.service.SousChef import SousChef
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 from snapred.meta.decorators.FromString import FromString
 from snapred.meta.decorators.Singleton import Singleton
 from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
@@ -108,8 +109,8 @@ class CalibrationService(Service):
         self.registerPath("runFeedback", self.runFeedback)
         return
 
-    @property
-    def MINIMUM_PEAKS_PER_GROUP(self):
+    @classproperty
+    def MINIMUM_PEAKS_PER_GROUP(cls):
         return Config["calibration.diffraction.minimumPeaksPerGroup"]
 
     @staticmethod

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -79,8 +79,6 @@ class CalibrationService(Service):
 
     """
 
-    MINIMUM_PEAKS_PER_GROUP = Config["calibration.diffraction.minimumPeaksPerGroup"]
-
     # register the service in ServiceFactory please!
     def __init__(self):
         super().__init__()
@@ -109,6 +107,10 @@ class CalibrationService(Service):
         self.registerPath("override", self.handleOverrides)
         self.registerPath("runFeedback", self.runFeedback)
         return
+
+    @property
+    def MINIMUM_PEAKS_PER_GROUP(self):
+        return Config["calibration.diffraction.minimumPeaksPerGroup"]
 
     @staticmethod
     def name():

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -148,7 +148,7 @@ class CalibrationService(Service):
         # TODO:  It would be nice for groceryclerk to be smart enough to flatten versions
         # However I will save that scope for another time
         if request.startingTableVersion == VersionState.DEFAULT:
-            request.startingTableVersion = VERSION_START
+            request.startingTableVersion = VERSION_START()
 
         self.groceryClerk.name("inputWorkspace").neutron(request.runNumber).useLiteMode(
             request.useLiteMode
@@ -321,7 +321,7 @@ class CalibrationService(Service):
         record = self.dataFactoryService.createCalibrationRecord(request.createRecordRequest)
         version = entry.version
         if self.dataFactoryService.calibrationExists(entry.runNumber, entry.useLiteMode):
-            if version == VERSION_START:
+            if version == VERSION_START():
                 raise RuntimeError("Overwriting the default calibration is not allowed.")
 
         # Rebuild the workspace names to strip any "iteration" number:

--- a/src/snapred/backend/service/CrystallographicInfoService.py
+++ b/src/snapred/backend/service/CrystallographicInfoService.py
@@ -3,7 +3,6 @@ from typing import Any, Dict
 from snapred.backend.recipe.CrystallographicInfoRecipe import CrystallographicInfoRecipe
 from snapred.backend.service.Service import Service
 from snapred.meta.decorators.ConfigDefault import ConfigDefault, ConfigValue
-from snapred.meta.decorators.FromString import FromString
 from snapred.meta.decorators.Singleton import Singleton
 
 
@@ -19,7 +18,6 @@ class CrystallographicInfoService(Service):
         return "ingestion"
 
     @ConfigDefault
-    @FromString
     def ingest(
         self,
         cifPath: str,

--- a/src/snapred/backend/service/CrystallographicInfoService.py
+++ b/src/snapred/backend/service/CrystallographicInfoService.py
@@ -9,13 +9,18 @@ from snapred.meta.decorators.Singleton import Singleton
 
 @Singleton
 class CrystallographicInfoService(Service):
-    D_MIN = Config["constants.CrystallographicInfo.crystalDMin"]
-    D_MAX = Config["constants.CrystallographicInfo.crystalDMax"]
-
     def __init__(self):
         super().__init__()
         self.registerPath("", self.ingest)
         return
+
+    @property
+    def D_MIN(self):
+        return Config["constants.CrystallographicInfo.crystalDMin"]
+
+    @property
+    def D_MAX(self):
+        return Config["constants.CrystallographicInfo.crystalDMax"]
 
     @staticmethod
     def name():

--- a/src/snapred/backend/service/CrystallographicInfoService.py
+++ b/src/snapred/backend/service/CrystallographicInfoService.py
@@ -18,8 +18,8 @@ class CrystallographicInfoService(Service):
     def name():
         return "ingestion"
 
-    @FromString
     @ConfigDefault
+    @FromString
     def ingest(
         self,
         cifPath: str,

--- a/src/snapred/backend/service/CrystallographicInfoService.py
+++ b/src/snapred/backend/service/CrystallographicInfoService.py
@@ -3,8 +3,19 @@ from typing import Any, Dict
 from snapred.backend.recipe.CrystallographicInfoRecipe import CrystallographicInfoRecipe
 from snapred.backend.service.Service import Service
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 from snapred.meta.decorators.FromString import FromString
 from snapred.meta.decorators.Singleton import Singleton
+
+
+class _Properties:
+    @classproperty
+    def D_MIN(cls):
+        return Config["constants.CrystallographicInfo.crystalDMin"]
+
+    @classproperty
+    def D_MAX(cls):
+        return Config["constants.CrystallographicInfo.crystalDMax"]
 
 
 @Singleton
@@ -14,20 +25,14 @@ class CrystallographicInfoService(Service):
         self.registerPath("", self.ingest)
         return
 
-    @property
-    def D_MIN(self):
-        return Config["constants.CrystallographicInfo.crystalDMin"]
-
-    @property
-    def D_MAX(self):
-        return Config["constants.CrystallographicInfo.crystalDMax"]
-
     @staticmethod
     def name():
         return "ingestion"
 
     @FromString
-    def ingest(self, cifPath: str, crystalDMin: float = D_MIN, crystalDMax: float = D_MAX) -> Dict[Any, Any]:
+    def ingest(
+        self, cifPath: str, crystalDMin: float = _Properties.D_MIN, crystalDMax: float = _Properties.D_MAX
+    ) -> Dict[Any, Any]:
         data: Dict[Any, Any] = {}
         # TODO: collect runs by state then by calibration of state, execute sets of runs by calibration of thier state
         try:

--- a/src/snapred/backend/service/CrystallographicInfoService.py
+++ b/src/snapred/backend/service/CrystallographicInfoService.py
@@ -2,20 +2,9 @@ from typing import Any, Dict
 
 from snapred.backend.recipe.CrystallographicInfoRecipe import CrystallographicInfoRecipe
 from snapred.backend.service.Service import Service
-from snapred.meta.Config import Config
-from snapred.meta.decorators.classproperty import classproperty
+from snapred.meta.decorators.ConfigDefault import ConfigDefault, ConfigValue
 from snapred.meta.decorators.FromString import FromString
 from snapred.meta.decorators.Singleton import Singleton
-
-
-class _Properties:
-    @classproperty
-    def D_MIN(cls):
-        return Config["constants.CrystallographicInfo.crystalDMin"]
-
-    @classproperty
-    def D_MAX(cls):
-        return Config["constants.CrystallographicInfo.crystalDMax"]
 
 
 @Singleton
@@ -30,8 +19,12 @@ class CrystallographicInfoService(Service):
         return "ingestion"
 
     @FromString
+    @ConfigDefault
     def ingest(
-        self, cifPath: str, crystalDMin: float = _Properties.D_MIN, crystalDMax: float = _Properties.D_MAX
+        self,
+        cifPath: str,
+        crystalDMin: float = ConfigValue("constants.CrystallographicInfo.crystalDMin"),
+        crystalDMax: float = ConfigValue("constants.CrystallographicInfo.crystalDMax"),
     ) -> Dict[Any, Any]:
         data: Dict[Any, Any] = {}
         # TODO: collect runs by state then by calibration of state, execute sets of runs by calibration of thier state

--- a/src/snapred/backend/service/Service.py
+++ b/src/snapred/backend/service/Service.py
@@ -31,11 +31,13 @@ Register = _makeRegister()
 
 
 class Service(ABC):
-    _pathDelimiter = Config["orchestration.path.delimiter"]
-
     def __init__(self):
         self._paths: Dict[str, Any] = self._getInstancePaths()
         self._lambdas: Dict[str, List[GroupingLambda]] = {}
+
+    @property
+    def _pathDelimiter(self):
+        return Config["orchestration.path.delimiter"]
 
     def _getInstancePaths(self):
         instPaths = {}

--- a/src/snapred/backend/service/Service.py
+++ b/src/snapred/backend/service/Service.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, List
 
 from snapred.backend.dao.SNAPRequest import SNAPRequest
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 
 # Type definition which is a callable function with a List of SNAPRequests as input,
 # and a Dict of str keys and List of SNAPRequests values as expected output.
@@ -35,8 +36,8 @@ class Service(ABC):
         self._paths: Dict[str, Any] = self._getInstancePaths()
         self._lambdas: Dict[str, List[GroupingLambda]] = {}
 
-    @property
-    def _pathDelimiter(self):
+    @classproperty
+    def _pathDelimiter(cls):
         return Config["orchestration.path.delimiter"]
 
     def _getInstancePaths(self):

--- a/src/snapred/backend/service/ServiceDirectory.py
+++ b/src/snapred/backend/service/ServiceDirectory.py
@@ -8,7 +8,10 @@ from snapred.meta.decorators.Singleton import Singleton
 @Singleton
 class ServiceDirectory:
     _services: Dict[str, Any] = {}
-    _pathDelimiter = Config["orchestration.path.delimiter"]
+
+    @property
+    def _pathDelimiter(self):
+        return Config["orchestration.path.delimiter"]
 
     def registerService(self, service):
         # register the service

--- a/src/snapred/backend/service/ServiceDirectory.py
+++ b/src/snapred/backend/service/ServiceDirectory.py
@@ -2,6 +2,7 @@ import inspect
 from typing import Any, Dict
 
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 from snapred.meta.decorators.Singleton import Singleton
 
 
@@ -9,8 +10,8 @@ from snapred.meta.decorators.Singleton import Singleton
 class ServiceDirectory:
     _services: Dict[str, Any] = {}
 
-    @property
-    def _pathDelimiter(self):
+    @classproperty
+    def _pathDelimiter(cls):
         return Config["orchestration.path.delimiter"]
 
     def registerService(self, service):

--- a/src/snapred/backend/service/ServiceFactory.py
+++ b/src/snapred/backend/service/ServiceFactory.py
@@ -22,7 +22,6 @@ from snapred.meta.decorators.Singleton import Singleton
 @Singleton
 class ServiceFactory:
     serviceDirectory: ServiceDirectory = ServiceDirectory()
-    _pathDelimiter = Config["orchestration.path.delimiter"]
 
     def __init__(self):
         # register the services
@@ -37,6 +36,10 @@ class ServiceFactory:
         self.serviceDirectory.registerService(NormalizationService)
         self.serviceDirectory.registerService(WorkspaceService)
         self.serviceDirectory.registerService(WorkspaceMetadataService)
+
+    @property
+    def _pathDelimiter(self):
+        return Config["orchestration.path.delimiter"]
 
     def getServiceNames(self):
         return self.serviceDirectory.keys()

--- a/src/snapred/backend/service/ServiceFactory.py
+++ b/src/snapred/backend/service/ServiceFactory.py
@@ -15,6 +15,7 @@ from snapred.backend.service.StateIdLookupService import StateIdLookupService
 from snapred.backend.service.WorkspaceMetadataService import WorkspaceMetadataService
 from snapred.backend.service.WorkspaceService import WorkspaceService
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 from snapred.meta.decorators.Singleton import Singleton
 
 
@@ -37,8 +38,8 @@ class ServiceFactory:
         self.serviceDirectory.registerService(WorkspaceService)
         self.serviceDirectory.registerService(WorkspaceMetadataService)
 
-    @property
-    def _pathDelimiter(self):
+    @classproperty
+    def _pathDelimiter(cls):
         return Config["orchestration.path.delimiter"]
 
     def getServiceNames(self):

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -165,7 +165,7 @@ class SousChef(Service):
             ingredients.crystalDBounds.maximum,
             ingredients.calibrantSamplePath,
         )
-        return CrystallographicInfoService().ingest(*key)["crystalInfo"]
+        return CrystallographicInfoService().ingest(*(key[:-1]))["crystalInfo"]
 
     def prepPeakIngredients(
         self, ingredients: FarmFreshIngredients, pixelMask: Optional[WorkspaceName] = None

--- a/src/snapred/meta/Config.py
+++ b/src/snapred/meta/Config.py
@@ -146,6 +146,18 @@ class _Config:
         if self.env is not None:
             self.refresh(self.env)
         self.warnSensitiveProperties(watchedProperties)
+        self.persistBackup()
+
+    @property
+    def userApplicationDataHome(self) -> Path:
+        userApplicationDataHome = Path.home() / ".snapred"
+        return userApplicationDataHome
+
+    def persistBackup(self) -> None:
+        self.userApplicationDataHome.mkdir(parents=True, exist_ok=True)
+        backupFile = self.userApplicationDataHome / "application.yml.bak"
+        with open(backupFile, "w") as file:
+            yaml.dump(self._config, file, default_flow_style=False)
 
     def getCurrentEnv(self) -> str:
         if self.env is not None:

--- a/src/snapred/meta/Config.py
+++ b/src/snapred/meta/Config.py
@@ -110,7 +110,6 @@ class _Config:
         if "samples" in self._config and "home" in self._config["samples"]:
             self._config["samples"]["home"] = expandhome(self._config["samples"]["home"])
 
-
     def reload(self) -> None:
         # use refresh to do initial load, clearing shouldn't matter
         self.refresh("application.yml", True)
@@ -131,6 +130,13 @@ class _Config:
         self.env = os.environ.get("env", self._config.get("environment", None))
         if self.env is not None:
             self.refresh(self.env)
+
+    def getCurrentEnv(self) -> str:
+        if self.env is not None:
+            return self.env
+        else:
+            # this is the default environment
+            return "default"
 
     def refresh(self, env_name: str, clearPrevious: bool = False) -> None:
         if clearPrevious:

--- a/src/snapred/meta/Config.py
+++ b/src/snapred/meta/Config.py
@@ -144,7 +144,10 @@ class _Config:
 
         self.env = os.environ.get("env", self._config.get("environment", None))
         if self.env is not None:
+            self._logger.info(f"Loading environment config: {self.env}")
             self.refresh(self.env)
+        else:
+            self._logger.info("No environment config specified, using default")
         self.warnSensitiveProperties(watchedProperties)
         self.persistBackup()
 
@@ -158,6 +161,7 @@ class _Config:
         backupFile = self.userApplicationDataHome / "application.yml.bak"
         with open(backupFile, "w") as file:
             yaml.dump(self._config, file, default_flow_style=False)
+        self._logger.info(f"Backup of application.yml created at {backupFile.absolute()}")
 
     def getCurrentEnv(self) -> str:
         if self.env is not None:

--- a/src/snapred/meta/decorators/ConfigDefault.py
+++ b/src/snapred/meta/decorators/ConfigDefault.py
@@ -14,8 +14,19 @@ class ConfigValue:
 
 
 def ConfigDefault(func: Callable[..., Any]):
+    """
+    This decorator allows methods to evaluate default args set to Config[] at "execution" time.
+    Where as the normal behavior of Python is to evaluate the default args at "compile" time.
+    This allows reloading of Config values without having to restart the program.
+    But maintains the pythonic style of using default args.
+    """
+
     @functools.wraps(func)
     def inner(*args, **kwargs):
+        # 1. Flatten args into their Config[] values
+        # 2. Collect unspecified kwargs which have default values
+        # 3. If said default values are ConfigValues, replace them with their Config[] value
+        # 4. Call the function with the new args and kwargs
         fullArgSpec: tuple = inspect.getfullargspec(func)
         func_args: List = fullArgSpec.args
         # map args to func_args
@@ -37,6 +48,8 @@ def ConfigDefault(func: Callable[..., Any]):
         defaultArgs = sig.parameters
         # now check if the function has any default args that are not in the kwargs
         for k, v in defaultArgs.items():
+            # If it has a default and was not specified in neither kwarg nor arg
+            # then we need to inspect if it is a ConfigValue later
             if v.default != inspect.Parameter.empty and k not in kwargs and k not in argMap:
                 kwargs[k] = v.default
 

--- a/src/snapred/meta/decorators/ConfigDefault.py
+++ b/src/snapred/meta/decorators/ConfigDefault.py
@@ -1,0 +1,16 @@
+import functools
+import inspect
+from typing import Any, Callable, List
+
+def ConfigDefault(**kwargs):
+    def decorator(func: Callable[..., Any]):
+        
+        fullArgSpec: tuple = inspect.getfullargspec(func)
+        func_args: List = fullArgSpec.args
+        
+        @functools.wraps(func)
+        def inner(*args, **kwargs):
+            return func(*args, **kwargs)
+        return inner
+    return decorator
+

--- a/src/snapred/meta/decorators/ConfigDefault.py
+++ b/src/snapred/meta/decorators/ConfigDefault.py
@@ -9,6 +9,9 @@ class ConfigValue:
     def __init__(self, value: Any):
         self.value = value
 
+    def get(self):
+        return Config[self.value]
+
 
 def ConfigDefault(func: Callable[..., Any]):
     @functools.wraps(func)
@@ -22,7 +25,7 @@ def ConfigDefault(func: Callable[..., Any]):
         newArgs = []
         for arg in args:
             if isinstance(arg, ConfigValue):
-                newArgs.append(Config[arg.value])
+                newArgs.append(arg.get())
             else:
                 newArgs.append(arg)
 
@@ -40,7 +43,7 @@ def ConfigDefault(func: Callable[..., Any]):
         # replace kwargs that are of type ConfigValue with their Config[] value
         for k, v in kwargs.items():
             if isinstance(v, ConfigValue):
-                newKwargs[k] = Config[v.value]
+                newKwargs[k] = v.get()
             else:
                 newKwargs[k] = v
 

--- a/src/snapred/meta/decorators/ConfigDefault.py
+++ b/src/snapred/meta/decorators/ConfigDefault.py
@@ -2,15 +2,48 @@ import functools
 import inspect
 from typing import Any, Callable, List
 
-def ConfigDefault(**kwargs):
-    def decorator(func: Callable[..., Any]):
-        
+from snapred.meta.Config import Config
+
+
+class ConfigValue:
+    def __init__(self, value: Any):
+        self.value = value
+
+
+def ConfigDefault(func: Callable[..., Any]):
+    @functools.wraps(func)
+    def inner(*args, **kwargs):
         fullArgSpec: tuple = inspect.getfullargspec(func)
         func_args: List = fullArgSpec.args
-        
-        @functools.wraps(func)
-        def inner(*args, **kwargs):
-            return func(*args, **kwargs)
-        return inner
-    return decorator
+        # map args to func_args
+        argMap = dict(zip(func_args, args))
 
+        # replace args that are of type ConfigValue with their Config[] value
+        newArgs = []
+        for arg in args:
+            if isinstance(arg, ConfigValue):
+                newArgs.append(Config[arg.value])
+            else:
+                newArgs.append(arg)
+
+        # now do the same for kwargs
+        newKwargs = {}
+
+        # get the default args from the function, add them to the kwargs
+        sig = inspect.signature(func)
+        defaultArgs = sig.parameters
+        # now check if the function has any default args that are not in the kwargs
+        for k, v in defaultArgs.items():
+            if v.default != inspect.Parameter.empty and k not in kwargs and k not in argMap:
+                kwargs[k] = v.default
+
+        # replace kwargs that are of type ConfigValue with their Config[] value
+        for k, v in kwargs.items():
+            if isinstance(v, ConfigValue):
+                newKwargs[k] = Config[v.value]
+            else:
+                newKwargs[k] = v
+
+        return func(*newArgs, **newKwargs)
+
+    return inner

--- a/src/snapred/meta/decorators/classproperty.py
+++ b/src/snapred/meta/decorators/classproperty.py
@@ -1,0 +1,6 @@
+# https://stackoverflow.com/questions/1697501/staticmethod-with-property
+
+
+class classproperty(property):
+    def __get__(self, cls, owner):
+        return classmethod(self.fget).__get__(None, owner)()

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -11,6 +11,7 @@ from typing_extensions import Annotated, Self
 
 from snapred.backend.dao.indexing.Versioning import VERSION_START, VersionState
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 
 
 class WorkspaceType(str, Enum):
@@ -151,48 +152,50 @@ if "sphinx" not in sys.modules:
     ]
 
 
-class ValueFormatter:
+class ValueFormat:
     class FormatTuple(NamedTuple):
         WORKSPACE: str
         PATH: str
 
-    @property
-    def versionFormat(self):
-        return ValueFormatter.FormatTuple(
+    @classproperty
+    def versionFormat(cls):
+        return ValueFormat.FormatTuple(
             WORKSPACE=Config["mantid.workspace.nameTemplate.formatter.version.workspace"],
             PATH=Config["mantid.workspace.nameTemplate.formatter.version.path"],
         )
 
-    @property
-    def timestampFormat(self):
-        return ValueFormatter.FormatTuple(
+    @classproperty
+    def timestampFormat(cls):
+        return ValueFormat.FormatTuple(
             WORKSPACE=Config["mantid.workspace.nameTemplate.formatter.timestamp.workspace"],
             PATH=Config["mantid.workspace.nameTemplate.formatter.timestamp.path"],
         )
 
-    @property
-    def numberTagFormat(self):
-        return ValueFormatter.FormatTuple(
+    @classproperty
+    def numberTagFormat(cls):
+        return ValueFormat.FormatTuple(
             WORKSPACE=Config["mantid.workspace.nameTemplate.formatter.numberTag.workspace"],
             PATH=Config["mantid.workspace.nameTemplate.formatter.numberTag.path"],
         )
 
-    @property
-    def runNumberFormat(self):
-        return ValueFormatter.FormatTuple(
+    @classproperty
+    def runNumberFormat(cls):
+        return ValueFormat.FormatTuple(
             WORKSPACE=Config["mantid.workspace.nameTemplate.formatter.runNumber.workspace"],
             PATH=Config["mantid.workspace.nameTemplate.formatter.runNumber.path"],
         )
 
-    @property
-    def stateIdFormat(self):
-        return ValueFormatter.FormatTuple(
+    @classproperty
+    def stateIdFormat(cls):
+        return ValueFormat.FormatTuple(
             WORKSPACE=Config["mantid.workspace.nameTemplate.formatter.stateId.workspace"],
             PATH=Config["mantid.workspace.nameTemplate.formatter.stateId.path"],
         )
 
+
+class ValueFormatter:
     @classmethod
-    def formatNumberTag(cls, number: int, fmt=numberTagFormat.WORKSPACE):
+    def formatNumberTag(cls, number: int, fmt=ValueFormat.numberTagFormat.WORKSPACE):
         # Mantid-workspace number tag: only resolves if number > 1
         if number == 1:
             return ""
@@ -203,18 +206,18 @@ class ValueFormatter:
         # Mantid-workspace number tag: only resolves if number > 1
         if number == 1:
             return ""
-        return cls.formatNumberTag(number, fmt=cls.numberTagFormat.PATH)
+        return cls.formatNumberTag(number, fmt=ValueFormat.numberTagFormat.PATH)
 
     @classmethod
-    def formatRunNumber(cls, runNumber: str, fmt=runNumberFormat.WORKSPACE):
+    def formatRunNumber(cls, runNumber: str, fmt=ValueFormat.runNumberFormat.WORKSPACE):
         return fmt.format(runNumber=runNumber)
 
     @classmethod
     def pathRunNumber(cls, runNumber: str):
-        return cls.formatRunNumber(runNumber=runNumber, fmt=cls.runNumberFormat.PATH)
+        return cls.formatRunNumber(runNumber=runNumber, fmt=ValueFormat.runNumberFormat.PATH)
 
     @classmethod
-    def formatVersion(cls, version: Optional[int], fmt=versionFormat.WORKSPACE):
+    def formatVersion(cls, version: Optional[int], fmt=ValueFormat.versionFormat.WORKSPACE):
         # handle two special cases of unassigned or default version
         # in those cases, format will be a user-specified string
 
@@ -233,10 +236,10 @@ class ValueFormatter:
 
         if version == VersionState.DEFAULT:
             return f"v_{VersionState.DEFAULT}"
-        return cls.formatVersion(version, fmt=cls.versionFormat.PATH)
+        return cls.formatVersion(version, fmt=ValueFormat.versionFormat.PATH)
 
     @classmethod
-    def formatTimestamp(cls, timestamp: Optional[float], fmt=timestampFormat.WORKSPACE):
+    def formatTimestamp(cls, timestamp: Optional[float], fmt=ValueFormat.timestampFormat.WORKSPACE):
         if timestamp is None:
             return ""
         if "timestamp" in fmt:
@@ -245,15 +248,15 @@ class ValueFormatter:
 
     @classmethod
     def pathTimestamp(cls, timestamp: float):
-        return cls.formatTimestamp(timestamp, fmt=cls.timestampFormat.PATH)
+        return cls.formatTimestamp(timestamp, fmt=ValueFormat.timestampFormat.PATH)
 
     @classmethod
-    def formatStateId(cls, stateId: str, fmt=stateIdFormat.WORKSPACE):
+    def formatStateId(cls, stateId: str, fmt=ValueFormat.stateIdFormat.WORKSPACE):
         return fmt.format(stateId=stateId)
 
     @classmethod
     def pathStateId(cls, stateId: str):
-        return cls.formatStateId(stateId, fmt=cls.stateIdFormat.PATH)
+        return cls.formatStateId(stateId, fmt=ValueFormat.stateIdFormat.PATH)
 
     @staticmethod
     def formatValueByKey(key: str, value: any):
@@ -324,44 +327,44 @@ class _WorkspaceNameGenerator:
     class Units:
         _templateRoot = "mantid.workspace.nameTemplate.units"
 
-        @property
-        def DSP(self):
-            return Config[f"{self._templateRoot}.dSpacing"]
+        @classproperty
+        def DSP(cls):
+            return Config[f"{cls._templateRoot}.dSpacing"]
 
-        @property
-        def TOF(self):
-            return Config[f"{self._templateRoot}.timeOfFlight"]
+        @classproperty
+        def TOF(cls):
+            return Config[f"{cls._templateRoot}.timeOfFlight"]
 
-        @property
-        def QSP(self):
-            return Config[f"{self._templateRoot}.momentumTransfer"]
+        @classproperty
+        def QSP(cls):
+            return Config[f"{cls._templateRoot}.momentumTransfer"]
 
-        @property
-        def LAM(self):
-            return Config[f"{self._templateRoot}.wavelength"]
+        @classproperty
+        def LAM(cls):
+            return Config[f"{cls._templateRoot}.wavelength"]
 
-        @property
-        def DIAG(self):
-            return Config[f"{self._templateRoot}.diagnostic"]
+        @classproperty
+        def DIAG(cls):
+            return Config[f"{cls._templateRoot}.diagnostic"]
 
     class Groups:
         _templateRoot = "mantid.workspace.nameTemplate.groups"
 
-        @property
-        def ALL(self):
-            return Config[f"{self._templateRoot}.all"]
+        @classproperty
+        def ALL(cls):
+            return Config[f"{cls._templateRoot}.all"]
 
-        @property
-        def COLUMN(self):
-            return Config[f"{self._templateRoot}.column"]
+        @classproperty
+        def COLUMN(cls):
+            return Config[f"{cls._templateRoot}.column"]
 
-        @property
-        def BANK(self):
-            return Config[f"{self._templateRoot}.bank"]
+        @classproperty
+        def BANK(cls):
+            return Config[f"{cls._templateRoot}.bank"]
 
-        @property
-        def UNFOC(self):
-            return Config[f"{self._templateRoot}.unfocussed"]
+        @classproperty
+        def UNFOC(cls):
+            return Config[f"{cls._templateRoot}.unfocussed"]
 
     class Lite:
         TRUE = "lite"

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -223,7 +223,7 @@ class ValueFormatter:
 
         formattedVersion = ""
         if version == VersionState.DEFAULT:
-            formattedVersion = f"v{VERSION_START}"
+            formattedVersion = f"v{VERSION_START()}"
         elif isinstance(version, int):
             formattedVersion = fmt.format(version=version)
         elif str(version).isdigit():

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -156,26 +156,40 @@ class ValueFormatter:
         WORKSPACE: str
         PATH: str
 
-    versionFormat = FormatTuple(
-        WORKSPACE=Config["mantid.workspace.nameTemplate.formatter.version.workspace"],
-        PATH=Config["mantid.workspace.nameTemplate.formatter.version.path"],
-    )
-    timestampFormat = FormatTuple(
-        WORKSPACE=Config["mantid.workspace.nameTemplate.formatter.timestamp.workspace"],
-        PATH=Config["mantid.workspace.nameTemplate.formatter.timestamp.path"],
-    )
-    numberTagFormat = FormatTuple(
-        WORKSPACE=Config["mantid.workspace.nameTemplate.formatter.numberTag.workspace"],
-        PATH=Config["mantid.workspace.nameTemplate.formatter.numberTag.path"],
-    )
-    runNumberFormat = FormatTuple(
-        WORKSPACE=Config["mantid.workspace.nameTemplate.formatter.runNumber.workspace"],
-        PATH=Config["mantid.workspace.nameTemplate.formatter.runNumber.path"],
-    )
-    stateIdFormat = FormatTuple(
-        WORKSPACE=Config["mantid.workspace.nameTemplate.formatter.stateId.workspace"],
-        PATH=Config["mantid.workspace.nameTemplate.formatter.stateId.path"],
-    )
+    @property
+    def versionFormat(self):
+        return ValueFormatter.FormatTuple(
+            WORKSPACE=Config["mantid.workspace.nameTemplate.formatter.version.workspace"],
+            PATH=Config["mantid.workspace.nameTemplate.formatter.version.path"],
+        )
+
+    @property
+    def timestampFormat(self):
+        return ValueFormatter.FormatTuple(
+            WORKSPACE=Config["mantid.workspace.nameTemplate.formatter.timestamp.workspace"],
+            PATH=Config["mantid.workspace.nameTemplate.formatter.timestamp.path"],
+        )
+
+    @property
+    def numberTagFormat(self):
+        return ValueFormatter.FormatTuple(
+            WORKSPACE=Config["mantid.workspace.nameTemplate.formatter.numberTag.workspace"],
+            PATH=Config["mantid.workspace.nameTemplate.formatter.numberTag.path"],
+        )
+
+    @property
+    def runNumberFormat(self):
+        return ValueFormatter.FormatTuple(
+            WORKSPACE=Config["mantid.workspace.nameTemplate.formatter.runNumber.workspace"],
+            PATH=Config["mantid.workspace.nameTemplate.formatter.runNumber.path"],
+        )
+
+    @property
+    def stateIdFormat(self):
+        return ValueFormatter.FormatTuple(
+            WORKSPACE=Config["mantid.workspace.nameTemplate.formatter.stateId.workspace"],
+            PATH=Config["mantid.workspace.nameTemplate.formatter.stateId.path"],
+        )
 
     @classmethod
     def formatNumberTag(cls, number: int, fmt=numberTagFormat.WORKSPACE):
@@ -266,10 +280,14 @@ class _WorkspaceNameGenerator:
     # TODO: define <workspace type> Enum
 
     _templateRoot = "mantid.workspace.nameTemplate"
-    _delimiter = Config[f"{_templateRoot}.delimiter"]
 
     def __init__(self):
+        # TODO: regenerate this on application.yml reload
         self._setupTemplateVars(Config[f"{self._templateRoot}.template"])
+
+    @property
+    def _delimiter(self):
+        return Config[f"{self._templateRoot}.delimiter"]
 
     def _setupTemplateVars(self, templateDict, namePrefix=""):
         """
@@ -305,18 +323,45 @@ class _WorkspaceNameGenerator:
 
     class Units:
         _templateRoot = "mantid.workspace.nameTemplate.units"
-        DSP = Config[f"{_templateRoot}.dSpacing"]
-        TOF = Config[f"{_templateRoot}.timeOfFlight"]
-        QSP = Config[f"{_templateRoot}.momentumTransfer"]
-        LAM = Config[f"{_templateRoot}.wavelength"]
-        DIAG = Config[f"{_templateRoot}.diagnostic"]
+
+        @property
+        def DSP(self):
+            return Config[f"{self._templateRoot}.dSpacing"]
+
+        @property
+        def TOF(self):
+            return Config[f"{self._templateRoot}.timeOfFlight"]
+
+        @property
+        def QSP(self):
+            return Config[f"{self._templateRoot}.momentumTransfer"]
+
+        @property
+        def LAM(self):
+            return Config[f"{self._templateRoot}.wavelength"]
+
+        @property
+        def DIAG(self):
+            return Config[f"{self._templateRoot}.diagnostic"]
 
     class Groups:
         _templateRoot = "mantid.workspace.nameTemplate.groups"
-        ALL = Config[f"{_templateRoot}.all"]
-        COLUMN = Config[f"{_templateRoot}.column"]
-        BANK = Config[f"{_templateRoot}.bank"]
-        UNFOC = Config[f"{_templateRoot}.unfocussed"]
+
+        @property
+        def ALL(self):
+            return Config[f"{self._templateRoot}.all"]
+
+        @property
+        def COLUMN(self):
+            return Config[f"{self._templateRoot}.column"]
+
+        @property
+        def BANK(self):
+            return Config[f"{self._templateRoot}.bank"]
+
+        @property
+        def UNFOC(self):
+            return Config[f"{self._templateRoot}.unfocussed"]
 
     class Lite:
         TRUE = "lite"

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -267,6 +267,7 @@ version:
 cis_mode:
   enabled: false
   preserveDiagnosticWorkspaces: false
+  reloadConfigButton: false
 
 constants:
   millisecondsPerSecond: 1000

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -117,15 +117,15 @@ class SNAPRedGUI(QMainWindow):
         Config.validate()
 
     @property
-    def _streamLevel(self):
+    def _streamlevel(self):
         return Config["logging.mantid.stream.level"]
 
     @property
-    def _fileLevel(self):
+    def _filelevel(self):
         return Config["logging.mantid.file.level"]
 
     @property
-    def _outputFile(self):
+    def _outputfile(self):
         return Config["logging.mantid.file.output"]
 
     @Slot()

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -22,6 +22,7 @@ from workbench.plugins.workspacewidget import WorkspaceWidget
 
 from snapred.backend.log.logger import CustomFormatter, snapredLogger
 from snapred.meta.Config import Config, Resource, datasearch_directories, fromMantidLoggingLevel, fromPythonLoggingLevel
+from snapred.meta.decorators.classproperty import classproperty
 from snapred.ui.widget.LogTable import LogTable
 from snapred.ui.widget.TestPanel import TestPanel
 from snapred.ui.widget.ToolBar import ToolBar
@@ -90,13 +91,19 @@ class SNAPRedGUI(QMainWindow):
             self.reloadConfigButton = QPushButton("Reload Config")
 
             def reloadAndInform():
-                Config.reload()
-                # Inform the user that the configuration has been reloaded
-                QMessageBox.information(
-                    self,
-                    "Configuration Reloaded",
-                    f"Env {Config.getCurrentEnv()} configuration has been successfully reloaded.",
-                )
+                try:
+                    Config.reload()
+                    # Inform the user that the configuration has been reloaded
+                    QMessageBox.information(
+                        self,
+                        "Configuration Reloaded",
+                        f"Env {Config.getCurrentEnv()} configuration has been successfully reloaded.",
+                    )
+                except Exception:  # noqa: BLE001
+                    # Additionally, show error message as popup
+                    msg = "Error encountered while reloading the configuration.\n"
+                    msg = msg + "Please ensure the `.yml` file is properly formatted and available\n"
+                    QMessageBox.critical(self, "Error", msg)
 
             self.reloadConfigButton.clicked.connect(reloadAndInform)
             splitter.addWidget(self.reloadConfigButton)
@@ -131,16 +138,16 @@ class SNAPRedGUI(QMainWindow):
         # Check for incompatible `Config` settings.
         Config.validate()
 
-    @property
-    def _streamlevel(self):
+    @classproperty
+    def _streamlevel(cls):
         return Config["logging.mantid.stream.level"]
 
-    @property
-    def _filelevel(self):
+    @classproperty
+    def _filelevel(cls):
         return Config["logging.mantid.file.level"]
 
-    @property
-    def _outputfile(self):
+    @classproperty
+    def _outputfile(cls):
         return Config["logging.mantid.file.output"]
 
     @Slot()

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -53,10 +53,6 @@ def prependDataSearchDirectories() -> List[str]:
 
 
 class SNAPRedGUI(QMainWindow):
-    _streamlevel = Config["logging.mantid.stream.level"]
-    _filelevel = Config["logging.mantid.file.level"]
-    _outputfile = Config["logging.mantid.file.output"]
-
     def __init__(self, parent=None, window_flags=None, translucentBackground=False):
         super(SNAPRedGUI, self).__init__(parent)
         if window_flags:
@@ -119,6 +115,18 @@ class SNAPRedGUI(QMainWindow):
 
         # Check for incompatible `Config` settings.
         Config.validate()
+
+    @property
+    def _streamLevel(self):
+        return Config["logging.mantid.stream.level"]
+
+    @property
+    def _fileLevel(self):
+        return Config["logging.mantid.file.level"]
+
+    @property
+    def _outputFile(self):
+        return Config["logging.mantid.file.output"]
 
     @Slot()
     def openCalibrationPanel(self):

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -102,8 +102,9 @@ class SNAPRedGUI(QMainWindow):
                 except Exception:  # noqa: BLE001
                     # Additionally, show error message as popup
                     msg = "Error encountered while reloading the configuration.\n"
-                    msg = msg + "Please ensure the `.yml` file is properly formatted and available\n"
+                    msg = msg + "Please ensure the `.yml` file is properly formatted and available.  "
                     msg = msg + "Previous Config has been maintained.\n"
+                    msg = msg + "Refer to ~/.snapred/application.yml.bak for the last working configuration.\n"
                     QMessageBox.critical(self, "Error", msg)
 
             self.reloadConfigButton.clicked.connect(reloadAndInform)

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -86,6 +86,21 @@ class SNAPRedGUI(QMainWindow):
 
         splitter.addWidget(AlgorithmProgressWidget())
 
+        if Config["cis_mode.reloadConfigButton"]:
+            self.reloadConfigButton = QPushButton("Reload Config")
+
+            def reloadAndInform():
+                Config.reload()
+                # Inform the user that the configuration has been reloaded
+                QMessageBox.information(
+                    self,
+                    "Configuration Reloaded",
+                    f"Env {Config.getCurrentEnv()} configuration has been successfully reloaded.",
+                )
+
+            self.reloadConfigButton.clicked.connect(reloadAndInform)
+            splitter.addWidget(self.reloadConfigButton)
+
         centralWidget = QWidget()
         centralWidget.setObjectName("centralwidget")
         centralLayout = QVBoxLayout()

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -103,6 +103,7 @@ class SNAPRedGUI(QMainWindow):
                     # Additionally, show error message as popup
                     msg = "Error encountered while reloading the configuration.\n"
                     msg = msg + "Please ensure the `.yml` file is properly formatted and available\n"
+                    msg = msg + "Previous Config has been maintained.\n"
                     QMessageBox.critical(self, "Error", msg)
 
             self.reloadConfigButton.clicked.connect(reloadAndInform)

--- a/src/snapred/ui/presenter/WorkflowPresenter.py
+++ b/src/snapred/ui/presenter/WorkflowPresenter.py
@@ -8,7 +8,7 @@ from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.error.LiveDataState import LiveDataState
 from snapred.backend.error.UserCancellation import UserCancellation
 from snapred.backend.log.logger import snapredLogger
-from snapred.meta.Config import Config
+from snapred.meta.decorators.ConfigDefault import ConfigDefault, ConfigValue
 from snapred.ui.handler.SNAPResponseHandler import SNAPResponseHandler
 from snapred.ui.model.WorkflowNodeModel import WorkflowNodeModel
 from snapred.ui.threading.worker_pool import WorkerPool
@@ -368,7 +368,8 @@ class WorkflowPresenter(QObject):
         # We've already asked for permission.
         self.reset()
 
-    def completeWorkflow(self, message: str = Config["ui.default.workflow.completionMessage"]):
+    @ConfigDefault
+    def completeWorkflow(self, message: str = ConfigValue("ui.default.workflow.completionMessage")):
         # Directly show the completion message and reset the workflow
         QMessageBox.information(
             self.view,

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -35,13 +35,6 @@ class DiffCalTweakPeakView(BackendRequestView):
 
     """
 
-    XTAL_DMIN = Config["constants.CrystallographicInfo.crystalDMin"]
-    XTAL_DMAX = Config["constants.CrystallographicInfo.crystalDMax"]
-    MIN_PEAKS = Config["calibration.diffraction.minimumPeaksPerGroup"]
-    PREF_PEAKS = Config["calibration.diffraction.preferredPeaksPerGroup"]
-    MAX_CHI_SQ = Config["constants.GroupDiffractionCalibration.MaxChiSq"]
-    FWHM = Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
-
     FIGURE_MARGIN = 0.5  # top + bottom: inches
 
     signalRunNumberUpdate = Signal(str)
@@ -127,6 +120,30 @@ class DiffCalTweakPeakView(BackendRequestView):
         self.initialLayoutHeight = self.size().height()
 
         self.signalUpdateRecalculationButton.connect(self.setEnableRecalculateButton)
+
+    @property
+    def XTAL_DMIN(self):
+        return Config["constants.CrystallographicInfo.crystalDMin"]
+
+    @property
+    def XTAL_DMAX(self):
+        return Config["constants.CrystallographicInfo.crystalDMax"]
+
+    @property
+    def MIN_PEAKS(self):
+        return Config["calibration.diffraction.minimumPeaksPerGroup"]
+
+    @property
+    def PREF_PEAKS(self):
+        return Config["calibration.diffraction.preferredPeaksPerGroup"]
+
+    @property
+    def MAX_CHI_SQ(self):
+        return Config["constants.GroupDiffractionCalibration.MaxChiSq"]
+
+    @property
+    def FWHM(self):
+        return Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
 
     def updateContinueAnyway(self, continueAnyway: bool):
         self.signalContinueAnyway.emit(continueAnyway)

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -37,6 +37,14 @@ class DiffCalTweakPeakView(BackendRequestView):
 
     FIGURE_MARGIN = 0.5  # top + bottom: inches
 
+    # Defaults, NOTE: the gui element will need to be closed for new defaults to take effect
+    XTAL_DMIN = Config["constants.CrystallographicInfo.crystalDMin"]
+    XTAL_DMAX = Config["constants.CrystallographicInfo.crystalDMax"]
+    MIN_PEAKS = Config["calibration.diffraction.minimumPeaksPerGroup"]
+    PREF_PEAKS = Config["calibration.diffraction.preferredPeaksPerGroup"]
+    MAX_CHI_SQ = Config["constants.GroupDiffractionCalibration.MaxChiSq"]
+    FWHM = Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
+
     signalRunNumberUpdate = Signal(str)
     signalValueChanged = Signal(int, float, float, SymmetricPeakEnum, Pair, float)
     signalUpdateRecalculationButton = Signal(bool)
@@ -120,30 +128,6 @@ class DiffCalTweakPeakView(BackendRequestView):
         self.initialLayoutHeight = self.size().height()
 
         self.signalUpdateRecalculationButton.connect(self.setEnableRecalculateButton)
-
-    @property
-    def XTAL_DMIN(self):
-        return Config["constants.CrystallographicInfo.crystalDMin"]
-
-    @property
-    def XTAL_DMAX(self):
-        return Config["constants.CrystallographicInfo.crystalDMax"]
-
-    @property
-    def MIN_PEAKS(self):
-        return Config["calibration.diffraction.minimumPeaksPerGroup"]
-
-    @property
-    def PREF_PEAKS(self):
-        return Config["calibration.diffraction.preferredPeaksPerGroup"]
-
-    @property
-    def MAX_CHI_SQ(self):
-        return Config["constants.GroupDiffractionCalibration.MaxChiSq"]
-
-    @property
-    def FWHM(self):
-        return Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
 
     def updateContinueAnyway(self, continueAnyway: bool):
         self.signalContinueAnyway.emit(continueAnyway)

--- a/src/snapred/ui/view/DiffCalTweakPeakView.py
+++ b/src/snapred/ui/view/DiffCalTweakPeakView.py
@@ -17,6 +17,7 @@ from snapred.backend.dao.Limit import Pair
 from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
 from snapred.meta.mantid.FitPeaksOutput import FitOutputEnum
@@ -37,14 +38,6 @@ class DiffCalTweakPeakView(BackendRequestView):
 
     FIGURE_MARGIN = 0.5  # top + bottom: inches
 
-    # Defaults, NOTE: the gui element will need to be closed for new defaults to take effect
-    XTAL_DMIN = Config["constants.CrystallographicInfo.crystalDMin"]
-    XTAL_DMAX = Config["constants.CrystallographicInfo.crystalDMax"]
-    MIN_PEAKS = Config["calibration.diffraction.minimumPeaksPerGroup"]
-    PREF_PEAKS = Config["calibration.diffraction.preferredPeaksPerGroup"]
-    MAX_CHI_SQ = Config["constants.GroupDiffractionCalibration.MaxChiSq"]
-    FWHM = Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
-
     signalRunNumberUpdate = Signal(str)
     signalValueChanged = Signal(int, float, float, SymmetricPeakEnum, Pair, float)
     signalUpdateRecalculationButton = Signal(bool)
@@ -56,6 +49,13 @@ class DiffCalTweakPeakView(BackendRequestView):
 
     def __init__(self, samples=[], groups=[], parent=None):
         super().__init__(parent=parent)
+
+        self.XTAL_DMIN = self.default_XTAL_DMIN
+        self.XTAL_DMAX = self.default_XTAL_DMAX
+        self.MIN_PEAKS = self.default_MIN_PEAKS
+        self.PREF_PEAKS = self.default_PREF_PEAKS
+        self.MAX_CHI_SQ = self.default_MAX_CHI_SQ
+        self.FWHM = self.default_FWHM
 
         self.mantidSnapper = MantidSnapper(None, "Utensils")
 
@@ -128,6 +128,30 @@ class DiffCalTweakPeakView(BackendRequestView):
         self.initialLayoutHeight = self.size().height()
 
         self.signalUpdateRecalculationButton.connect(self.setEnableRecalculateButton)
+
+    @classproperty
+    def default_XTAL_DMIN(cls):
+        return Config["constants.CrystallographicInfo.crystalDMin"]
+
+    @classproperty
+    def default_XTAL_DMAX(cls):
+        return Config["constants.CrystallographicInfo.crystalDMax"]
+
+    @classproperty
+    def default_MIN_PEAKS(cls):
+        return Config["calibration.diffraction.minimumPeaksPerGroup"]
+
+    @classproperty
+    def default_PREF_PEAKS(cls):
+        return Config["calibration.diffraction.preferredPeaksPerGroup"]
+
+    @classproperty
+    def default_MAX_CHI_SQ(cls):
+        return Config["constants.GroupDiffractionCalibration.MaxChiSq"]
+
+    @classproperty
+    def default_FWHM(cls):
+        return Pair.model_validate(Config["calibration.parameters.default.FWHMMultiplier"])
 
     def updateContinueAnyway(self, continueAnyway: bool):
         self.signalContinueAnyway.emit(continueAnyway)

--- a/src/snapred/ui/view/NormalizationTweakPeakView.py
+++ b/src/snapred/ui/view/NormalizationTweakPeakView.py
@@ -37,9 +37,6 @@ class NormalizationTweakPeakView(BackendRequestView):
 
     """
 
-    XTAL_DMIN = Config["constants.CrystallographicInfo.crystalDMin"]
-    XTAL_DMAX = Config["constants.CrystallographicInfo.crystalDMax"]
-
     signalRunNumberUpdate = Signal(str)
     signalBackgroundRunNumberUpdate = Signal(str)
     signalValueChanged = Signal(int, float, float, float)
@@ -104,6 +101,14 @@ class NormalizationTweakPeakView(BackendRequestView):
         self.signalUpdateRecalculationButton.connect(self.setEnableRecalculateButton)
         self.signalUpdateFields.connect(self._updateFields)
         self.signalPopulateGroupingDropdown.connect(self._populateGroupingDropdown)
+
+    @property
+    def XTAL_DMIN(self):
+        return Config["constants.CrystallographicInfo.crystalDMin"]
+
+    @property
+    def XTAL_DMAX(self):
+        return Config["constants.CrystallographicInfo.crystalDMax"]
 
     @Slot(str)
     def _updateRunNumber(self, runNumber):

--- a/src/snapred/ui/view/NormalizationTweakPeakView.py
+++ b/src/snapred/ui/view/NormalizationTweakPeakView.py
@@ -15,6 +15,7 @@ from workbench.plotting.toolbar import WorkbenchNavigationToolbar
 from snapred.backend.dao import GroupPeakList
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 from snapred.meta.decorators.Resettable import Resettable
 from snapred.ui.plotting.Factory import mantidAxisFactory
 from snapred.ui.view.BackendRequestView import BackendRequestView
@@ -102,12 +103,12 @@ class NormalizationTweakPeakView(BackendRequestView):
         self.signalUpdateFields.connect(self._updateFields)
         self.signalPopulateGroupingDropdown.connect(self._populateGroupingDropdown)
 
-    @property
-    def XTAL_DMIN(self):
+    @classproperty
+    def XTAL_DMIN(cls):
         return Config["constants.CrystallographicInfo.crystalDMin"]
 
-    @property
-    def XTAL_DMAX(self):
+    @classproperty
+    def XTAL_DMAX(cls):
         return Config["constants.CrystallographicInfo.crystalDMax"]
 
     @Slot(str)

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -101,9 +101,9 @@ class DiffCalWorkflow(WorkflowImplementer):
         self._requestView.skipPixelCalToggle.stateChanged.connect(self._tweakPeakView.skipPixelCalToggle.setState)
         self._tweakPeakView.skipPixelCalToggle.stateChanged.connect(self._requestView.skipPixelCalToggle.setState)
 
-        self.prevFWHM = DiffCalTweakPeakView.FWHM
-        self.prevXtalDMin = DiffCalTweakPeakView.XTAL_DMIN
-        self.prevXtalDMax = DiffCalTweakPeakView.XTAL_DMAX
+        self.prevFWHM = DiffCalTweakPeakView.default_FWHM
+        self.prevXtalDMin = DiffCalTweakPeakView.default_XTAL_DMIN
+        self.prevXtalDMax = DiffCalTweakPeakView.default_XTAL_DMAX
 
         self.peaksWerePurged = False
 

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -25,6 +25,7 @@ from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.FitMultiplePeaksAlgorithm import FitOutputEnum
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
 from snapred.meta.decorators.ExceptionToErrLog import ExceptionToErrLog
 from snapred.meta.mantid.AllowedPeakTypes import SymmetricPeakEnum
 from snapred.meta.mantid.WorkspaceNameGenerator import (
@@ -136,24 +137,24 @@ class DiffCalWorkflow(WorkflowImplementer):
             .build()
         )
 
-    @property
-    def DEFAULT_DMIN(self):
+    @classproperty
+    def DEFAULT_DMIN(cls):
         return Config["constants.CrystallographicInfo.crystalDMin"]
 
-    @property
-    def DEFAULT_DMAX(self):
+    @classproperty
+    def DEFAULT_DMAX(cls):
         return Config["constants.CrystallographicInfo.crystalDMax"]
 
-    @property
-    def DEFAULT_NBINS(self):
+    @classproperty
+    def DEFAULT_NBINS(cls):
         return Config["calibration.diffraction.nBinsAcrossPeakWidth"]
 
-    @property
-    def DEFAULT_CONV(self):
+    @classproperty
+    def DEFAULT_CONV(cls):
         return Config["calibration.diffraction.convergenceThreshold"]
 
-    @property
-    def DEFAULT_MAX_CHI_SQ(self):
+    @classproperty
+    def DEFAULT_MAX_CHI_SQ(cls):
         return Config["constants.GroupDiffractionCalibration.MaxChiSq"]
 
     def _continueAnywayHandlerTweak(self, continueInfo: ContinueWarning.Model):  # noqa: ARG002

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -52,12 +52,6 @@ class DiffCalWorkflow(WorkflowImplementer):
 
     """
 
-    DEFAULT_DMIN = Config["constants.CrystallographicInfo.crystalDMin"]
-    DEFAULT_DMAX = Config["constants.CrystallographicInfo.crystalDMax"]
-    DEFAULT_NBINS = Config["calibration.diffraction.nBinsAcrossPeakWidth"]
-    DEFAULT_CONV = Config["calibration.diffraction.convergenceThreshold"]
-    DEFAULT_MAX_CHI_SQ = Config["constants.GroupDiffractionCalibration.MaxChiSq"]
-
     def __init__(self, parent=None):
         super().__init__(parent)
 
@@ -141,6 +135,26 @@ class DiffCalWorkflow(WorkflowImplementer):
             .addNode(self._saveCalibration, self._saveView, name="Saving")
             .build()
         )
+
+    @property
+    def DEFAULT_DMIN(self):
+        return Config["constants.CrystallographicInfo.crystalDMin"]
+
+    @property
+    def DEFAULT_DMAX(self):
+        return Config["constants.CrystallographicInfo.crystalDMax"]
+
+    @property
+    def DEFAULT_NBINS(self):
+        return Config["calibration.diffraction.nBinsAcrossPeakWidth"]
+
+    @property
+    def DEFAULT_CONV(self):
+        return Config["calibration.diffraction.convergenceThreshold"]
+
+    @property
+    def DEFAULT_MAX_CHI_SQ(self):
+        return Config["constants.GroupDiffractionCalibration.MaxChiSq"]
 
     def _continueAnywayHandlerTweak(self, continueInfo: ContinueWarning.Model):  # noqa: ARG002
         self._continueAnywayHandler(continueInfo)

--- a/tests/cis_tests/reload_application.py
+++ b/tests/cis_tests/reload_application.py
@@ -1,0 +1,77 @@
+# import mantid algorithms, numpy and matplotlib
+# from mantid.simpleapi import *
+# import matplotlib.pyplot as plt
+# import numpy as np
+# 
+# import sys
+# import inspect
+# import importlib
+# 
+# def is_config_imported(member):
+#     return inspect.ismodule(member) and member.__name__ != '__main__'
+#     
+# 
+# loaded_modules = sys.modules.keys()
+# snapredModules = [module for module in loaded_modules if "snapred" in module]
+# print("Currently loaded modules:")
+# for module_name in snapredModules:
+#     imported_modules = [name for name, member in inspect.getmembers(sys.modules[module_name])]
+#     if "Config" in imported_modules:
+#         print(f"{module_name} : {imported_modules}")
+#         importlib.reload(sys.modules[module_name])
+
+from snapred.backend.dao import InstrumentConfig
+from snapred.backend.dao import reload
+reload()
+
+
+def eg(): 
+    return InstrumentConfig(facility="..",
+    name="..",
+    nexusFileExtension="..",
+    nexusFilePrefix="..",
+    calibrationFileExtension="..",
+    calibrationFilePrefix="..",
+    calibrationDirectory="..",
+    pixelGroupingDirectory="..",
+    sharedDirectory="..",
+    nexusDirectory="..",
+    reducedDataDirectory="..",
+    reductionRecordDirectory="..",
+    bandwidth=1.1,
+    maxBandwidth=1.1,
+    L1=1.1,
+    L2=1.1,
+    delTOverT=1.1,
+    delLOverL=1.1,
+    delThNoGuide=1.1,
+    delThWithGuide=1.1,
+    width=1.1,
+    frequency=1.1,
+    version=1)
+
+
+import sys
+modulenames = set(sys.modules) & set(locals())
+allmodules = [sys.modules[name] for name in modulenames]
+print(sys.modules)
+print(locals())
+import inspect
+clazzes = [clazz for k, clazz in locals().items() if inspect.isclass(clazz)]
+
+import importlib
+for clazz in clazzes:
+    modulePath = getattr(inspect.getmodule(clazz), "__name__", None)
+    # print(clazz.__name__)
+    if modulePath:
+        module = importlib.import_module(modulePath)
+        importlib.reload(module)
+        module = importlib.import_module(modulePath)
+        localz = { clazz.__name__: getattr(module, clazz.__name__)}
+        locals().update(localz)
+        print(f"updated: {localz}")
+        
+    
+    # importlib.reload(inspect.getmodule(clazz).__name__)
+print(eg().lowWavelengthCrop)
+    

--- a/tests/cis_tests/reload_application.py
+++ b/tests/cis_tests/reload_application.py
@@ -21,8 +21,8 @@
 #         importlib.reload(sys.modules[module_name])
 
 from snapred.backend.dao import InstrumentConfig
-from snapred.backend.dao import reload
-reload()
+from snapred.meta.Config import Config
+Config.reload()
 
 
 def eg(): 
@@ -51,26 +51,7 @@ def eg():
     version=1)
 
 
-import sys
-modulenames = set(sys.modules) & set(locals())
-allmodules = [sys.modules[name] for name in modulenames]
-print(sys.modules)
-print(locals())
-import inspect
-clazzes = [clazz for k, clazz in locals().items() if inspect.isclass(clazz)]
 
-import importlib
-for clazz in clazzes:
-    modulePath = getattr(inspect.getmodule(clazz), "__name__", None)
-    # print(clazz.__name__)
-    if modulePath:
-        module = importlib.import_module(modulePath)
-        importlib.reload(module)
-        module = importlib.import_module(modulePath)
-        localz = { clazz.__name__: getattr(module, clazz.__name__)}
-        locals().update(localz)
-        print(f"updated: {localz}")
-        
     
     # importlib.reload(inspect.getmodule(clazz).__name__)
 print(eg().lowWavelengthCrop)

--- a/tests/integration/test_versions_in_order.py
+++ b/tests/integration/test_versions_in_order.py
@@ -124,7 +124,7 @@ class ImitationDataService(LocalDataService):
         """
         Note this replicates the original in every respect, except using the ImitationGroceryService
         """
-        version = VERSION_START
+        version = VERSION_START()
         grocer = ImitationGroceryService()
         outWS = grocer.fetchDefaultDiffCalTable(runNumber, useLiteMode, version)
         filename = Path(outWS + ".h5")
@@ -310,7 +310,7 @@ class TestVersioning(TestCase):
         # ensure the new state has grouping map, calibration state, and default diffcal table
         diffCalTableName = wng.diffCalTable().runNumber("default").version(VersionState.DEFAULT).build()
         assert self.localDataService._groupingMapPath(self.stateId).exists()
-        versionDir = wnvf.pathVersion(VERSION_START)
+        versionDir = wnvf.pathVersion(VERSION_START())
         assert Path(self.stateRoot, "lite", "diffraction", versionDir, "CalibrationParameters.json").exists()
         assert Path(self.stateRoot, "native", "diffraction", versionDir, "CalibrationParameters.json").exists()
         assert Path(self.stateRoot, "lite", "diffraction", versionDir, diffCalTableName + ".h5").exists()
@@ -320,22 +320,22 @@ class TestVersioning(TestCase):
         assert [] == self.get_index()
 
         # assert the current diffcal version is the default, and the next is the start
-        assert self.indexer.currentVersion() == VERSION_START
-        assert self.indexer.latestApplicableVersion(self.runNumber) == VERSION_START
-        assert self.indexer.nextVersion() == VERSION_START + 1
+        assert self.indexer.currentVersion() == VERSION_START()
+        assert self.indexer.latestApplicableVersion(self.runNumber) == VERSION_START()
+        assert self.indexer.nextVersion() == VERSION_START() + 1
 
         # run diffraction calibration for the first time, and save
         res = self.run_diffcal()
         self.save_diffcal(res, version=VersionState.NEXT)
 
         # ensure things saved correctly
-        self.assert_diffcal_saved(VERSION_START + 1)
+        self.assert_diffcal_saved(VERSION_START() + 1)
         assert len(self.get_index()) == 1
 
         # run diffraction calibration for a second time, and save
         res = self.run_diffcal()
         self.save_diffcal(res, version=VersionState.NEXT)
-        self.assert_diffcal_saved(VERSION_START + 2)
+        self.assert_diffcal_saved(VERSION_START() + 2)
         assert len(self.get_index()) == 2
 
         # now save at version 7
@@ -435,7 +435,7 @@ class TestVersioning(TestCase):
         assert self.indexer.recordPath(version).exists()
         assert self.indexer.parametersPath(version).exists()
         savedRecord = None
-        if version == VERSION_START:
+        if version == VERSION_START():
             savedRecord = parse_file_as(CalibrationDefaultRecord, self.indexer.recordPath(version))
         else:
             savedRecord = parse_file_as(CalibrationRecord, self.indexer.recordPath(version))
@@ -444,7 +444,7 @@ class TestVersioning(TestCase):
         assert savedRecord.calculationParameters.version == version
         # make sure all workspaces exist
         workspaces = savedRecord.workspaces
-        if not version == VERSION_START:
+        if not version == VERSION_START():
             assert (self.indexer.versionPath(version) / (workspaces[wngt.DIFFCAL_OUTPUT][0] + ".nxs.h5")).exists()
             assert (self.indexer.versionPath(version) / (workspaces[wngt.DIFFCAL_DIAG][0] + ".nxs.h5")).exists()
         assert (self.indexer.versionPath(version) / (workspaces[wngt.DIFFCAL_TABLE][0] + ".h5")).exists()

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -273,6 +273,7 @@ test:
 cis_mode:
   enabled: false
   preserveDiagnosticWorkspaces: false
+  reloadConfigButton: false
 
 version:
   friendlyName:

--- a/tests/unit/backend/dao/test_VersionedObject.py
+++ b/tests/unit/backend/dao/test_VersionedObject.py
@@ -63,7 +63,7 @@ def test_write_version_int():
         version = randint(0, 1000)
         vo = VersionedObject(version=version)
         assert vo.model_dump_json() == f'{{"version":{version}}}'
-        assert vo.dict()["version"] == version
+        assert vo.model_dump()["version"] == version
 
 
 def test_write_version_none():
@@ -76,7 +76,7 @@ def test_write_version_default():
     assert vo.version == VERSION_START()
     assert vo.model_dump_json() == f'{{"version":{VERSION_START()}}}'
     assert vo.model_dump_json() != f'{{"version":"{VERSION_START()}"}}'
-    assert vo.dict()["version"] == VERSION_START()
+    assert vo.model_dump()["version"] == VERSION_START()
 
 
 def test_can_set_valid():
@@ -116,7 +116,7 @@ def test_shaped_liked_itself():
     vo_old.version = VERSION_START()
     vo_new = VersionedObject.model_validate(vo_old.model_dump())
     assert vo_old == vo_new
-    vo_new = VersionedObject.model_validate(vo_old.dict())
+    vo_new = VersionedObject.model_validate(vo_old.model_dump())
     assert vo_old == vo_new
     vo_new = VersionedObject.model_validate_json(vo_old.model_dump_json())
     assert vo_old == vo_new
@@ -125,7 +125,7 @@ def test_shaped_liked_itself():
     vo_old = VersionedObject(version=randint(0, 120))
     vo_new = VersionedObject.model_validate(vo_old.model_dump())
     assert vo_old == vo_new
-    vo_new = VersionedObject.model_validate(vo_old.dict())
+    vo_new = VersionedObject.model_validate(vo_old.model_dump())
     assert vo_old == vo_new
     vo_new = VersionedObject.model_validate_json(vo_old.model_dump_json())
     assert vo_old == vo_new
@@ -200,7 +200,7 @@ def test_write_version_index_entry():
     vo.version = VERSION_START()
     assert f'"version":{VERSION_START()}' in vo.model_dump_json()
     assert f'"version":"{VERSION_START()}"' not in vo.model_dump_json()
-    assert vo.dict()["version"] == VERSION_START()
+    assert vo.model_dump()["version"] == VERSION_START()
 
 
 ### TESTS OF RECORDS AS VERSIONED OBJECTS ###
@@ -266,7 +266,7 @@ def test_write_version_record():
         version = randint(0, 1000)
         vo = recordWithVersion(version)
         assert f'"version":{version}' in vo.model_dump_json()
-        assert vo.dict()["version"] == version
+        assert vo.model_dump()["version"] == version
 
     # test write default
     vo = recordWithVersion(VersionState.DEFAULT)
@@ -278,4 +278,4 @@ def test_write_version_record():
 
     assert f'"version":{VERSION_START()}' in vo.model_dump_json()
     assert f'"version":"{VERSION_START()}"' not in vo.model_dump_json()
-    assert vo.dict()["version"] == VERSION_START()
+    assert vo.model_dump()["version"] == VERSION_START()

--- a/tests/unit/backend/dao/test_VersionedObject.py
+++ b/tests/unit/backend/dao/test_VersionedObject.py
@@ -72,11 +72,11 @@ def test_write_version_none():
 
 
 def test_write_version_default():
-    vo = VersionedObject(version=VERSION_START)
-    assert vo.version == VERSION_START
-    assert vo.model_dump_json() == f'{{"version":{VERSION_START}}}'
-    assert vo.model_dump_json() != f'{{"version":"{VERSION_START}"}}'
-    assert vo.dict()["version"] == VERSION_START
+    vo = VersionedObject(version=VERSION_START())
+    assert vo.version == VERSION_START()
+    assert vo.model_dump_json() == f'{{"version":{VERSION_START()}}}'
+    assert vo.model_dump_json() != f'{{"version":"{VERSION_START()}"}}'
+    assert vo.dict()["version"] == VERSION_START()
 
 
 def test_can_set_valid():
@@ -113,7 +113,7 @@ def test_shaped_liked_itself():
     vo_old = VersionedObject(version=VersionState.DEFAULT)
     with pytest.raises(ValueError, match="must be flattened to an int before writing to"):
         vo_old.model_dump_json()
-    vo_old.version = VERSION_START
+    vo_old.version = VERSION_START()
     vo_new = VersionedObject.model_validate(vo_old.model_dump())
     assert vo_old == vo_new
     vo_new = VersionedObject.model_validate(vo_old.dict())
@@ -171,8 +171,8 @@ def test_set_index_entry():
     vo.version = new_version
     assert vo.version == new_version
 
-    vo.version = VERSION_START
-    assert vo.version == VERSION_START
+    vo.version = VERSION_START()
+    assert vo.version == VERSION_START()
 
     vo = indexEntryWithVersion(randint(0, 120))
     with pytest.raises(ValueError):
@@ -197,10 +197,10 @@ def test_write_version_index_entry():
     with pytest.raises(ValueError, match="must be flattened to an int before writing to"):
         vo.model_dump_json()
 
-    vo.version = VERSION_START
-    assert f'"version":{VERSION_START}' in vo.model_dump_json()
-    assert f'"version":"{VERSION_START}"' not in vo.model_dump_json()
-    assert vo.dict()["version"] == VERSION_START
+    vo.version = VERSION_START()
+    assert f'"version":{VERSION_START()}' in vo.model_dump_json()
+    assert f'"version":"{VERSION_START()}"' not in vo.model_dump_json()
+    assert vo.dict()["version"] == VERSION_START()
 
 
 ### TESTS OF RECORDS AS VERSIONED OBJECTS ###
@@ -274,8 +274,8 @@ def test_write_version_record():
 
     with pytest.raises(ValueError, match="must be flattened to an int before writing to"):
         vo.model_dump_json()
-    vo.version = VERSION_START
+    vo.version = VERSION_START()
 
-    assert f'"version":{VERSION_START}' in vo.model_dump_json()
-    assert f'"version":"{VERSION_START}"' not in vo.model_dump_json()
-    assert vo.dict()["version"] == VERSION_START
+    assert f'"version":{VERSION_START()}' in vo.model_dump_json()
+    assert f'"version":"{VERSION_START()}"' not in vo.model_dump_json()
+    assert vo.dict()["version"] == VERSION_START()

--- a/tests/unit/backend/data/test_Indexer.py
+++ b/tests/unit/backend/data/test_Indexer.py
@@ -263,7 +263,7 @@ class TestIndexer(unittest.TestCase):
 
     def test_defaultVersion(self):
         indexer = self.initIndexer()
-        assert indexer.defaultVersion() == VERSION_START
+        assert indexer.defaultVersion() == VERSION_START()
 
     def test_currentVersion_none(self):
         # ensure the current version of an empty index is unitialized
@@ -271,7 +271,7 @@ class TestIndexer(unittest.TestCase):
         assert indexer.currentVersion() is None
         # if there is no current version then there is no current path on disk.
         with pytest.raises(ValueError, match=r".*The indexer has encountered an invalid version*"):
-            indexer.currentPath() == self.versionPath(VERSION_START)
+            indexer.currentPath() == self.versionPath(VERSION_START())
 
     def test_flattenVersion(self):
         indexer = self.initIndexer()
@@ -422,23 +422,23 @@ class TestIndexer(unittest.TestCase):
     def test_latestApplicableVersion_returns_default(self):
         # ensure latest applicable version will be default if it is the only one
         runNumber = "123"
-        versionList = [VERSION_START]
+        versionList = [VERSION_START()]
         self.prepareVersions(versionList)
         indexer = self.initIndexer()
         # make it applicable
         indexer.index[indexer.defaultVersion()].appliesTo = f">={runNumber}"
         # get latest apllicable
         latest = indexer.latestApplicableVersion(runNumber)
-        assert latest == VERSION_START
+        assert latest == VERSION_START()
 
     def test_latestApplicableVersion_excludes_default(self):
         # ensure latest applicable version will remove default if other runs exist
         runNumber = "123"
-        versionList = [VERSION_START, 4, 5]
+        versionList = [VERSION_START(), 4, 5]
         self.prepareVersions(versionList)
         indexer = self.initIndexer()
         # make some entries applicable
-        applicableVersions = [VERSION_START, 4]
+        applicableVersions = [VERSION_START(), 4]
         print(indexer.index)
         for version in applicableVersions:
             indexer.index[version].appliesTo = f">={runNumber}"
@@ -484,10 +484,10 @@ class TestIndexer(unittest.TestCase):
         # there is no current version
         assert indexer.currentVersion() is None
         # the first "next" version is the start
-        assert indexer.nextVersion() == VERSION_START
+        assert indexer.nextVersion() == VERSION_START()
 
         # add an entry to the calibration index
-        here = VERSION_START
+        here = VERSION_START()
         # it should be added at the start
         entry = self.indexEntry(indexer.nextVersion())
         indexer.addIndexEntry(entry)
@@ -578,40 +578,40 @@ class TestIndexer(unittest.TestCase):
         # there is no current version
         assert indexer.currentVersion() is None
         # the first "next" version is the start
-        assert indexer.nextVersion() == VERSION_START
+        assert indexer.nextVersion() == VERSION_START()
 
         # add an entry at the default version
         entry = self.indexEntry(VersionState.DEFAULT)
         record = self.recordFromIndexEntry(entry)
-        expectedIndex[VERSION_START] = entry
+        expectedIndex[VERSION_START()] = entry
         indexer.writeNewVersion(record, entry)
         assert self.recordPath(indexer.defaultVersion()).exists()
         # the current version is still the default version
         assert indexer.currentVersion() == indexer.defaultVersion()
         # the next version will be the starting version + 1
-        assert indexer.nextVersion() == VERSION_START + 1
+        assert indexer.nextVersion() == VERSION_START() + 1
 
         # add another entry -- now at the start
         entry = self.indexEntry(indexer.nextVersion())
         expectedIndex[indexer.nextVersion()] = entry
         indexer.addIndexEntry(entry)
         assert indexer.index == expectedIndex
-        assert indexer.currentVersion() == VERSION_START + 1
+        assert indexer.currentVersion() == VERSION_START() + 1
 
         # the next version should be the starting version
         # until a record is written
-        assert indexer.nextVersion() == VERSION_START + 1
+        assert indexer.nextVersion() == VERSION_START() + 1
         expectedIndex.pop(entry.version)
         assert indexer.index == expectedIndex
         # now write the record -- ensure it is written at the
         record = self.recordFromIndexEntry(entry)
         entry = self.indexEntryFromRecord(record)
         indexer.writeNewVersion(record, entry)
-        assert self.recordPath(VERSION_START).exists()
+        assert self.recordPath(VERSION_START()).exists()
         # ensure current still here
-        assert indexer.currentVersion() == VERSION_START + 1
+        assert indexer.currentVersion() == VERSION_START() + 1
         # ensure next is after here
-        assert indexer.nextVersion() == VERSION_START + 2
+        assert indexer.nextVersion() == VERSION_START() + 2
 
     def test_nextVersion_with_default_record_first(self):
         # check default behaves correctly if a record is written first
@@ -623,18 +623,18 @@ class TestIndexer(unittest.TestCase):
         assert indexer.currentVersion() is None
 
         # the first "next" version is the start
-        assert indexer.nextVersion() == VERSION_START
+        assert indexer.nextVersion() == VERSION_START()
 
         # add a record at the default version
         record = self.record(VersionState.DEFAULT)
         entry = self.indexEntryFromRecord(record)
-        assert indexer._flattenVersion(record.version) == VERSION_START
+        assert indexer._flattenVersion(record.version) == VERSION_START()
         indexer.writeNewVersion(record, entry)
 
         # the current version is still the default version
-        assert indexer.currentVersion() == VERSION_START
+        assert indexer.currentVersion() == VERSION_START()
         # the next version will be one past the starting version
-        assert indexer.nextVersion() == VERSION_START + 1
+        assert indexer.nextVersion() == VERSION_START() + 1
 
     ### TESTS OF VERSION COMPARISON METHODS ###
 
@@ -817,7 +817,7 @@ class TestIndexer(unittest.TestCase):
         self.prepareVersions(versions)
         indexer = self.initIndexer()
         nextVersion = indexer.nextVersion()
-        assert nextVersion != VERSION_START
+        assert nextVersion != VERSION_START()
         # now write then read the record
         # make sure the record was saved at the next version
         # and the read / written records match
@@ -893,7 +893,7 @@ class TestIndexer(unittest.TestCase):
         self.prepareVersions(versions)
         indexer = self.initIndexer()
         nextVersion = indexer.nextVersion()
-        assert nextVersion != VERSION_START
+        assert nextVersion != VERSION_START()
         # now write the record
         record = self.record(nextVersion)
         entry = self.indexEntryFromRecord(record)

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -1412,7 +1412,7 @@ def test_createCalibrationIndexEntry():
         localDataService.calibrationIndexer(request.runNumber, request.useLiteMode)
         ans = localDataService.createCalibrationIndexEntry(request)
         # Set to next version, which on the first call should be the start version
-        assert ans.version == VERSION_START
+        assert ans.version == VERSION_START()
 
 
 def test_createCalibrationRecord():
@@ -1430,7 +1430,7 @@ def test_createCalibrationRecord():
         localDataService.calibrationIndexer(request.runNumber, request.useLiteMode)
         ans = localDataService.createCalibrationRecord(request)
         # Set to next version, which on the first call should be the start version
-        assert ans.version == VERSION_START
+        assert ans.version == VERSION_START()
 
 
 def test_readCalibrationRecord_with_version():
@@ -1621,7 +1621,7 @@ def test_createNormalizationIndexEntry():
         localDataService.normalizationIndexer(request.runNumber, request.useLiteMode)
         ans = localDataService.createNormalizationIndexEntry(request)
         # Set to next version, which on the first call should be the start version
-        assert ans.version == VERSION_START
+        assert ans.version == VERSION_START()
 
 
 def test_createNormalizationRecord():
@@ -1637,7 +1637,7 @@ def test_createNormalizationRecord():
 
         request.version = VersionState.NEXT
         ans = localDataService.createNormalizationRecord(request)
-        assert ans.version == VERSION_START
+        assert ans.version == VERSION_START()
 
 
 def test_readNormalizationRecord_with_version():
@@ -1662,7 +1662,7 @@ def test_readWriteNormalizationRecord():
     localDataService = LocalDataService()
     for useLiteMode in [True, False]:
         record.useLiteMode = useLiteMode
-        currentVersion = randint(VERSION_START, 120)
+        currentVersion = randint(VERSION_START(), 120)
         runNumber = record.runNumber
         record.version = currentVersion
         # NOTE redirect nested so assertion occurs outside of redirect
@@ -2372,7 +2372,7 @@ def test_readCalibrationState_hasWritePermissions():
 def test_writeDefaultDiffCalTable(fetchInstrumentDonor, createDiffCalTableWorkspaceName):
     # verify that the default diffcal table is being written to the default state directory
     runNumber = "default"
-    version = VERSION_START
+    version = VERSION_START()
     useLiteMode = True
     # mock the grocery service to return the fake instrument to use for geometry
     idfWS = mtd.unique_name(prefix="_idf_")
@@ -2784,7 +2784,7 @@ def test_initializeState():
     testCalibrationData = DAOFactory.calibrationParameters(
         runNumber=runNumber,
         useLiteMode=useLiteMode,
-        version=VERSION_START,
+        version=VERSION_START(),
         instrumentState=DAOFactory.pv_instrument_state.model_copy(),
     )
 

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -2844,23 +2844,25 @@ def test_badPaths():
     """This verifies that a broken configuration (from production) can't find all of the files"""
     # get a handle on the service
     service = LocalDataService()
-    service.verifyPaths = True  # override test setting
-    with Config_override("instrument.home", "this/path/does/not/exist"):
+    with (
+        Config_override("instrument.home", "this/path/does/not/exist"),
+        Config_override("localdataservice.config.verifypaths", True),
+    ):
         with pytest.raises(FileNotFoundError):
             service.readInstrumentConfig(12345)
-    service.verifyPaths = False  # put the setting back
 
 
 def test_noInstrumentConfig():
     """This verifies that a broken configuration (from production) can't find all of the files"""
     # get a handle on the service
     service = LocalDataService()
-    service.verifyPaths = True  # override test setting
     with tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/")) as tempdir:
-        with Config_override("instrument.parameters.home", str(tempdir)):
+        with (
+            Config_override("instrument.parameters.home", str(tempdir)),
+            Config_override("localdataservice.config.verifypaths", True),
+        ):
             with pytest.raises(FileNotFoundError):
                 service.readInstrumentConfig(12345)
-    service.verifyPaths = False  # put the setting back
 
 
 # interlude -- a missplaced calibrant sample method test #

--- a/tests/unit/backend/recipe/algorithm/test_WashDishes.py
+++ b/tests/unit/backend/recipe/algorithm/test_WashDishes.py
@@ -2,6 +2,7 @@ import unittest
 
 # mantid imports
 from mantid.simpleapi import CreateWorkspace, mtd
+from util.Config_helpers import Config_override
 
 # the algorithm to test
 from snapred.backend.recipe.algorithm.WashDishes import WashDishes
@@ -17,15 +18,15 @@ class TestWashDishes(unittest.TestCase):
         algo.initialize()
         algo.setProperty("Workspace", wsname)
         # verify workspace not deleted when in CIS mode
-        algo.cis_enabled = True
-        algo.cis_preserve = True
-
-        algo.execute()
+        with Config_override("cis_mode.enabled", True), Config_override("cis_mode.preserveDiagnosticWorkspaces", True):
+            algo.execute()
         assert wsname in mtd
         # verify workspace deleted when not in CIS mode
-        algo.cis_enabled = False
-        algo.cis_preserve = False
-        algo.execute()
+        with (
+            Config_override("cis_mode.enabled", False),
+            Config_override("cis_mode.preserveDiagnosticWorkspaces", False),
+        ):
+            algo.execute()
         assert wsname not in mtd
 
     def test_wash_some_dishes(self):
@@ -40,15 +41,16 @@ class TestWashDishes(unittest.TestCase):
         algo.initialize()
         algo.setProperty("WorkspaceList", wsnames)
         # verify no workapces deleted when in CIS mode
-        algo.cis_enabled = True
-        algo.cis_preserve = True
-        algo.execute()
+        with Config_override("cis_mode.enabled", True), Config_override("cis_mode.preserveDiagnosticWorkspaces", True):
+            algo.execute()
         for wsname in wsnames:
             assert wsname in mtd
         # verify all workspaces deleted when not in CIS mode
-        algo.cis_enabled = False
-        algo.cis_preserve = False
-        algo.execute()
+        with (
+            Config_override("cis_mode.enabled", False),
+            Config_override("cis_mode.preserveDiagnosticWorkspaces", False),
+        ):
+            algo.execute()
         for wsname in wsnames:
             assert wsname not in mtd
 

--- a/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
+++ b/tests/unit/meta/mantid/test_WorkspaceNameGenerator.py
@@ -7,12 +7,11 @@ from pydantic import BaseModel, ConfigDict
 
 from snapred.meta.Config import Config
 from snapred.meta.mantid.WorkspaceNameGenerator import (
-    ValueFormatter as wnvf,
-)
-from snapred.meta.mantid.WorkspaceNameGenerator import (
+    ValueFormat,
     VersionState,
     WorkspaceName,
 )
+from snapred.meta.mantid.WorkspaceNameGenerator import ValueFormatter as wnvf
 from snapred.meta.mantid.WorkspaceNameGenerator import (
     WorkspaceNameGenerator as wng,
 )
@@ -222,7 +221,7 @@ def testWorkspaceNameTokens_incomplete():
 
 
 def testNumberTagFormat():
-    fmt = wnvf.numberTagFormat
+    fmt = ValueFormat.numberTagFormat
     number = 24
     assert wnvf.formatNumberTag(number) == fmt.WORKSPACE.format(number=number)
     assert wnvf.pathNumberTag(number) == fmt.PATH.format(number=number)
@@ -234,20 +233,20 @@ def testNumberTagFormat():
 
 
 def testNumberTagFormatConfig():
-    fmt = wnvf.numberTagFormat
+    fmt = ValueFormat.numberTagFormat
     assert fmt.WORKSPACE == Config["mantid.workspace.nameTemplate.formatter.numberTag.workspace"]
     assert fmt.PATH == Config["mantid.workspace.nameTemplate.formatter.numberTag.path"]
 
 
 def testRunNumberFormat():
-    fmt = wnvf.runNumberFormat
+    fmt = ValueFormat.runNumberFormat
     runNumber = "012345"
     assert wnvf.formatRunNumber(runNumber) == fmt.WORKSPACE.format(runNumber=runNumber)
     assert wnvf.pathRunNumber(runNumber) == fmt.PATH.format(runNumber=runNumber)
 
 
 def testRunNumberFormatConfig():
-    fmt = wnvf.runNumberFormat
+    fmt = ValueFormat.runNumberFormat
     assert fmt.WORKSPACE == Config["mantid.workspace.nameTemplate.formatter.runNumber.workspace"]
     assert fmt.PATH == Config["mantid.workspace.nameTemplate.formatter.runNumber.path"]
 
@@ -259,7 +258,7 @@ def testStateIdFormat():
 
 
 def testTimestampFormat():
-    fmt = wnvf.timestampFormat
+    fmt = ValueFormat.timestampFormat
     timestamp = time.time()
     assert wnvf.formatTimestamp(timestamp) == datetime.fromtimestamp(timestamp).strftime(fmt.WORKSPACE)
     assert wnvf.pathTimestamp(timestamp) == datetime.fromtimestamp(timestamp).strftime(fmt.PATH)
@@ -274,7 +273,7 @@ def testTimestampFormatLegacy():
 
 
 def testTimestampFormatConfig():
-    fmt = wnvf.timestampFormat
+    fmt = ValueFormat.timestampFormat
     assert fmt.WORKSPACE == Config["mantid.workspace.nameTemplate.formatter.timestamp.workspace"]
     assert fmt.PATH == Config["mantid.workspace.nameTemplate.formatter.timestamp.path"]
 

--- a/tests/unit/meta/test_Config.py
+++ b/tests/unit/meta/test_Config.py
@@ -204,6 +204,23 @@ def test_resource_packageMode_open():
             mockResourcesPath.assert_called_once_with("snapred.resources", test_path)
 
 
+def test_Config_persistBackup():
+    # mock Path.home() to temporary directory
+    with TemporaryDirectory() as tmpdir:
+        with mock.patch.object(Config_module._Config, "userApplicationDataHome", Path(tmpdir) / ".snapred"):
+            inst = Config_module._Config()
+            # remove the application.yml.bak file if it exists
+            if (Path(tmpdir) / ".snapred" / "application.yml.bak").exists():
+                os.remove(Path(tmpdir) / ".snapred" / "application.yml.bak")
+                os.rmdir(Path(tmpdir) / ".snapred")
+
+            assert not (Path(tmpdir) / ".snapred").exists()
+            # call the persistBackup method
+            inst.persistBackup()
+            assert (Path(tmpdir) / ".snapred").exists()
+            assert (Path(tmpdir) / ".snapred" / "application.yml.bak").exists()
+
+
 def test_Config_accessor():
     # these values are copied from tests/resources/application.yml
     assert Config["environment"] == "test"

--- a/tests/util/WhateversInTheFridge.py
+++ b/tests/util/WhateversInTheFridge.py
@@ -48,7 +48,6 @@ class WhateversInTheFridge(LocalDataService):
     iptsCache: Dict[Tuple[str, str], Any] = {}
 
     def __init__(self) -> None:
-        self.verifyPaths = False
         self.mantidSnapper = MantidSnapper(None, "Utensils")
         self.latestVersion = Config["version.start"]
 

--- a/tests/util_tests/test_state_helpers.py
+++ b/tests/util_tests/test_state_helpers.py
@@ -93,7 +93,7 @@ def test_state_root_override_enter(
         assert Path(stateRootPath) == expectedStateRootPath
         assert Path(stateRootPath).exists()
         assert Path(stateRootPath).joinpath("groupingMap.json").exists()
-        versionString = wnvf.pathVersion(VERSION_START)
+        versionString = wnvf.pathVersion(VERSION_START())
         assert (Path(stateRootPath) / "lite" / "diffraction" / versionString / "CalibrationParameters.json").exists()
 
 


### PR DESCRIPTION
## Description of work

The goal of this pr is to enable snapred's Config to be re-loadable at runtime.

This is mostly accomplished in this pr with a couple minor exceptions.

## Explanation of work

Essentially I had to replace each flattened call to Config (i.e. saved as a prop, default method param, default member value) to a generator so that the latest value is always pulled.

This ranged from adding Field default_generators, to creating a decorator that inspects args and replaces defaults.

## To test

Refer to the cis test script, also use the new button in the main gui.
You can actually turn off the button in the cis_mode props, reload, close and reopen the main gui to make that button disappear.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#2990](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2990)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] add a cis_mode flag to enable a `Reload Configuration` button
- [x] the reload button provides a positive message informing the user of the env they reloaded.
- [x] Reloading the configuration is effective across the codebase
