### PR TITLE
Clean up workspaces in Diffcal workflow

### DIFF
--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -302,7 +302,7 @@ class GroceryService:
         if groupingScheme == "Lite":
             return wng.liteDataMap().build()
         instr = "lite" if useLiteMode else "native"
-        return f"{Config['grouping.workspacename.' + instr]}_{groupingScheme}_{runNumber}"
+        return f"__{Config['grouping.workspacename.' + instr]}_{groupingScheme}_{runNumber}"
 
     def _createDiffCalInputWorkspaceName(self, runNumber: str) -> WorkspaceName:
         return wng.diffCalInput().runNumber(runNumber).build()

--- a/src/snapred/backend/recipe/GroupDiffCalRecipe.py
+++ b/src/snapred/backend/recipe/GroupDiffCalRecipe.py
@@ -203,7 +203,7 @@ class GroupDiffCalRecipe(Recipe[Ingredients]):
 
         for index in range(len(self.groupIDs)):
             groupID: int = self.groupIDs[index]
-            DIFCpd: str = f"_tmp_DIFCgroup_{groupID}"
+            DIFCpd: str = f"__tmp_DIFCgroup_{groupID}"
             diagnosticWSgroup: str = f"__pdcal_diag_{groupID}"
             self.mantidSnapper.PDCalibration(
                 f"Perform PDCalibration on group {groupID}",

--- a/src/snapred/backend/recipe/GroupDiffCalRecipe.py
+++ b/src/snapred/backend/recipe/GroupDiffCalRecipe.py
@@ -204,7 +204,7 @@ class GroupDiffCalRecipe(Recipe[Ingredients]):
         for index in range(len(self.groupIDs)):
             groupID: int = self.groupIDs[index]
             DIFCpd: str = f"_tmp_DIFCgroup_{groupID}"
-            diagnosticWSgroup: str = f"_pdcal_diag_{groupID}"
+            diagnosticWSgroup: str = f"__pdcal_diag_{groupID}"
             self.mantidSnapper.PDCalibration(
                 f"Perform PDCalibration on group {groupID}",
                 # in common with FitPeaks

--- a/src/snapred/backend/recipe/PixelDiffCalRecipe.py
+++ b/src/snapred/backend/recipe/PixelDiffCalRecipe.py
@@ -202,8 +202,8 @@ class PixelDiffCalRecipe(Recipe[Ingredients]):
         self.convertUnitsAndRebin(self.wsTOF, self.wsDSP)
 
         self.totalOffsetWS: str = f"offsets_{self.runNumber}_{self._counts}"
-        wsoff: str = f"_{self.runNumber}_tmp_group_offset_{self._counts}"
-        wscc: str = f"_{self.runNumber}_tmp_group_CC_{self._counts}"
+        wsoff: str = f"__{self.runNumber}_tmp_group_offset_{self._counts}"
+        wscc: str = f"__{self.runNumber}_tmp_group_CC_{self._counts}"
 
         for i, (groupID, workspaceIndices) in enumerate(self.groupWorkspaceIndices.items()):
             workspaceIndices = list(workspaceIndices)
@@ -331,7 +331,7 @@ class PixelDiffCalRecipe(Recipe[Ingredients]):
         logger.info(f"Pixel calibration converged.  Offsets: {self.medianOffsets}")
 
         # create for inspection
-        outputWorkspace = f"{self.wsDSP}_afterCrossCor"
+        outputWorkspace = f"__{self.wsDSP}_afterCrossCor"
         self.convertUnitsAndRebin(self.wsTOF, outputWorkspace)
         self.mantidSnapper.DeleteWorkspace(
             "Deleting tof workspace",

--- a/src/snapred/backend/recipe/algorithm/CalculateDiffCalTable.py
+++ b/src/snapred/backend/recipe/algorithm/CalculateDiffCalTable.py
@@ -46,7 +46,7 @@ class CalculateDiffCalTable(PythonAlgorithm):
         self.log().notice("Creating DIFC table")
 
         # prepare initial diffraction calibration workspace
-        tmpDifc = mtd.unique_name(prefix="_tmp_")
+        tmpDifc = mtd.unique_name(prefix="__tmp_")
         CalculateDIFC(
             InputWorkspace=self.getPropertyValue("InputWorkspace"),
             OutputWorkspace=tmpDifc,

--- a/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
+++ b/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
@@ -12,7 +12,6 @@ from mantid.simpleapi import (
     ExtractSingleSpectrum,
     GroupWorkspaces,
     RenameWorkspace,
-    UnGroupWorkspace,
     mtd,
 )
 
@@ -73,7 +72,8 @@ class ConjoinDiagnosticWorkspaces(PythonAlgorithm):
 
         # if the input is expected to autodelete, it must be ungrouped first
         if self.autoDelete:
-            UnGroupWorkspace(diag1)
+            for name in oldNames:
+                mtd[diag1].remove(name)
 
         if index == 0:
             for old, new in zip(oldNames, newNames):

--- a/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
+++ b/src/snapred/backend/recipe/algorithm/ConjoinDiagnosticWorkspaces.py
@@ -16,7 +16,7 @@ from mantid.simpleapi import (
     mtd,
 )
 
-from snapred.meta.mantid.FitPeaksOutput import FIT_PEAK_DIAG_SUFFIX
+from snapred.meta.mantid.FitPeaksOutput import FIT_PEAK_DIAG_SUFFIX, FitOutputEnum
 
 
 class ConjoinDiagnosticWorkspaces(PythonAlgorithm):
@@ -33,13 +33,16 @@ class ConjoinDiagnosticWorkspaces(PythonAlgorithm):
 
     def newNamesFromOld(self, oldNames: List[str], newName: str) -> List[str]:
         selectedNames = set(self.diagnosticSuffix.values())
-        suffixes = []
+        result = []
         for oldName in oldNames:
             elements = oldName.split("_")
             suffix = next((f"_{x}" for x in elements if f"_{x}" in selectedNames), None)
             if suffix is not None:
-                suffixes.append(suffix)
-        return [f"{newName}{suffix}" for suffix in suffixes]
+                if self.diagnosticSuffix[FitOutputEnum.PeakPosition] in suffix:
+                    result.append(f"__{newName}{suffix}")  # Prepend "__" to the entire string
+                else:
+                    result.append(f"{newName}{suffix}")
+        return result
 
     def PyInit(self):
         # declare properties

--- a/src/snapred/backend/recipe/algorithm/FitMultiplePeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FitMultiplePeaksAlgorithm.py
@@ -78,7 +78,7 @@ class FitMultiplePeaksAlgorithm(PythonAlgorithm):
 
         for index, groupID in enumerate(self.groupIDs):
             tmpSpecName = mtd.unique_name(prefix=f"__tmp_fitspec_{index}_")
-            outputNameTmp = mtd.unique_name(prefix=f"_tmp_fitdiag_{index}_")
+            outputNameTmp = mtd.unique_name(prefix=f"__tmp_fitdiag_{index}_")
             outputNamesTmp = {x: f"{outputNameTmp}{self.outputSuffix[x]}_{index}" for x in FitOutputEnum}
 
             peakCenters = []

--- a/src/snapred/backend/recipe/algorithm/FitMultiplePeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FitMultiplePeaksAlgorithm.py
@@ -77,8 +77,8 @@ class FitMultiplePeaksAlgorithm(PythonAlgorithm):
         self.unbagGroceries()
 
         for index, groupID in enumerate(self.groupIDs):
-            tmpSpecName = mtd.unique_name(prefix=f"tmp_fitspec_{index}_")
-            outputNameTmp = mtd.unique_name(prefix=f"tmp_fitdiag_{index}_")
+            tmpSpecName = mtd.unique_name(prefix=f"__tmp_fitspec_{index}_")
+            outputNameTmp = mtd.unique_name(prefix=f"_tmp_fitdiag_{index}_")
             outputNamesTmp = {x: f"{outputNameTmp}{self.outputSuffix[x]}_{index}" for x in FitOutputEnum}
 
             peakCenters = []

--- a/src/snapred/backend/recipe/algorithm/FitMultiplePeaksAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FitMultiplePeaksAlgorithm.py
@@ -43,7 +43,7 @@ class FitMultiplePeaksAlgorithm(PythonAlgorithm):
         self.declareProperty(
             "PeakFunction", "Gaussian", StringListValidator(allowed_peak_type_list), direction=Direction.Input
         )
-        self.declareProperty("OutputWorkspaceGroup", defaultValue="fitPeaksWSGroup", direction=Direction.Output)
+        self.declareProperty("OutputWorkspaceGroup", defaultValue="__fitPeaksWSGroup", direction=Direction.Output)
         self.setRethrows(True)
         self.mantidSnapper = MantidSnapper(self, __name__)
 

--- a/tests/unit/backend/recipe/algorithm/test_ConjoinDiagnosticWorkspaces.py
+++ b/tests/unit/backend/recipe/algorithm/test_ConjoinDiagnosticWorkspaces.py
@@ -35,7 +35,7 @@ class TestConjoinDiagnosticWorkspaces(unittest.TestCase):
 
     def test_naming(self):
         oldNames = ["xyz_d4_dspacing_2", "not_in_list", "feg_abc_fitted_fx"]
-        expNames = ["fun_dspacing", "fun_fitted"]
+        expNames = ["__fun_dspacing", "fun_fitted"]
         algo = Algo()
         algo.initialize()
         assert expNames == algo.newNamesFromOld(oldNames, "fun")
@@ -66,7 +66,6 @@ class TestConjoinDiagnosticWorkspaces(unittest.TestCase):
         # add in the first group
         algo = Algo()
         algo.initialize()
-        algo.diagnosticSuffix = {0: "_fitted"}
         algo.setProperty("DiagnosticWorkspace", name1)
         algo.setProperty("TotalDiagnosticWorkspace", finalname)
         algo.setProperty("AddAtIndex", 0)
@@ -79,7 +78,6 @@ class TestConjoinDiagnosticWorkspaces(unittest.TestCase):
         # add in the second group
         algo = Algo()
         algo.initialize()
-        algo.diagnosticSuffix = {0: "_fitted"}
         algo.setProperty("DiagnosticWorkspace", name2)
         algo.setProperty("TotalDiagnosticWorkspace", finalname)
         algo.setProperty("AddAtIndex", 1)
@@ -124,7 +122,6 @@ class TestConjoinDiagnosticWorkspaces(unittest.TestCase):
 
         algo = Algo()
         algo.initialize()
-        algo.diagnosticSuffix = {0: "_dspacing"}
         algo.setProperty("DiagnosticWorkspace", name1)
         algo.setProperty("TotalDiagnosticWorkspace", finalname)
         algo.setProperty("AddAtIndex", 0)
@@ -138,7 +135,6 @@ class TestConjoinDiagnosticWorkspaces(unittest.TestCase):
 
         algo = Algo()
         algo.initialize()
-        algo.diagnosticSuffix = {0: "_dspacing"}
         algo.setProperty("DiagnosticWorkspace", name2)
         algo.setProperty("TotalDiagnosticWorkspace", finalname)
         algo.setProperty("AddAtIndex", 1)
@@ -183,7 +179,6 @@ class TestConjoinDiagnosticWorkspaces(unittest.TestCase):
 
         algo = Algo()
         algo.initialize()
-        algo.diagnosticSuffix = {0: "_dspacing"}
         algo.setProperty("DiagnosticWorkspace", name1)
         algo.setProperty("TotalDiagnosticWorkspace", finalname)
         algo.setProperty("AddAtIndex", 0)
@@ -197,7 +192,6 @@ class TestConjoinDiagnosticWorkspaces(unittest.TestCase):
 
         algo = Algo()
         algo.initialize()
-        algo.diagnosticSuffix = {0: "_dspacing"}
         algo.setProperty("DiagnosticWorkspace", name2)
         algo.setProperty("TotalDiagnosticWorkspace", finalname)
         algo.setProperty("AddAtIndex", 1)
@@ -242,7 +236,6 @@ class TestConjoinDiagnosticWorkspaces(unittest.TestCase):
 
         algo = Algo()
         algo.initialize()
-        algo.diagnosticSuffix = {0: "_dspacing"}
         algo.setProperty("DiagnosticWorkspace", name1)
         algo.setProperty("TotalDiagnosticWorkspace", finalname)
         algo.setProperty("AddAtIndex", 0)
@@ -256,7 +249,6 @@ class TestConjoinDiagnosticWorkspaces(unittest.TestCase):
 
         algo = Algo()
         algo.initialize()
-        algo.diagnosticSuffix = {0: "_dspacing"}
         algo.setProperty("DiagnosticWorkspace", name2)
         algo.setProperty("TotalDiagnosticWorkspace", finalname)
         algo.setProperty("AddAtIndex", 1)

--- a/tests/unit/backend/recipe/algorithm/test_FitMultiplePeaksAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FitMultiplePeaksAlgorithm.py
@@ -57,9 +57,12 @@ with mock.patch.dict(
         fmpAlgo.setProperty("DetectorPeaks", list_to_raw(peaks))
         fmpAlgo.execute()
         wsGroupName = fmpAlgo.getProperty("OutputWorkspaceGroup").value
-        assert wsGroupName == "fitPeaksWSGroup"
+        assert wsGroupName == "__fitPeaksWSGroup"
         wsGroup = list(mtd[wsGroupName].getNames())
-        expected = [f"{wsGroupName}{suffix}" for suffix in FIT_PEAK_DIAG_SUFFIX.values()]
+        expected = [
+            f"{'__' if suffix == '_dspacing' else ''}{wsGroupName}{suffix}" for suffix in FIT_PEAK_DIAG_SUFFIX.values()
+        ]
+        print(expected)
         assert wsGroup == expected
         assert not mtd.doesExist("fitPeaksWSGroup_fitted_1")
         assert not mtd.doesExist("fitPeaksWSGroup_fitparam_1")


### PR DESCRIPTION
## Description of work

This is cleaning up workspaces at the end of the DiffCal workflow, so that they do not appear. The list of workspaces to be cleaned up is defined in the story.

## Explanation of work

Mainly just adds "__" to workspace names to hide them. One workspace had to be handled differently because there is a bug with mantid that does not hide workspaces inside a GroupWorkspace. I just remove the workspace entirely after it is done being used.

## To test

### Dev testing

Run Diffcal all the way to the save step, and right before clicking save, verify these workspaces exist:

calib_metrics_sigma_{run}_{timestamp}
calib_metrics_strain_{run}_{timestamp}
diagnostic_{pixel group}_{run} [Workspace group]
   - diagnostic_{pixel group}_{run}_fitparam
   - diagnostic_{pixel group}_{run}_fitted 
   - tof_{pixel group}_{run} 
diffract_consts_{run}
diffract_consts_mask_{run}
dsp_{pixel group}_{run}

The story was written before the afterCrossCor workspace existed, so I am assuming we want to keep that workspace.

### CIS testing

See dev testing above.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#7710](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7710)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] required workspaces appear
- [x] unwanted workspaces are not shown
