### PR TITLE
Add dependency checking to pre-commit and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Workflow files stored in the default location of `.github/workflows`
     schedule:
       interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,8 @@
+ci:
+  # Leave pip-audit to only run locally and not in CI
+  # pre-commit.ci does not allow network calls
+  skip: [pip-audit]
+
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
@@ -23,6 +28,10 @@ repos:
       exclude: "tests/cis_tests/.*"
     - id: ruff-format
       exclude: "tests/cis_tests/.*"
+- repo: https://github.com/pypa/pip-audit
+  rev: v2.9.0
+  hooks:
+    - id: pip-audit
 # disable for now
 #- repo: https://github.com/pre-commit/mirrors-mypy
 #  rev: v1.1.1


### PR DESCRIPTION
This is based on some investigation with finddata and the changes queued up in https://github.com/neutrons/finddata/pull/36. It adds python dependency auditing for what is listed in `pyproject.toml` both in pre-commit and in dependabot. I selected this repository because snapred already has [dependencies in its insights](https://github.com/neutrons/SNAPRed/network/dependencies). 
