### PR TITLE
make the crosscor workspace visiblie again and hide it after tweak pe…

### DIFF
--- a/src/snapred/backend/recipe/PixelDiffCalRecipe.py
+++ b/src/snapred/backend/recipe/PixelDiffCalRecipe.py
@@ -334,7 +334,7 @@ class PixelDiffCalRecipe(Recipe[Ingredients]):
         logger.info(f"Pixel calibration converged.  Offsets: {self.medianOffsets}")
 
         # create for inspection
-        outputWorkspace = f"__{self.wsDSP}_afterCrossCor"
+        outputWorkspace = f"{self.wsDSP}_afterCrossCor"
         self.convertUnitsAndRebin(self.wsTOF, outputWorkspace)
         self.mantidSnapper.DeleteWorkspace(
             "Deleting tof workspace",

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -19,6 +19,7 @@ from snapred.backend.dao.request import (
     RunMetadataRequest,
     SimpleDiffCalRequest,
 )
+from snapred.backend.dao.request.RenameWorkspaceRequest import RenameWorkspaceRequest
 from snapred.backend.dao.SNAPResponse import ResponseCode, SNAPResponse
 from snapred.backend.error.ContinueWarning import ContinueWarning
 from snapred.backend.log.logger import snapredLogger
@@ -617,6 +618,12 @@ class DiffCalWorkflow(WorkflowImplementer):
         response = self.request(path="calibration/assessment", payload=payload)
         assessmentResponse = response.data
         self.calibrationRecord = assessmentResponse.record
+
+        # rename self.pixelCalibratedWorkspace
+        renameRequest = RenameWorkspaceRequest(
+            oldName=self.pixelCalibratedWorkspace, newName=f"__{self.pixelCalibratedWorkspace}"
+        )
+        self.request(path="workspace/rename", payload=renameRequest)
 
         self.outputs.update(assessmentResponse.metricWorkspaces)
         for calibrationWorkspaces in self.calibrationRecord.workspaces.values():


### PR DESCRIPTION
…ak/calibration finishes

## Description of work

This just makes the aftercrosscorr workspace visible again in calibration, and hides it after tweak peaks. 

## To test

Run Calibration and observe the workspace and when it vanishes.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#11327](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=11327)

### Verification

- [ ] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] 1. the workspaces dsp_{run}_raw_beforeCrossCor and dsp_{run}_raw_afterCrossCor are both be visible at the same time at the inspection point between pixel calibration and group calibration. This allows the user to assess if the pixel calibration worked.
- [ ] 2. After difcal completes dsp_{run}_raw_beforeCrossCor is deleted: THIS IS CORRECT
- [ ] 3. After difcal completes dsp_{run}_raw_afterCrossCor is retained, but hidden: THIS IS ALSO CORRECT
