### PR TITLE
Ewm11197 calibration lookup by state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ docs/source/developer/dao.rst
 docs/source/developer/snapred/*
 mantidlog.txt
 
+# vscode configuration
+.vscode/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -99,7 +99,7 @@ class GroceryListItem(BaseModel):
     # name the property the workspace will be used for
     propertyName: Optional[str] = None
 
-    alternativeState: Optional[str] = None
+    state: Optional[str] = None
 
     def builder():
         # NOTE this import is here to avoid circular dependencies -- don't bother trying to move it
@@ -167,8 +167,8 @@ class GroceryListItem(BaseModel):
                         raise ValueError("diffraction-calibration input table workspace requires a run number")
                 # output (i.e. special-order) workspaces
                 case "diffcal_output" | "diffcal_diagnostic":
-                    if v.get("runNumber") is None:
-                        raise ValueError(f"diffraction-calibration {v['workspaceType']} requires a run number")
+                    if v.get("state") is None:
+                        raise ValueError(f"diffraction-calibration {v['workspaceType']} requires a state")
                     if v.get("instrumentPropertySource") is not None:
                         raise ValueError("Loading diffcal-output data should not specify an instrument")
                     if v.get("useLiteMode") is None:
@@ -176,15 +176,15 @@ class GroceryListItem(BaseModel):
                     if v.get("diffCalVersion") is None:
                         raise ValueError("diffcal output can only be loaded with a diffCalVersion number")
                 case "diffcal_table" | "diffcal_mask":
-                    if v.get("runNumber") is None:
-                        raise ValueError(f"diffraction-calibration {v['workspaceType']} requires a run number")
+                    if v.get("state") is None:
+                        raise ValueError(f"diffraction-calibration {v['workspaceType']} requires a state")
                     if v.get("useLiteMode") is None:
                         raise ValueError("Loading diffcal table requires specifying resolution (lite/native)")
                     if v.get("diffCalVersion") is None:
                         raise ValueError("diffcal tables can only be loaded with a diffCalVersion number")
                 case "normalization":
-                    if v.get("runNumber") is None:
-                        raise ValueError(f"normalization {v['workspaceType']} requires run number")
+                    if v.get("state") is None:
+                        raise ValueError(f"normalization {v['workspaceType']} requires state")
                     if v.get("normCalVersion") is None:
                         raise ValueError("normalization output can only be loaded with a normCalVersion number")
                 case "reduction_pixel_mask":

--- a/src/snapred/backend/dao/request/FarmFreshIngredients.py
+++ b/src/snapred/backend/dao/request/FarmFreshIngredients.py
@@ -72,7 +72,7 @@ class FarmFreshIngredients(BaseModel):
 
     focusGroups: Optional[List[FocusGroup]] = None
 
-    alternativeState: Optional[str] = None
+    state: Optional[str] = None
 
     # Allow 'focusGroups' to be accessed as a single 'focusGroup'
     @property

--- a/src/snapred/backend/data/DataFactoryService.py
+++ b/src/snapred/backend/data/DataFactoryService.py
@@ -84,16 +84,12 @@ class DataFactoryService:
 
     ##### CALIBRATION METHODS #####
 
-    def calibrationExists(self, runId: str, useLiteMode: bool, alternativeState: Optional[str] = None):
-        return self.lookupService.calibrationExists(runId, useLiteMode, alternativeState)
+    def calibrationExists(self, runId: str, useLiteMode: bool, state: str):
+        return self.lookupService.calibrationExists(runId, useLiteMode, state)
 
     @validate_call
-    def getCalibrationDataPath(
-        self, runId: str, useLiteMode: bool, version: Version, alternativeState: Optional[str] = None
-    ):
-        return self.lookupService.calibrationIndexer(runId, useLiteMode, alternativeState=alternativeState).versionPath(
-            version
-        )
+    def getCalibrationDataPath(self, useLiteMode: bool, version: Version, state: Optional[str] = None):
+        return self.lookupService.calibrationIndexer(useLiteMode, state=state).versionPath(version)
 
     def checkCalibrationStateExists(self, runId: str):
         return self.lookupService.checkCalibrationFileExists(runId)
@@ -105,12 +101,12 @@ class DataFactoryService:
         return self.lookupService.createCalibrationRecord(request)
 
     @validate_call
-    def getCalibrationState(self, runId: str, useLiteMode: bool, alternativeState: Optional[str] = None):
-        return self.lookupService.readCalibrationState(runId, useLiteMode, alternativeState=alternativeState)
+    def getCalibrationState(self, runId: str, useLiteMode: bool, state: str):
+        return self.lookupService.readCalibrationState(runId, useLiteMode, state=state)
 
     @validate_call
-    def getCalibrationIndex(self, runId: str, useLiteMode: bool) -> List[IndexEntry]:
-        return self.lookupService.calibrationIndexer(runId, useLiteMode).getIndex()
+    def getCalibrationIndex(self, useLiteMode: bool, state: str) -> List[IndexEntry]:
+        return self.lookupService.calibrationIndexer(useLiteMode, state).getIndex()
 
     @validate_call
     def getCalibrationRecord(
@@ -118,34 +114,30 @@ class DataFactoryService:
         runId: str,
         useLiteMode: bool,
         version: Version = VersionState.LATEST,
-        alternativeState: Optional[str] = None,
+        state: Optional[str] = None,
     ) -> CalibrationRecord:
         """
         If no version is passed, will use the latest version applicable to runId
         """
-        return self.lookupService.readCalibrationRecord(runId, useLiteMode, version, alternativeState=alternativeState)
+        return self.lookupService.readCalibrationRecord(runId, useLiteMode, state, version)
 
     @validate_call
-    def getCalibrationDataWorkspace(self, runId: str, useLiteMode: bool, version: Version, name: str):
-        path = self.lookupService.calibrationIndexer(runId, useLiteMode).versionPath(version)
+    def getCalibrationDataWorkspace(self, useLiteMode: bool, version: Version, name: str, state: str):
+        path = self.lookupService.calibrationIndexer(useLiteMode, state).versionPath(version)
         return self.groceryService.fetchWorkspace(os.path.join(path, name) + ".nxs", name)
 
     @validate_call
-    def getLatestApplicableCalibrationVersion(
-        self, runId: str, useLiteMode: bool, alternativeState: Optional[str] = None
-    ):
-        return self.lookupService.calibrationIndexer(runId, useLiteMode, alternativeState).latestApplicableVersion(
-            runId
-        )
+    def getLatestApplicableCalibrationVersion(self, runId: str, useLiteMode: bool, state: str):
+        return self.lookupService.calibrationIndexer(useLiteMode, state).latestApplicableVersion(runId)
 
     ##### NORMALIZATION METHODS #####
 
-    def normalizationExists(self, runId: str, useLiteMode: bool):
-        return self.lookupService.normalizationExists(runId, useLiteMode)
+    def normalizationExists(self, runId: str, useLiteMode: bool, state: str):
+        return self.lookupService.normalizationExists(runId, useLiteMode, state)
 
     @validate_call
-    def getNormalizationDataPath(self, runId: str, useLiteMode: bool, version: Version):
-        return self.lookupService.normalizationIndexer(runId, useLiteMode).versionPath(version)
+    def getNormalizationDataPath(self, useLiteMode: bool, version: Version, state: str):
+        return self.lookupService.normalizationIndexer(useLiteMode, state).versionPath(version)
 
     def createNormalizationIndexEntry(self, request: NormalizationExportRequest) -> IndexEntry:
         return self.lookupService.createNormalizationIndexEntry(request)
@@ -158,26 +150,26 @@ class DataFactoryService:
         return self.lookupService.readNormalizationState(runId, useLiteMode)
 
     @validate_call
-    def getNormalizationIndex(self, runId: str, useLiteMode: bool) -> List[IndexEntry]:
-        return self.lookupService.normalizationIndexer(runId, useLiteMode).getIndex()
+    def getNormalizationIndex(self, useLiteMode: bool, state: str) -> List[IndexEntry]:
+        return self.lookupService.normalizationIndexer(useLiteMode, state).getIndex()
 
     @validate_call
     def getNormalizationRecord(
-        self, runId: str, useLiteMode: bool, version: Version = VersionState.LATEST
+        self, runId: str, useLiteMode: bool, state: str, version: Version = VersionState.LATEST
     ) -> NormalizationRecord:
         """
         If no version is passed, will use the latest version applicable to runId
         """
-        return self.lookupService.readNormalizationRecord(runId, useLiteMode, version)
+        return self.lookupService.readNormalizationRecord(runId, useLiteMode, state, version)
 
     @validate_call
-    def getNormalizationDataWorkspace(self, runId: str, useLiteMode: bool, version: Version, name: str):
-        path = self.getNormalizationDataPath(runId, useLiteMode, version)
+    def getNormalizationDataWorkspace(self, useLiteMode: bool, version: Version, state: str, name: str):
+        path = self.getNormalizationDataPath(useLiteMode, version, state)
         return self.groceryService.fetchWorkspace(os.path.join(path, name) + ".nxs", name)
 
     @validate_call
-    def getLatestApplicableNormalizationVersion(self, runId: str, useLiteMode: bool):
-        return self.lookupService.normalizationIndexer(runId, useLiteMode).latestApplicableVersion(runId)
+    def getLatestApplicableNormalizationVersion(self, runId: str, useLiteMode: bool, state: str):
+        return self.lookupService.normalizationIndexer(useLiteMode, state).latestApplicableVersion(runId)
 
     ##### REDUCTION METHODS #####
 

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -421,8 +421,6 @@ class GroceryService:
         return wng.diffCalMask().runNumber(runNumber).version(version).build()
 
     def _lookupNormcalRunNumber(self, sampleRunNumber: str, useLiteMode: bool, version: int, state: str):
-        # runNumber = self._lookupNormcalRunNumber(<run number>, <use lite mode> [, ...])
-
         indexer = self.dataService.normalizationIndexer(useLiteMode, state)
         record = indexer.readRecord(version)
 

--- a/src/snapred/meta/builder/GroceryListBuilder.py
+++ b/src/snapred/meta/builder/GroceryListBuilder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from typing import Dict, List
 
@@ -14,93 +16,103 @@ class GroceryListBuilder:
         self._list = []
         pass
 
-    def neutron(self, runId: str):
+    def neutron(self, runId: str) -> GroceryListBuilder:
         self._tokens["workspaceType"] = "neutron"
         self._tokens["runNumber"] = runId
         return self
 
-    def grouping(self, groupingScheme: str):
+    def grouping(self, groupingScheme: str) -> GroceryListBuilder:
         self._tokens["workspaceType"] = "grouping"
         self._tokens["groupingScheme"] = groupingScheme
         return self
 
-    def group(self, groupingScheme: str):
+    def group(self, groupingScheme: str) -> GroceryListBuilder:
         self._tokens["groupingScheme"] = groupingScheme
         return self
 
-    def diffCalVersion(self, version: Version):
+    def state(self, state: str) -> GroceryListBuilder:
+        self._tokens["state"] = state
+        return self
+
+    def diffCalVersion(self, version: Version) -> GroceryListBuilder:
         self._tokens["diffCalVersion"] = version
         return self
 
-    def fromRun(self, runId: str):
+    def fromRun(self, runId: str) -> GroceryListBuilder:
         self._tokens["runNumber"] = runId
         return self
 
-    def diffcal(self, runId: str):
+    def diffcal(self, runId: str) -> GroceryListBuilder:
         self._tokens["workspaceType"] = "diffcal"
         self._tokens["runNumber"] = runId
         return self
 
-    def diffcal_output(self, runId: str, version: int):
+    def diffcal_output(self, state: str, version: int) -> GroceryListBuilder:
         self._tokens["workspaceType"] = "diffcal_output"
-        self._tokens["runNumber"] = runId
+        self._tokens["state"] = state
         self._tokens["diffCalVersion"] = version
         return self
 
-    def diffcal_diagnostic(self, runId: str, version: int):
+    def diffcal_diagnostic(self, state: str, version: int) -> GroceryListBuilder:
         self._tokens["workspaceType"] = "diffcal_diagnostic"
-        self._tokens["runNumber"] = runId
+        self._tokens["state"] = state
         self._tokens["diffCalVersion"] = version
         return self
 
-    def diffcal_table(self, runId: str, version: int, alternativeState: str = None):
+    def diffcal_table(self, state: str, version: int, sampleRunNumber: str = None) -> GroceryListBuilder:
         self._tokens["workspaceType"] = "diffcal_table"
-        self._tokens["runNumber"] = runId
         self._tokens["diffCalVersion"] = version
-        self._tokens["alternativeState"] = alternativeState
+        self._tokens["state"] = state
+        # sample run number is just used as a faster intrument-donor
+        if sampleRunNumber is not None:
+            self._tokens["runNumber"] = sampleRunNumber
         return self
 
-    def diffcal_mask(self, runId: str, version: int, alternativeState: str = None):
+    def diffcal_mask(self, state: str, version: int, sampleRunNumber: str = None) -> GroceryListBuilder:
         self._tokens["workspaceType"] = "diffcal_mask"
-        self._tokens["runNumber"] = runId
+        self._tokens["state"] = state
         self._tokens["diffCalVersion"] = version
-        self._tokens["alternativeState"] = alternativeState
+        # sample run number is just used as a faster intrument-donor
+        if sampleRunNumber is not None:
+            self._tokens["runNumber"] = sampleRunNumber
         return self
 
-    def normalization(self, runId: str, version: int):
+    def normalization(self, runNumber: str, state: str, version: int) -> GroceryListBuilder:
         self._tokens["workspaceType"] = "normalization"
-        self._tokens["runNumber"] = runId
+        self._tokens["state"] = state
         self._tokens["normCalVersion"] = version
+        # NOTE: required to lookup instrument state and apply filtering
+        self._tokens["runNumber"] = runNumber
         self._tokens["hidden"] = True
         return self
 
-    def reduction_pixel_mask(self, runId: str, timestamp: float):
+    def reduction_pixel_mask(self, runId: str, timestamp: float) -> GroceryListBuilder:
         self._tokens["workspaceType"] = "reduction_pixel_mask"
         self._tokens["runNumber"] = runId
         self._tokens["timestamp"] = timestamp
         return self
 
-    def native(self):
+    def native(self) -> GroceryListBuilder:
         self._tokens["useLiteMode"] = False
         return self
 
-    def lite(self):
+    def lite(self) -> GroceryListBuilder:
         self._tokens["useLiteMode"] = True
         return self
 
-    def useLiteMode(self, useLiteMode: bool):
+    def useLiteMode(self, useLiteMode: bool) -> GroceryListBuilder:
         self._tokens["useLiteMode"] = useLiteMode
         return self
 
-    def liveData(self, duration: datetime.timedelta):
+    def liveData(self, duration: datetime.timedelta) -> GroceryListBuilder:
         self._tokens["liveDataArgs"] = LiveDataArgs(duration=duration)
         return self
 
-    def unit(self, unit_: str):
+    def unit(self, unit_: str) -> GroceryListBuilder:
         self._tokens["unit"] = unit_
         return self
 
-    def source(self, **kwarg):
+    def source(self, **kwarg) -> GroceryListBuilder:
         # This setter is retained primarily to allow overriding the
         #   automatic instrument-donor caching system.
         if len(kwarg.keys()) > 1:
@@ -112,15 +124,15 @@ class GroceryListBuilder:
             self._tokens["instrumentSource"] = instrumentSource
         return self
 
-    def name(self, name: str):
+    def name(self, name: str) -> GroceryListBuilder:
         self._tokens["propertyName"] = name
         return self
 
-    def clean(self):
+    def clean(self) -> GroceryListBuilder:
         self._tokens["keepItClean"] = True
         return self
 
-    def dirty(self):
+    def dirty(self) -> GroceryListBuilder:
         self._tokens["keepItClean"] = False
         return self
 

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -472,6 +472,7 @@ class ReductionWorkflow(WorkflowImplementer):
 
         # Get the calibration and normalization versions for all runs to be processed
         matchRequest = MatchRunsRequest(runNumbers=self.runNumbers, useLiteMode=self.useLiteMode)
+        # TODO: Remove this orchestration, this should be handled in the backend
         loadedCalibrations, calVersions = self.request(path="calibration/fetchMatches", payload=matchRequest).data
         loadedNormalizations, normVersions = self.request(path="normalization/fetchMatches", payload=matchRequest).data
 
@@ -479,7 +480,7 @@ class ReductionWorkflow(WorkflowImplementer):
         self._keeps.update(loadedCalibrations)
         self._keeps.update(loadedNormalizations)
         # NOTE: Normalization Workspaces are expensive to load and thus cached between reductions.
-        #       This reduces the number of loads escpially for the case of multiple similar runs.
+        #       This reduces the number of loads especially for the case of multiple similar runs.
         self.outputs.update(loadedNormalizations)
 
         distinctNormVersions = set(normVersions.values())

--- a/tests/cis_tests/alternative_calibration_in_reduction_script.py
+++ b/tests/cis_tests/alternative_calibration_in_reduction_script.py
@@ -33,7 +33,7 @@ requestPayload = ReductionRequest(
     useLiteMode=useLiteMode,
     timestamp=time.time(),
     focusGroups=[columnGroup],
-    alternativeState=altStateId
+    state=altStateId
 )
 
 request = SNAPRequest(path="reduction", payload=requestPayload.model_dump_json())

--- a/tests/integration/test_versions_in_order.py
+++ b/tests/integration/test_versions_in_order.py
@@ -128,7 +128,7 @@ class ImitationDataService(LocalDataService):
         grocer = ImitationGroceryService()
         outWS = grocer.fetchDefaultDiffCalTable(runNumber, useLiteMode, version)
         filename = Path(outWS + ".h5")
-        calibrationDataPath = self.calibrationIndexer(runNumber, useLiteMode).versionPath(version)
+        calibrationDataPath = self.calibrationIndexer(useLiteMode, self.stateId).versionPath(version)
         self.writeDiffCalWorkspaces(calibrationDataPath, filename, outWS)
 
     # TODO delete this method override when SaveNexusProcessed has been fixed
@@ -261,11 +261,11 @@ class TestVersioning(TestCase):
         self.instance.dataFactoryService.lookupService = self.localDataService
         self.instance.sousChef.dataFactoryService = self.instance.dataFactoryService
 
-        self.stateId = self.localDataService.generateStateId(self.runNumber)
+        self.stateId, _ = self.localDataService.generateStateId(self.runNumber)
         self.stateRoot = self.localDataService.constructCalibrationStateRoot(self.stateId)
 
         # grab the associated Indexer
-        self.indexer = self.localDataService.calibrationIndexer(self.runNumber, self.useLiteMode)
+        self.indexer = self.localDataService.calibrationIndexer(self.useLiteMode, self.stateId)
 
         # create an InterfaceController
         self.api = InterfaceController()

--- a/tests/unit/backend/data/test_DataFactoryService.py
+++ b/tests/unit/backend/data/test_DataFactoryService.py
@@ -140,9 +140,8 @@ class TestDataFactoryService(unittest.TestCase):
     ## TEST CALIBRATION METHODS
 
     def test_getCalibrationDataPath(self):
-        run = "123"
         for useLiteMode in [True, False]:
-            actual = self.instance.getCalibrationDataPath(run, useLiteMode, self.version)
+            actual = self.instance.getCalibrationDataPath(useLiteMode, self.version)
             assert actual == self.expected("Calibration", self.version)  # NOTE mock indexer called only with version
 
     def test_checkCalibrationStateExists(self):
@@ -161,37 +160,36 @@ class TestDataFactoryService(unittest.TestCase):
 
     def test_getCalibrationState(self):
         for useLiteMode in [True, False]:
-            actual = self.instance.getCalibrationState("123", useLiteMode)
-            assert actual == self.expected("123", useLiteMode, alternativeState=None)
+            actual = self.instance.getCalibrationState("123", useLiteMode, "stateId")
+            assert actual == self.expected("123", useLiteMode, state="stateId")
 
     def test_getCalibrationIndex(self):
-        run = "123"
         for useLiteMode in [True, False]:
-            actual = self.instance.getCalibrationIndex(run, useLiteMode)
+            actual = self.instance.getCalibrationIndex(useLiteMode, "stateId")
             assert actual == [self.expected("Calibration")]
 
     def test_getCalibrationRecord(self):
         runId = "345"
         for useLiteMode in [True, False]:
-            actual = self.instance.getCalibrationRecord(runId, useLiteMode, self.version)
-            assert actual == self.expected(runId, useLiteMode, self.version, alternativeState=None)
+            actual = self.instance.getCalibrationRecord(runId, useLiteMode, self.version, "stateId")
+            assert actual == self.expected(runId, useLiteMode, "stateId", self.version)
 
     def test_getCalibrationDataWorkspace(self):
         self.instance.groceryService.fetchWorkspace = mock.Mock()
         for useLiteMode in [True, False]:
-            actual = self.instance.getCalibrationDataWorkspace("456", useLiteMode, self.version, "bunko")
+            actual = self.instance.getCalibrationDataWorkspace(useLiteMode, self.version, "bunko", "stateId")
             assert actual == self.instance.groceryService.fetchWorkspace.return_value
 
     def test_getLatestCalibrationVersion(self):
         for useLiteMode in [True, False]:
-            actual = self.instance.getLatestApplicableCalibrationVersion("123", useLiteMode)
+            actual = self.instance.getLatestApplicableCalibrationVersion("123", useLiteMode, "stateID")
             assert actual == self.expected("Calibration", "123")
 
     ## TEST NORMALIZATION METHODS
 
     def test_getNormalizationDataPath(self):
         for useLiteMode in [True, False]:
-            actual = self.instance.getNormalizationDataPath("123", useLiteMode, self.version)
+            actual = self.instance.getNormalizationDataPath(useLiteMode, self.version, "stateId")
             assert actual == self.expected("Normalization", self.version)  # NOTE mock indexer called only with version
 
     def test_createNormalizationIndexEntry(self):
@@ -211,23 +209,23 @@ class TestDataFactoryService(unittest.TestCase):
 
     def test_getNormalizationIndex(self):
         for useLiteMode in [True, False]:
-            actual = self.instance.getNormalizationIndex("123", useLiteMode)
+            actual = self.instance.getNormalizationIndex(useLiteMode, "stateId")
             assert actual == [self.expected("Normalization")]
 
     def test_getNormalizationRecord(self):
         for useLiteMode in [True, False]:
-            actual = self.instance.getNormalizationRecord("123", useLiteMode, self.version)
-            assert actual == self.expected("123", useLiteMode, self.version)
+            actual = self.instance.getNormalizationRecord("123", useLiteMode, "stateId", self.version)
+            assert actual == self.expected("123", useLiteMode, "stateId", self.version)
 
     def test_getNormalizationDataWorkspace(self):
         self.instance.groceryService.fetchWorkspace = mock.Mock()
         for useLiteMode in [True, False]:
-            actual = self.instance.getNormalizationDataWorkspace("456", useLiteMode, self.version, "bunko")
+            actual = self.instance.getNormalizationDataWorkspace(useLiteMode, self.version, "stateId", "bunko")
             assert actual == self.instance.groceryService.fetchWorkspace.return_value
 
     def test_getLatestNormalizationVersion(self):
         for useLiteMode in [True, False]:
-            actual = self.instance.getLatestApplicableNormalizationVersion("123", useLiteMode)
+            actual = self.instance.getLatestApplicableNormalizationVersion("123", useLiteMode, "stateId")
             assert actual == self.expected("Normalization", "123")
 
     ## TEST REDUCTION METHODS

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -1003,7 +1003,7 @@ class TestGroceryService(unittest.TestCase):
         res = self.instance.fetchNeutronDataSingleUse(liteItem)
         assert self.instance._loadedRuns.get(testKeyLite) is None
         workspaceNameLite = self.instance._createNeutronWorkspaceName(liteItem.runNumber, liteItem.useLiteMode)
-        self.instance.convertToLiteMode.assert_called_once_with(workspaceNameLite, export=False)
+        self.instance.convertToLiteMode.assert_called_once_with(workspaceNameLite, export=True)
         assert mtd.doesExist(workspaceNameLite)
 
     def test_fetch_cached_native(self):
@@ -1348,7 +1348,7 @@ class TestGroceryService(unittest.TestCase):
                                 mock.call(mock.sentinel.nativeWorkspaceName, workspaceName),
                             ]
                         )
-                        mockConvertToLiteMode.assert_called_once_with(workspaceName, export=False)
+                        mockConvertToLiteMode.assert_called_once_with(workspaceName, export=True)
                         mockUpdateNeutronCache.assert_has_calls(
                             [mock.call(runNumber, True), mock.call(runNumber, False)]
                         )
@@ -1361,7 +1361,7 @@ class TestGroceryService(unittest.TestCase):
                             mockCreateNeutronWorkspaceName(runNumber, False),
                             item.loader,
                         )
-                        mockConvertToLiteMode.assert_called_once_with(workspaceName, export=False)
+                        mockConvertToLiteMode.assert_called_once_with(workspaceName, export=True)
                         mockUpdateNeutronCache.assert_has_calls(
                             [mock.call(runNumber, True), mock.call(runNumber, False)]
                         )

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -2504,9 +2504,7 @@ def test_readWriteNormalizationState():
     mockNormalization = mock.Mock(spec=Normalization, seedRun=runNumber, useLiteMode=useLiteMode)
 
     localDataService.writeNormalizationState(mockNormalization)
-    localDataService.normalizationIndexer.assert_called_once_with(
-        mockNormalization.seedRun, mockNormalization.useLiteMode
-    )
+    localDataService.normalizationIndexer.assert_called_once_with(mockNormalization.useLiteMode, "123")
     mockNormalizationIndexer.writeParameters.assert_called_once_with(mockNormalization)
     localDataService.normalizationIndexer.reset_mock()
     mockNormalizationIndexer.reset_mock()

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -133,6 +133,7 @@ class TestNormalizationService(unittest.TestCase):
         )
 
         self.instance = NormalizationService()
+        self.instance.dataFactoryService.constructStateId = MagicMock(return_value=("12345", None))
         self.instance.sousChef = SculleryBoy()
         mockRecipeInst = mockRecipe.return_value
         mockRecipeInst.executeRecipe.return_value = "expected"
@@ -164,6 +165,7 @@ class TestNormalizationService(unittest.TestCase):
         self.instance._sameStates = MagicMock(return_value=True)
         self.instance.sousChef = SculleryBoy()
         self.instance.dataFactoryService = MagicMock()
+        self.instance.dataFactoryService.constructStateId = MagicMock(return_value=("12345", None))
 
         FarmFreshIngredients.return_value.get.return_value = True
 
@@ -200,6 +202,7 @@ class TestNormalizationService(unittest.TestCase):
         self.instance = NormalizationService()
         self.instance.sousChef = SculleryBoy()
         self.instance.dataFactoryService.getCifFilePath = mock.Mock(return_value="path/to/cif")
+        self.instance.dataFactoryService.constructStateId = mock.Mock(return_value=("12345", None))
 
         mockRecipeInst = mockRecipe.return_value
 
@@ -217,6 +220,7 @@ class TestNormalizationService(unittest.TestCase):
             side_effect=[mock.sentinel.version1, mock.sentinel.version2],
         )
         request = mock.Mock(runNumbers=[mock.sentinel.run1, mock.sentinel.run2], useLiteMode=True)
+        self.instance.dataFactoryService.constructStateId = mock.Mock(return_value=("12345", None))
         response = self.instance.matchRunsToNormalizationVersions(request)
         assert response == {
             mock.sentinel.run1: mock.sentinel.version1,
@@ -231,6 +235,7 @@ class TestNormalizationService(unittest.TestCase):
         }
         mockGroceries = [mock.sentinel.grocery1, mock.sentinel.grocery2, mock.sentinel.grocery2]
         self.instance.matchRunsToNormalizationVersions = mock.Mock(return_value=mockCalibrations)
+        self.instance.dataFactoryService.constructStateId = mock.Mock(return_value=("12345", None))
         self.instance.groceryService.fetchGroceryList = mock.Mock(return_value=mockGroceries)
         self.instance.groceryClerk = mock.Mock()
 
@@ -243,6 +248,7 @@ class TestNormalizationService(unittest.TestCase):
         self.instance = NormalizationService()
         self.instance.sousChef = SculleryBoy()
         self.instance.dataFactoryService.createNormalizationRecord = MagicMock()
+        self.instance.dataFactoryService.constructStateId = MagicMock(return_value=("12345", None))
 
         result = self.instance.normalizationAssessment(self.request)
 
@@ -284,6 +290,7 @@ class TestNormalizationService(unittest.TestCase):
         self.instance.groceryService = mockGroceryService
         self.instance.dataFactoryService.getCifFilePath = MagicMock(return_value="path/to/cif")
         self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
+        self.instance.dataFactoryService.constructStateId = mock.Mock(return_value=("12345", None))
         self.instance.dataExportService.getCalibrationStateRoot = mock.Mock(return_value="lah/dee/dah")
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
         self.instance.dataFactoryService.getCalibrationRecord = mock.Mock(return_value=mock.Mock(runNumber="12345"))
@@ -327,6 +334,7 @@ class TestNormalizationService(unittest.TestCase):
         self.instance._sameStates = mock.Mock(return_value=True)
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
         self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
+        self.instance.dataFactoryService.constructStateId = mock.Mock(return_value=("12345", None))
         permissionsRequest = CalibrationWritePermissionsRequest(
             runNumber=self.request.runNumber, continueFlags=self.request.continueFlags
         )
@@ -339,6 +347,7 @@ class TestNormalizationService(unittest.TestCase):
         request = mock.Mock(runNumber="12345", backgroundRunNumber="67890", continueFlags=ContinueWarning.Type.UNSET)
         self.instance.sousChef = SculleryBoy()
         self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=None)
+        self.instance.dataFactoryService.constructStateId = mock.Mock(return_value=("12345", None))
 
         with pytest.raises(
             ContinueWarning,
@@ -354,6 +363,7 @@ class TestNormalizationService(unittest.TestCase):
         )
         self.instance.sousChef = SculleryBoy()
         self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=None)
+        self.instance.dataFactoryService.constructStateId = mock.Mock(return_value=("12345", None))
         self.instance._validateDiffractionCalibrationExists(request)
 
     def test_validateRequest_different_states(self):
@@ -397,6 +407,7 @@ class TestNormalizationService(unittest.TestCase):
         self.instance.groceryService = mock.Mock()
         self.instance.groceryService.workSpaceDoesExist = mock.Mock(return_value=True)
         self.instance.dataFactoryService.getCifFilePath = mock.Mock(return_value="path/to/cif")
+        self.instance.dataFactoryService.constructStateId = mock.Mock(return_value=("12345", None))
         self.instance.dataExportService.getCalibrationStateRoot = mock.Mock(return_value="lah/dee/dah")
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
         self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)

--- a/tests/unit/backend/service/test_ReductionService.py
+++ b/tests/unit/backend/service/test_ReductionService.py
@@ -527,6 +527,7 @@ class TestReductionService(unittest.TestCase):
         fakeDataService = mock.Mock()
         fakeDataService.calibrationExists.return_value = True
         fakeDataService.normalizationExists.return_value = True
+        fakeDataService.constructStateId.return_value = ("state", None)
         self.instance.dataFactoryService = fakeDataService
         fakeExportService = mock.Mock()
         fakeExportService.checkWritePermissions.return_value = False
@@ -540,6 +541,7 @@ class TestReductionService(unittest.TestCase):
         fakeDataService = mock.Mock()
         fakeDataService.calibrationExists.return_value = True
         fakeDataService.normalizationExists.return_value = True
+        fakeDataService.constructStateId.return_value = ("state", None)
         self.instance.dataFactoryService = fakeDataService
         fakeExportService = mock.Mock()
         fakeExportService.checkWritePermissions.return_value = False

--- a/tests/unit/backend/service/test_ReductionService.py
+++ b/tests/unit/backend/service/test_ReductionService.py
@@ -1037,9 +1037,6 @@ class TestReductionServiceMasks:
         NOTE this probably belongs more properly to the other test class.
         However, it was already here, for simplicity of review I am not moving it.
         """
-
-        # self.service.dataFactoryService.constructStateId = mock.Mock(return_value=(self.stateId1, None))
-
         # timestamp must be unique: see comment at `test_prepCombinedMask`.
         timestamp = self.service.getUniqueTimestamp()
         request = ReductionRequest(

--- a/tests/unit/backend/service/test_ReductionService.py
+++ b/tests/unit/backend/service/test_ReductionService.py
@@ -137,6 +137,7 @@ class TestReductionService(unittest.TestCase):
         self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
         self.instance.dataFactoryService.getLatestApplicableNormalizationVersion = mock.Mock(return_value=1)
         self.instance.groceryService._processNeutronDataCopy = mock.Mock()
+        self.instance.groceryService._lookupNormcalRunNumber = mock.Mock(return_value="123456")
         self.instance._markWorkspaceMetadata = mock.Mock()
         self.request.continueFlags = ContinueWarning.Type.UNSET
         res = self.instance.fetchReductionGroceries(self.request)
@@ -148,7 +149,9 @@ class TestReductionService(unittest.TestCase):
 
         self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
         self.instance.dataFactoryService.getLatestApplicableNormalizationVersion = mock.Mock(return_value=1)
+        self.instance.dataFactoryService.constructStateId = mock.Mock(return_value=("state", None))
         self.instance.groceryService._processNeutronDataCopy = mock.Mock()
+        self.instance.groceryService._lookupNormcalRunNumber = mock.Mock(return_value="123456")
         self.instance._markWorkspaceMetadata = mock.Mock()
         self.instance.groceryService.dataService.hasLiveDataConnection = mock.Mock(return_value=True)
 
@@ -159,7 +162,7 @@ class TestReductionService(unittest.TestCase):
 
         self.instance.groceryClerk.name("inputWorkspace").neutron(request.runNumber).useLiteMode(
             request.useLiteMode
-        ).liveData(duration=request.liveDataDuration).diffCalVersion(1).dirty().add()
+        ).liveData(duration=request.liveDataDuration).diffCalVersion(1).state("state").dirty().add()
         liveDataInputGroceryItem = self.instance.groceryClerk.buildList()[0]
 
         res = self.instance.fetchReductionGroceries(request)  # noqa: F841
@@ -177,6 +180,7 @@ class TestReductionService(unittest.TestCase):
         self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
         self.instance.dataFactoryService.getLatestApplicableNormalizationVersion = mock.Mock(return_value=1)
         self.instance.groceryService._processNeutronDataCopy = mock.Mock()
+        self.instance.groceryService._lookupNormcalRunNumber = mock.Mock(return_value="123456")
         self.instance._markWorkspaceMetadata = mock.Mock()
         self.instance.prepCombinedMask = mock.Mock(return_value=mock.sentinel.mask)
         self.request.continueFlags = ContinueWarning.Type.UNSET
@@ -210,7 +214,9 @@ class TestReductionService(unittest.TestCase):
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
         self.instance.dataFactoryService.getLatestApplicableNormalizationVersion = mock.Mock(return_value=1)
         self.instance.dataFactoryService.normalizationExists = mock.Mock(return_value=True)
+        self.instance.dataFactoryService.constructStateId = mock.Mock(return_value=("state", None))
         self.instance.groceryService._processNeutronDataCopy = mock.Mock()
+        self.instance.groceryService._lookupNormcalRunNumber = mock.Mock(return_value="123456")
         self.instance._markWorkspaceMetadata = mock.Mock()
 
         result = self.instance.reduction(self.request)
@@ -316,7 +322,7 @@ class TestReductionService(unittest.TestCase):
         self.instance._markWorkspaceMetadata(request, wsName)
         self.instance.groceryService.writeWorkspaceMetadataAsTags.assert_called_once_with(wsName, metadata)
 
-    def test_markWorkspaceMetadata_alternativeState(self):
+    def test_markWorkspaceMetadata_state(self):
         self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
         self.instance.dataFactoryService.getCalibrationDataPath = mock.Mock(return_value="path")
 
@@ -461,6 +467,7 @@ class TestReductionService(unittest.TestCase):
         fakeDataService = mock.Mock()
         fakeDataService.calibrationExists.return_value = True
         fakeDataService.normalizationExists.return_value = True
+        fakeDataService.constructStateId.return_value = ("state", None)
         self.instance.dataFactoryService = fakeDataService
         self.instance.validateReduction(self.request)
 
@@ -472,6 +479,7 @@ class TestReductionService(unittest.TestCase):
         fakeDataService = mock.Mock()
         fakeDataService.calibrationExists.return_value = False
         fakeDataService.normalizationExists.return_value = True
+        fakeDataService.constructStateId.return_value = ("state", None)
         self.instance.dataFactoryService = fakeDataService
         with pytest.raises(ContinueWarning) as excInfo:
             self.instance.validateReduction(self.request)
@@ -482,6 +490,7 @@ class TestReductionService(unittest.TestCase):
         fakeDataService = mock.Mock()
         fakeDataService.calibrationExists.return_value = True
         fakeDataService.normalizationExists.return_value = False
+        fakeDataService.constructStateId.return_value = ("state", None)
         self.instance.dataFactoryService = fakeDataService
         with pytest.raises(ContinueWarning) as excInfo:
             self.instance.validateReduction(self.request)
@@ -492,6 +501,7 @@ class TestReductionService(unittest.TestCase):
         fakeDataService = mock.Mock()
         fakeDataService.calibrationExists.return_value = False
         fakeDataService.normalizationExists.return_value = False
+        fakeDataService.constructStateId.return_value = ("state", None)
         self.instance.dataFactoryService = fakeDataService
         self.request.continueFlags = (
             ContinueWarning.Type.MISSING_DIFFRACTION_CALIBRATION | ContinueWarning.Type.MISSING_NORMALIZATION
@@ -503,6 +513,7 @@ class TestReductionService(unittest.TestCase):
         fakeDataService = mock.Mock()
         fakeDataService.calibrationExists.return_value = True
         fakeDataService.normalizationExists.return_value = True
+        fakeDataService.constructStateId.return_value = ("state", None)
         self.instance.dataFactoryService = fakeDataService
         fakeExportService = mock.Mock()
         fakeExportService.checkWritePermissions.return_value = False
@@ -542,6 +553,7 @@ class TestReductionService(unittest.TestCase):
         fakeDataService = mock.Mock()
         fakeDataService.calibrationExists.return_value = True
         fakeDataService.normalizationExists.return_value = True
+        fakeDataService.constructStateId.return_value = ("state", None)
         self.instance.dataFactoryService = fakeDataService
         fakeExportService = mock.Mock()
         fakeExportService.checkReductionWritePermissions.return_value = False
@@ -554,6 +566,7 @@ class TestReductionService(unittest.TestCase):
         fakeDataService = mock.Mock()
         fakeDataService.calibrationExists.return_value = False
         fakeDataService.normalizationExists.return_value = False
+        fakeDataService.constructStateId.return_value = ("state", None)
         self.instance.dataFactoryService = fakeDataService
 
         fakeExportService = mock.Mock()
@@ -572,6 +585,7 @@ class TestReductionService(unittest.TestCase):
         fakeDataService = mock.Mock()
         fakeDataService.calibrationExists.return_value = False
         fakeDataService.normalizationExists.return_value = False
+        fakeDataService.constructStateId.return_value = ("state", None)
         self.instance.dataFactoryService = fakeDataService
         fakeExportService = mock.Mock()
         fakeExportService.checkWritePermissions.return_value = False
@@ -589,6 +603,7 @@ class TestReductionService(unittest.TestCase):
         fakeDataService = mock.Mock()
         fakeDataService.calibrationExists.return_value = False
         fakeDataService.normalizationExists.return_value = False
+        fakeDataService.constructStateId.return_value = ("fake", None)
         self.instance.dataFactoryService = fakeDataService
         fakeExportService = mock.Mock()
         fakeExportService.checkReductionWritePermissions.return_value = False
@@ -928,7 +943,7 @@ class TestReductionServiceMasks:
 
             # prepare the expected grocery dicionary
             groceryClerk = self.service.groceryClerk
-            groceryClerk.name("diffcalMaskWorkspace").diffcal_mask(request.runNumber, 1).useLiteMode(
+            groceryClerk.name("diffcalMaskWorkspace").diffcal_mask(self.stateId1, 1, request.runNumber).useLiteMode(
                 request.useLiteMode
             ).add()
             for mask in (self.maskWS1, self.maskWS2):
@@ -1004,7 +1019,7 @@ class TestReductionServiceMasks:
 
             # prepare the expected grocery dicionary
             groceryClerk = self.service.groceryClerk
-            groceryClerk.name("diffcalMaskWorkspace").diffcal_mask(request.runNumber, 1, None).useLiteMode(
+            groceryClerk.name("diffcalMaskWorkspace").diffcal_mask(self.stateId1, 1, request.runNumber).useLiteMode(
                 request.useLiteMode
             ).add()
             exp = self.service.groceryService.fetchGroceryDict(groceryClerk.buildDict())
@@ -1020,6 +1035,8 @@ class TestReductionServiceMasks:
         NOTE this probably belongs more properly to the other test class.
         However, it was already here, for simplicity of review I am not moving it.
         """
+
+        # self.service.dataFactoryService.constructStateId = mock.Mock(return_value=(self.stateId1, None))
 
         # timestamp must be unique: see comment at `test_prepCombinedMask`.
         timestamp = self.service.getUniqueTimestamp()
@@ -1045,9 +1062,11 @@ class TestReductionServiceMasks:
         groceryClerk = self.service.groceryClerk
         groceryClerk.name("inputWorkspace").neutron(request.runNumber).useLiteMode(request.useLiteMode).diffCalVersion(
             request.versions.calibration
-        ).dirty().add()
+        ).state(self.stateId1).dirty().add()
         groceryClerk.name("normalizationWorkspace").normalization(
-            request.runNumber, request.versions.normalization
+            request.runNumber,
+            self.stateId1,
+            request.versions.normalization,
         ).useLiteMode(request.useLiteMode).diffCalVersion(1).dirty().add()
         loadableOtherGroceryItems = groceryClerk.buildDict()
         residentOtherGroceryKwargs = {"combinedPixelMask": combinedMaskName}

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -144,7 +144,7 @@ class TestSousChef(unittest.TestCase):
             spec=FarmFreshIngredients,
             runNumber="12345",
             useLiteMode=True,
-            alternativeState=None,
+            state=None,
         )
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=False)
         self.instance.dataFactoryService.getDefaultInstrumentState = mock.Mock(return_value=mock.Mock())
@@ -487,6 +487,7 @@ class TestSousChef(unittest.TestCase):
         self.instance.prepPixelGroup = mock.Mock()
         self.instance.prepDetectorPeaks = mock.Mock()
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
+        self.instance.dataFactoryService.constructStateId = mock.Mock(return_value=("stateId", "DetectorState"))
 
         res = self.instance.prepNormalizationIngredients(self.ingredients)
 
@@ -506,6 +507,7 @@ class TestSousChef(unittest.TestCase):
         self.instance.prepPixelGroup = mock.Mock()
         self.instance.prepDetectorPeaks = mock.Mock()
         self.instance.dataFactoryService.calibrationExists = mock.Mock(return_value=True)
+        self.instance.dataFactoryService.constructStateId = mock.Mock(return_value=("stateId", "DetectorState"))
 
         result = self.instance.prepDiffractionCalibrationIngredients(self.ingredients)
 

--- a/tests/util/pytest_helpers.py
+++ b/tests/util/pytest_helpers.py
@@ -160,7 +160,8 @@ def calibration_home_from_mirror():
         # WARNING: for these integration tests `LocalDataService` is a singleton.
         #   The Indexer's `lru_cache` MUST be reset after the Config override, otherwise
         #     it will return indexers synched to the previous `Config["instrument.calibration.powder.home"]`.
-        LocalDataService()._indexer.cache_clear()
+        LocalDataService().calibrationIndexer.cache_clear()
+        LocalDataService().normalizationIndexer.cache_clear()
 
         # Create symlinks to metadata files and directories.
         metadatas = [Path("LiteGroupMap.hdf"), Path("PixelGroupingDefinitions"), Path("SNAPLite.xml")]
@@ -172,7 +173,8 @@ def calibration_home_from_mirror():
 
     # teardown => __exit__
     _stack.close()
-    LocalDataService()._indexer.cache_clear()
+    LocalDataService().calibrationIndexer.cache_clear()
+    LocalDataService().normalizationIndexer.cache_clear()
 
 
 @pytest.fixture

--- a/tests/util/state_helpers.py
+++ b/tests/util/state_helpers.py
@@ -113,7 +113,9 @@ class state_root_redirect:
         # assert Path(target).exists()
 
     def saveObjectAt(self, thing: BaseModel, target: str):
-        assert Path(self.tmpdir.name) in Path(target).parents
+        assert (
+            Path(self.tmpdir.name) in Path(target).parents
+        ), f"{self.tmpdir.name} is not any of {list(Path(target).parents)}"
 
         Path(target).parent.mkdir(parents=True, exist_ok=True)
         write_model_pretty(thing, target)

--- a/tests/util_tests/test_state_helpers.py
+++ b/tests/util_tests/test_state_helpers.py
@@ -171,9 +171,9 @@ def test_state_root_redirect_no_stateid():
         # verify it can be found by data services and equals the value written
         localDataService.calibrationExists = mock.Mock(return_value=True)
         expected = DAOFactory.calibrationParameters("xyz", True, 1)
-        indexer = localDataService.calibrationIndexer("xyz", True)
+        indexer = localDataService.calibrationIndexer(True, "stateId")
         tmpRoot.saveObjectAt(expected, indexer.parametersPath(1))
-        ans = localDataService.readCalibrationState("xyz", True, 1)
+        ans = localDataService.readCalibrationState("xyz", True, "stateId", 1)
         assert ans == expected
         # make sure files can only be added inside the directory
         with pytest.raises(AssertionError):


### PR DESCRIPTION
## Description of work

This is intended to fix the way snapred reads calibration/normalization workspaces such that users do not require read perms to anything besides the reduction run and the calibration root.


## Explanation of work

Right now snapred requires read permissions to the original files used to generate the Calibration and Normalization files.
This is because it uses their logs to generate the state id we use for lookup, but this is redundant as we can generate that from the target sample run.
In addition, we already supply "version" as part of Calibration and Normalization lookup, which means at Service level we already have access to this info.

Thus, this pr refactors the calibration and normalization lookups to remove the optional `alternativeState`, and instead require `state`.

## To test

This requires a regression test of each workflow, and most of all reduction.
It may require that you inspect/insert logs to ensure no run data is required to load calibration/normalizations.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#11197](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=11197)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] snapred no longer requires the inspection of calibration/normalization sample workspaces (i.e. the original ones stored in the ipts that may not have read perms for everyone) as part of reduction,
