### PR TITLE
Use `DiffractionFocussing` with 'FullBinsOnly' in `FocusSpectraAlgorithm`

### DIFF
--- a/src/snapred/backend/dao/RunMetadata.py
+++ b/src/snapred/backend/dao/RunMetadata.py
@@ -49,8 +49,8 @@ class RunMetadata(BaseModel, Mapping):
 
     runTitle: str
 
-    startTime: datetime
-    endTime: datetime
+    startTime: datetime.datetime
+    endTime: datetime.datetime
 
     protonCharge: float
 

--- a/src/snapred/backend/dao/ingredients/ReductionGroupProcessingIngredients.py
+++ b/src/snapred/backend/dao/ingredients/ReductionGroupProcessingIngredients.py
@@ -5,6 +5,7 @@ from snapred.backend.dao.state.PixelGroup import PixelGroup
 
 class ReductionGroupProcessingIngredients(BaseModel):
     pixelGroup: PixelGroup
+    preserveEvents: bool
 
     model_config = ConfigDict(
         extra="forbid",

--- a/src/snapred/backend/dao/ingredients/ReductionIngredients.py
+++ b/src/snapred/backend/dao/ingredients/ReductionIngredients.py
@@ -51,7 +51,7 @@ class ReductionIngredients(BaseModel):
         return self.detectorPeaksMany[groupingIndex]
 
     def groupProcessing(self, groupingIndex: int) -> ReductionGroupProcessingIngredients:
-        return ReductionGroupProcessingIngredients(pixelGroup=self.pixelGroups[groupingIndex])
+        return ReductionGroupProcessingIngredients(pixelGroup=self.pixelGroups[groupingIndex], preserveEvents=False)
 
     def generateFocussedVanadium(self, groupingIndex: int) -> GenerateFocussedVanadiumIngredients:
         return GenerateFocussedVanadiumIngredients(

--- a/src/snapred/backend/dao/request/FocusSpectraRequest.py
+++ b/src/snapred/backend/dao/request/FocusSpectraRequest.py
@@ -9,6 +9,7 @@ class FocusSpectraRequest(BaseModel):
     runNumber: str
     useLiteMode: bool
     focusGroup: FocusGroup
+    preserveEvents: bool
 
     inputWorkspace: str
     groupingWorkspace: str

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -283,11 +283,7 @@ class GroceryService:
 
     @validate_call
     def _lookupNormalizationWorkspaceFilename(
-        self,
-        normcalRunNumber: str,
-        useLiteMode: bool,
-        version: Optional[int],
-        state: str
+        self, normcalRunNumber: str, useLiteMode: bool, version: Optional[int], state: str
     ) -> str:
         # NOTE: The normCal Record currently does NOT store workspace type -> workspace name mappings.
         #       It is just a list of workspace names. So we need to infer.

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -2,6 +2,7 @@ import copy
 import datetime
 import glob
 import json
+import numpy as np
 import os
 import re
 import shutil
@@ -15,7 +16,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 from urllib.parse import urlparse
 
 import h5py
-from mantid.api import Run
+from mantid.api import IEventWorkspace, Run
 from mantid.dataobjects import MaskWorkspace
 from mantid.kernel import ConfigService, PhysicalConstants
 from pydantic import validate_call
@@ -676,12 +677,31 @@ class LocalDataService:
         Record must be set with correct version and workspace names must be finalized.
         -- assumes that `writeNormalizationRecord` has already been called, and that the version folder exists
         """
-        state, _ = self.generateStateId(record.runNumber)
-        indexer = self.normalizationIndexer(record.useLiteMode, state)
+        instrumentState = self.generateInstrumentState(record.runNumber)
+        indexer = self.normalizationIndexer(record.useLiteMode, instrumentState.id.hex)
         normalizationDataPath: Path = indexer.versionPath(record.version)
         if not normalizationDataPath.exists():
             normalizationDataPath.mkdir(parents=True, exist_ok=True)
+
         for workspace in record.workspaceNames:
+            ws = self.mantidSnapper.mtd[workspace]
+            if Config["nexus.dataFormat.event"] and isinstance(ws, IEventWorkspace):
+                # Remove binning from any event workspaces in order to speed-up reload:
+                #    (XMin, XMax, Delta) == (NaN, NaN, <outer bound>) will create a single bin
+                #    [<actual minimum>, <actual maximum>]
+                TOFOuterBound = instrumentState.particleBounds.tof.maximum * 10.0
+                numberOfSpectra = ws.getNumberHistograms()
+                self.mantidSnapper.RebinRagged(
+                    "strip binning info, before saving normalization workspace",
+                    OutputWorkspace=workspace,
+                    InputWorkspace=workspace,
+                    XMin=list((np.nan,) * numberOfSpectra),
+                    XMax=list((np.nan,) * numberOfSpectra),
+                    Delta=list((TOFOuterBound,) * numberOfSpectra),
+                    PreserveEvents=True
+                )
+                self.mantidSnapper.executeQueue()
+                            
             filename = Path(workspace + ".nxs")
             self.writeWorkspace(normalizationDataPath, filename, workspace)
 

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -2,7 +2,6 @@ import copy
 import datetime
 import glob
 import json
-import numpy as np
 import os
 import re
 import shutil
@@ -16,6 +15,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 from urllib.parse import urlparse
 
 import h5py
+import numpy as np
 from mantid.api import IEventWorkspace, Run
 from mantid.dataobjects import MaskWorkspace
 from mantid.kernel import ConfigService, PhysicalConstants
@@ -698,10 +698,10 @@ class LocalDataService:
                     XMin=list((np.nan,) * numberOfSpectra),
                     XMax=list((np.nan,) * numberOfSpectra),
                     Delta=list((TOFOuterBound,) * numberOfSpectra),
-                    PreserveEvents=True
+                    PreserveEvents=True,
                 )
                 self.mantidSnapper.executeQueue()
-                            
+
             filename = Path(workspace + ".nxs")
             self.writeWorkspace(normalizationDataPath, filename, workspace)
 

--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -23,7 +23,7 @@ class FetchGroceriesRecipe:
         instrumentPropertySource=None,
         instrumentSource="",
         *,
-        loaderArgs: str = "",
+        loaderArgs: str = "{}",
     ) -> Dict[str, Any]:
         """
         Wraps the fetch groceries algorithm

--- a/src/snapred/backend/recipe/GenerateFocussedVanadiumRecipe.py
+++ b/src/snapred/backend/recipe/GenerateFocussedVanadiumRecipe.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, List, Set, Tuple
 
 from snapred.backend.dao.ingredients import GenerateFocussedVanadiumIngredients as Ingredients
 from snapred.backend.log.logger import snapredLogger
-from snapred.backend.recipe.RebinFocussedGroupDataRecipe import RebinFocussedGroupDataRecipe
 from snapred.backend.recipe.Recipe import Recipe
 
 logger = snapredLogger.getLogger(__name__)
@@ -61,20 +60,13 @@ class GenerateFocussedVanadiumRecipe(Recipe[Ingredients]):
             SmoothingParameter=self.smoothingParameter,
         )
 
-    def _rebinInputWorkspace(self):
-        """
-        Rebins the input workspace to the pixel group.
-        """
-        rebinRecipe = RebinFocussedGroupDataRecipe(self.utensils)
-        rebinIngredients = RebinFocussedGroupDataRecipe.Ingredients(pixelGroup=self.pixelGroup)
-        rebinRecipe.cook(rebinIngredients, {"inputWorkspace": self.inputWS})
-
     def queueAlgos(self):
         """
-        Queues up the procesing algorithms for the recipe.
+        Queues up the processing algorithms for the recipe.
         Requires: unbagged groceries.
         """
-        self._rebinInputWorkspace()
+        # Note: rebinning of the input workspace is no longer required here.
+        #   After `ReductionGroupProcessing`, the workspace will already have optimal ragged binning.
 
         if self.artificialNormalizationIngredients is not None:
             self.queueArtificialNormalization()

--- a/src/snapred/backend/recipe/GroupDiffCalRecipe.py
+++ b/src/snapred/backend/recipe/GroupDiffCalRecipe.py
@@ -81,9 +81,7 @@ class GroupDiffCalRecipe(Recipe[Ingredients]):
         self.runNumber: str = ingredients.runConfig.runNumber
 
         # from grouping parameters, read the overall min/max d-spacings
-        self.dMin = ingredients.pixelGroup.dMin()
-        self.dMax = ingredients.pixelGroup.dMax()
-        self.dBin = ingredients.pixelGroup.dBin()
+        self.pixelGroup = ingredients.pixelGroup
 
         self.grouping = ingredients.pixelGroup.focusGroup.name
 
@@ -325,24 +323,14 @@ class GroupDiffCalRecipe(Recipe[Ingredients]):
             Target="dSpacing",
         )
 
-        # Diffraction-focus the d-spacing data
-        self.mantidSnapper.DiffractionFocussing(
+        # Diffraction focus, and rebin the d-spacing data.
+        self.mantidSnapper.FocusSpectraAlgorithm(
             "Diffraction-focus the d-spacing data",
             InputWorkspace=tmpWSdsp,
             GroupingWorkspace=self.focusWS,
             OutputWorkspace=tmpWSdsp,
-        )
-
-        # Ragged rebin the diffraction-focussed data
-        self.mantidSnapper.RebinRagged(
-            "Ragged rebin the diffraction-focussed data",
-            InputWorkspace=tmpWSdsp,
-            OutputWorkspace=tmpWSdsp,
-            XMin=self.dMin,
-            XMax=self.dMax,
-            Delta=self.dBin,
-            preserveEvents=keepEvents,
-            FullBinsOnly=True,
+            PixelGroup=self.pixelGroup.model_dump_json(),
+            PreserveEvents=keepEvents,
         )
 
         if units == "TOF":

--- a/src/snapred/backend/recipe/RebinFocussedGroupDataRecipe.py
+++ b/src/snapred/backend/recipe/RebinFocussedGroupDataRecipe.py
@@ -56,7 +56,7 @@ class RebinFocussedGroupDataRecipe(Recipe[Ingredients]):
 
     def queueAlgos(self):
         """
-        Queues up the procesing algorithms for the recipe.
+        Queues up the processing algorithms for the recipe.
         Requires: unbagged groceries and chopped ingredients.
         """
         self.mantidSnapper.RebinRagged(

--- a/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
+++ b/src/snapred/backend/recipe/ReductionGroupProcessingRecipe.py
@@ -27,6 +27,7 @@ class ReductionGroupProcessingRecipe(Recipe[Ingredients]):
 
     def chopIngredients(self, ingredients):
         self.pixelGroup = ingredients.pixelGroup
+        self.preserveEvents = ingredients.preserveEvents
         logger.debug(f"dMin: {self.pixelGroup.dMin()}")
         logger.debug(f"dMax: {self.pixelGroup.dMax()}")
         logger.debug(f"dBin: {self.pixelGroup.dBin()}")
@@ -59,8 +60,8 @@ class ReductionGroupProcessingRecipe(Recipe[Ingredients]):
             InputWorkspace=self.rawInput,
             OutputWorkspace=self.outputWS,
             GroupingWorkspace=self.groupingWS,
-            PixelGroup=self.pixelGroup.json(),
-            RebinOutput=True,
+            PixelGroup=self.pixelGroup.model_dump_json(),
+            PreserveEvents=self.preserveEvents,
         )
 
         normalizeArgs = {

--- a/src/snapred/backend/recipe/ReductionRecipe.py
+++ b/src/snapred/backend/recipe/ReductionRecipe.py
@@ -267,7 +267,6 @@ class ReductionRecipe(Recipe[Ingredients]):
         )
 
         if self.normalizationWs:
-            # Temporarily convert the normalization workspace to d-spacing
             self.mantidSnapper.ConvertUnits(
                 "Converting normalization data to d-spacing",
                 InputWorkspace=self.normalizationWs,

--- a/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
@@ -161,10 +161,7 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
             match loaderType:
                 case "":
                     _, loaderType, _ = self.mantidSnapper.Load(
-                        "Loading with unspecified loader",
-                        Filename=filename,
-                        OutputWorkspace=outWS,
-                        **loaderArgs
+                        "Loading with unspecified loader", Filename=filename, OutputWorkspace=outWS, **loaderArgs
                     )
                 case "LoadCalibrationWorkspaces":
                     self.mantidSnapper.LoadCalibrationWorkspaces(
@@ -194,10 +191,7 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
                     )
                 case _:
                     getattr(self.mantidSnapper, loaderType)(
-                        f"Loading data using {loaderType}",
-                        Filename=filename,
-                        OutputWorkspace=outWS,
-                        **loaderArgs
+                        f"Loading data using {loaderType}", Filename=filename, OutputWorkspace=outWS, **loaderArgs
                     )
 
             self.mantidSnapper.executeQueue()

--- a/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
@@ -65,7 +65,7 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
         )
         self.declareProperty(
             "LoaderArgs",
-            defaultValue="",
+            defaultValue="{}",
             direction=Direction.Input,
             doc="loader keyword args (JSON format)",
         )
@@ -104,8 +104,11 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
         if loader in ["LoadCalibrationWorkspaces", "LoadLiveDataInterval"]:
             if self.getProperty("LoaderArgs").isDefault:
                 issues["LoaderArgs"] = f"loader '{loader}' requires additional keyword arguments"
-        elif not self.getProperty("LoaderArgs").isDefault:
-            issues["LoaderArgs"] = f"Loader '{loader}' does not have any keyword arguments"
+        elif loader not in [
+            "LoadEventNexus",
+        ]:
+            if not self.getProperty("LoaderArgs").isDefault:
+                issues["LoaderArgs"] = f"Loader '{loader}' does not have any keyword arguments"
 
         # `InstrumentName`, `InstrumentFilename`, and `InstrumentDonor` properties:
         instrumentSources = ["InstrumentName", "InstrumentFilename", "InstrumentDonor"]
@@ -154,16 +157,16 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
         # TODO: the `if .. doesExist` should be centralized to cache treatment
         #    here, it is redundant.
         if addOrReplace or not self.mantidSnapper.mtd.doesExist(outWS):
+            loaderArgs = json.loads(self.getPropertyValue("LoaderArgs"))
             match loaderType:
                 case "":
                     _, loaderType, _ = self.mantidSnapper.Load(
                         "Loading with unspecified loader",
                         Filename=filename,
                         OutputWorkspace=outWS,
+                        **loaderArgs
                     )
                 case "LoadCalibrationWorkspaces":
-                    self.validateCalibrationFile(filename)
-                    loaderArgs = json.loads(self.getPropertyValue("LoaderArgs"))
                     self.mantidSnapper.LoadCalibrationWorkspaces(
                         "Loading diffraction-calibration workspaces",
                         Filename=filename,
@@ -182,7 +185,6 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
                         **{instrumentPropertySource: instrumentSource},
                     )
                 case "LoadLiveDataInterval":
-                    loaderArgs = json.loads(self.getPropertyValue("LoaderArgs"))
                     self.mantidSnapper.LoadLiveDataInterval(
                         "loading live-data interval",
                         OutputWorkspace=outWS,
@@ -195,6 +197,7 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
                         f"Loading data using {loaderType}",
                         Filename=filename,
                         OutputWorkspace=outWS,
+                        **loaderArgs
                     )
 
             self.mantidSnapper.executeQueue()

--- a/src/snapred/backend/recipe/algorithm/FocusSpectraAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FocusSpectraAlgorithm.py
@@ -106,7 +106,7 @@ class FocusSpectraAlgorithm(PythonAlgorithm):
             DMin=self.pixelGroup.dMin(),
             DMax=self.pixelGroup.dMax(),
             Delta=self.pixelGroup.dBin(),
-            FullBinsOnly=True
+            FullBinsOnly=True,
         )
         # With these arguments, output from `DiffractionFocussing` will now have ragged binning,
         #   so the former call to `RebinRagged` has been removed.

--- a/src/snapred/backend/recipe/algorithm/FocusSpectraAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FocusSpectraAlgorithm.py
@@ -16,10 +16,9 @@ from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 
 class FocusSpectraAlgorithm(PythonAlgorithm):
     """
-    This algorithm performs diffraction focusing on TOF data. It converts the
-    input workspace from time-of-flight (TOF) to d-spacing and applies
-    diffraction focusing using a grouping workspace. Optionally, it rebins
-    the output to ensure uniform binning.
+    This algorithm performs diffraction focussing on dSpacing data. It applies
+    diffraction focussing using a grouping workspace, which then additionally applies
+    the optimal binning constraints using the provided PixelGroup.
 
     """
 
@@ -50,7 +49,7 @@ class FocusSpectraAlgorithm(PythonAlgorithm):
                 PropertyMode.Mandatory,
                 validator=WorkspaceUnitValidator("dSpacing"),
             ),
-            doc="The diffraction-focused data",
+            doc="The diffraction-focused, and rebinned data",
         )
         self.declareProperty(
             "PixelGroup",
@@ -58,25 +57,18 @@ class FocusSpectraAlgorithm(PythonAlgorithm):
             validator=StringMandatoryValidator(),
             direction=Direction.Input,
         )
-        self.declareProperty(
-            "RebinOutput",
-            defaultValue=True,
-            direction=Direction.Input,
-        )
+        self.declareProperty("PreserveEvents", defaultValue=True, direction=Direction.Input)
         self.setRethrows(True)
         self.mantidSnapper = MantidSnapper(self, __name__)
 
-    def chopIngredients(self, pixelGroup: PixelGroup):
-        self.dMin = pixelGroup.dMin()
-        self.dMax = pixelGroup.dMax()
-        self.dBin = pixelGroup.dBin()
-        pass
+    def chopIngredients(self):
+        self.pixelGroup: PixelGroup = PixelGroup.model_validate_json(self.getPropertyValue("PixelGroup"))
+        self.preserveEvents = self.getProperty("PreserveEvents").value
 
     def unbagGroceries(self):
         self.inputWSName = self.getPropertyValue("InputWorkspace")
         self.groupingWSName = self.getPropertyValue("GroupingWorkspace")
         self.outputWSName = self.getPropertyValue("OutputWorkspace")
-        self.rebinOutput = self.getProperty("RebinOutput").value
 
     def validateInputs(self) -> Dict[str, str]:
         errors = {}
@@ -102,40 +94,30 @@ class FocusSpectraAlgorithm(PythonAlgorithm):
         return errors
 
     def PyExec(self):
-        pixelGroup: PixelGroup = PixelGroup.model_validate_json(self.getPropertyValue("PixelGroup"))
-        self.chopIngredients(pixelGroup)
+        self.chopIngredients()
         self.unbagGroceries()
-
-        self.log().debug("Execute of FocusSpectra START!")
 
         self.mantidSnapper.DiffractionFocussing(
             "Performing Diffraction Focusing ...",
             InputWorkspace=self.inputWSName,
             GroupingWorkspace=self.groupingWSName,
             OutputWorkspace=self.outputWSName,
-            PreserveEvents=True,
+            PreserveEvents=self.preserveEvents,
+            DMin=self.pixelGroup.dMin(),
+            DMax=self.pixelGroup.dMax(),
+            Delta=self.pixelGroup.dBin(),
+            FullBinsOnly=True
         )
-
-        # TODO: Compress events here if preserving events
-        if self.rebinOutput is True:
-            self.mantidSnapper.RebinRagged(
-                "Rebinning ragged bins...",
-                InputWorkspace=self.outputWSName,
-                XMin=self.dMin,
-                XMax=self.dMax,
-                Delta=self.dBin,
-                OutputWorkspace=self.outputWSName,
-                PreserveEvents=False,
-                FullBinsOnly=True,
-            )
+        # With these arguments, output from `DiffractionFocussing` will now have ragged binning,
+        #   so the former call to `RebinRagged` has been removed.
 
         self.mantidSnapper.executeQueue()
 
         # Throughout SNAPRed, the assumption is made that the workspace indices of workspace spectra
-        #   are in order of their subgroup-IDs.  This correspondance is validated here.
+        #   are in order of their subgroup-IDs.  This correspondance, for the `PixelGroup`, is validated here.
         # TODO: FIX THIS ISSUE!
         outputWS = self.mantidSnapper.mtd[self.outputWSName]
-        for n, subgroupId in enumerate(pixelGroup.groupIDs):
+        for n, subgroupId in enumerate(self.pixelGroup.groupIDs):
             # After `DiffractionFocussing`, the spectrum number for each spectrum is set to its subgroup-ID.
             if outputWS.getSpectrum(n).getSpectrumNo() != subgroupId:
                 raise RuntimeError("Usage error: subgroup IDs for 'PixelGroup' are not in workspace-index order.")

--- a/src/snapred/backend/service/CalibrationService.py
+++ b/src/snapred/backend/service/CalibrationService.py
@@ -307,8 +307,9 @@ class CalibrationService(Service):
             FocusSpectraRecipe().executeRecipe(
                 InputWorkspace=focusedWorkspace,
                 GroupingWorkspace=groupingWorkspace,
-                PixelGroup=pixelGroup,
                 OutputWorkspace=focusedWorkspace,
+                PixelGroup=pixelGroup,
+                PreserveEvents=request.preserveEvents,
             )
         return focusedWorkspace, groupingWorkspace
 

--- a/src/snapred/backend/service/LiteDataService.py
+++ b/src/snapred/backend/service/LiteDataService.py
@@ -42,7 +42,8 @@ class LiteDataService(Service):
         liteDataMap = self._ensureLiteDataMap()
         runNumber = inputWorkspace.split("_")[-1].lstrip("0")
 
-        ffIngredients = FarmFreshIngredients(runNumber=runNumber, useLiteMode=True)
+        state, _ = self.dataFactoryService.constructStateId(runNumber)
+        ffIngredients = FarmFreshIngredients(runNumber=runNumber, useLiteMode=True, state=state)
         ingredients = self.sousChef.prepInstrumentState(ffIngredients)
 
         recipeKwargs = {

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -198,7 +198,7 @@ class NormalizationService(Service):
         groceries["outputWorkspace"] = focusedVanadium
 
         ReductionGroupProcessingRecipe().cook(
-            ReductionGroupProcessingRecipe.Ingredients(pixelGroup=ingredients.pixelGroup),
+            ReductionGroupProcessingRecipe.Ingredients(pixelGroup=ingredients.pixelGroup, preserveEvents=False),
             groceries={
                 "inputWorkspace": groceries["inputWorkspace"],
                 "outputWorkspace": groceries["outputWorkspace"],
@@ -391,12 +391,13 @@ class NormalizationService(Service):
             focusGroups=[request.focusGroup],
             state=state,
         )
-        ingredients = self.sousChef.prepPixelGroup(farmFresh)
+        pixelGroup = self.sousChef.prepPixelGroup(farmFresh)
         return FocusSpectraRecipe().executeRecipe(
             InputWorkspace=request.inputWorkspace,
             GroupingWorkspace=request.groupingWorkspace,
-            Ingredients=ingredients,
             OutputWorkspace=request.outputWorkspace,
+            PixelGroup=pixelGroup,
+            PreserveEvents=request.preserveEvents,
         )
 
     @FromString

--- a/src/snapred/backend/service/ReductionService.py
+++ b/src/snapred/backend/service/ReductionService.py
@@ -28,7 +28,6 @@ from snapred.backend.error.StateValidationException import StateValidationExcept
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.backend.recipe.GenericRecipe import ArtificialNormalizationRecipe, ConvertUnitsRecipe
-from snapred.backend.recipe.RebinFocussedGroupDataRecipe import RebinFocussedGroupDataRecipe
 from snapred.backend.recipe.ReductionGroupProcessingRecipe import ReductionGroupProcessingRecipe
 from snapred.backend.recipe.ReductionRecipe import ReductionRecipe
 from snapred.backend.service.Service import Service
@@ -709,22 +708,11 @@ class ReductionService(Service):
             "outputWorkspace": artNormBasisWorkspace,
         }
 
-        # 3. Diffraction Focus Spectra
+        # 3. Diffraction Focus Spectra, including rebinning
         ReductionGroupProcessingRecipe().cook(ingredients.groupProcessing(0), groceries)
 
-        # 4. Rebin
-        rebinIngredients = RebinFocussedGroupDataRecipe.Ingredients(
-            pixelGroup=ingredients.pixelGroups[0], preserveEvents=True
-        )
-
-        # NOTE: This is PURPOSELY re-instanced to support testing.
-        #       `assert_called_with` DOES NOT deep copy the dictionary.
-        #       Thus re-using the above dict would fail the test.
-        groceries = {"inputWorkspace": artNormBasisWorkspace}
-
-        rebinResult = RebinFocussedGroupDataRecipe().cook(rebinIngredients, groceries)
-        # 5. Return the rebin result
-        return rebinResult
+        # 4. Return the result
+        return artNormBasisWorkspace
 
     def hasLiveDataConnection(self) -> bool:
         """For 'live data' methods: verify that there is a listener connection to the instrument."""

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -122,8 +122,11 @@ nexus:
     prefix: nexus/SNAP_
     extension: .nxs.h5
   file:
-    extension: .nxs.h5
     prefix: SNAP_
+    extension: .nxs.h5
+  dataFormat:
+    # Assume that input data will be in event format:
+    event: true
 
 grouping:
   workspacename:

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -498,6 +498,7 @@ class DiffCalWorkflow(WorkflowImplementer):
             runNumber=self.runNumber,
             useLiteMode=self.useLiteMode,
             focusGroup=self.focusGroups[self.focusGroupPath],
+            preserveEvents=False,
             inputWorkspace=self.groceries["inputWorkspace"],
             groupingWorkspace=self.groceries["groupingWorkspace"],
         )

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -121,10 +121,12 @@ nexus:
   native:
     prefix: nexus/SNAP_
     extension: .nxs.h5
-  home: nexus/
   file:
-    extension: .nxs.h5
     prefix: SNAP_
+    extension: .nxs.h5
+  dataFormat:
+    # Assume that input data will be in event format:
+    event: true
 
 grouping:
   workspacename:

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -32,8 +32,8 @@ from mantid.simpleapi import (
     DeleteWorkspaces,
     EditInstrumentGeometry,
     GroupWorkspaces,
-    LoadInstrument,
     LoadEmptyInstrument,
+    LoadInstrument,
     LoadNexusProcessed,
     RenameWorkspaces,
     SaveDiffCal,
@@ -1892,17 +1892,14 @@ def test_writeNormalizationWorkspaces_event_binning(cleanup_workspace_at_exit):
             filePath = basePath / Path(wsName + ".nxs")
             reloadedWsName = wsName + "_reloaded"
             assert (filePath).exists()
-            LoadNexusProcessed(
-                FileName=str(filePath),
-                OutputWorkspace=reloadedWsName
-            )
+            LoadNexusProcessed(FileName=str(filePath), OutputWorkspace=reloadedWsName)
             assert mtd.doesExist(reloadedWsName)
             cleanup_workspace_at_exit(reloadedWsName)
             ws_ = mtd[reloadedWsName]
             maxBinEdges = max([len(ws_.readX(n)) for n in range(ws_.getNumberHistograms())])
             assert maxBinEdges == 2
-            
-                        
+
+
 ### TESTS OF REDUCTION METHODS ###
 
 

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -1790,17 +1790,14 @@ def test_writeNormalizationWorkspaces(cleanup_workspace_at_exit):
     testNormalizationRecord = DAOFactory.normalizationRecord(version=version)
     with (
         mock.patch.object(localDataService, "generateInstrumentState") as mockGenerateInstrumentState,
-        state_root_redirect(localDataService, stateId=stateId)
+        state_root_redirect(localDataService, stateId=stateId),
     ):
         mockGenerateInstrumentState.return_value = mock.Mock(
             spec=InstrumentState,
             id=mock.Mock(spec=ObjectSHA, hex=ENDURING_STATE_ID),
-            particleBounds=mock.Mock(
-                spec=ParticleBounds,
-                tof=Limit(minimum=0.001, maximum=200000.0)
-            )
+            particleBounds=mock.Mock(spec=ParticleBounds, tof=Limit(minimum=0.001, maximum=200000.0)),
         )
-        
+
         # Workspace names need to match the names that are used in the test record.
         runNumber = testNormalizationRecord.runNumber  # noqa: F841
         useLiteMode = testNormalizationRecord.useLiteMode

--- a/tests/unit/backend/recipe/test_GenerateFocussedVanadiumRecipe.py
+++ b/tests/unit/backend/recipe/test_GenerateFocussedVanadiumRecipe.py
@@ -91,13 +91,3 @@ class TestGenerateFocussedVanadiumRecipe(unittest.TestCase):
 
         assert self.recipe.cook.called
         assert output[0] == self.recipe.cook.return_value
-
-    @mock.patch(f"{ThisRecipe}.RebinFocussedGroupDataRecipe")
-    def test_rebinInputWorkspace(self, mockRebinRecipe):
-        self.recipe.prep(self.fakeIngredients, self.groceryList)
-        self.recipe._rebinInputWorkspace()
-
-        mockRebinRecipe().cook.assert_called_with(
-            mockRebinRecipe.Ingredients(pixelGroup=self.fakeIngredients.pixelGroup),
-            {"inputWorkspace": self.fakeInputWorkspace},
-        )

--- a/tests/unit/backend/recipe/test_GroupDiffCalRecipe.py
+++ b/tests/unit/backend/recipe/test_GroupDiffCalRecipe.py
@@ -24,7 +24,7 @@ class TestGroupDiffCalRecipe(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Create a set of mocked ingredients for calculating DIFC corrected by offsets"""
-        syntheticInputs = SyntheticData()
+        syntheticInputs = SyntheticData(workspaceType="Event")
         cls.fakeIngredients = syntheticInputs.ingredients
         fakeDBin = max([abs(d) for d in cls.fakeIngredients.pixelGroup.dBin()])
 
@@ -60,7 +60,7 @@ class TestGroupDiffCalRecipe(unittest.TestCase):
         assert rx.runNumber == self.fakeIngredients.runConfig.runNumber
         assert rx.TOF.minimum == self.fakeIngredients.pixelGroup.timeOfFlight.minimum
         assert rx.TOF.maximum == self.fakeIngredients.pixelGroup.timeOfFlight.maximum
-        assert rx.dBin == self.fakeIngredients.pixelGroup.dBin()
+        assert rx.pixelGroup == self.fakeIngredients.pixelGroup
 
     def test_execute(self):
         """Test that the recipe xecutes"""

--- a/tests/unit/backend/service/test_LiteDataService.py
+++ b/tests/unit/backend/service/test_LiteDataService.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 import pytest
 from mantid.simpleapi import CloneWorkspace, CreateSingleValuedWorkspace
 from util.Config_helpers import Config_override
+from util.dao import DAOFactory
 
 from snapred.backend.service.LiteDataService import LiteDataService
 from snapred.meta.Config import Resource
@@ -33,6 +34,9 @@ class TestLiteDataService(unittest.TestCase):
 
         liteDataService = LiteDataService()
         liteDataService._ensureLiteDataMap = Mock(return_value="lite_map")
+        liteDataService.dataFactoryService.constructStateId = mock.Mock(
+            return_value=(DAOFactory.real_state_id.hex, DAOFactory.real_detector_state)
+        )
         liteDataService.sousChef.prepInstrumentState = Mock()
         liteDataService.sousChef.prepInstrumentState.return_value = Mock()
         liteDataService.sousChef.prepInstrumentState.return_value.model_dump_json.return_value = "{}"  # noqa: E501
@@ -72,6 +76,9 @@ class TestLiteDataService(unittest.TestCase):
 
         liteDataService = LiteDataService()
         liteDataService._ensureLiteDataMap = Mock(return_value="lite map")
+        liteDataService.dataFactoryService.constructStateId = mock.Mock(
+            return_value=(DAOFactory.real_state_id.hex, DAOFactory.real_detector_state)
+        )
         liteDataService.sousChef.prepInstrumentState = Mock()
         liteDataService.sousChef.prepInstrumentState.return_value = Mock()
         liteDataService.sousChef.prepInstrumentState.return_value.model_dump_json.return_value = "{}"  # noqa: E501

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -125,8 +125,9 @@ class TestNormalizationService(unittest.TestCase):
     ):
         mockRequest = FocusSpectraRequest(
             runNumber="12345",
-            focusGroup=self.request.focusGroup,
             useLiteMode=True,
+            focusGroup=self.request.focusGroup,
+            preserveEvents=False,
             inputWorkspace="input_ws",
             groupingWorkspace="grouping_ws",
             outputWorkspace="output_ws",
@@ -135,18 +136,19 @@ class TestNormalizationService(unittest.TestCase):
         self.instance = NormalizationService()
         self.instance.dataFactoryService.constructStateId = MagicMock(return_value=("12345", None))
         self.instance.sousChef = SculleryBoy()
-        mockRecipeInst = mockRecipe.return_value
-        mockRecipeInst.executeRecipe.return_value = "expected"
+        mockRecipeInstance = mockRecipe.return_value
+        mockRecipeInstance.executeRecipe.return_value = "expected"
 
         res = self.instance.focusSpectra(mockRequest)
 
-        mockRecipeInst.executeRecipe.assert_called_once_with(
+        mockRecipeInstance.executeRecipe.assert_called_once_with(
             InputWorkspace=mockRequest.inputWorkspace,
             GroupingWorkspace=mockRequest.groupingWorkspace,
-            Ingredients=self.instance.sousChef.prepPixelGroup(FarmFreshIngredients()),
             OutputWorkspace=mockRequest.outputWorkspace,
+            PixelGroup=self.instance.sousChef.prepPixelGroup(FarmFreshIngredients()),
+            PreserveEvents=False,
         )
-        assert res == mockRecipeInst.executeRecipe.return_value
+        assert res == mockRecipeInstance.executeRecipe.return_value
 
     @patch(thisService + "FarmFreshIngredients")
     @patch(thisService + "RawVanadiumCorrectionRecipe")
@@ -171,14 +173,14 @@ class TestNormalizationService(unittest.TestCase):
 
         res = self.instance.vanadiumCorrection(mockRequest)
 
-        mockRecipeInst = RawVanadiumCorrectionRecipe.return_value
-        mockRecipeInst.executeRecipe.assert_called_once_with(
+        mockRecipeInstance = RawVanadiumCorrectionRecipe.return_value
+        mockRecipeInstance.executeRecipe.assert_called_once_with(
             InputWorkspace=mockRequest.inputWorkspace,
             BackgroundWorkspace=mockRequest.backgroundWorkspace,
             Ingredients=self.instance.sousChef.prepNormalizationIngredients({}),
             OutputWorkspace=mockRequest.outputWorkspace,
         )
-        assert res == mockRecipeInst.executeRecipe.return_value
+        assert res == mockRecipeInstance.executeRecipe.return_value
 
     @patch(thisService + "FarmFreshIngredients")
     @patch(thisService + "SmoothDataExcludingPeaksRecipe")
@@ -204,11 +206,11 @@ class TestNormalizationService(unittest.TestCase):
         self.instance.dataFactoryService.getCifFilePath = mock.Mock(return_value="path/to/cif")
         self.instance.dataFactoryService.constructStateId = mock.Mock(return_value=("12345", None))
 
-        mockRecipeInst = mockRecipe.return_value
+        mockRecipeInstance = mockRecipe.return_value
 
         self.instance.smoothDataExcludingPeaks(mockRequest)
 
-        mockRecipeInst.executeRecipe.assert_called_once_with(
+        mockRecipeInstance.executeRecipe.assert_called_once_with(
             InputWorkspace=mockRequest.inputWorkspace,
             OutputWorkspace=mockRequest.outputWorkspace,
             DetectorPeaks=ANY,  # NOTE it is impossible to see this pointer

--- a/tests/unit/backend/service/test_ReductionService.py
+++ b/tests/unit/backend/service/test_ReductionService.py
@@ -694,7 +694,6 @@ class TestReductionService(unittest.TestCase):
         assert result == mockResult
 
     @mock.patch(thisService + "ConvertUnitsRecipe")
-    @mock.patch(thisService + "RebinFocussedGroupDataRecipe")
     @mock.patch(thisService + "ReductionGroupProcessingRecipe")
     @mock.patch(thisService + "GroceryService")
     @mock.patch(thisService + "DataFactoryService")
@@ -703,7 +702,6 @@ class TestReductionService(unittest.TestCase):
         mockDataFactoryService,
         mockGroceryService,
         mockReductionGroupProcessingRecipe,
-        mockRebinFocussedGroupDataRecipe,
         mockConvertUnitsRecipe,  # noqa: ARG002
     ):
         self.instance.groceryService = mockGroceryService
@@ -741,12 +739,8 @@ class TestReductionService(unittest.TestCase):
         }
 
         mockReductionGroupProcessingRecipe().cook.assert_called_once_with(mockIngredients.groupProcessing(0), groceries)
-        groceries = {"inputWorkspace": groceries["outputWorkspace"]}
-        rebinIngredients = mockRebinFocussedGroupDataRecipe.Ingredients()
-        mockRebinFocussedGroupDataRecipe().cook.assert_called_once_with(rebinIngredients, groceries)
 
     @mock.patch(thisService + "ConvertUnitsRecipe")
-    @mock.patch(thisService + "RebinFocussedGroupDataRecipe")
     @mock.patch(thisService + "ReductionGroupProcessingRecipe")
     @mock.patch(thisService + "GroceryService")
     @mock.patch(thisService + "DataFactoryService")
@@ -755,7 +749,6 @@ class TestReductionService(unittest.TestCase):
         mockDataFactoryService,
         mockGroceryService,
         mockReductionGroupProcessingRecipe,  # noqa: ARG002
-        mockRebinFocussedGroupDataRecipe,  # noqa: ARG002
         mockConvertUnitsRecipe,  # noqa: ARG002
     ):
         # This test verifies that live-data args are passed correctly to the fetch methods.

--- a/tests/util/diffraction_calibration_synthetic_data.py
+++ b/tests/util/diffraction_calibration_synthetic_data.py
@@ -54,7 +54,7 @@ class SyntheticData(object):
     SNAPInstrumentFilePath = str(Path(mantid.__file__).parent / "instrument" / "SNAP_Definition.xml")
     SNAPLiteInstrumentFilePath = Resource.getPath("inputs/pixel_grouping/SNAPLite_Definition.xml")
 
-    def __init__(self, workspaceType: str = "Histogram", scale: float = 1000.0):
+    def __init__(self, workspaceType: str = "Histogram", scale: float = 1000.0, numEvents=int(1.0e5)):
         fakeRunNumber = "555"
         self.fakeRunConfig = RunConfig(
             runNumber=str(fakeRunNumber),
@@ -72,6 +72,11 @@ class SyntheticData(object):
         # Overall _magnitude_ scale factor:
         self.scale = scale
 
+        self.numEvents = numEvents
+
+        # ad hoc S/N factor: reduce S/N (from scale) using this factor.
+        self.signalToNoiseDivisor = 20.0
+
         self.workspaceType = workspaceType
 
         # The pixel group's TOF-domain will be used to convert the original `CreateSampleWorkspace` 'Powder Diffraction'
@@ -79,7 +84,7 @@ class SyntheticData(object):
         TOFMin = self.fakePixelGroup.timeOfFlight.minimum
         TOFMax = self.fakePixelGroup.timeOfFlight.maximum
         self.peaks, self.background_function = SyntheticData._fakePowderDiffractionPeakList(
-            TOFMin, TOFMax, dMin, dMax, self.scale
+            TOFMin, TOFMax, dMin, dMax, self.scale, self.signalToNoiseDivisor
         )
 
         crystalPeaks = SyntheticData.crystalInfo().peaks
@@ -115,7 +120,7 @@ class SyntheticData(object):
         )
 
     @staticmethod
-    def fakeDetectorPeaks(scale: float = 1000.0) -> List[DetectorPeak]:
+    def fakeDetectorPeaks(scale: float = 1000.0, signalToNoiseDivisor: float = 20.0) -> List[DetectorPeak]:
         fakePixelGroup = DAOFactory.synthetic_pixel_group.copy()
 
         # Place all peaks within the _minimum_ d-space range of any pixel group.
@@ -126,7 +131,7 @@ class SyntheticData(object):
         #   predefined function: this allows peak widths to be properly scaled to generate data for a d-spacing domain.
         TOFMin = fakePixelGroup.timeOfFlight.minimum
         TOFMax = fakePixelGroup.timeOfFlight.maximum
-        peaks, _ = SyntheticData._fakePowderDiffractionPeakList(TOFMin, TOFMax, dMin, dMax, scale)
+        peaks, _ = SyntheticData._fakePowderDiffractionPeakList(TOFMin, TOFMax, dMin, dMax, scale, signalToNoiseDivisor)
 
         crystalPeaks = SyntheticData.crystalInfo().peaks
 
@@ -156,7 +161,7 @@ class SyntheticData(object):
 
     @staticmethod
     def _fakePowderDiffractionPeakList(
-        tofMin: float, tofMax: float, dMin: float, dMax: float, scale: float
+        tofMin: float, tofMax: float, dMin: float, dMax: float, scale: float, signalToNoiseDivisor: float
     ) -> Tuple[List[Tuple[float, float, float]], str]:
         """Duplicate the `CreateSampleWorkspace` 'Powder Diffraction' predefined function,
              but in d-spacing instead of TOF units.
@@ -183,6 +188,7 @@ class SyntheticData(object):
         centres = np.arange(dMin, dMax, 0.1 * (dMax - dMin))
         dspDomain = dMax - dMin
         tofDomain = tofMax - tofMin
+        f_SN = signalToNoiseDivisor
         peaks = [
             Peak(centres[1], 14.3772 * dspDomain / tofDomain, scale * 0.584528),
             Peak(centres[2], 15.2516 * dspDomain / tofDomain, scale * 1.33361),
@@ -194,7 +200,12 @@ class SyntheticData(object):
             Peak(centres[8], 21.9932 * dspDomain / tofDomain, scale * 2.05237),
             Peak(centres[9], 25.2751 * dspDomain / tofDomain, scale * 8.40976),
         ]
-        background = f"name= LinearBackground,A0={scale * 0.0850208},A1={scale * -4.89583e-06 * dspDomain / tofDomain};"
+        background = (
+            "name= LinearBackground,"
+            + f"A0={scale * 0.0850208 / f_SN},"
+            + f"A1={scale * -4.89583e-06 * dspDomain / tofDomain / f_SN};"
+        )
+
         return peaks, background
 
     def generateWorkspaces(self, rawWS: str, groupingWS: str, maskWS: str) -> None:
@@ -253,6 +264,7 @@ class SyntheticData(object):
         CreateSampleWorkspace(
             OutputWorkspace=rawWS,
             WorkspaceType=self.workspaceType,
+            NumEvents=self.numEvents,
             Function="User Defined",
             UserDefinedFunction=functionString,
             Xmin=overallDMin,


### PR DESCRIPTION
## Description of work
Combine separate `DiffractionFocussing` and `RebinRagged` calls into a single call to `DiffractionFocussing` with specified rebinning args.

## Explanation of work
This commit includes the following changes:

  * In `FocusSpectraAlgorithm`: combine `DiffractionFocussing` and `RebinRagged` calls into a single `DiffractionFocussing` call.  The required ragged-binning is now accomplished at the same time as diffraction focussing.  This uses the `DiffractionFocussing` binning args, along with the new `FullBinsOnly` flag.

  * Use `FocusSpectraAlgorithm` everywhere that `DiffractionFocussing` was previously used.

  * Optimization: when input data is loaded in event format:  where possible, use only a single bin during loading.  At present, there's no way to apply this optimization to data loaded using `LoadNexusProcessed`.  In order to apply this optimization correctly, Mantid's file-loader methods must be used to determine in advance _which_ loader algorithm will actually be used.

  * Add a new `Config` flag 'nexus.dataFormat.event' to preserve some options for input data in histogram format. Also add a `preserveEvents` arg in a few places for this same reason.

  * Improve the peak-fitting stability of data generated by `diffraction_calibration_synthetic_data`.  This data is used by `test_GroupDiffCalRecipe`, and previously quite a few of the peak fits were only barely succeeding.  These improvements should improve the signal-to-noise ratio so that the peak fits are more stable.  In addition, `test_GroupDiffCalRecipe` now uses event data, as the most common use-case for this recipe uses event data.

## To test
Most of the new changes are directly tested within `test_GroupDiffCalRecipe.py`.

### Dev testing
Run the diffraction-calibration workflow.  Using the logs output, and the properties in the workspace panel:
  
  * Verify that the input-data _event_ workspace is loaded with a single bin.
  * Verify that there are only calls to `FocusSpectraAlgorithm`, and no isolated calls to `DiffractionFocussing`.

### CIS testing
The _result_ of the diffraction-calibration workflow should be _essentially_ the same as that previously produced, and this fact should be verified.  Most of the new changes involve computational-resource _optimizations_ and should not involve any changes in the calculation sequence. 

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#7798](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=7798)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

1. All calls to `DiffractionFocussing` in SNAPRed use the new binning parameters, as appropriate;
2. All use of `DiffractionFocussing` in SNAPRed works via `FocusSpectraAlgorithm` -- there are no longer any separate calls;
3. Loading of Nexus event data (in `GroceryService`) uses `NumberOfBins=1`.   (Although see the description and comments about this issue as this optimization could not be applied to `LoadNexusProcessed` data, regardless of whether or not it is using events.).  Hopefully this change is centralized!
4. There are no extra `Rebin` calls where rebinning could practically occur within `DiffractionFocussing`.
5. There are unit tests covering the new changes.

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] acceptance criterion 1
- [ ] acceptance criterion 2
- [ ] acceptance criterion 3
- [ ] acceptance criterion 4
- [ ] acceptance criterion 5


