### PR TITLE
Live-data: assembly from multiple chunks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "A desktop application for Lifecycle Managment of data collected f
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "mantidworkbench >= 6.12.0.2rc2",
+    "mantidworkbench >= 6.12.0.2rc3",
     "pyoncat ~= 1.6"
 ]
 readme = "README.md"

--- a/src/snapred/backend/dao/ingredients/GroceryListItem.py
+++ b/src/snapred/backend/dao/ingredients/GroceryListItem.py
@@ -58,7 +58,7 @@ class GroceryListItem(BaseModel):
         "LoadNexusMonitors",
         "LoadEventNexus",
         "LoadGroupingDefinition",
-        "LoadLiveData",
+        "LoadLiveDataInterval",
         "LoadNexus",
         "LoadNexusProcessed",
     ] = ""

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -1,7 +1,7 @@
 # ruff: noqa: F811
 import json
 from collections.abc import Iterable
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
@@ -831,7 +831,7 @@ class GroceryService:
         return data
 
     def _fetchLiveData(self, item: GroceryListItem):
-        loader = "LoadLiveData"
+        loader = "LoadLiveDataInterval"
         runNumber, useLiteMode, liveDataArgs = item.runNumber, item.useLiteMode, item.liveDataArgs
         workspaceName: WorkspaceName = self._createNeutronWorkspaceName(runNumber, useLiteMode)
         # Live-data fallback
@@ -840,22 +840,20 @@ class GroceryService:
                 # Only warn if live-data mode hasn't been explicitly requested.
                 logger.warning(f"Input data for run '{runNumber}' was not found in IPTS, trying live-data fallback...")
 
-            # When not specified in the `liveDataArgs` or when `liveDataArgs.duration == 0`,
+            # When not specified in the `liveDataArgs` or when `liveDataArgs.duration == timedelta(0)`,
             #   the default behavior will be to load the entire run.
             startTime = (
                 (datetime.utcnow() - liveDataArgs.duration).isoformat()
-                if liveDataArgs is not None and liveDataArgs.duration != 0
+                if liveDataArgs is not None and liveDataArgs.duration != timedelta(0)
                 else RunMetadata.FROM_START_ISO8601
             )
 
             loaderArgs = {
                 "Facility": Config["liveData.facility.name"],
                 "Instrument": Config["liveData.instrument.name"],
-                "AccumulationMethod": Config["liveData.accumulationMethod"],
                 "PreserveEvents": True,
                 "StartTime": startTime,
             }
-
             data = self.grocer.executeRecipe(workspace=workspaceName, loader=loader, loaderArgs=json.dumps(loaderArgs))
             data["fromLiveData"] = True
             if data["result"]:

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -982,7 +982,7 @@ class LocalDataService:
 
     def readDetectorState(self, runNumber: str) -> DetectorState | None:
         # Assemble a detector state from either the PVLogs, or the current live-data run.
-        
+
         # Note that `readRunMetadata` uses `lru_cache`: it is redundant to additionally apply it to this
         #   method.
         return self.readRunMetadata(runNumber).detectorState

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -980,9 +980,11 @@ class LocalDataService:
         indexer = self.normalizationIndexer(normalization.seedRun, normalization.useLiteMode)
         indexer.writeParameters(normalization)
 
-    @lru_cache
     def readDetectorState(self, runNumber: str) -> DetectorState | None:
         # Assemble a detector state from either the PVLogs, or the current live-data run.
+        
+        # Note that `readRunMetadata` uses `lru_cache`: it is redundant to additionally apply it to this
+        #   method.
         return self.readRunMetadata(runNumber).detectorState
 
     def detectorStateFromWorkspace(self, wsName: WorkspaceName) -> DetectorState:

--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -43,7 +43,7 @@ class FetchGroceriesRecipe:
             "result": False,
             "loader": "",
         }
-        liveDataMode = loader == "LoadLiveData"
+        liveDataMode = loader == "LoadLiveDataInterval"
         if liveDataMode:
             logger.info(f"Fetching live data into {workspace}")
         else:

--- a/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
@@ -34,7 +34,7 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
             FileProperty(
                 "Filename",
                 defaultValue="",
-                # `Filename` is an optional property when `loader == 'LoadLiveData'`.
+                # `Filename` is an optional property when `loader == 'LoadLiveDataInterval'`.
                 action=FileAction.OptionalLoad,
                 extensions=["xml", "h5", "nxs", "hd5"],
                 direction=Direction.Input,
@@ -54,7 +54,7 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
                     "LoadCalibrationWorkspaces",
                     "LoadEventNexus",
                     "LoadGroupingDefinition",
-                    "LoadLiveData",
+                    "LoadLiveDataInterval",
                     "LoadNexus",
                     "LoadNexusProcessed",
                     "LoadNexusMonitors",
@@ -100,7 +100,7 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
                 issues["OutputWorkspace"] = f"loader '{loader}' requires an 'OutputWorkspace' argument"
 
         # `LoaderArgs` property:
-        if loader in ["LoadCalibrationWorkspaces", "LoadLiveData"]:
+        if loader in ["LoadCalibrationWorkspaces", "LoadLiveDataInterval"]:
             if self.getProperty("LoaderArgs").isDefault:
                 issues["LoaderArgs"] = f"loader '{loader}' requires additional keyword arguments"
         elif not self.getProperty("LoaderArgs").isDefault:
@@ -121,7 +121,7 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
         loaderType = self.getPropertyValue("LoaderType")
 
         # Allow live-data mode to replace an existing workspace
-        addOrReplace = loaderType == "LoadLiveData"
+        addOrReplace = loaderType == "LoadLiveDataInterval"
 
         # TODO: the `if .. doesExist` should be centralized to cache treatment
         #    here, it is redundant.
@@ -152,13 +152,12 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
                         OutputWorkspace=outWS,
                         **{instrumentPropertySource: instrumentSource},
                     )
-                case "LoadLiveData":
+                case "LoadLiveDataInterval":
                     loaderArgs = json.loads(self.getPropertyValue("LoaderArgs"))
-                    self.mantidSnapper.LoadLiveData(
-                        "loading live-data chunk",
+                    self.mantidSnapper.LoadLiveDataInterval(
+                        "loading live-data interval",
                         OutputWorkspace=outWS,
                         Instrument=loaderArgs["Instrument"],
-                        AccumulationMethod=loaderArgs["AccumulationMethod"],
                         PreserveEvents=loaderArgs["PreserveEvents"],
                         StartTime=loaderArgs["StartTime"],
                     )
@@ -176,7 +175,7 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
             loaderType = ""
 
         if loaderType in ["LoadNexus", "LoadEventNexus", "LoadNexusProcessed"]:
-            # TODO: (1) Does `LoadLiveData` correctly set the instrument parameters?
+            # TODO: (1) Does `LoadLiveData` / `LoadLiveDataInterval` correctly set the instrument parameters?
             # TODO: (2) See EWM#7437:
             #   this clause is necessary to be able to accurately set detector positions
             #   on files written prior to the merge of the

--- a/src/snapred/backend/recipe/algorithm/LoadLiveDataInterval.py
+++ b/src/snapred/backend/recipe/algorithm/LoadLiveDataInterval.py
@@ -300,6 +300,7 @@ class LoadLiveDataInterval(PythonAlgorithm):
             loadLiveData.execute()
 
             run = self.mantidSnapper.mtd[chunkWs].getRun()
+            activeRunNumber = self.mantidSnapper.mtd[chunkWs].getRunNumber() 
 
             logger.info(f"Run interval: ({run.startTime().to_datetime64()}, {run.endTime().to_datetime64()})")
             logger.info(
@@ -328,7 +329,11 @@ class LoadLiveDataInterval(PythonAlgorithm):
                 waitTime += waitTimeIncrement
                 # Load another chunk of data.
                 loadLiveData.execute()
-
+                
+                # Check for possible run-state change:
+                if activeRunNumber != self.mantidSnapper.mtd[chunkWs].getRunNumber():
+                    break
+                
                 logger.info(
                     f"Loaded-chunk interval: ({self.mantidSnapper.mtd[chunkWs].getPulseTimeMin().to_datetime64()}, "
                     f"{self.mantidSnapper.mtd[chunkWs].getPulseTimeMax().to_datetime64()})"

--- a/src/snapred/backend/recipe/algorithm/LoadLiveDataInterval.py
+++ b/src/snapred/backend/recipe/algorithm/LoadLiveDataInterval.py
@@ -31,8 +31,9 @@ class LoadLiveDataInterval(PythonAlgorithm):
     @classproperty
     def USING_ADARA_FileReader(cls):
         # Enable a correction for the limitations of the mock "ADARA_FileReader":
-        return Config["liveData.facility.name"] == "TEST_LIVE" and Config["liveData.instrument.name"] == "ADARA_FileReader"
-
+        return (
+            Config["liveData.facility.name"] == "TEST_LIVE" and Config["liveData.instrument.name"] == "ADARA_FileReader"
+        )
 
     def category(self):
         return "Live data"
@@ -115,7 +116,7 @@ class LoadLiveDataInterval(PythonAlgorithm):
                 errors["EndTime"] = "'StartTime' must be before 'EndTime'."
 
         try:
-            instrument = ConfigService.getFacility().instrument(self.getProperty("Instrument").value) # noqa: F841
+            instrument = ConfigService.getFacility().instrument(self.getProperty("Instrument").value)  # noqa: F841
         except RuntimeError as e:
             if "FacilityInfo search object" not in str(e):
                 raise
@@ -185,7 +186,7 @@ class LoadLiveDataInterval(PythonAlgorithm):
         *,
         # `exact`: match the boundary points, otherwise cover, but don't necessarily match the inverval boundaries
         exact,
-        comparisonThreshold=ConfigValue("liveData.time_comparison_threshold")
+        comparisonThreshold=ConfigValue("liveData.time_comparison_threshold"),
     ):
         startDelta = requiredStartTime - intervalPulseTimeMin
         endDelta = intervalPulseTimeMax - requiredEndTime
@@ -250,7 +251,7 @@ class LoadLiveDataInterval(PythonAlgorithm):
     def _noDataGaps(
         cls,
         intervals: List[Tuple[np.datetime64, np.datetime64]],
-        comparisonThreshold=ConfigValue("liveData.time_comparison_threshold")
+        comparisonThreshold=ConfigValue("liveData.time_comparison_threshold"),
     ) -> bool:
         # Check a list of intervals for interval-to-interval gaps.
 

--- a/src/snapred/backend/recipe/algorithm/LoadLiveDataInterval.py
+++ b/src/snapred/backend/recipe/algorithm/LoadLiveDataInterval.py
@@ -300,7 +300,7 @@ class LoadLiveDataInterval(PythonAlgorithm):
             loadLiveData.execute()
 
             run = self.mantidSnapper.mtd[chunkWs].getRun()
-            activeRunNumber = self.mantidSnapper.mtd[chunkWs].getRunNumber() 
+            activeRunNumber = self.mantidSnapper.mtd[chunkWs].getRunNumber()
 
             logger.info(f"Run interval: ({run.startTime().to_datetime64()}, {run.endTime().to_datetime64()})")
             logger.info(
@@ -329,11 +329,11 @@ class LoadLiveDataInterval(PythonAlgorithm):
                 waitTime += waitTimeIncrement
                 # Load another chunk of data.
                 loadLiveData.execute()
-                
+
                 # Check for possible run-state change:
                 if activeRunNumber != self.mantidSnapper.mtd[chunkWs].getRunNumber():
                     break
-                
+
                 logger.info(
                     f"Loaded-chunk interval: ({self.mantidSnapper.mtd[chunkWs].getPulseTimeMin().to_datetime64()}, "
                     f"{self.mantidSnapper.mtd[chunkWs].getPulseTimeMax().to_datetime64()})"

--- a/src/snapred/backend/recipe/algorithm/LoadLiveDataInterval.py
+++ b/src/snapred/backend/recipe/algorithm/LoadLiveDataInterval.py
@@ -1,0 +1,377 @@
+import datetime
+from time import sleep
+from typing import Dict, List, Tuple
+
+import numpy as np
+from mantid.api import (
+    AlgorithmFactory,
+    MatrixWorkspaceProperty,
+    PropertyMode,
+    PythonAlgorithm,
+    mtd,
+)
+from mantid.kernel import ConfigService, DateAndTime, Direction
+
+from snapred.backend.dao.RunMetadata import RunMetadata
+from snapred.backend.data.util.PV_logs_util import datetimeFromLogTime
+from snapred.backend.log.logger import snapredLogger
+from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
+from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
+from snapred.meta.decorators.ConfigDefault import ConfigDefault, ConfigValue
+
+logger = snapredLogger.getLogger(__name__)
+
+
+class LoadLiveDataInterval(PythonAlgorithm):
+    """
+    Load a sub-interval of live data from the active run.
+    """
+
+    @classproperty
+    def USING_ADARA_FileReader(cls):
+        # Enable a correction for the limitations of the mock "ADARA_FileReader":
+        return Config["liveData.facility.name"] == "TEST_LIVE" and Config["liveData.instrument.name"] == "ADARA_FileReader"
+
+
+    def category(self):
+        return "Live data"
+
+    #
+    # Implementation notes:
+    #
+    #   * The use of `<Algorithm>.createChildAlgorithm` in key places ties the lifetime of the child algorithms
+    #     to the lifetime of the parent -- this is critical for the `LoadLiveData` algorithm, which instantiates
+    #     an instance of `SNSLiveListener` internally.
+
+    #   * Where fully-managed algorithm instances are appropriate: `MantidSnapper` will also be used.
+    #
+    #   * In regards to cancellation: the bulk of execution time for this algorithm occurs during the `LoadLiveData`
+    #     child algorithm.  Therefore, `LoadLiveData`'s `interruption_point` should be sufficient to this parent
+    #     algorithm as well.
+    #
+    #   * To avoid any unnecessary data collection by the `SNSLiveListener`, the `LoadLiveData` child is deleted
+    #     immediately following the successful execution of its parent.  This is automatic in the implementation
+    #     of the `AlgorithmManager`.
+    #
+    #   * All of this should be sufficient to allow `mantidworkbench` to successfully shut down
+    #     without generating a SEGFAULT.
+    #
+
+    def PyInit(self):
+        self.declareProperty(
+            MatrixWorkspaceProperty(
+                "OutputWorkspace", defaultValue="", direction=Direction.Output, optional=PropertyMode.Mandatory
+            ),
+            doc="Output event workspace containing the data interval",
+        )
+
+        self.declareProperty(
+            "StartTime",
+            defaultValue="",
+            direction=Direction.Input,
+            doc="absolute time of start of interval in ISO-8601 format (UTC)",
+        )
+        self.declareProperty(
+            "EndTime",
+            defaultValue=RunMetadata.FROM_NOW_ISO8601,
+            direction=Direction.Input,
+            doc="[optional] absolute time of end of interval in ISO-8601 format (UTC)",
+        )
+
+        self.declareProperty("Instrument", defaultValue="", direction=Direction.Input)
+
+        # TODO: should "PreserveEvents" even be a declared property?
+        #  Does this algorithm even work when this is turned off?
+        self.declareProperty("PreserveEvents", defaultValue=True, direction=Direction.Input)
+
+        self.mantidSnapper = MantidSnapper(self, __name__)
+
+    def validateInputs(self) -> Dict[str, str]:
+        errors = {}
+
+        if mtd.doesExist(self.getProperty("OutputWorkspace").valueAsStr):
+            logger.warning(
+                f"Output workspace '{self.getProperty('OutputWorkspace').valueAsStr}' already exists."
+                "  Its contents will be replaced!"
+            )
+
+        # These times are converted from ISO8601 here, in order to verify the input.
+        #   However, when calling `LoadLiveData` the ISO8601-format strings will be passed.
+        try:
+            self._startTime = np.datetime64(self.getProperty("StartTime").value)
+        except ValueError as e:
+            errors["StartTime"] = str(e)
+
+        try:
+            self._endTime = np.datetime64(self.getProperty("EndTime").value)
+        except ValueError as e:
+            errors["EndTime"] = str(e)
+
+        if not self.getProperty("EndTime").isDefault and not ("StartTime" in errors or "EndTime" in errors):
+            # FROM_NOW_ISO8601 is encoded as 1 second after the epoch,
+            #   so this comparison usually only makes sense if an 'EndTime' has been specified.
+            if not self._endTime > self._startTime:
+                errors["EndTime"] = "'StartTime' must be before 'EndTime'."
+
+        try:
+            instrument = ConfigService.getFacility().instrument(self.getProperty("Instrument").value) # noqa: F841
+        except RuntimeError as e:
+            if "FacilityInfo search object" not in str(e):
+                raise
+            errors["Instrument"] = (
+                f"Instrument '{self.getProperty('Instrument').value}' not found in current facility.\n"
+                "  Please execute `ConfigService.setFacility(...)` before using this algorithm."
+            )
+
+        return errors
+
+    # --- Break-out `LoadLiveDataInterval` calls, and wrap `Algorithm` calls as `classmethod` to help with mocking. ---
+    @classmethod
+    def _requiredLoadInterval(cls, wsName: str, startTime: str) -> Tuple[np.datetime64, np.datetime64]:
+        # Calculate the required loaded-data interval given the run interval and the argument values.
+
+        # Implementation notes:
+        #
+        # * This interval will be used to check whether or not the data-loading is complete.
+        #
+        # * Note that the end-time returned does not necessarily correspond to the requested filter interval.
+        #   The current listener implementation does not filter by end-time, so we need to load
+        #   to the latest time-point possible.
+        #
+
+        run = mtd[wsName].getRun()
+        runStartTime = run.startTime().to_datetime64()
+        runEndTime = run.endTime().to_datetime64()
+
+        if not cls.USING_ADARA_FileReader:
+            requiredStartTime = (
+                runStartTime
+                if (startTime == RunMetadata.FROM_START_ISO8601)
+                else DateAndTime(startTime).to_datetime64()
+            )
+            requiredEndTime = np.datetime64(datetime.datetime.now(datetime.timezone.utc).isoformat(), "ns")
+        else:
+            # Make a correction for the limitations of the mock "ADARA_FileReader":
+            #   move the requested start-time to be relative to the end of the run.
+            startTimeDelta = datetime.datetime.now(datetime.timezone.utc) - datetimeFromLogTime(
+                DateAndTime(startTime).to_datetime64()
+            )
+            requiredStartTime = (
+                runStartTime
+                if (startTime == RunMetadata.FROM_START_ISO8601)
+                else DateAndTime((datetimeFromLogTime(runEndTime) - startTimeDelta).isoformat()).to_datetime64()
+            )
+            requiredEndTime = runEndTime
+
+        if requiredStartTime < runStartTime:
+            requiredStartTime = runStartTime
+        if requiredEndTime > runEndTime:
+            requiredEndTime = runEndTime
+
+        return requiredStartTime, requiredEndTime
+
+    @classmethod
+    @ConfigDefault
+    def _compareIntervalEndpoints(
+        # `numpy.datetime64` is used here as an intermediate type.
+        #   * Python generally uses `datetime` and `timedelta`;
+        #   * Mantid uses `mantid.kernel.DateAndTime`.
+        cls,
+        requiredStartTime: np.datetime64,
+        requiredEndTime: np.datetime64,
+        intervalPulseTimeMin: np.datetime64,
+        intervalPulseTimeMax: np.datetime64,
+        *,
+        # `exact`: match the boundary points, otherwise cover, but don't necessarily match the inverval boundaries
+        exact,
+        comparisonThreshold=ConfigValue("liveData.time_comparison_threshold")
+    ):
+        startDelta = requiredStartTime - intervalPulseTimeMin
+        endDelta = intervalPulseTimeMax - requiredEndTime
+
+        if not exact:
+            # Test whether or not the data completely covers the interval:
+            #   time-comparison delta is (-comparisonThreshold, comparisonThreshold).
+            if startDelta > np.timedelta64(-comparisonThreshold, "s") and endDelta > np.timedelta64(
+                -comparisonThreshold, "s"
+            ):
+                return True
+        else:
+            # Test whether the data boundary points match those of the requested interval:
+            #   time-comparison delta is (-comparisonThreshold, comparisonThreshold).
+            if abs(startDelta) < np.timedelta64(comparisonThreshold, "s") and abs(endDelta) < np.timedelta64(
+                comparisonThreshold, "s"
+            ):
+                return True
+        return False
+
+    @classmethod
+    def _loadIsComplete(
+        cls, wsName: str, startTime: str, chunkIntervals: List[Tuple[np.datetime64, np.datetime64]]
+    ) -> bool:
+        # Determine whether or not the data completely covers the interval.
+        # When the data covers the interval, determine whether or not there are any gaps.
+
+        # Implementation notes:
+        #
+        #   * When the ADARA reader is busy, it may return the data in more than one chunk.
+        #
+        #   * In this case, it has been observed that historical data is returned after more-recent data,
+        #     but we cannot assume that this is always the case.
+        #
+        #   * A complete dataset will include data with pulse times spanning the interval: (<start time>, <end time>),
+        #     where the boundary points must match to within `Config['liveData.time_comparison_threshold']` seconds.
+        #
+        #   * In addition, a complete dataset will not have any pulse-time gaps that are larger than this same
+        #     comparison threshold.
+        #
+
+        requiredStartTime, requiredEndTime = cls._requiredLoadInterval(wsName, startTime)
+
+        ws = mtd[wsName]
+        dataStartTime = ws.getPulseTimeMin().to_datetime64()
+        dataEndTime = ws.getPulseTimeMax().to_datetime64()
+
+        boundariesOK = cls._compareIntervalEndpoints(
+            requiredStartTime,
+            requiredEndTime,
+            dataStartTime,
+            dataEndTime,
+            # Test for coverage: no need to match the boundary points.
+            exact=False,
+        )
+        if boundariesOK:
+            return cls._noDataGaps(chunkIntervals)
+        return False
+
+    @classmethod
+    @ConfigDefault
+    def _noDataGaps(
+        cls,
+        intervals: List[Tuple[np.datetime64, np.datetime64]],
+        comparisonThreshold=ConfigValue("liveData.time_comparison_threshold")
+    ) -> bool:
+        # Check a list of intervals for interval-to-interval gaps.
+
+        # Sort intervals by start time.
+        intervals_ = sorted(intervals, key=lambda dt: dt[0])
+
+        gapsOK = True
+        for n, dt0 in enumerate(intervals_[:-1]):
+            dt1 = intervals_[n + 1]
+            if dt1[0] - dt0[1] > np.timedelta64(comparisonThreshold, "s"):
+                gapsOK = False
+                break
+        return gapsOK
+
+    @classmethod
+    def _createChildAlgorithm(cls, self_, *args, **kwargs):
+        return self_.createChildAlgorithm(*args, **kwargs)
+
+    # --------- end: `LoadLiveDataInterval` call break out to static methods. ------------------------------------------
+
+    def PyExec(self):
+        chunkWs = self.mantidSnapper.mtd.unique_hidden_name()
+        self.chunkIntervals = []
+        try:
+            outputWs = self.getProperty("OutputWorkspace").valueAsStr
+            startTime = self.getProperty("StartTime").value
+
+            waitTimeIncrement = 10  # seconds
+            dataLoadTimeout = Config["liveData.dataLoadTimeout"]
+
+            # Create the "LoadLiveData" child and set its properties.
+            loadLiveData = self._createChildAlgorithm(self, "LoadLiveData", 0.0, 0.75, self.isLogging())
+            loadLiveData.initialize()
+            loadLiveData.setAlwaysStoreInADS(True)
+            loadLiveData.setRethrows(True)
+            loadLiveData.setPropertyValue("OutputWorkspace", chunkWs)
+            loadLiveData.setProperty("Instrument", self.getProperty("Instrument").value)
+            loadLiveData.setProperty("StartTime", startTime)
+            loadLiveData.setProperty("PreserveEvents", self.getProperty("PreserveEvents").value)
+            #   In order to extract the chunk pulse-time span:
+            #     each chunk of data will be loaded to the `chunkWs` first,
+            #     before transferring its events to the output workspace.
+            loadLiveData.setProperty("AccumulationMethod", "Replace")
+
+            # Load the first data-chunk: this replaces any contents of the output workspace.
+            loadLiveData.execute()
+
+            run = self.mantidSnapper.mtd[chunkWs].getRun()
+
+            logger.info(f"Run interval: ({run.startTime().to_datetime64()}, {run.endTime().to_datetime64()})")
+            logger.info(
+                f"Loaded-chunk interval: ({self.mantidSnapper.mtd[chunkWs].getPulseTimeMin().to_datetime64()}, "
+                f"{self.mantidSnapper.mtd[chunkWs].getPulseTimeMax().to_datetime64()})"
+            )
+
+            self.chunkIntervals.append(
+                (
+                    self.mantidSnapper.mtd[chunkWs].getPulseTimeMin().to_datetime64(),
+                    self.mantidSnapper.mtd[chunkWs].getPulseTimeMax().to_datetime64(),
+                )
+            )
+
+            self.mantidSnapper.CloneWorkspace(
+                "replace output workspace", OutputWorkspace=outputWs, InputWorkspace=chunkWs
+            )
+            self.mantidSnapper.executeQueue()
+
+            # For any remaining data, events will be added to those already in the output workspace.
+            waitTime = 0
+            dataLoadTimeout = Config["liveData.dataLoadTimeout"]
+            waitTimeIncrement = Config["liveData.chunkLoadWait"]
+            while (waitTime < dataLoadTimeout) and not self._loadIsComplete(outputWs, startTime, self.chunkIntervals):
+                sleep(waitTimeIncrement)
+                waitTime += waitTimeIncrement
+                # Load another chunk of data.
+                loadLiveData.execute()
+
+                logger.info(
+                    f"Loaded-chunk interval: ({self.mantidSnapper.mtd[chunkWs].getPulseTimeMin().to_datetime64()}, "
+                    f"{self.mantidSnapper.mtd[chunkWs].getPulseTimeMax().to_datetime64()})"
+                )
+
+                self.chunkIntervals.append(
+                    (
+                        self.mantidSnapper.mtd[chunkWs].getPulseTimeMin().to_datetime64(),
+                        self.mantidSnapper.mtd[chunkWs].getPulseTimeMax().to_datetime64(),
+                    )
+                )
+                self.mantidSnapper.Plus(
+                    "accumulate chunk to output workspace",
+                    OutputWorkspace=outputWs,
+                    LHSWorkspace=outputWs,
+                    RHSWorkspace=chunkWs,
+                    ClearRHSWorkspace=True,
+                )
+                self.mantidSnapper.executeQueue()
+
+            if not self._loadIsComplete(outputWs, startTime, self.chunkIntervals):
+                if waitTime >= dataLoadTimeout:
+                    logger.warning("A timeout occurred during data loading.")
+                logger.warning(
+                    "The complete data interval could not be loaded -- please check ADARA status at 'monitor.sns.gov'"
+                )
+        finally:
+            if self.mantidSnapper.mtd.doesExist(chunkWs):
+                self.mantidSnapper.DeleteWorkspace("delete chunk workspace", Workspace=chunkWs)
+                self.mantidSnapper.executeQueue()
+
+        if not self.getProperty("EndTime").isDefault and not self.USING_ADARA_FileReader:
+            # Use the specified time interval to filter the output-workspace events.
+            self.mantidSnapper.FilterByTime(
+                "filter time interval of output workspace",
+                OutputWorkspace=outputWs,
+                InputWorkspace=outputWs,
+                AbsoluteStartTime=self.getProperty("StartTime").value,
+                AbsoluteStopTime=self.getProperty("EndTime").value,
+            )
+            self.mantidSnapper.executeQueue()
+
+        self.setProperty("OutputWorkspace", outputWs)
+
+
+# Register algorithm with Mantid
+AlgorithmFactory.subscribe(LoadLiveDataInterval)

--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -54,7 +54,8 @@ class MantidSnapper:
     ##
     ## KNOWN NON-REENTRANT ALGORITHMS
     ##
-    _nonReentrantMutexes = {"LoadLiveData": Lock()}
+    _liveDataLock = Lock()
+    _nonReentrantMutexes = {"LoadLiveData": _liveDataLock, "LoadLiveDataInterval": _liveDataLock}
 
     ##
     ## KNOWN NON-CONCURRENT ALGORITHMS
@@ -166,7 +167,6 @@ class MantidSnapper:
     @classmethod
     def _createAlgorithm(cls, name):
         alg = AlgorithmManager.create(name)
-
         alg.setChild(True)
         alg.setAlwaysStoreInADS(True)
         alg.setRethrows(True)

--- a/src/snapred/backend/recipe/algorithm/StayResidentWrapper.py
+++ b/src/snapred/backend/recipe/algorithm/StayResidentWrapper.py
@@ -1,0 +1,64 @@
+from typing import Any
+
+from mantid.api import AlgorithmFactory, AlgorithmProperty, PythonAlgorithm
+from mantid.kernel import Property
+
+
+class StayResidentWrapper(PythonAlgorithm):
+    """
+    Allow an algorithm to be managed by `AlgorithmManager`, while controlling its persistence.
+    """
+
+    # Implementation notes:
+    # * This wrapper algorithm is managed by `AlgorithmManager`, in order that
+    #   any cleanup operations can be completed for its child algorithm at application exit.
+    # * `StayResidentWrapper.isRunning()` returns `True` until the wrapper is cancelled.
+
+    def category(self):
+        return "SNAPRed Internal"
+
+    def isRunning(self) -> bool:
+        # This returns `True` until `cancel` is called,
+        #   and thereby keeps the algorithm from being deleted by the `AlgorithmManager`.
+        # (See `mantid/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp`.)
+        return self._isRunning
+
+    def cancel(self):
+        # Cancel this algorithm and its child -- this triggers garbage collection of the algorithm instances.
+        # (See `mantid/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp`.)
+        child = self.getProperty("ChildAlgorithm")
+        child.cancel()
+        self._isRunning = False
+        # Beyond this point, `self.isRunning()` will always return `False`.
+        #   This instance, and it's child will then be deleted by the `AlgorithmManager`.
+
+    def setProperty(self, key: str, value: Any):
+        # Pass-through to the `<child>.setProperty`.
+        child = self.getProperty("ChildAlgorithm")
+        child.setProperty(key, value)
+
+    def getProperty(self, key: str) -> Property:
+        # Pass-through to the `<child>.getProperty`.
+        child = self.getProperty("ChildAlgorithm")
+        return child.getProperty(key)
+
+    def PyInit(self):
+        self.declareProperty(AlgorithmProperty("ChildAlgorithm"))
+
+        # For the `StayResidentWrapper` itself: `_isRunning` functions in "one shot" mode:
+        #   it should not be reset after the algorithm is cancelled.
+        self._isRunning = True
+
+    def PyExec(self):
+        # [Re-]execute the wrapped algorithm,
+        #   provided it has completed its last execution.
+
+        child = self.getProperty("ChildAlgorithm")
+        if child.isRunning():
+            # It may be OK if the child is still running. Don't hammer it!
+            return
+        child.executeAsynch()
+
+
+# Register algorithm with Mantid
+AlgorithmFactory.subscribe(StayResidentWrapper)

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -90,6 +90,13 @@ liveData:
     name: ${instrument.name}
     # name: ADARA_FileReader
 
+  # Maximum accumulated wait time during the load of a live-data interval.
+  dataLoadTimeout: 120 # seconds
+  chunkLoadWait: 3 # seconds
+
+  # Comparison threshold for the data pulse-time interval.
+  time_comparison_threshold: 10 # seconds
+
   # The ONLY supported mode right now is 'REPLACE':
   #   any other mode requires stay-resident `LoadLiveData` treatment.
   accumulationMethod: Replace

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -90,6 +90,13 @@ liveData:
     name: ${instrument.name}
     # name: ADARA_FileReader
 
+  # Maximum accumulated wait time during the load of a live-data interval.
+  dataLoadTimeout: 60 # seconds
+  chunkLoadWait: 10 # seconds
+
+  # Comparison threshold for the data pulse-time interval.
+  time_comparison_threshold: 10 # seconds
+
   # The ONLY supported mode right now is 'REPLACE':
   #   any other mode requires stay-resident `LoadLiveData` treatment.
   accumulationMethod: Replace

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -1388,7 +1388,6 @@ class TestGroceryService(unittest.TestCase):
             expectedLoaderArgs = {
                 "Facility": Config["liveData.facility.name"],
                 "Instrument": Config["liveData.instrument.name"],
-                "AccumulationMethod": Config["liveData.accumulationMethod"],
                 "PreserveEvents": True,
                 "StartTime": expectedStartTime.isoformat(),
             }
@@ -1463,7 +1462,7 @@ class TestGroceryService(unittest.TestCase):
                 # Action-related mocks:
                 mockFetchGroceriesRecipe.executeRecipe.return_value = {
                     "result": True,
-                    "loader": "LoadLiveData",
+                    "loader": "LoadLiveDataInterval",
                     "workspace": workspaceName,
                 }
 
@@ -1488,7 +1487,7 @@ class TestGroceryService(unittest.TestCase):
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
                     workspace=workspaceName,
-                    loader="LoadLiveData",
+                    loader="LoadLiveDataInterval",
                     loaderArgs=json.dumps(expectedLoaderArgs),
                 )
                 if useLiteMode:
@@ -1519,7 +1518,6 @@ class TestGroceryService(unittest.TestCase):
             expectedLoaderArgs = {
                 "Facility": Config["liveData.facility.name"],
                 "Instrument": Config["liveData.instrument.name"],
-                "AccumulationMethod": Config["liveData.accumulationMethod"],
                 "PreserveEvents": True,
                 "StartTime": expectedStartTime.isoformat(),
             }
@@ -1593,7 +1591,7 @@ class TestGroceryService(unittest.TestCase):
                 # Action-related mocks:
                 mockFetchGroceriesRecipe.executeRecipe.return_value = {
                     "result": True,
-                    "loader": "LoadLiveData",
+                    "loader": "LoadLiveDataInterval",
                     "workspace": workspaceName,
                 }
 
@@ -1620,7 +1618,7 @@ class TestGroceryService(unittest.TestCase):
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
                     workspace=workspaceName,
-                    loader="LoadLiveData",
+                    loader="LoadLiveDataInterval",
                     loaderArgs=json.dumps(expectedLoaderArgs),
                 )
                 mockConvertToLiteMode.assert_not_called()
@@ -1644,7 +1642,6 @@ class TestGroceryService(unittest.TestCase):
             expectedLoaderArgs = {
                 "Facility": Config["liveData.facility.name"],
                 "Instrument": Config["liveData.instrument.name"],
-                "AccumulationMethod": Config["liveData.accumulationMethod"],
                 "PreserveEvents": True,
                 "StartTime": RunMetadata.FROM_START_ISO8601,
             }
@@ -1716,7 +1713,7 @@ class TestGroceryService(unittest.TestCase):
                 # Action-related mocks:
                 mockFetchGroceriesRecipe.executeRecipe.return_value = {
                     "result": True,
-                    "loader": "LoadLiveData",
+                    "loader": "LoadLiveDataInterval",
                     "workspace": workspaceName,
                 }
 
@@ -1735,7 +1732,7 @@ class TestGroceryService(unittest.TestCase):
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
                     workspace=workspaceName,
-                    loader="LoadLiveData",
+                    loader="LoadLiveDataInterval",
                     loaderArgs=json.dumps(expectedLoaderArgs),
                 )
                 if useLiteMode:
@@ -1762,7 +1759,6 @@ class TestGroceryService(unittest.TestCase):
             expectedLoaderArgs = {
                 "Facility": Config["liveData.facility.name"],
                 "Instrument": Config["liveData.instrument.name"],
-                "AccumulationMethod": Config["liveData.accumulationMethod"],
                 "PreserveEvents": True,
                 "StartTime": RunMetadata.FROM_START_ISO8601,
             }
@@ -1834,7 +1830,7 @@ class TestGroceryService(unittest.TestCase):
                 # Action-related mocks:
                 mockFetchGroceriesRecipe.executeRecipe.return_value = {
                     "result": True,
-                    "loader": "LoadLiveData",
+                    "loader": "LoadLiveDataInterval",
                     "workspace": workspaceName,
                 }
 
@@ -1858,7 +1854,7 @@ class TestGroceryService(unittest.TestCase):
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
                     workspace=workspaceName,
-                    loader="LoadLiveData",
+                    loader="LoadLiveDataInterval",
                     loaderArgs=json.dumps(expectedLoaderArgs),
                 )
                 mockConvertToLiteMode.assert_not_called()
@@ -2048,7 +2044,6 @@ class TestGroceryService(unittest.TestCase):
             expectedLoaderArgs = {
                 "Facility": Config["liveData.facility.name"],
                 "Instrument": Config["liveData.instrument.name"],
-                "AccumulationMethod": Config["liveData.accumulationMethod"],
                 "PreserveEvents": True,
                 "StartTime": expectedStartTime.isoformat(),
             }
@@ -2123,7 +2118,7 @@ class TestGroceryService(unittest.TestCase):
                 # Action-related mocks:
                 mockFetchGroceriesRecipe.executeRecipe.return_value = {
                     "result": True,
-                    "loader": "LoadLiveData",
+                    "loader": "LoadLiveDataInterval",
                     "workspace": workspaceName,
                 }
 
@@ -2155,7 +2150,7 @@ class TestGroceryService(unittest.TestCase):
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
                     workspace=workspaceName,
-                    loader="LoadLiveData",
+                    loader="LoadLiveDataInterval",
                     loaderArgs=json.dumps(expectedLoaderArgs),
                 )
                 mockRunMetadata.fromRun.assert_called_once_with(mock.sentinel.run)
@@ -2190,7 +2185,6 @@ class TestGroceryService(unittest.TestCase):
             expectedLoaderArgs = {
                 "Facility": Config["liveData.facility.name"],
                 "Instrument": Config["liveData.instrument.name"],
-                "AccumulationMethod": Config["liveData.accumulationMethod"],
                 "PreserveEvents": True,
                 "StartTime": expectedStartTime.isoformat(),
             }
@@ -2260,7 +2254,7 @@ class TestGroceryService(unittest.TestCase):
                 # Action-related mocks:
                 mockFetchGroceriesRecipe.executeRecipe.return_value = {
                     "result": True,
-                    "loader": "LoadLiveData",
+                    "loader": "LoadLiveDataInterval",
                     "workspace": workspaceName,
                 }
 
@@ -2291,7 +2285,7 @@ class TestGroceryService(unittest.TestCase):
                 # it gets loaded into the native workspace first, then cache renames it to raw
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
                     workspace=workspaceName,
-                    loader="LoadLiveData",
+                    loader="LoadLiveDataInterval",
                     loaderArgs=json.dumps(expectedLoaderArgs),
                 )
                 mockConvertToLiteMode.assert_not_called()
@@ -2315,7 +2309,6 @@ class TestGroceryService(unittest.TestCase):
             expectedLoaderArgs = {
                 "Facility": Config["liveData.facility.name"],
                 "Instrument": Config["liveData.instrument.name"],
-                "AccumulationMethod": Config["liveData.accumulationMethod"],
                 "PreserveEvents": True,
                 "StartTime": RunMetadata.FROM_START_ISO8601,
             }
@@ -2383,7 +2376,7 @@ class TestGroceryService(unittest.TestCase):
                 # Action-related mocks:
                 mockFetchGroceriesRecipe.executeRecipe.return_value = {
                     "result": True,
-                    "loader": "LoadLiveData",
+                    "loader": "LoadLiveDataInterval",
                     "workspace": workspaceName,
                 }
 
@@ -2412,7 +2405,7 @@ class TestGroceryService(unittest.TestCase):
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
                     workspace=workspaceName,
-                    loader="LoadLiveData",
+                    loader="LoadLiveDataInterval",
                     loaderArgs=json.dumps(expectedLoaderArgs),
                 )
                 if useLiteMode:
@@ -2442,7 +2435,6 @@ class TestGroceryService(unittest.TestCase):
             expectedLoaderArgs = {
                 "Facility": Config["liveData.facility.name"],
                 "Instrument": Config["liveData.instrument.name"],
-                "AccumulationMethod": Config["liveData.accumulationMethod"],
                 "PreserveEvents": True,
                 "StartTime": RunMetadata.FROM_START_ISO8601,
             }
@@ -2509,7 +2501,7 @@ class TestGroceryService(unittest.TestCase):
                 # Action-related mocks:
                 mockFetchGroceriesRecipe.executeRecipe.return_value = {
                     "result": True,
-                    "loader": "LoadLiveData",
+                    "loader": "LoadLiveDataInterval",
                     "workspace": workspaceName,
                 }
 
@@ -2535,7 +2527,7 @@ class TestGroceryService(unittest.TestCase):
                 mockHasLiveDataConnection.assert_called_once()
                 mockFetchGroceriesRecipe.executeRecipe.assert_called_once_with(
                     workspace=workspaceName,
-                    loader="LoadLiveData",
+                    loader="LoadLiveDataInterval",
                     loaderArgs=json.dumps(expectedLoaderArgs),
                 )
                 mockConvertToLiteMode.assert_not_called()

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -2548,80 +2548,15 @@ def test_readWriteNormalizationState():
 
 
 def test_readDetectorState():
+    # Verify that `readDetectorState` uses `readRunMetadata`.
     runNumber = "123"
     expected = mockDetectorState("123")
     mockMetadata = mock.Mock(spec=RunMetadata, runNumber=runNumber, detectorState=expected)
-    mockRunMetadata = mock.Mock(fromNeXusLogs=mock.Mock(return_value=mockMetadata))
-    with mock.patch(ThisService + "RunMetadata", mockRunMetadata) as mockMetaData:  # noqa: F841
-        instance = LocalDataService()
-        instance._readPVFile = mock.Mock(return_value=mock.sentinel.h5)
-        instance._constructPVFilePath = mock.Mock(return_value="/mock/path")
-        actual = instance.readDetectorState(runNumber)
-        assert actual == expected
-        mockRunMetadata.fromNeXusLogs.assert_called_once_with(mock.sentinel.h5)
-
-
-def test_readDetectorState_no_PVFile():
-    # test live-data fallback, with run number mismatch
-    runNumber = "123"
     instance = LocalDataService()
-    instance._readPVFile = mock.Mock(side_effect=FileNotFoundError("No PVFile exists for run"))
-    instance.readLiveMetadata = mock.Mock(return_value=mock.MagicMock(runNumber=-1))
-    instance.hasLiveDataConnection = mock.Mock(return_value=True)
-    with pytest.raises(
-        RuntimeError,
-        match=(
-            f"No PVFile exists for run: {runNumber}, and it isn't the live run: "
-            + f"{instance.readLiveMetadata.return_value.runNumber}."
-        ),
-    ):
-        instance.readDetectorState(runNumber)
-
-
-def test_readDetectorState_no_PVFile_no_connection():
-    runNumber = "12345"
-    instance = LocalDataService()
-    instance._readPVFile = mock.Mock(side_effect=FileNotFoundError("lah dee dah"))
-    instance.hasLiveDataConnection = mock.Mock(return_value=False)
-    with pytest.raises(FileNotFoundError, match="lah dee dah"):
-        instance.readDetectorState(runNumber)
-
-
-def test_readDetectorState_live_run():
-    runNumber = "123"
-    expected = mockDetectorState(runNumber)
-    mockRunMetadata = mock.Mock(spec=RunMetadata, runNumber=runNumber, detectorState=expected, protonCharge=1000.0)
-
-    instance = LocalDataService()
-    instance._readPVFile = mock.Mock(side_effect=FileNotFoundError("No PVFile exists for run"))
-    instance.hasLiveDataConnection = mock.Mock(return_value=True)
-    instance.readLiveMetadata = mock.Mock(return_value=mockRunMetadata)
-
+    instance.readRunMetadata = mock.Mock(return_value= mockMetadata)
     actual = instance.readDetectorState(runNumber)
     assert actual == expected
-
-    instance._readPVFile.assert_called_once_with(runNumber)
-    instance.hasLiveDataConnection.assert_called_once()
-    instance.readLiveMetadata.assert_called_once()
-
-
-def test_readDetectorState_live_run_mismatch():
-    # Test that an unexpected live run number throws an exception.
-    runNumber0 = "12345"
-    runNumber1 = "67890"
-    mockRunMetadata = mock.Mock(
-        spec=RunMetadata, runNumber=runNumber1, detectorState=mockDetectorState(runNumber1), protonCharge=1000.0
-    )
-
-    instance = LocalDataService()
-    instance._readPVFile = mock.Mock(side_effect=FileNotFoundError("No PVFile exists for run"))
-    instance.hasLiveDataConnection = mock.Mock(return_value=True)
-    instance.readLiveMetadata = mock.Mock(return_value=mockRunMetadata)
-
-    with pytest.raises(
-        RuntimeError, match=f"No PVFile exists for run: {runNumber0}, and it isn't the live run: {runNumber1}"
-    ):
-        instance.readDetectorState(runNumber0)
+    instance.readRunMetadata.assert_called_once_with(runNumber)
 
 
 @mock.patch(ThisService + "MantidSnapper")

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -2553,7 +2553,7 @@ def test_readDetectorState():
     expected = mockDetectorState("123")
     mockMetadata = mock.Mock(spec=RunMetadata, runNumber=runNumber, detectorState=expected)
     instance = LocalDataService()
-    instance.readRunMetadata = mock.Mock(return_value= mockMetadata)
+    instance.readRunMetadata = mock.Mock(return_value=mockMetadata)
     actual = instance.readDetectorState(runNumber)
     assert actual == expected
     instance.readRunMetadata.assert_called_once_with(runNumber)

--- a/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
+++ b/tests/unit/backend/recipe/algorithm/test_LoadGroupingDefinition.py
@@ -58,7 +58,7 @@ class TestLoadGroupingDefinition(unittest.TestCase):
                 cls.isFull: "/opt/anaconda/envs/mantid-dev/instrument/SNAP_Definition.xml",
             }
 
-            # file locations for remtoe grouping files
+            # file locations for remote grouping files
             pgdFolder = "/SNS/SNAP/shared/Calibration/Powder/PixelGroupingDefinitions/"
             cls.remoteGroupingFile = {
                 (cls.isLite, "xml"): f"{pgdFolder}SNAPFocGrp_Column.lite.xml",

--- a/tests/unit/backend/recipe/algorithm/test_LoadLiveDataInterval.py
+++ b/tests/unit/backend/recipe/algorithm/test_LoadLiveDataInterval.py
@@ -1,0 +1,1083 @@
+import datetime
+import inspect
+import unittest
+from datetime import timedelta
+from unittest import mock
+
+import numpy as np
+import pytest
+from mantid.api import MatrixWorkspaceProperty, Run, mtd
+from mantid.kernel import DateAndTime
+from mantid.simpleapi import (
+    CloneWorkspace,
+    CreateSampleWorkspace,
+    DeleteWorkspace,
+    DeleteWorkspaces,
+    FilterByTime,
+    Plus,
+)
+from util.Config_helpers import Config_override
+
+from snapred.backend.dao.RunMetadata import RunMetadata
+from snapred.backend.data.util.PV_logs_util import datetimeFromLogTime
+from snapred.backend.recipe.algorithm.LoadLiveDataInterval import LoadLiveDataInterval
+from snapred.meta.Config import Config
+
+
+class TestLoadLiveDataInterval(unittest.TestCase):
+    def setUp(self):
+        # Use `LoadLiveDataInterval()` here instead of `AlgorithmManager.create("LoadLiveDataInterval")`:
+        #   initializing the mocks will require the complete instance, rather than just the `IAlgorithm`.
+        self.instance = LoadLiveDataInterval()  # AlgorithmManager.create("LoadLiveDataInterval")
+        self.outputWs = "output_ws"
+        self.startTime = (datetime.datetime.now(datetime.timezone.utc) - timedelta(minutes=10)).isoformat()
+        self.endTime = (datetime.datetime.now(datetime.timezone.utc) - timedelta(minutes=9)).isoformat()
+        self.instrument = Config["instrument.name"]
+        self.preserveEvents = True
+
+    def tearDown(self):
+        if mtd.doesExist(self.outputWs):
+            DeleteWorkspace(self.outputWs)
+
+    @classmethod
+    def setUpClass(cls):
+        # Create a workspace representing the full time interval,
+        #   and break it into several chunks.
+        cls.N_chunk = 4
+
+        # The full workspace, which is the completely loaded data interval:
+        #   * ['start_time', 'end_time']: ['2010-01-01T00:00:00', '2010-01-01T01:00:00']
+        #   * 16 spectra, each of which includes events spanning
+        #     [<minimum pulse time>, <maximum pulse time>]: <approximately the run interval above>
+
+        cls.fullWs = "fullWs"
+        CreateSampleWorkspace(OutputWorkspace=cls.fullWs, WorkspaceType="Event", NumBanks=4, BankPixelWidth=2)
+
+        # Mantid time arguments are generally ISO8601 strings,
+        #   but it's easiest to deal either with `numpy.datetime64` (just an int64)
+        #   or with `datetime` and `timedelta`.
+        run = mtd[cls.fullWs].getRun()
+        cls.sampleRunInterval = (
+            DateAndTime(run["start_time"].value).to_datetime64(),
+            DateAndTime(run["end_time"].value).to_datetime64(),
+        )
+
+        # The following does not work with `np.linspace` for some reason.
+        chunkDelta = (cls.sampleRunInterval[1] - cls.sampleRunInterval[0]) // cls.N_chunk
+        cls.chunkEdges = np.arange(cls.sampleRunInterval[0], cls.sampleRunInterval[1] + chunkDelta, chunkDelta)
+
+        cls.chunkWss = [f"chunk_{n}" for n in range(cls.N_chunk)]
+        for n in range(cls.N_chunk):
+            FilterByTime(
+                OutputWorkspace=cls.chunkWss[n],
+                InputWorkspace=cls.fullWs,
+                AbsoluteStartTime=str(DateAndTime(cls.chunkEdges[n])),
+                AbsoluteStopTime=str(DateAndTime(cls.chunkEdges[n + 1])),
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        wss = [cls.fullWs]
+        wss.extend(cls.chunkWss)
+        DeleteWorkspaces(wss)
+
+    class _MockLoadLiveData:
+        def __init__(self, chunkWss):
+            # properties dict:
+            self._properties = {}
+
+            # Chunks to use during `execute` calls,
+            #   for either `AccumulationMethod='Replace'` or
+            #   `AccumulationMethod='Add'.
+            self._chunkWss = chunkWss
+
+            # workspace from `chunkWss` to use during the next call.
+            self._wsIndex = 0
+
+        def setProperty(self, key, value):
+            self._properties[key] = value
+
+        def setPropertyValue(self, key, value):
+            self._properties[key] = value
+
+        def getProperty(self, key):
+            return self._properties[key]
+
+        def initialize(self):
+            pass
+
+        def setAlwaysStoreInADS(self, flag: bool):
+            pass
+
+        def setRethrows(self, flag: bool):
+            pass
+
+        def execute(self):
+            if self._properties["AccumulationMethod"] == "Replace":
+                CloneWorkspace(
+                    OutputWorkspace=self._properties["OutputWorkspace"],
+                    InputWorkspace=self._chunkWss[self._wsIndex],
+                )
+            elif self._properties["AccumulationMethod"] == "Add":
+                if not mtd.doesExist(self._properties["OutputWorkspace"]):
+                    CloneWorkspace(
+                        OutputWorkspace=self._properties["OutputWorkspace"],
+                        InputWorkspace=self._chunkWss[self._wsIndex],
+                    )
+                else:
+                    Plus(
+                        OutputWorkspace=self._properties["OutputWorkspace"],
+                        LHSWorkspace=self._properties["OutputWorkspace"],
+                        RHSWorkspace=self._chunkWss[self._wsIndex],
+                    )
+            else:
+                raise RuntimeError(f"Unimplemented accumulation method: '{self._properties['AccumulationMethod']}'")
+            self._wsIndex += 1
+
+    @classmethod
+    def _mockLoadLiveData(cls, chunkWss) -> mock.Mock:
+        # Create a simple `LoadLiveData` emulation that on `execute`,
+        #   applies the next chunk from the `chunkWss` workspace sequence,
+        #   using either `AccumulationMode="Replace"` or `AccumulationMode="Add"`.
+        return mock.Mock(wraps=TestLoadLiveDataInterval._MockLoadLiveData(chunkWss))
+
+    def _setProperties(self, instance, **kwargs):
+        for key, value in kwargs.items():
+            if isinstance(instance.getProperty(key), MatrixWorkspaceProperty):
+                instance.setPropertyValue(key, value)
+            else:
+                instance.setProperty(key, value)
+
+    def test_init(self):
+        self.instance.initialize()
+
+        assert set([p.name for p in self.instance.getProperties()]) == set(
+            ("OutputWorkspace", "StartTime", "EndTime", "Instrument", "PreserveEvents")
+        )
+
+        # verify default values
+        assert self.instance.getProperty("EndTime").isDefault
+        assert self.instance.getProperty("EndTime").value == RunMetadata.FROM_NOW_ISO8601
+
+        assert self.instance.getProperty("PreserveEvents").value
+
+    def test_validateInputs(self):
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "mtd") as mock_mtd,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_mtd.doesExist.return_value = False
+
+            self.instance.initialize()
+            self._setProperties(
+                self.instance,
+                OutputWorkspace=self.outputWs,
+                StartTime=self.startTime,
+                EndTime=self.endTime,
+                Instrument=Config["instrument.name"],
+                PreserveEvents=self.preserveEvents,
+            )
+            self.instance.validateInputs()
+
+    def test_validateInputs_output_exists(self):
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "mtd") as mock_mtd,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "logger") as mock_logger,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_mtd.doesExist.return_value = True
+
+            self.instance.initialize()
+            self._setProperties(
+                self.instance,
+                OutputWorkspace=self.outputWs,
+                StartTime=self.startTime,
+                EndTime=self.endTime,
+                Instrument=Config["instrument.name"],
+                PreserveEvents=self.preserveEvents,
+            )
+            self.instance.validateInputs()
+
+            warningMessage = mock_logger.warning.mock_calls[0].args[0]
+            assert f"Output workspace '{self.outputWs}' already exists." in warningMessage
+
+    def test_validateInputs_StartTime_format(self):
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "mtd") as mock_mtd,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_mtd.doesExist.return_value = False
+
+            self.instance.initialize()
+            self._setProperties(
+                self.instance,
+                OutputWorkspace=self.outputWs,
+                StartTime="12.00",
+                EndTime=self.endTime,
+                Instrument=Config["instrument.name"],
+                PreserveEvents=self.preserveEvents,
+            )
+            errors = self.instance.validateInputs()
+
+            assert "StartTime" in errors
+            assert "Error parsing datetime string" in errors["StartTime"]
+
+    def test_validateInputs_EndTime_format(self):
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "mtd") as mock_mtd,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_mtd.doesExist.return_value = False
+
+            self.instance.initialize()
+            self._setProperties(
+                self.instance,
+                OutputWorkspace=self.outputWs,
+                StartTime=self.startTime,
+                EndTime="12.00",
+                Instrument=Config["instrument.name"],
+                PreserveEvents=self.preserveEvents,
+            )
+            errors = self.instance.validateInputs()
+
+            assert "EndTime" in errors
+            assert "Error parsing datetime string" in errors["EndTime"]
+
+    def test_validateInputs_time_order(self):
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "mtd") as mock_mtd,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_mtd.doesExist.return_value = False
+
+            now = datetime.datetime.now(datetime.timezone.utc)
+            self.instance.initialize()
+            self._setProperties(
+                self.instance,
+                OutputWorkspace=self.outputWs,
+                # End time cannot be before start time.
+                StartTime=(now - timedelta(minutes=10)).isoformat(),
+                EndTime=(now - timedelta(minutes=11)).isoformat(),
+                Instrument=Config["instrument.name"],
+                PreserveEvents=self.preserveEvents,
+            )
+            errors = self.instance.validateInputs()
+
+            assert "EndTime" in errors
+            assert "'StartTime' must be before 'EndTime'." in errors["EndTime"]
+
+    def test_validateInputs_instrument(self):
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "mtd") as mock_mtd,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.side_effect = RuntimeError(
+                "FacilityInfo search object"
+            )
+            mock_mtd.doesExist.return_value = False
+
+            self.instance.initialize()
+            self._setProperties(
+                self.instance,
+                OutputWorkspace=self.outputWs,
+                StartTime=self.startTime,
+                EndTime=self.endTime,
+                Instrument=Config["instrument.name"],
+                PreserveEvents=self.preserveEvents,
+            )
+            errors = self.instance.validateInputs()
+
+            assert "Instrument" in errors
+            assert f"Instrument '{Config['instrument.name']}' not found in current facility." in errors["Instrument"]
+
+    def test_validateInputs_instrument_other_exception(self):
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "mtd") as mock_mtd,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.side_effect = RuntimeError(
+                "Some other facility error"
+            )
+            mock_mtd.doesExist.return_value = False
+
+            self.instance.initialize()
+            self._setProperties(
+                self.instance,
+                OutputWorkspace=self.outputWs,
+                StartTime=self.startTime,
+                EndTime=self.endTime,
+                Instrument=Config["instrument.name"],
+                PreserveEvents=self.preserveEvents,
+            )
+            with pytest.raises(RuntimeError, match="Some other facility error"):
+                errors = self.instance.validateInputs()  # noqa: F841
+
+    def test__requiredLoadInterval(self):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "mtd") as mock_mtd,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "datetime") as mock_datetime,
+        ):
+            runStartTime = DateAndTime(
+                (datetime.datetime.fromisoformat(self.startTime) - timedelta(minutes=10)).isoformat()
+            )
+            runEndTime = DateAndTime(now.isoformat())
+            mock_run = mock.Mock(spec=Run)
+            mock_run.startTime.return_value = runStartTime
+            mock_run.endTime.return_value = runEndTime
+            mock_mtd.__getitem__.return_value.getRun.return_value = mock_run
+            mock_datetime.datetime.now.return_value = now
+
+            expectedInterval = (
+                DateAndTime(self.startTime).to_datetime64(),
+                DateAndTime(now.isoformat()).to_datetime64(),
+            )
+            actualInterval = LoadLiveDataInterval._requiredLoadInterval(self.outputWs, self.startTime)
+            assert actualInterval == expectedInterval
+
+    def test__requiredLoadInterval_start_of_run(self):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "mtd") as mock_mtd,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "datetime") as mock_datetime,
+        ):
+            runStartTime = DateAndTime(
+                (datetime.datetime.fromisoformat(self.startTime) - timedelta(minutes=10)).isoformat()
+            )
+            runEndTime = DateAndTime(now.isoformat())
+            mock_run = mock.Mock(spec=Run)
+            mock_run.startTime.return_value = runStartTime
+            mock_run.endTime.return_value = runEndTime
+            mock_mtd.__getitem__.return_value.getRun.return_value = mock_run
+            mock_datetime.datetime.now.return_value = now
+
+            fromStartCode = RunMetadata.FROM_START_ISO8601
+            expectedInterval = (runStartTime.to_datetime64(), DateAndTime(now.isoformat()).to_datetime64())
+            actualInterval = LoadLiveDataInterval._requiredLoadInterval(self.outputWs, fromStartCode)
+
+            assert actualInterval == expectedInterval
+
+    def test__loadIsComplete(self):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "mtd") as mock_mtd,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "datetime") as mock_datetime,
+        ):
+            runStartTime = DateAndTime(
+                (datetime.datetime.fromisoformat(self.startTime) - timedelta(minutes=10)).isoformat()
+            )
+            runEndTime = DateAndTime(now.isoformat())
+            mock_run = mock.Mock(spec=Run)
+            mock_run.startTime.return_value = runStartTime
+            mock_run.endTime.return_value = runEndTime
+            mock_mtd.__getitem__.return_value.getRun.return_value = mock_run
+            mock_mtd.__getitem__.return_value.getPulseTimeMin.return_value = DateAndTime(self.startTime)
+            mock_mtd.__getitem__.return_value.getPulseTimeMax.return_value = DateAndTime(now.isoformat())
+            mock_datetime.datetime.now.return_value = now
+
+            actual = LoadLiveDataInterval._loadIsComplete(self.outputWs, self.startTime, chunkIntervals=[])
+
+            assert actual
+            # ... assert various calls ...
+
+    def test__loadIsComplete_min_pulse_too_late(self):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "mtd") as mock_mtd,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "datetime") as mock_datetime,
+        ):
+            runStartTime = DateAndTime(
+                (datetime.datetime.fromisoformat(self.startTime) - timedelta(minutes=10)).isoformat()
+            )
+            runEndTime = DateAndTime(now.isoformat())
+            mock_run = mock.Mock(spec=Run)
+            mock_run.startTime.return_value = runStartTime
+            mock_run.endTime.return_value = runEndTime
+            mock_mtd.__getitem__.return_value.getRun.return_value = mock_run
+
+            comparisonThreshold = Config["liveData.time_comparison_threshold"]
+            minPulseTime = DateAndTime(
+                (
+                    datetime.datetime.fromisoformat(self.startTime) + timedelta(seconds=2 * comparisonThreshold)
+                ).isoformat()
+            )
+            mock_mtd.__getitem__.return_value.getPulseTimeMin.return_value = minPulseTime
+            mock_mtd.__getitem__.return_value.getPulseTimeMax.return_value = DateAndTime(now.isoformat())
+            mock_datetime.datetime.now.return_value = now
+
+            actual = LoadLiveDataInterval._loadIsComplete(self.outputWs, self.startTime, chunkIntervals=[])
+
+            assert not actual
+
+    def test__loadIsComplete_max_pulse_too_early(self):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "mtd") as mock_mtd,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "datetime") as mock_datetime,
+        ):
+            runStartTime = DateAndTime(
+                (datetime.datetime.fromisoformat(self.startTime) - timedelta(minutes=10)).isoformat()
+            )
+            runEndTime = DateAndTime(now.isoformat())
+            mock_run = mock.Mock(spec=Run)
+            mock_run.startTime.return_value = runStartTime
+            mock_run.endTime.return_value = runEndTime
+            mock_mtd.__getitem__.return_value.getRun.return_value = mock_run
+
+            comparisonThreshold = Config["liveData.time_comparison_threshold"]
+            maxPulseTime = DateAndTime((now - timedelta(seconds=2 * comparisonThreshold)).isoformat())
+            mock_mtd.__getitem__.return_value.getPulseTimeMin.return_value = DateAndTime(self.startTime)
+            mock_mtd.__getitem__.return_value.getPulseTimeMax.return_value = maxPulseTime
+            mock_datetime.datetime.now.return_value = now
+
+            actual = LoadLiveDataInterval._loadIsComplete(self.outputWs, self.startTime, chunkIntervals=[])
+
+            assert not actual
+
+    def test__noDataGaps_chunk_intervals_no_gap(self):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "mtd") as mock_mtd,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "datetime") as mock_datetime,
+        ):
+            runStartTime = DateAndTime(
+                (datetime.datetime.fromisoformat(self.startTime) - timedelta(minutes=10)).isoformat()
+            )
+            runEndTime = DateAndTime(now.isoformat())
+            mock_run = mock.Mock(spec=Run)
+            mock_run.startTime.return_value = runStartTime
+            mock_run.endTime.return_value = runEndTime
+            mock_mtd.__getitem__.return_value.getRun.return_value = mock_run
+
+            minPulseTime, maxPulseTime = DateAndTime(self.startTime), DateAndTime(now.isoformat())
+            mock_mtd.__getitem__.return_value.getPulseTimeMin.return_value = minPulseTime
+            mock_mtd.__getitem__.return_value.getPulseTimeMax.return_value = maxPulseTime
+            mock_datetime.datetime.now.return_value = now
+
+            # Break [self.startTime, now] into four chunks:
+            N_chunk = 4
+            dt = (maxPulseTime.to_datetime64() - minPulseTime.to_datetime64()) / (N_chunk + 1)
+            ts = [(minPulseTime.to_datetime64() + n * dt) for n in range(N_chunk + 1)]
+            chunkIntervals = [(ts[n], ts[n + 1]) for n in range(N_chunk)]
+
+            actual = LoadLiveDataInterval._noDataGaps(intervals=chunkIntervals)
+
+            assert actual
+
+    def test__noDataGaps_chunk_intervals_no_gap_out_of_order(self):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "mtd") as mock_mtd,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "datetime") as mock_datetime,
+        ):
+            runStartTime = DateAndTime(
+                (datetime.datetime.fromisoformat(self.startTime) - timedelta(minutes=10)).isoformat()
+            )
+            runEndTime = DateAndTime(now.isoformat())
+            mock_run = mock.Mock(spec=Run)
+            mock_run.startTime.return_value = runStartTime
+            mock_run.endTime.return_value = runEndTime
+            mock_mtd.__getitem__.return_value.getRun.return_value = mock_run
+
+            minPulseTime, maxPulseTime = DateAndTime(self.startTime), DateAndTime(now.isoformat())
+            mock_mtd.__getitem__.return_value.getPulseTimeMin.return_value = minPulseTime
+            mock_mtd.__getitem__.return_value.getPulseTimeMax.return_value = maxPulseTime
+            mock_datetime.datetime.now.return_value = now
+
+            # Break [self.startTime, now] into four chunks:
+            N_chunk = 4
+            dt = (maxPulseTime.to_datetime64() - minPulseTime.to_datetime64()) / (N_chunk + 1)
+            ts = [(minPulseTime.to_datetime64() + n * dt) for n in range(N_chunk + 1)]
+            chunkIntervals = [(ts[n], ts[n + 1]) for n in range(N_chunk)]
+
+            actual = LoadLiveDataInterval._noDataGaps(intervals=[chunkIntervals[n] for n in (0, 3, 1, 2)])
+
+            assert actual
+
+    def test__noDataGaps_chunk_intervals_with_gap(self):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "mtd") as mock_mtd,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "datetime") as mock_datetime,
+        ):
+            runStartTime = DateAndTime(
+                (datetime.datetime.fromisoformat(self.startTime) - timedelta(minutes=10)).isoformat()
+            )
+            runEndTime = DateAndTime(now.isoformat())
+            mock_run = mock.Mock(spec=Run)
+            mock_run.startTime.return_value = runStartTime
+            mock_run.endTime.return_value = runEndTime
+            mock_mtd.__getitem__.return_value.getRun.return_value = mock_run
+
+            minPulseTime, maxPulseTime = DateAndTime(self.startTime), DateAndTime(now.isoformat())
+            mock_mtd.__getitem__.return_value.getPulseTimeMin.return_value = minPulseTime
+            mock_mtd.__getitem__.return_value.getPulseTimeMax.return_value = maxPulseTime
+            mock_datetime.datetime.now.return_value = now
+
+            # Break [self.startTime, now] into four chunks:
+            N_chunk = 4
+            dt = (maxPulseTime.to_datetime64() - minPulseTime.to_datetime64()) / (N_chunk + 1)
+            ts = [(minPulseTime.to_datetime64() + n * dt) for n in range(N_chunk + 1)]
+            chunkIntervals = [(ts[n], ts[n + 1]) for n in range(N_chunk)]
+
+            actual = LoadLiveDataInterval._noDataGaps(
+                # dt #2 is missing
+                intervals=[chunkIntervals[n] for n in (0, 1, 3)]
+            )
+
+            assert not actual
+
+    def test_exec_child_init(self):
+        mock_LoadLiveData = mock.Mock()
+
+        self.instance.initialize()
+        self._setProperties(
+            self.instance,
+            OutputWorkspace=self.outputWs,
+            StartTime=self.startTime,
+            # bypass `FilterByTime` call: use the default-value for EndTime
+            Instrument=Config["instrument.name"],
+            PreserveEvents=self.preserveEvents,
+        )
+
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(self.instance, "createChildAlgorithm") as mock_createChildAlgorithm,
+            mock.patch.object(self.instance, "mantidSnapper") as mock_snapper,
+            mock.patch.object(self.instance, "isLogging") as mock_isLogging,
+            mock.patch.object(LoadLiveDataInterval, "_loadIsComplete") as mock_loadIsComplete,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_createChildAlgorithm.return_value = mock_LoadLiveData
+
+            mock_chunkWs = mock.Mock()
+            mock_chunkWs.getPulseTimeMin.return_value = DateAndTime(self.startTime)
+            mock_chunkWs.getPulseTimeMax.return_value = DateAndTime(
+                (datetime.datetime.fromisoformat(self.startTime) + timedelta(minutes=15)).isoformat()
+            )
+            mock_chunkIntervals = [
+                (
+                    mock_chunkWs.getPulseTimeMin.return_value.to_datetime64(),
+                    mock_chunkWs.getPulseTimeMax.return_value.to_datetime64(),
+                )
+            ]
+            mock_mtd = mock.MagicMock()
+            mock_mtd.__getitem__.return_value = mock_chunkWs
+            mock_mtd.doesExist.side_effect = lambda ws: ws == mock.sentinel.chunkWs
+            mock_mtd.unique_hidden_name.return_value = mock.sentinel.chunkWs
+            mock_snapper.mtd = mock_mtd
+
+            mock_isLogging.return_value = mock.sentinel.isLogging
+            mock_loadIsComplete.return_value = True
+
+            self.instance.execute()
+            mock_createChildAlgorithm.assert_called_once_with(
+                "LoadLiveData", 0.0, 0.75, self.instance.isLogging.return_value
+            )
+            mock_LoadLiveData.initialize.assert_called_once()
+
+            mock_LoadLiveData.setPropertyValue.assert_any_call("OutputWorkspace", mock.sentinel.chunkWs)
+            mock_LoadLiveData.setProperty.assert_any_call("Instrument", self.instance.getProperty("Instrument").value)
+            mock_LoadLiveData.setProperty.assert_any_call("StartTime", self.instance.getProperty("StartTime").value)
+            mock_LoadLiveData.setProperty.assert_any_call(
+                "PreserveEvents", self.instance.getProperty("PreserveEvents").value
+            )
+            mock_LoadLiveData.setProperty.assert_any_call("AccumulationMethod", "Replace")
+            mock_LoadLiveData.execute.assert_called_once()
+
+            mock_snapper.CloneWorkspace.assert_called_once_with(
+                "replace output workspace", OutputWorkspace=self.outputWs, InputWorkspace=mock.sentinel.chunkWs
+            )
+
+            mock_loadIsComplete.call_count == 2
+            mock_loadIsComplete.assert_any_call(self.outputWs, self.startTime, mock_chunkIntervals)
+
+            mock_snapper.FilterByTime.assert_not_called()
+
+    def test_exec_incomplete_load_warning(self):
+        mock_LoadLiveData = mock.Mock()
+
+        self.instance.initialize()
+        self._setProperties(
+            self.instance,
+            OutputWorkspace=self.outputWs,
+            StartTime=self.startTime,
+            # bypass `FilterByTime` call: use the default-value for EndTime
+            Instrument=Config["instrument.name"],
+            PreserveEvents=self.preserveEvents,
+        )
+
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "logger") as mock_logger,
+            mock.patch.object(self.instance, "createChildAlgorithm") as mock_createChildAlgorithm,
+            mock.patch.object(self.instance, "mantidSnapper") as mock_snapper,
+            mock.patch.object(self.instance, "isLogging") as mock_isLogging,
+            mock.patch.object(LoadLiveDataInterval, "_loadIsComplete") as mock_loadIsComplete,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_createChildAlgorithm.return_value = mock_LoadLiveData
+
+            mock_chunkWs = mock.Mock()
+            mock_chunkWs.getPulseTimeMin.return_value = DateAndTime(self.startTime)
+            mock_chunkWs.getPulseTimeMax.return_value = DateAndTime(
+                (datetime.datetime.fromisoformat(self.startTime) + timedelta(minutes=15)).isoformat()
+            )
+            mock_chunkIntervals = [ # noqa: F841
+                (mock_chunkWs.getPulseTimeMin.return_value, mock_chunkWs.getPulseTimeMax.return_value)
+            ]
+            mock_mtd = mock.MagicMock()
+            mock_mtd.__getitem__.return_value = mock_chunkWs
+            mock_mtd.doesExist.side_effect = lambda ws: ws == mock.sentinel.chunkWs
+            mock_mtd.unique_hidden_name.return_value = mock.sentinel.chunkWs
+            mock_snapper.mtd = mock_mtd
+
+            mock_isLogging.return_value = mock.sentinel.isLogging
+
+            # `<class>._loadIsComplete`:
+            #   * first call checks whether to exit the chunk-loading loap;
+            #   * second call checks after the loop whether or not there was a complete load.
+            mock_loadIsComplete.side_effect = (
+                True,
+                False,
+                RuntimeError("'_loadIsComplete' mock called too many times!"),
+            )
+
+            self.instance.execute()
+            msg = mock_logger.warning.mock_calls[0].args[0]
+            assert "The complete data interval could not be loaded" in msg
+
+    def test_exec_load_timeout(self):
+        mock_LoadLiveData = mock.Mock()
+
+        self.instance.initialize()
+        self._setProperties(
+            self.instance,
+            OutputWorkspace=self.outputWs,
+            StartTime=self.startTime,
+            # bypass `FilterByTime` call: use the default-value for EndTime
+            Instrument=Config["instrument.name"],
+            PreserveEvents=self.preserveEvents,
+        )
+
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "logger") as mock_logger,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "sleep") as mock_sleep,
+            mock.patch.object(self.instance, "createChildAlgorithm") as mock_createChildAlgorithm,
+            mock.patch.object(self.instance, "mantidSnapper") as mock_snapper,
+            mock.patch.object(self.instance, "isLogging") as mock_isLogging,
+            mock.patch.object(LoadLiveDataInterval, "_loadIsComplete") as mock_loadIsComplete,
+            Config_override("liveData.dataLoadTimeout", 10),
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_createChildAlgorithm.return_value = mock_LoadLiveData
+
+            mock_chunkWs = mock.Mock()
+            mock_chunkWs.getPulseTimeMin.return_value = DateAndTime(self.startTime)
+            mock_chunkWs.getPulseTimeMax.return_value = DateAndTime(
+                (datetime.datetime.fromisoformat(self.startTime) + timedelta(minutes=15)).isoformat()
+            )
+            mock_chunkIntervals = [ # noqa: F841
+                (mock_chunkWs.getPulseTimeMin.return_value, mock_chunkWs.getPulseTimeMax.return_value)
+            ]
+            mock_mtd = mock.MagicMock()
+            mock_mtd.__getitem__.return_value = mock_chunkWs
+            mock_mtd.doesExist.side_effect = lambda ws: ws == mock.sentinel.chunkWs
+            mock_mtd.unique_hidden_name.return_value = mock.sentinel.chunkWs
+            mock_snapper.mtd = mock_mtd
+
+            mock_isLogging.return_value = mock.sentinel.isLogging
+
+            mock_loadIsComplete.return_value = False
+            mock_sleep.side_effect = lambda _: None
+
+            self.instance.execute()
+            msg = mock_logger.warning.mock_calls[0].args[0]
+            assert "A timeout occurred during data loading" in msg
+
+    def test_exec_filter_init(self):
+        mock_LoadLiveData = mock.Mock()
+
+        def createChildAlgorithm_(self_, *args, **_kwargs): # noqa: ARG001
+            name = args[0]
+            match name:
+                case "LoadLiveData":
+                    return mock_LoadLiveData
+                case _:
+                    raise RuntimeError(f"'createChildAlgorithm' mock unimplemented for args: '{args}'")
+
+        self.instance.initialize()
+        self._setProperties(
+            self.instance,
+            OutputWorkspace=self.outputWs,
+            StartTime=self.startTime,
+            # trigger the `FilterByTime` call:
+            EndTime=self.endTime,
+            Instrument=Config["instrument.name"],
+            PreserveEvents=self.preserveEvents,
+        )
+
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "logger") as mock_logger, # noqa: F841
+            mock.patch.object(LoadLiveDataInterval, "_createChildAlgorithm") as mock_createChildAlgorithm,
+            mock.patch.object(self.instance, "mantidSnapper") as mock_snapper,
+            mock.patch.object(self.instance, "isLogging") as mock_isLogging,
+            mock.patch.object(LoadLiveDataInterval, "_loadIsComplete") as mock_loadIsComplete,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_createChildAlgorithm.side_effect = createChildAlgorithm_
+
+            mock_chunkWs = mock.Mock()
+            mock_chunkWs.getPulseTimeMin.return_value = DateAndTime(self.startTime)
+            mock_chunkWs.getPulseTimeMax.return_value = DateAndTime(
+                (datetime.datetime.fromisoformat(self.startTime) + timedelta(minutes=15)).isoformat()
+            )
+            mock_chunkIntervals = [ # noqa: F841
+                (mock_chunkWs.getPulseTimeMin.return_value, mock_chunkWs.getPulseTimeMax.return_value)
+            ]
+            mock_mtd = mock.MagicMock()
+            mock_mtd.__getitem__.return_value = mock_chunkWs
+            mock_mtd.doesExist.side_effect = lambda ws: ws == mock.sentinel.chunkWs
+            mock_mtd.unique_hidden_name.return_value = mock.sentinel.chunkWs
+            mock_snapper.mtd = mock_mtd
+
+            mock_isLogging.return_value = mock.sentinel.isLogging
+            mock_loadIsComplete.return_value = True
+
+            self.instance.execute()
+            mock_snapper.CloneWorkspace.assert_called_once_with(
+                "replace output workspace", OutputWorkspace=self.outputWs, InputWorkspace=mock.sentinel.chunkWs
+            )
+
+            mock_snapper.DeleteWorkspace.assert_called_once_with(
+                "delete chunk workspace", Workspace=mock.sentinel.chunkWs
+            )
+
+            mock_snapper.FilterByTime.assert_called_once_with(
+                "filter time interval of output workspace",
+                OutputWorkspace=self.outputWs,
+                InputWorkspace=self.outputWs,
+                AbsoluteStartTime=self.startTime,
+                AbsoluteStopTime=self.endTime,
+            )
+            assert mock_snapper.executeQueue.call_count == 3
+
+    def test_exec_filter(self):
+        # For this test, the complete interval will be loaded at once.
+        mock_LoadLiveData = self._mockLoadLiveData((self.fullWs,))
+
+        def createChildAlgorithm_(self_, *args, **_kwargs): # noqa: ARG001
+            name = args[0]
+            match name:
+                case "LoadLiveData":
+                    return mock_LoadLiveData
+                case _:
+                    raise RuntimeError(f"'createChildAlgorithm' mock unimplemented for args: '{args}'")
+
+        # Set the interval start and end times so that they are _within_ the sample-workspace interval.
+        requiredStartTime = DateAndTime(
+            (datetimeFromLogTime(self.sampleRunInterval[0]) + timedelta(minutes=15)).isoformat()
+        ).to_datetime64()
+        requiredEndTime = DateAndTime(
+            (datetimeFromLogTime(self.sampleRunInterval[1]) - timedelta(minutes=15)).isoformat()
+        ).to_datetime64()
+
+        self.instance.initialize()
+        self._setProperties(
+            self.instance,
+            OutputWorkspace=self.outputWs,
+            StartTime=str(DateAndTime(requiredStartTime)),
+            EndTime=str(DateAndTime(requiredEndTime)),
+            Instrument=Config["instrument.name"],
+            PreserveEvents=self.preserveEvents,
+        )
+
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(LoadLiveDataInterval, "_createChildAlgorithm") as mock_createChildAlgorithm,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "datetime") as mock_datetime,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "sleep") as mock_sleep,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_createChildAlgorithm.side_effect = createChildAlgorithm_
+
+            # `datetime.now` is used to determine the load-complete interval end time.
+            mock_datetime.datetime.now.return_value = datetimeFromLogTime(self.sampleRunInterval[1])
+            mock_sleep.side_effect = lambda _: None
+
+            self.instance.execute()
+
+            # Verify that the data pulse-time interval of the output workspace is correct.
+            ws = mtd[self.outputWs]
+            assert LoadLiveDataInterval._compareIntervalEndpoints(
+                requiredStartTime,
+                requiredEndTime,
+                ws.getPulseTimeMin().to_datetime64(),
+                ws.getPulseTimeMax().to_datetime64(),
+                exact=True,
+            )
+
+    def test_exec_forward_chunks(self):
+        # For this test, the interval is loaded as four chunks, moving forwards in time.
+        mock_LoadLiveData = self._mockLoadLiveData(self.chunkWss)
+        mock_FilterByTime = mock.Mock()
+
+        def createChildAlgorithm_(self_, *args, **_kwargs): # noqa: ARG001
+            name = args[0]
+            match name:
+                case "LoadLiveData":
+                    return mock_LoadLiveData
+                case _:
+                    raise RuntimeError(f"'createChildAlgorithm' mock unimplemented for args: '{args}'")
+
+        # Set the start and end times so that no filtering is required.
+        requiredStartTime = self.sampleRunInterval[0]
+        requiredEndTime = self.sampleRunInterval[1]
+
+        self.instance.initialize()
+        self._setProperties(
+            self.instance,
+            OutputWorkspace=self.outputWs,
+            StartTime=str(DateAndTime(requiredStartTime)),
+            # default 'EndTime' is now.
+            Instrument=Config["instrument.name"],
+            PreserveEvents=self.preserveEvents,
+        )
+
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(LoadLiveDataInterval, "_createChildAlgorithm") as mock_createChildAlgorithm,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "datetime") as mock_datetime,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "sleep") as mock_sleep,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_createChildAlgorithm.side_effect = createChildAlgorithm_
+            self.instance.mantidSnapper.FilterByTime = mock_FilterByTime
+
+            # `datetime.now` is used to determine the load-complete interval end time.
+            #  (For this test, this is the same as the `requiredEndTime`, but here we will be explicit.)
+            mock_datetime.datetime.now.return_value = datetimeFromLogTime(self.sampleRunInterval[1])
+            mock_sleep.side_effect = lambda _: None
+
+            self.instance.execute()
+
+            # Verify that the data pulse-time interval of the output workspace is correct:
+            #   this should include the entire run.
+            ws = mtd[self.outputWs]
+            assert LoadLiveDataInterval._compareIntervalEndpoints(
+                requiredStartTime,
+                requiredEndTime,
+                ws.getPulseTimeMin().to_datetime64(),
+                ws.getPulseTimeMax().to_datetime64(),
+                exact=True,
+            )
+
+            # Verify the key 'LoadLiveData' calls:
+            mock_LoadLiveData.setProperty.assert_any_call("AccumulationMethod", "Replace")
+            assert mock_LoadLiveData.execute.call_count == len(self.chunkWss)
+
+            # Verify that no filtering was required:
+            self.instance.mantidSnapper.FilterByTime.assert_not_called()
+
+    def test_exec_backward_chunks(self):
+        # For this test, the interval is loaded as four chunks, moving backwards in time.
+        mock_LoadLiveData = self._mockLoadLiveData(self.chunkWss[-1::-1])
+        mock_FilterByTime = mock.Mock()
+
+        def createChildAlgorithm_(self_, *args, **_kwargs): # noqa: ARG001
+            name = args[0]
+            match name:
+                case "LoadLiveData":
+                    return mock_LoadLiveData
+                case _:
+                    raise RuntimeError(f"'createChildAlgorithm' mock unimplemented for args: '{args}'")
+
+        # Set the start and end times so that no filtering is required.
+        requiredStartTime = self.sampleRunInterval[0]
+        requiredEndTime = self.sampleRunInterval[1]
+
+        self.instance.initialize()
+        self._setProperties(
+            self.instance,
+            OutputWorkspace=self.outputWs,
+            StartTime=str(DateAndTime(requiredStartTime)),
+            # default 'EndTime' is now.
+            Instrument=Config["instrument.name"],
+            PreserveEvents=self.preserveEvents,
+        )
+
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(LoadLiveDataInterval, "_createChildAlgorithm") as mock_createChildAlgorithm,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "datetime") as mock_datetime,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "sleep") as mock_sleep,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_createChildAlgorithm.side_effect = createChildAlgorithm_
+            self.instance.mantidSnapper.FilterByTime = mock_FilterByTime
+
+            # `datetime.now` is used to determine the load-complete interval end time.
+            #  (For this test, this is the same as the `requiredEndTime`, but here we will be explicit.)
+            mock_datetime.datetime.now.return_value = datetimeFromLogTime(self.sampleRunInterval[1])
+            mock_sleep.side_effect = lambda _: None
+
+            self.instance.execute()
+
+            # Verify that the data pulse-time interval of the output workspace is correct:
+            #   this should include the entire run.
+            ws = mtd[self.outputWs]
+            assert LoadLiveDataInterval._compareIntervalEndpoints(
+                requiredStartTime,
+                requiredEndTime,
+                ws.getPulseTimeMin().to_datetime64(),
+                ws.getPulseTimeMax().to_datetime64(),
+                exact=True,
+            )
+
+            # Verify the key 'LoadLiveData' calls:
+            mock_LoadLiveData.setProperty.assert_any_call("AccumulationMethod", "Replace")
+            assert mock_LoadLiveData.execute.call_count == len(self.chunkWss)
+
+            # Verify that no filtering was required:
+            self.instance.mantidSnapper.FilterByTime.assert_not_called()
+
+    def test_exec_scrambled_chunks(self):
+        # For this test, the interval is loaded as four chunks,
+        #   but in a random order so that there's a time-gap in the required interval, prior to its completion.
+
+        mock_LoadLiveData = self._mockLoadLiveData([self.chunkWss[i] for i in (0, 3, 1, 2)])
+        mock_FilterByTime = mock.Mock()
+
+        def createChildAlgorithm_(self_, *args, **_kwargs): # noqa: ARG001
+            name = args[0]
+            match name:
+                case "LoadLiveData":
+                    return mock_LoadLiveData
+                case _:
+                    raise RuntimeError(f"'createChildAlgorithm' mock unimplemented for args: '{args}'")
+
+        # Set the start and end times so that no filtering is required.
+        requiredStartTime = self.sampleRunInterval[0]
+        requiredEndTime = self.sampleRunInterval[1]
+
+        self.instance.initialize()
+        self._setProperties(
+            self.instance,
+            OutputWorkspace=self.outputWs,
+            StartTime=str(DateAndTime(requiredStartTime)),
+            # default 'EndTime' is now.
+            Instrument=Config["instrument.name"],
+            PreserveEvents=self.preserveEvents,
+        )
+
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(LoadLiveDataInterval, "_createChildAlgorithm") as mock_createChildAlgorithm,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "datetime") as mock_datetime,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "sleep") as mock_sleep,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_createChildAlgorithm.side_effect = createChildAlgorithm_
+            self.instance.mantidSnapper.FilterByTime = mock_FilterByTime
+
+            # `datetime.now` is used to determine the load-complete interval end time.
+            #  (For this test, this is the same as the `requiredEndTime`, but here we will be explicit.)
+            mock_datetime.datetime.now.return_value = datetimeFromLogTime(self.sampleRunInterval[1])
+            mock_sleep.side_effect = lambda _: None
+
+            self.instance.execute()
+
+            # Verify that the data pulse-time interval of the output workspace is correct:
+            #   this should include the entire run.
+            ws = mtd[self.outputWs]
+            assert LoadLiveDataInterval._compareIntervalEndpoints(
+                requiredStartTime,
+                requiredEndTime,
+                ws.getPulseTimeMin().to_datetime64(),
+                ws.getPulseTimeMax().to_datetime64(),
+                exact=True,
+            )
+
+            # Verify the key 'LoadLiveData' calls:
+            mock_LoadLiveData.setProperty.assert_any_call("AccumulationMethod", "Replace")
+            assert mock_LoadLiveData.execute.call_count == len(self.chunkWss)
+
+            # Verify that no filtering was required:
+            self.instance.mantidSnapper.FilterByTime.assert_not_called()
+
+    def test_exec_incomplete_load(self):
+        # For this test, the interval is loaded as four chunks, moving backwards in time.
+        mock_LoadLiveData = self._mockLoadLiveData(
+            # Accumulate 70s of wait time, without any complete load.
+            [
+                self.chunkWss[1],
+                self.chunkWss[2],
+                self.chunkWss[1],
+                self.chunkWss[2],
+                self.chunkWss[1],
+                self.chunkWss[2],
+                self.chunkWss[1],
+                self.chunkWss[2],
+            ]
+        )
+        mock_FilterByTime = mock.Mock()
+
+        def createChildAlgorithm_(self_, *args, **_kwargs): # noqa: ARG001
+            name = args[0]
+            match name:
+                case "LoadLiveData":
+                    return mock_LoadLiveData
+                case _:
+                    raise RuntimeError(f"'createChildAlgorithm' mock unimplemented for args: '{args}'")
+
+        # Set the start and end times so that no filtering is required.
+        requiredStartTime = self.sampleRunInterval[0]
+        requiredEndTime = self.sampleRunInterval[1] # noqa: F841
+
+        self.instance.initialize()
+        self._setProperties(
+            self.instance,
+            OutputWorkspace=self.outputWs,
+            StartTime=str(DateAndTime(requiredStartTime)),
+            # default 'EndTime' is now.
+            Instrument=Config["instrument.name"],
+            PreserveEvents=self.preserveEvents,
+        )
+
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "logger") as mock_logger,
+            mock.patch.object(LoadLiveDataInterval, "_createChildAlgorithm") as mock_createChildAlgorithm,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "datetime") as mock_datetime,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "sleep") as mock_sleep,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_createChildAlgorithm.side_effect = createChildAlgorithm_
+            self.instance.mantidSnapper.FilterByTime = mock_FilterByTime
+
+            # `datetime.now` is used to determine the load-complete interval end time.
+            #  (For this test, this is the same as the `requiredEndTime`, but here we will be explicit.)
+            mock_datetime.datetime.now.return_value = datetimeFromLogTime(self.sampleRunInterval[1])
+            mock_sleep.side_effect = lambda _: None
+
+            self.instance.execute()
+
+            # Check that the correct warnings were logged.
+            msg = mock_logger.warning.mock_calls[0].args[0]
+            assert "A timeout occurred during data loading." in msg
+            msg = mock_logger.warning.mock_calls[1].args[0]
+            assert "The complete data interval could not be loaded" in msg
+
+            # Verify the key 'LoadLiveData' calls:
+            mock_LoadLiveData.setProperty.assert_any_call("AccumulationMethod", "Replace")
+            assert mock_LoadLiveData.execute.call_count == 7  # 10s wait per call => 60s timeout.
+
+            # Verify that no filtering was required:
+            mock_FilterByTime.execute.assert_not_called()

--- a/tests/unit/backend/recipe/algorithm/test_LoadLiveDataInterval.py
+++ b/tests/unit/backend/recipe/algorithm/test_LoadLiveDataInterval.py
@@ -628,7 +628,7 @@ class TestLoadLiveDataInterval(unittest.TestCase):
             mock_chunkWs.getPulseTimeMax.return_value = DateAndTime(
                 (datetime.datetime.fromisoformat(self.startTime) + timedelta(minutes=15)).isoformat()
             )
-            mock_chunkIntervals = [ # noqa: F841
+            mock_chunkIntervals = [  # noqa: F841
                 (mock_chunkWs.getPulseTimeMin.return_value, mock_chunkWs.getPulseTimeMax.return_value)
             ]
             mock_mtd = mock.MagicMock()
@@ -683,7 +683,7 @@ class TestLoadLiveDataInterval(unittest.TestCase):
             mock_chunkWs.getPulseTimeMax.return_value = DateAndTime(
                 (datetime.datetime.fromisoformat(self.startTime) + timedelta(minutes=15)).isoformat()
             )
-            mock_chunkIntervals = [ # noqa: F841
+            mock_chunkIntervals = [  # noqa: F841
                 (mock_chunkWs.getPulseTimeMin.return_value, mock_chunkWs.getPulseTimeMax.return_value)
             ]
             mock_mtd = mock.MagicMock()
@@ -704,7 +704,7 @@ class TestLoadLiveDataInterval(unittest.TestCase):
     def test_exec_filter_init(self):
         mock_LoadLiveData = mock.Mock()
 
-        def createChildAlgorithm_(self_, *args, **_kwargs): # noqa: ARG001
+        def createChildAlgorithm_(self_, *args, **_kwargs):  # noqa: ARG001
             name = args[0]
             match name:
                 case "LoadLiveData":
@@ -725,7 +725,7 @@ class TestLoadLiveDataInterval(unittest.TestCase):
 
         with (
             mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
-            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "logger") as mock_logger, # noqa: F841
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "logger") as mock_logger,  # noqa: F841
             mock.patch.object(LoadLiveDataInterval, "_createChildAlgorithm") as mock_createChildAlgorithm,
             mock.patch.object(self.instance, "mantidSnapper") as mock_snapper,
             mock.patch.object(self.instance, "isLogging") as mock_isLogging,
@@ -739,7 +739,7 @@ class TestLoadLiveDataInterval(unittest.TestCase):
             mock_chunkWs.getPulseTimeMax.return_value = DateAndTime(
                 (datetime.datetime.fromisoformat(self.startTime) + timedelta(minutes=15)).isoformat()
             )
-            mock_chunkIntervals = [ # noqa: F841
+            mock_chunkIntervals = [  # noqa: F841
                 (mock_chunkWs.getPulseTimeMin.return_value, mock_chunkWs.getPulseTimeMax.return_value)
             ]
             mock_mtd = mock.MagicMock()
@@ -773,7 +773,7 @@ class TestLoadLiveDataInterval(unittest.TestCase):
         # For this test, the complete interval will be loaded at once.
         mock_LoadLiveData = self._mockLoadLiveData((self.fullWs,))
 
-        def createChildAlgorithm_(self_, *args, **_kwargs): # noqa: ARG001
+        def createChildAlgorithm_(self_, *args, **_kwargs):  # noqa: ARG001
             name = args[0]
             match name:
                 case "LoadLiveData":
@@ -829,7 +829,7 @@ class TestLoadLiveDataInterval(unittest.TestCase):
         mock_LoadLiveData = self._mockLoadLiveData(self.chunkWss)
         mock_FilterByTime = mock.Mock()
 
-        def createChildAlgorithm_(self_, *args, **_kwargs): # noqa: ARG001
+        def createChildAlgorithm_(self_, *args, **_kwargs):  # noqa: ARG001
             name = args[0]
             match name:
                 case "LoadLiveData":
@@ -891,7 +891,7 @@ class TestLoadLiveDataInterval(unittest.TestCase):
         mock_LoadLiveData = self._mockLoadLiveData(self.chunkWss[-1::-1])
         mock_FilterByTime = mock.Mock()
 
-        def createChildAlgorithm_(self_, *args, **_kwargs): # noqa: ARG001
+        def createChildAlgorithm_(self_, *args, **_kwargs):  # noqa: ARG001
             name = args[0]
             match name:
                 case "LoadLiveData":
@@ -955,7 +955,7 @@ class TestLoadLiveDataInterval(unittest.TestCase):
         mock_LoadLiveData = self._mockLoadLiveData([self.chunkWss[i] for i in (0, 3, 1, 2)])
         mock_FilterByTime = mock.Mock()
 
-        def createChildAlgorithm_(self_, *args, **_kwargs): # noqa: ARG001
+        def createChildAlgorithm_(self_, *args, **_kwargs):  # noqa: ARG001
             name = args[0]
             match name:
                 case "LoadLiveData":
@@ -1029,7 +1029,7 @@ class TestLoadLiveDataInterval(unittest.TestCase):
         )
         mock_FilterByTime = mock.Mock()
 
-        def createChildAlgorithm_(self_, *args, **_kwargs): # noqa: ARG001
+        def createChildAlgorithm_(self_, *args, **_kwargs):  # noqa: ARG001
             name = args[0]
             match name:
                 case "LoadLiveData":
@@ -1039,7 +1039,7 @@ class TestLoadLiveDataInterval(unittest.TestCase):
 
         # Set the start and end times so that no filtering is required.
         requiredStartTime = self.sampleRunInterval[0]
-        requiredEndTime = self.sampleRunInterval[1] # noqa: F841
+        requiredEndTime = self.sampleRunInterval[1]  # noqa: F841
 
         self.instance.initialize()
         self._setProperties(

--- a/tests/unit/backend/recipe/algorithm/test_LoadLiveDataInterval.py
+++ b/tests/unit/backend/recipe/algorithm/test_LoadLiveDataInterval.py
@@ -731,13 +731,13 @@ class TestLoadLiveDataInterval(unittest.TestCase):
             mock_chunkWs.getPulseTimeMax.return_value = DateAndTime(
                 (datetime.datetime.fromisoformat(self.startTime) + timedelta(minutes=15)).isoformat()
             )
-            
+
             # Force a run-state change during the chunk-assembly loop:
             # * Note that there's no separate log message for this case,
             #   which is not an error.  When required, the state-change will be logged elsewhere.
             # * In the case of the present test however, the assembled data-interval will be incomplete.
             mock_chunkWs.getRunNumber.side_effect = ("12345", "12345", 0)
-            
+
             mock_chunkIntervals = [  # noqa: F841
                 (mock_chunkWs.getPulseTimeMin.return_value, mock_chunkWs.getPulseTimeMax.return_value)
             ]

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -147,29 +147,29 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
 
     @mock.patch("snapred.backend.recipe.FetchGroceriesRecipe.logger")
     @mock.patch("snapred.backend.recipe.FetchGroceriesRecipe.FetchGroceriesAlgorithm")
-    def test_fetch_logging_LoadLiveData(self, mockAlgo, mockLogger):
+    def test_fetch_logging_LoadLiveDataInterval(self, mockAlgo, mockLogger):
         """Test that fetch logs correct source: live data"""
         mock_instance = mockAlgo.return_value
         mock_instance.execute.return_value = "data"
-        mock_instance.getPropertyValue.return_value = "LoadLiveData"
+        mock_instance.getPropertyValue.return_value = "LoadLiveDataInterval"
 
         self.clearoutWorkspaces()
-        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadLiveData")
+        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadLiveDataInterval")
         mockLogger.info.assert_called_with(f"Fetching live data into {res['workspace']}")
         mockLogger.debug.assert_called_with(f"Finished fetching {res['workspace']} from live-data listener")
 
     @mock.patch("snapred.backend.recipe.FetchGroceriesRecipe.FetchGroceriesAlgorithm")
-    def test_fetch_with_LoadLiveData(self, mockAlgo):
-        """Test fetch method with LoadLiveData loader"""
+    def test_fetch_with_LoadLiveDataInterval(self, mockAlgo):
+        """Test fetch method with LoadLiveDataInterval loader"""
         mock_instance = mockAlgo.return_value
         mock_instance.execute.return_value = "data"
-        mock_instance.getPropertyValue.return_value = "LoadLiveData"
+        mock_instance.getPropertyValue.return_value = "LoadLiveDataInterval"
 
         self.clearoutWorkspaces()
-        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadLiveData")
+        res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadLiveDataInterval")
         assert len(res) > 0
         assert res["result"]
-        assert res["loader"] == "LoadLiveData"
+        assert res["loader"] == "LoadLiveDataInterval"
         assert res["workspace"] == self.fetchedWSname
 
     def test_fetch_failed(self):

--- a/tests/util/InstaEats.py
+++ b/tests/util/InstaEats.py
@@ -168,7 +168,7 @@ class InstaEats(GroceryService):
 
         # Live-data mode can be requested explicitly,
         #   but it also serves as the fallback mode.
-        liveDataMode = loader == "LoadLiveData" or liveDataArgs is not None
+        liveDataMode = loader == "LoadLiveDataInterval" or liveDataArgs is not None
 
         success = False
         convertToLiteMode = False
@@ -242,12 +242,11 @@ class InstaEats(GroceryService):
                 loaderArgs = {
                     "Facility": Config["liveData.facility.name"],
                     "Instrument": Config["liveData.instrument.name"],
-                    "AccumulationMethod": Config["liveData.accumulationMethod"],
                     "PreserveEvents": True,
                     "StartTime": startTime,
                 }
                 data = self.grocer.executeRecipe(
-                    workspace=nativeRawWorkspaceName, loader="LoadLiveData", loaderArgs=json.dumps(loaderArgs)
+                    workspace=nativeRawWorkspaceName, loader="LoadLiveDataInterval", loaderArgs=json.dumps(loaderArgs)
                 )
                 if data["result"]:
                     # For `InstaEats` purposes: here we are never going to trigger this case:


### PR DESCRIPTION
## Description of work

A live-data request to the ADARA reader may include a start time, and the meaning of such a request is to receive data from that start time to the present time. The reader responds to this request by returning data in workspaces, one chunk at a time.  In the most common scenario, this single chunk will consist of the entire data time-interval. This particular scenario corresponds to the case for which SNAPRed's live-data system was originally implemented.

Depending on its load, the ADARA reader may also return a series of chunks, starting from the earlier time-point.  Unfortunately, the reader may also return out-of-order chunks.  These latter two cases are dealt with by the new implementation.

## Explanation of work

This commit includes the following changes:

  * Implementation of a new Algorithm: `LoadLiveDataInterval`.  This algorithm serves as a drop-in replacement for `LoadLiveData`. This algorithm allows the specification of a data time-interval: as a 'StartTime' followed by an optional 'EndTime'.  The purpose of this algorithm is to obtain and assemble chunks of data, and to guarantee that the final assembly covers the complete time-interval.  Optionally, this algorithm also allows time-filtering of this assembled data, thereby providing any requested sub-interval from the time-interval of the active run.

  * The algorithm recognizes its output workspace as complete when the pulse-times of the event data span the requested time interval.  In addition, there should be chunk-to-chunk gaps within this interval.  All time comparisons are implemented to an accuracy of `Config["liveData.time_comparison_threshold"]`.

  * The algorithm waits `Config["liveData.chunkWait"]` seconds, between the loading of each chunk, up to a maximum accumulated wait time of `Config["liveData.dataLoadTimeout"]`.  Note that in general, the ADARA reader seems to return about 2-minutes of data per chunk, and it can be quite fast, so `Config["liveData.chunkWait"]` only needs to be a few seconds or so.  Since a run may consist of _hours_ of data, the corresponding setting of `Config["liveData.dataLoadTimeout"]` needs to take this into account.

  * Both `LoadLiveDataInterval` and `LoadLiveData` now share the same non-re-entrant mutex in `MantidSnapper`.

  * The implementation of `LoadLiveDataInterval` additionally creates an instance of `LoadLiveData` using `<Algorithm>.createChildAlgorithm`.  This is critically important in order to assure that this instance has the correct lifetime, and that it is deleted when its parent is deleted.  When this is not done correctly, mantidworkbench SEGFAULTs at exit.

  * Extensive unit tests for the new algorithm.

Defects fixed:

  * 'GroceryService' 'liveDataArgs.duration != timedelta(0)'. Previously this was 'liveDataArgs.duration != 0' which erroneously _always_ evaluates to `True`.

  *  Add an automatic correction when 'ADARA_FileReader' is in use to adjust the requested start-time to match that of the data workspace.  This is a work-around, as the "ADARA_FileReader" really needs to be fixed so that time data it returns has better correspondence to that returned by the ADARA listener.

## To test

### Dev testing

Unit tests have been added to exercise the features of the new algorithm.  The standard method of testing the live-data system using the fake `ADARA_FileReader` does work with these changes, but it isn't particularly useful as it doesn't present its data chunks in terms of time intervals.  (This is a major limitation of the fake listener, and it needs to be fixed.)

**Important reminder: when testing with the actual ADARA reader (e.g. on analysis):  do NOT enable DEBUG-level logging** -- this will lock up mantidworkbench.   (The problem is that in this case, the `SNSLiveListener` spams the logs, and does not follow the `Algorithm` logging conventions.) 

### CIS testing

This works the same way as the previous live-data system.  There should be no visible changes except that loading will work as it should have, and unfortunately, now it may take a bit longer -- it's useful to use the slider to _reduce_ the loading interval from the entire active run.

Please be aware of the following settings in `application.yml`:

```
liveData:
  enabled: true
  # Maximum accumulated wait time during the load of a live-data interval:
  #    note that the maximum number of chunks you can load before timeout is
  #    dataLoadTimeout / chunkLoadWait  .
  dataLoadTimeout: 120 # seconds
  chunkLoadWait: 3 # seconds
  
  # Comparison threshold for the data pulse-time interval.
  time_comparison_threshold: 10 # seconds
```

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#11210](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=11210)


<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria
Note that the original solution proposed in the description (at the defect) is _not_ the approach taken here.  Unfortunately that solution would not have worked correctly in support of the "live-data fallback" feature.