### PR TITLE
Input validation of grouping-workspaces

### DIFF
--- a/docs/source/developer/architecture/backend/algorithms/lite_data_creation_algo.rst
+++ b/docs/source/developer/architecture/backend/algorithms/lite_data_creation_algo.rst
@@ -27,11 +27,11 @@ Expected Inputs:
    - **Property Mode**: `Mandatory`
    - **Description**: Path to the lite instrument definition file.
 
-4. **AutoDeleteNonLiteWS**:
-   - **Type**: `Bool`
+4. **Ingredients**:
+   - **Type**: `String`
    - **Direction**: `Input`
-   - **Property Mode**: `Optional`
-   - **Description**: Flag indicating whether to automatically delete the non-lite workspace after conversion.
+   - **Property Mode**: `Mandatory`
+   - **Description**: JSON-format 'LiteDataCreationIngredients': compression-related args.
 
 Expected Outputs:
 -----------------
@@ -40,3 +40,9 @@ Expected Outputs:
    - **Direction**: `Output`
    - **Property Mode**: `Mandatory`
    - **Description**: The workspace reduced to lite resolution and compressed.
+
+2. **Tolerance**:
+   - **Type**: `float`
+   - **Direction**: `Output`
+   - **Property Mode**: `Mandatory`
+   - **Description**: The compression tolerance 'deltaT' when compression has been used.

--- a/src/snapred/backend/dao/ingredients/LiteDataCreationIngredients.py
+++ b/src/snapred/backend/dao/ingredients/LiteDataCreationIngredients.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+from snapred.backend.dao.state.InstrumentState import InstrumentState
+
+
+class LiteDataCreationIngredients(BaseModel):
+    """Class to hold the ingredients necessary for lite-data conversion."""
+
+    instrumentState: InstrumentState | None = None
+
+    toleranceOverride: float | None = None

--- a/src/snapred/backend/dao/ingredients/PixelGroupingIngredients.py
+++ b/src/snapred/backend/dao/ingredients/PixelGroupingIngredients.py
@@ -11,6 +11,6 @@ class PixelGroupingIngredients(BaseModel):
 
     instrumentState: InstrumentState
 
-    groupingScheme: Optional[str] = None
+    groupingScheme: str | None = None
 
     nBinsAcrossPeakWidth: int = Field(default_factory=lambda: Config["calibration.diffraction.nBinsAcrossPeakWidth"])

--- a/src/snapred/backend/recipe/GroupDiffCalRecipe.py
+++ b/src/snapred/backend/recipe/GroupDiffCalRecipe.py
@@ -67,13 +67,13 @@ class GroupDiffCalRecipe(Recipe[Ingredients]):
         groupIDs = [peakList.groupID for peakList in ingredients.groupedPeakLists]
         if groupIDs != pixelGroupIDs:
             raise RuntimeError(
-                f"Group IDs do not match between peak list and the pixel group: {groupIDs} vs {pixelGroupIDs}"
+                f"Group IDs do not match between peak list and the pixel group: '{groupIDs}' vs. '{pixelGroupIDs}'"
             )
 
         diffocWS = self.mantidSnapper.mtd[groceries["groupingWorkspace"]]
-        if groupIDs != list(diffocWS.getGroupIDs()):
+        if groupIDs != diffocWS.getGroupIDs().tolist():
             raise RuntimeError(
-                f"Group IDs do not match between peak list and focus WS: {groupIDs} vs {diffocWS.getGroupIDs()}"
+                f"Group IDs do not match between peak list and focus WS: '{groupIDs}' vs. '{diffocWS.getGroupIDs()}'"
             )
 
     def chopIngredients(self, ingredients: Ingredients) -> None:
@@ -107,8 +107,6 @@ class GroupDiffCalRecipe(Recipe[Ingredients]):
                 allPeakBoundaries.append(peak.maximum)
             self.groupedPeaks[peakList.groupID] = allPeaks
             self.groupedPeakBoundaries[peakList.groupID] = allPeakBoundaries
-        # NOTE: this sort is necessary to correspond to the sort inside mantid's GroupingWorkspace
-        self.groupIDs = sorted(self.groupIDs)
 
     def unbagGroceries(self, groceries: Dict[str, WorkspaceName]) -> None:
         """

--- a/src/snapred/backend/recipe/algorithm/FocusSpectraAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FocusSpectraAlgorithm.py
@@ -70,26 +70,63 @@ class FocusSpectraAlgorithm(PythonAlgorithm):
         self.groupingWSName = self.getPropertyValue("GroupingWorkspace")
         self.outputWSName = self.getPropertyValue("OutputWorkspace")
 
+    @staticmethod
+    def _appendErrorMessage(errors: Dict[str, str], key: str, msg: str):
+        existingMsg = errors.get(key, "")
+        if bool(existingMsg):
+            existingMsg += "\n"
+        errors[key] = existingMsg + msg
+ 
     def validateInputs(self) -> Dict[str, str]:
         errors = {}
-        # make sure the input workspace can be reduced by this grouping workspace
-        inWS = self.mantidSnapper.mtd[self.getPropertyValue("InputWorkspace")]
+        
+        inputWs = self.mantidSnapper.mtd[self.getPropertyValue("InputWorkspace")]
+        
+        groupingWs = self.mantidSnapper.mtd[self.getPropertyValue("GroupingWorkspace")]
+        if not isinstance(groupingWs, GroupingWorkspace):
+            errors["GroupingWorkspace"] = "Grouping workspace must be an instance of `GroupingWorkspace`"
+        
+            # EARLY RETURN:
+            return errors
+            
+        # Make sure that the input-data workspace can be reduced by the grouping workspace.
 
-        groupWS = self.mantidSnapper.mtd[self.getPropertyValue("GroupingWorkspace")]
-        if not isinstance(groupWS, GroupingWorkspace):
-            errors["GroupingWorkspace"] = "Grouping workspace must be an actual GroupingWorkspace"
-        elif inWS.getNumberHistograms() == len(groupWS.getGroupIDs()):
-            msg = "The data appears to have already been diffraction focused"
-            errors["InputWorkspace"] = msg
-            errors["GroupingWorkspace"] = msg
-        elif inWS.getNumberHistograms() != groupWS.getNumberHistograms():
-            msg = f"""
-                The workspaces {self.getPropertyValue("InputWorkspace")}
-                and {self.getPropertyValue("GroupingWorkspace")}
-                have inconsistent number of spectra
-                """
-            errors["InputWorkspace"] = msg
-            errors["GroupingWorkspace"] = msg
+        # The input-data and grouping workspaces must have the same instrument.
+        # Comparing instruments is problematic: however, requiring both the instrument-name,
+        #   and the pixel count to match is a fairly safe verification.    
+        if (inputWs.getInstrument().getName() != groupingWs.getInstrument().getName())\
+            or (inputWs.getInstrument().getNumberDetectors(True)\
+                != groupingWs.getInstrument().getNumberDetectors(True)):
+            msg = "The input-data and grouping workspaces must have the same instrument."
+            self._appendErrorMessage(
+                errors,
+                "InputWorkspace",
+                msg
+            )
+            self._appendErrorMessage(
+                errors,
+                "GroupingWorkspace",
+                msg
+            )
+
+        # Verify that the input-data hasn't already been focussed.
+        if inputWs.getNumberHistograms() == len(groupingWs.getGroupIDs()):
+            self._appendErrorMessage(
+                errors,
+                "InputWorkspace",
+                "The input data appears to already have been diffraction focussed."
+            )
+
+        # Verify that the input-data has one spectrum per [non-monitor] pixel.
+        if inputWs.getNumberHistograms() != inputWs.getInstrument().getNumberDetectors(True):
+            self._appendErrorMessage(
+                errors,
+                "InputWorkspace",
+                "The input workspace must have one spectrum per [non-monitor] pixel."
+            )
+             
+        # IMPORTANT: There is no requirement that the grouping workspace have one spectrum per detector.
+        #   Its spectrum-to-detector map may be used to reduce this number.
 
         return errors
 
@@ -98,7 +135,7 @@ class FocusSpectraAlgorithm(PythonAlgorithm):
         self.unbagGroceries()
 
         self.mantidSnapper.DiffractionFocussing(
-            "Performing Diffraction Focusing ...",
+            "Performing Diffraction Focussing ...",
             InputWorkspace=self.inputWSName,
             GroupingWorkspace=self.groupingWSName,
             OutputWorkspace=self.outputWSName,
@@ -106,7 +143,7 @@ class FocusSpectraAlgorithm(PythonAlgorithm):
             DMin=self.pixelGroup.dMin(),
             DMax=self.pixelGroup.dMax(),
             Delta=self.pixelGroup.dBin(),
-            FullBinsOnly=True,
+            FullBinsOnly=True
         )
         # With these arguments, output from `DiffractionFocussing` will now have ragged binning,
         #   so the former call to `RebinRagged` has been removed.
@@ -114,13 +151,15 @@ class FocusSpectraAlgorithm(PythonAlgorithm):
         self.mantidSnapper.executeQueue()
 
         # Throughout SNAPRed, the assumption is made that the workspace indices of workspace spectra
-        #   are in order of their subgroup-IDs.  This correspondance, for the `PixelGroup`, is validated here.
+        #   are in order of their subgroup-IDs.  This correspondence is validated here.
         # TODO: FIX THIS ISSUE!
         outputWS = self.mantidSnapper.mtd[self.outputWSName]
         for n, subgroupId in enumerate(self.pixelGroup.groupIDs):
             # After `DiffractionFocussing`, the spectrum number for each spectrum is set to its subgroup-ID.
             if outputWS.getSpectrum(n).getSpectrumNo() != subgroupId:
-                raise RuntimeError("Usage error: subgroup IDs for 'PixelGroup' are not in workspace-index order.")
+                raise RuntimeError(
+                    "Usage error: subgroup IDs for 'PixelGroup' are not in the expected workspace-index order."
+                )
 
         self.setPropertyValue("OutputWorkspace", self.outputWSName)
 

--- a/src/snapred/backend/recipe/algorithm/GroupedDetectorIDs.py
+++ b/src/snapred/backend/recipe/algorithm/GroupedDetectorIDs.py
@@ -42,12 +42,16 @@ class GroupedDetectorIDs(PythonAlgorithm):
         self.setRethrows(True)
 
     def PyExec(self):
-        # get handle to group focusing workspace and retrieve workspace indices for all detectors in each group
-        focusWSname: str = str(self.getPropertyValue("GroupingWorkspace"))
-        focusWS = mtd[focusWSname]
+        # Retrieve pixel-IDs for all pixels in each subgroup.
+        groupingWs = mtd[self.getPropertyValue("GroupingWorkspace")]
+        
         groupWorkspaceIndices: Dict[int, List[int]] = {}
-        for groupID in [int(x) for x in focusWS.getGroupIDs()]:
-            groupWorkspaceIndices[groupID] = [int(x) for x in focusWS.getDetectorIDsOfGroup(groupID)]
+        
+        #`<numpy ndarray>.tolist()` both converts to the nearest native-Python type, which is in this case `int`,
+        #    and also converts to a Python list.
+        for subgroupID in groupingWs.getGroupIDs().tolist():
+            groupWorkspaceIndices[subgroupID] = groupingWs.getDetectorIDsOfGroup(subgroupID).tolist()
+        
         self.setProperty("GroupWorkspaceIndices", create_pointer(groupWorkspaceIndices))
 
 

--- a/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/LiteDataCreationAlgo.py
@@ -8,6 +8,7 @@ from mantid.api import (
 )
 from mantid.kernel import Direction
 
+from snapred.backend.dao.ingredients import LiteDataCreationIngredients
 from snapred.backend.dao.state.InstrumentState import InstrumentState
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
@@ -24,104 +25,165 @@ class LiteDataCreationAlgo(PythonAlgorithm):
         )
         self.declareProperty(
             MatrixWorkspaceProperty("LiteDataMapWorkspace", "", Direction.Input, PropertyMode.Mandatory),
-            doc="Grouping workspace which converts maps full pixel resolution to lite data",
+            doc="Grouping workspace which maps full pixel resolution to lite data resolution",
         )
         self.declareProperty(
             MatrixWorkspaceProperty("OutputWorkspace", "", Direction.Output, PropertyMode.Mandatory),
             doc="the workspace reduced to lite resolution and compressed",
         )
         self.declareProperty(
-            "ToleranceOverride",
-            defaultValue=0.0,
-            direction=Direction.Input,
+            "Ingredients",
+            defaultValue="",
+            direction=Direction.Input
         )
+        
         # output float property for the tolerance used
         self.declareProperty(
             "Tolerance",
             defaultValue=0.0,
             direction=Direction.Output,
         )
-        self.declareProperty(
-            "Ingredients",
-            defaultValue="",
-            direction=Direction.Input,
-        )
-        # TODO this is needed by LoadInstrument, which needs to be removed
+
         self.declareProperty(
             "LiteInstrumentDefinitionFile",
             "instrument.lite.definition.file",
             Direction.Input,
         )
-        self.declareProperty("AutoDeleteNonLiteWS", defaultValue=False, direction=Direction.Input)
+        
         self.setRethrows(True)
         self.mantidSnapper = MantidSnapper(self, __name__)
 
+    @staticmethod
+    def _appendErrorMessage(errors: Dict[str, str], key: str, msg: str):
+        existingMsg = errors.get(key, "")
+        if bool(existingMsg):
+            existingMsg += "\n"
+        errors[key] = existingMsg + msg
+    
     def validateInputs(self) -> Dict[str, str]:
         errors = {}
-        # make sure map is consistent with input data
-        inWS = self.mantidSnapper.mtd[self.getPropertyValue("InputWorkspace")]
-        groupWS = self.mantidSnapper.mtd[self.getPropertyValue("LiteDataMapWorkspace")]
-        if inWS.getNumberHistograms() == len(groupWS.getGroupIDs()):
-            # the data has already been reduced -- not an issue
-            pass
-        elif inWS.getNumberHistograms() != groupWS.getNumberHistograms():
-            msg = f"""
-                The workspaces {self.getPropertyValue("InputWorkspace")}
-                and {self.getPropertyValue("LiteDataMapWorkspace")}
-                have inconsistent number of spectra
-                """
-            errors["InputWorkspace"] = msg
-            errors["LiteDataMapWorkspace"] = msg
-        self._liteModeResolution = len(groupWS.getGroupIDs())
+
+        if self.getProperty("Ingredients").isDefault:
+            errors["Ingredients"] = "A valid instance of 'LiteDataCreationIngredients' must be specified."
+            
+        # Make sure that the input workspace is consistent with the lite-data map.
+        inputWs = self.mantidSnapper.mtd[self.getPropertyValue("InputWorkspace")]
+        groupingWs = self.mantidSnapper.mtd[self.getPropertyValue("LiteDataMapWorkspace")]
+        if inputWs.getNumberHistograms() == len(groupingWs.getGroupIDs()):
+            # This is definitely a usage error: do not _mask_ defects!
+            self._appendErrorMessage(
+                errors,
+                "InputWorkspace",
+                "Usage error: the input workspace has already been converted to lite mode."
+            )
+                
+        else:
+            # Implementation notes:
+            #
+            # In support of generalized lite-mode conversions we require:
+            #
+            #   a) The number of lite-mode pixels corresponds to the number of subgroups 
+            #     in the lite-data map (the default pixel-number is |native-mode pixels| / 64),
+            #     this must also be the number of pixels in the output instrument.
+            #
+            #   b) The input-data and lite-mode data map must use the same instrument.
+            #
+            #   c) The input-data has one spectrum per pixel. In order to include the effect of all
+            #     of the input data, this requirement cannot be modified, but might be relaxed
+            #     in special cases.
+            #
+            #   d) Apart from the previous, there is no required relationship between the number of
+            #     input spectra, and the number of spectra in the lite-data map, except that the latter
+            #     have >= the number of spectra as lite-data pixels.  The "application.yml"
+            #     constants will be used to validate these numbers.
+            #
+            
+            # "a)": Note that we do not have the lite-mode instrument yet, so we don't validate that here,
+            #       otherwise we'd need to load the lite-mode instrument twice.
+            if len(groupingWs.getGroupIDs()) != Config["instrument.lite.pixelResolution"]:
+                
+                # *** DEBUG ***
+                print(f"====== a) {len(groupingWs.getGroupIDs())} < {Config['instrument.lite.pixelResolution']}")
+                
+                self._appendErrorMessage(
+                    errors,
+                    "LiteDataMapWorkspace",
+                    "The lite-data map must have one subgroup for each lite-mode pixel."\
+                    "\n  The expected lite-mode pixel count may be specified in the 'application.yml'."
+                )
+                
+            # "b)": The input-data and lite-data map must have the same instrument.
+            # Comparing instruments is problematic: however, requiring both the instrument-name,
+            #   and the pixel count to match is a fairly safe verification.    
+            if (inputWs.getInstrument().getName() != groupingWs.getInstrument().getName())\
+                or (inputWs.getInstrument().getNumberDetectors(True)\
+                    != groupingWs.getInstrument().getNumberDetectors(True)):
+ 
+                 # *** DEBUG ***
+                print(f"====== b) {inputWs.getInstrument().getName()} != {groupingWs.getInstrument().getName()}")
+                print(f"       OR {inputWs.getInstrument().getNumberDetectors(True)} != {groupingWs.getInstrument().getNumberDetectors(True)}")
+
+                msg = "The lite-data map must have the same instrument as the input data workspace."
+                self._appendErrorMessage(
+                    errors,
+                    "InputWorkspace",
+                    msg
+                )
+                self._appendErrorMessage(
+                    errors,
+                    "LiteDataMapWorkspace",
+                    msg
+                )
+                
+            # "c), d)": the input-data has one spectrum per [non-monitor] pixel
+            if (inputWs.getNumberHistograms() != inputWs.getInstrument().getNumberDetectors(True))\
+                or (inputWs.getNumberHistograms() != Config["instrument.native.pixelResolution"]):
+                
+                
+                # *** DEBUG ***
+                print(f"====== b) {inputWs.getNumberHistograms()} != {inputWs.getInstrument().getNumberDetectors(True)}")
+                print(f"      OR {inputWs.getNumberHistograms()} != {Config['instrument.native.pixelResolution']}")
+                
+                self._appendErrorMessage(
+                    errors,
+                    "InputWorkspace",
+                    "The input-data workspace must have one spectrum per non-monitor pixel "\
+                    + "in the native-mode instrument."\
+                    + "\n  The expected native-mode pixel count may be specified in the 'application.yml'."
+                )
+
+        self._liteModeResolution = len(groupingWs.getGroupIDs())
         return errors
 
-    def chopIngredients(self, ingredients: InstrumentState):
-        self.deltaTOverT = ingredients.instrumentConfig.delTOverT
-        self.delLOverL = ingredients.instrumentConfig.delLOverL
-        self.L = ingredients.instrumentConfig.L1 + ingredients.instrumentConfig.L2
+    def chopIngredients(self, ingredients: LiteDataCreationIngredients):
+        instrumentState = ingredients.instrumentState
+        self.deltaTOverT = instrumentState.instrumentConfig.delTOverT
+        self.delLOverL = instrumentState.instrumentConfig.delLOverL
+        self.L = instrumentState.instrumentConfig.L1 + instrumentState.instrumentConfig.L2
         self.delL = self.delLOverL * self.L
-        self.delTheta = ingredients.delTh
-        return
+        self.delTheta = instrumentState.delTh
 
     def PyExec(self):
-        self.log().notice("Lite Data Creation START!")
-
+        ingredients = LiteDataCreationIngredients.model_validate_json(self.getProperty("Ingredients").value)
+    
         if self.getProperty("LiteInstrumentDefinitionFile").isDefault:
             liteInstrumentDefinitionFileKey = self.getPropertyValue("LiteInstrumentDefinitionFile")
             self.setPropertyValue("LiteInstrumentDefinitionFile", Config[liteInstrumentDefinitionFileKey])
 
-        ingredients = InstrumentState.model_validate_json(self.getProperty("Ingredients").value)
-        self.chopIngredients(ingredients)
+        useCompression = ingredients.instrumentState is not None\
+                           or ingredients.toleranceOverride is not None
+        overrideTolerance = ingredients.toleranceOverride is not None
+        
+        # Only calculate the deltaT if an override hasn't been specified.
+        if useCompression and not overrideTolerance:
+            self.chopIngredients(ingredients)
+        
         # load input workspace
         inputWorkspaceName = self.getPropertyValue("InputWorkspace")
         outputWorkspaceName = self.getPropertyValue("OutputWorkspace")
         groupingWorkspaceName = self.getPropertyValue("LiteDataMapWorkspace")
 
-        # flag for auto deletion of non-lite data
-        autoDelete = self.getProperty("AutoDeleteNonLiteWS").value
-
-        # check that we are not already in lite mode
-        # if we are, simply copy over the workspace and continue
-        # lite mode could be indicated by:
-        # - the word "Lite" in the comments of the workspace
-        # - the workspace having exactly as many pixels as Lite data
-        inputWS = self.mantidSnapper.mtd[inputWorkspaceName]
-        if "Lite" in inputWS.getComment() or inputWS.getNumberHistograms() == self._liteModeResolution:
-            self.log().notice("Input data already in Lite mode")
-            if outputWorkspaceName != inputWorkspaceName:
-                self.mantidSnapper.CloneWorkspace(
-                    "Workspace already lite, cloning it to output",
-                    InputWorkspace=inputWorkspaceName,
-                    OutputWorkspace=outputWorkspaceName,
-                )
-                self.mantidSnapper.executeQueue()
-            # add the word "Lite" to the comments for good measure
-            outWS = self.mantidSnapper.mtd[outputWorkspaceName]
-            outWS.setComment(outWS.getComment() + "\nLite")
-            self.setProperty("OutputWorkspace", outWS)
-            return  # NOTE EARLY
-
-        # use group detector with specific grouping file to create lite data
+        # Use `GroupDetectors` algorithm with the specified grouping file to create lite data.
         self.mantidSnapper.GroupDetectors(
             "Creating lite version...",
             InputWorkspace=inputWorkspaceName,
@@ -129,42 +191,44 @@ class LiteDataCreationAlgo(PythonAlgorithm):
             CopyGroupingFromWorkspace=groupingWorkspaceName,
         )
 
-        # Estimate resolution for the unfocused workspace
-        resolutionWorkspaceName = f"{outputWorkspaceName}_resolution"
-        partialResolutionWorkspaceName = f"{resolutionWorkspaceName}_partial"
-        resolutionWorkspaceName = self.mantidSnapper.CloneWorkspace(
-            "Workspace already lite, cloning it to output",
-            InputWorkspace=outputWorkspaceName,
-            OutputWorkspace=resolutionWorkspaceName,
-        )
+        if useCompression and not overrideTolerance:
+            # Estimate resolution for the unfocused workspace
+            resolutionWorkspaceName = f"{outputWorkspaceName}_resolution"
+            partialResolutionWorkspaceName = f"{resolutionWorkspaceName}_partial"
+            resolutionWorkspaceName = self.mantidSnapper.CloneWorkspace(
+                "Copying output workspace for resolution calculation",
+                InputWorkspace=outputWorkspaceName,
+                OutputWorkspace=resolutionWorkspaceName,
+            )
 
-        self.mantidSnapper.EstimateResolutionDiffraction(
-            f"Estimating resolution for {outputWorkspaceName}...",
-            InputWorkspace=resolutionWorkspaceName,
-            OutputWorkspace=resolutionWorkspaceName,
-            PartialResolutionWorkspaces=partialResolutionWorkspaceName,
-            DeltaTOFOverTOF=self.deltaTOverT,
-            SourceDeltaL=self.delL,
-            SourceDeltaTheta=self.delTheta,
-        )
+            self.mantidSnapper.EstimateResolutionDiffraction(
+                f"Estimating resolution for {outputWorkspaceName}...",
+                InputWorkspace=resolutionWorkspaceName,
+                OutputWorkspace=resolutionWorkspaceName,
+                PartialResolutionWorkspaces=partialResolutionWorkspaceName,
+                DeltaTOFOverTOF=self.deltaTOverT,
+                SourceDeltaL=self.delL,
+                SourceDeltaTheta=self.delTheta,
+            )
 
-        self.mantidSnapper.WashDishes(
-            "Remove the partial resolution workspace",
-            Workspace=partialResolutionWorkspaceName,
-        )
+            self.mantidSnapper.WashDishes(
+                "Remove the partial resolution workspace",
+                Workspace=partialResolutionWorkspaceName,
+            )
 
-        # Calculate ΔΤ as the negative of the minimum deltaDOverD
         self.mantidSnapper.executeQueue()
-        resolutionWS = self.mantidSnapper.mtd[resolutionWorkspaceName]
-        deltaDOverD = resolutionWS.extractY().flatten()
-        deltaT = -min(deltaDOverD)
-
-        if not self.getProperty("ToleranceOverride").isDefault:
-            deltaT = self.getProperty("ToleranceOverride").value
-
+        
+        deltaT = 0.0
+        if useCompression and not overrideTolerance:
+            # Calculate the resolved 'deltaT' as the negative of the minimum deltaDOverD.
+            resolutionWS = self.mantidSnapper.mtd[resolutionWorkspaceName]
+            deltaDOverD = resolutionWS.extractY().flatten()
+            deltaT = -min(deltaDOverD)
+        elif overrideTolerance:
+            deltaT = ingredients.toleranceOverride
+            
         self.setProperty("Tolerance", deltaT)
 
-        # TODO how can this be removed?
         # replace instrument definition with lite
         self.mantidSnapper.LoadInstrument(
             "Replacing instrument definition with Lite instrument",
@@ -172,35 +236,47 @@ class LiteDataCreationAlgo(PythonAlgorithm):
             Filename=self.getPropertyValue("LiteInstrumentDefinitionFile"),
             RewriteSpectraMap=False,
         )
+        
+        if useCompression:
+            compressEventsKwargs = {
+                "InputWorkspace": outputWorkspaceName,
+                "OutputWorkspace": outputWorkspaceName,
+            }
+            if Config["constants.LiteDataCreationAlgo.toggleCompressionTolerance"]:
+                compressEventsKwargs["Tolerance"] = deltaT
 
-        compressEventsKwargs = {
-            "InputWorkspace": outputWorkspaceName,
-            "OutputWorkspace": outputWorkspaceName,
-        }
-        if Config["constants.LiteDataCreationAlgo.toggleCompressionTolerance"]:
-            compressEventsKwargs["Tolerance"] = deltaT
-
-        self.mantidSnapper.CompressEvents(
-            f"Compressing events in {outputWorkspaceName}...",
-            **compressEventsKwargs,
-        )
-
-        if autoDelete is True:
-            self.mantidSnapper.WashDishes(
-                f"Deleting {inputWorkspaceName}...",
-                Workspace=inputWorkspaceName,
+            self.mantidSnapper.CompressEvents(
+                f"Compressing events in {outputWorkspaceName}...",
+                **compressEventsKwargs,
             )
-
-        # iterate over spectra in grouped workspace, delete old ids and replace
+        
         self.mantidSnapper.executeQueue()
-        liteWksp = self.mantidSnapper.mtd[outputWorkspaceName]
-        nHst = liteWksp.getNumberHistograms()
+
+        outputWs = self.mantidSnapper.mtd[outputWorkspaceName]
+
+        # Double-check that the newly-inserted output instrument makes sense:
+        #   for efficiency reasons this was not done at `validateInputs`.
+        if outputWs.getInstrument().getNumberDetectors(True) != Config["instrument.lite.pixelResolution"]:
+            raise RuntimeError("The specified lite-mode instrument does not have the expeced number of pixels")
+        
+        # Update the spectrum-to-detector map:
+        #   iterate over all of the spectra in the output workspace,
+        #   replacing each group of native-mode pixels with a single pixel.                       
+        nHst = outputWs.getNumberHistograms()
         for i in range(nHst):
-            el = liteWksp.getSpectrum(i)
+            el = outputWs.getSpectrum(i)
             el.clearDetectorIDs()
             el.addDetectorID(i)
-        liteWksp.setComment(liteWksp.getComment() + "\nLite")
-        self.setProperty("OutputWorkspace", liteWksp)
+        
+        # Mark the output workspace as containing lite-mode data.    
+        # TODO: use metadata for this -- why use the comment?
+        outputWs.setComment(outputWs.getComment() + "\nLite")
+                
+        # Enforce consistency between the parametrized detector positions,
+        #   and those specified in the workspace logs.
+        outputWs.populateInstrumentParameters()
+
+        self.setProperty("OutputWorkspace", outputWs)
 
 
 # Register algorithm with Mantid

--- a/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculation.py
+++ b/src/snapred/backend/recipe/algorithm/PixelGroupingParametersCalculation.py
@@ -56,10 +56,11 @@ class PixelGroupingParametersCalculation(PythonAlgorithm):
         )
         self.setRethrows(True)
         self.mantidSnapper = MantidSnapper(self, __name__)
-        return
 
-    def chopIngredients(self, ingredients: PixelGroupingIngredients) -> None:
-        # define/calculate some auxiliary state-derived parameters
+    def chopIngredients(self, ingredients: PixelGroupingIngredients):
+        self.groupingScheme = ingredients.groupingScheme
+        
+        # define / calculate some auxiliary state-derived parameters
         self.tofMin = ingredients.instrumentState.particleBounds.tof.minimum
         self.tofMax = ingredients.instrumentState.particleBounds.tof.maximum
         self.deltaTOverT = ingredients.instrumentState.instrumentConfig.delTOverT
@@ -67,7 +68,6 @@ class PixelGroupingParametersCalculation(PythonAlgorithm):
         self.L = ingredients.instrumentState.instrumentConfig.L1 + ingredients.instrumentState.instrumentConfig.L2
         self.delL = self.delLOverL * self.L
         self.delTheta = ingredients.instrumentState.delTh
-        return
 
     def unbagGroceries(self, ingredients: PixelGroupingIngredients):  # noqa: ARG002
         self.groupingWorkspaceName: str = self.getPropertyValue("GroupingWorkspace")
@@ -76,17 +76,15 @@ class PixelGroupingParametersCalculation(PythonAlgorithm):
         self.partialResolutionWorkspaceName: str = self.resolutionWorkspaceName + "_partial"
 
     def PyExec(self):
-        self.log().notice("Calculate pixel grouping state-derived parameters")
-
         lowdSpacingCrop = Config["constants.CropFactors.lowdSpacingCrop"]
         highdSpacingCrop = Config["constants.CropFactors.highdSpacingCrop"]
 
-        if lowdSpacingCrop < 0:
+        if lowdSpacingCrop < 0.0:
             raise ValueError("Low d-spacing crop factor must be positive")
-        if highdSpacingCrop < 0:
+        if highdSpacingCrop < 0.0:
             raise ValueError("High d-spacing crop factor must be positive")
 
-        if (lowdSpacingCrop > 100) or (highdSpacingCrop > 100):
+        if (lowdSpacingCrop > 100.0) or (highdSpacingCrop > 100.0):
             raise ValueError("d-spacing crop factors are too large")
 
         # define/calculate some auxiliary state-derived parameters
@@ -112,8 +110,8 @@ class PixelGroupingParametersCalculation(PythonAlgorithm):
         self.mantidSnapper.executeQueue()
 
         # Create a grouped-by-detector workspace from the grouping workspace
-        # and estimate the relative resolution for all pixel groupings.
-        # These algorithms use detector mask-flag information from the 'InputWorkspace'.
+        # and estimate the relative resolution for all pixel subgroups.
+        # These algorithms use detector mask-flags information from the 'InputWorkspace'.
 
         self.mantidSnapper.GroupDetectors(
             "Grouping detectors...",
@@ -122,7 +120,7 @@ class PixelGroupingParametersCalculation(PythonAlgorithm):
             OutputWorkspace=self.resolutionWorkspaceName,
         )
 
-        #  => resolution will be _zero_ for any fully-masked pixel group
+        #  Note that resolution will be _zero_ for any fully-masked pixel subgroup.
         self.mantidSnapper.EstimateResolutionDiffraction(
             "Estimating diffraction resolution...",
             InputWorkspace=self.resolutionWorkspaceName,
@@ -138,7 +136,7 @@ class PixelGroupingParametersCalculation(PythonAlgorithm):
         )
         self.mantidSnapper.executeQueue()
 
-        # calculate parameters for all pixel groupings and store them in json format
+        # Calculate parameters for all pixel subgroups.
         allGroupingParams = []
         groupingWS = self.mantidSnapper.mtd[tmpGroupingWSName]
         resolutionWS = self.mantidSnapper.mtd[self.resolutionWorkspaceName]
@@ -178,7 +176,7 @@ class PixelGroupingParametersCalculation(PythonAlgorithm):
                 except RuntimeError as e:
                     # Also entered as defect EWM#5073:
                     # `DetectorInfo.azimuthal()` has issues in calculating ambiguous azimuth values:
-                    #   * by convention, these values can be set to zero, without overly affecting the mean value.
+                    #   * by convention, these values can be treated as zero, without overly affecting the mean value.
                     if "Failed to create up axis orthogonal to the beam direction" not in str(e):
                         raise
                     logger.debug(e)

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -120,15 +120,16 @@ class SousChef(Service):
         if key not in self._pixelGroupCache:
             focusGroup = self.prepFocusGroup(ingredients)
             instrumentState = self.prepInstrumentState(ingredients)
-            pixelIngredients = PixelGroupingIngredients(
+            pixelGroupingIngredients = PixelGroupingIngredients(
                 instrumentState=instrumentState,
+                groupingScheme=focusGroup.name,
                 nBinsAcrossPeakWidth=ingredients.nBinsAcrossPeakWidth,
             )
             self.groceryClerk.name("groupingWorkspace").fromRun(ingredients.runNumber).grouping(
                 focusGroup.name
             ).useLiteMode(ingredients.useLiteMode).add()
             groceries = self.groceryService.fetchGroceryDict(self.groceryClerk.buildDict(), maskWorkspace=pixelMask)
-            data = PixelGroupingParametersCalculationRecipe().executeRecipe(pixelIngredients, groceries)
+            data = PixelGroupingParametersCalculationRecipe().executeRecipe(pixelGroupingIngredients, groceries)
 
             self._pixelGroupCache[key] = PixelGroup(
                 focusGroup=focusGroup,

--- a/tests/unit/backend/recipe/algorithm/test_LiteDataCreationAlgo.py
+++ b/tests/unit/backend/recipe/algorithm/test_LiteDataCreationAlgo.py
@@ -1,46 +1,42 @@
-import os
-import unittest.mock as mock
+from mantid.simpleapi import (
+    CloneWorkspace,
+    ConvertToEventWorkspace,
+    CreateWorkspace,
+    LoadDetectorsGroupingFile,
+    LoadEmptyInstrument,
+    LoadInstrument,
+    mtd
+)
 
-import pytest
-from mantid.simpleapi import DeleteWorkspace, mtd
-from util.dao import DAOFactory
-
+from snapred.backend.dao.ingredients import LiteDataCreationIngredients
 from snapred.backend.recipe.algorithm.LiteDataCreationAlgo import LiteDataCreationAlgo
 from snapred.meta.Config import Resource
 
-HAVE_MOUNT_SNAP = os.path.exists("/SNS/SNAP/")
+import unittest.mock as mock
+import pytest
+from util.Config_helpers import Config_override
+from util.dao import DAOFactory
 
 
 @pytest.fixture(autouse=True)
 def _setup_teardown():
     """Clear all workspaces before and after tests."""
-    workspaces = mtd.getObjectNames()
-    for workspace in workspaces:
-        try:
-            DeleteWorkspace(workspace)
-        except ValueError:
-            print(f"Workspace {workspace} doesn't exist!")
-
-
-def test_LiteDataCreationAlgo_invalid_input():
-    """Test how the algorithm handles an invalid input workspace."""
+    mtd.clear()
+    yield
+    
+    # teardown:
+    mtd.clear()
+    
+    
+def test_LiteDataCreationAlgo_mandatory_properties():
+    """Test mandatory input properties."""
     liteDataCreationAlgo = LiteDataCreationAlgo()
     liteDataCreationAlgo.initialize()
-    liteDataCreationAlgo.setPropertyValue("AutoDeleteNonLiteWS", "1")
     with pytest.raises(RuntimeError):
         liteDataCreationAlgo.execute()
 
 
 def test_fakeInstrument():
-    from mantid.simpleapi import (
-        ConvertToEventWorkspace,
-        CreateWorkspace,
-        DeleteWorkspace,
-        LoadDetectorsGroupingFile,
-        LoadInstrument,
-        mtd,
-    )
-
     fullInstrumentWS = "_test_lite_algo_native"
     liteInstrumentWS = "_test_lite_algo_lite"
     focusWS = "_test_lite_data_map"
@@ -48,44 +44,50 @@ def test_fakeInstrument():
     fullInstrumentFile = Resource.getPath("inputs/testInstrument/fakeSNAP_Definition.xml")
     liteInstrumentFile = Resource.getPath("inputs/testInstrument/fakeSNAPLite.xml")
     liteInstrumentMap = Resource.getPath("inputs/testInstrument/fakeSNAPLiteGroupMap.xml")
-    instrumentState = DAOFactory.synthetic_instrument_state.copy()
+    ingredients = LiteDataCreationIngredients(
+        instrumentState=DAOFactory.synthetic_instrument_state.copy()
+    )
 
     fullResolution: int = 16
     liteResolution: int = 4
 
-    # create simple event data with a different number in each pixel
-    CreateWorkspace(
-        OutputWorkspace=fullInstrumentWS,
-        DataX=[0.5, 1.5] * fullResolution,
-        DataY=range(fullResolution),
-        DataE=[0.01] * fullResolution,
-        NSpec=fullResolution,
-    )
-    ConvertToEventWorkspace(
-        InputWorkspace=fullInstrumentWS,
-        OutputWorkspace=fullInstrumentWS,
-    )
-    # load the instrument, and load the grouping file
-    LoadInstrument(
-        Workspace=fullInstrumentWS,
-        Filename=fullInstrumentFile,
-        RewriteSpectraMap=True,
-    )
-    LoadDetectorsGroupingFile(
-        InputFile=liteInstrumentMap,
-        InputWorkspace=fullInstrumentWS,
-        OutputWorkspace=focusWS,
-    )
+    with (
+        Config_override("instrument.native.pixelResolution", fullResolution),
+        Config_override("instrument.lite.pixelResolution", liteResolution)
+    ):
+        # create simple event data with a different number in each pixel
+        CreateWorkspace(
+            OutputWorkspace=fullInstrumentWS,
+            DataX=[0.5, 1.5] * fullResolution,
+            DataY=range(fullResolution),
+            DataE=[0.01] * fullResolution,
+            NSpec=fullResolution,
+        )
+        ConvertToEventWorkspace(
+            InputWorkspace=fullInstrumentWS,
+            OutputWorkspace=fullInstrumentWS,
+        )
+        # load the instrument, and load the grouping file
+        LoadInstrument(
+            Workspace=fullInstrumentWS,
+            Filename=fullInstrumentFile,
+            RewriteSpectraMap=True,
+        )
+        LoadDetectorsGroupingFile(
+            InputFile=liteInstrumentMap,
+            InputWorkspace=fullInstrumentWS,
+            OutputWorkspace=focusWS,
+        )
 
-    # run the algorithm
-    liteDataCreationAlgo = LiteDataCreationAlgo()
-    liteDataCreationAlgo.initialize()
-    liteDataCreationAlgo.setPropertyValue("InputWorkspace", fullInstrumentWS)
-    liteDataCreationAlgo.setPropertyValue("OutputWorkspace", liteInstrumentWS)
-    liteDataCreationAlgo.setPropertyValue("LiteDataMapWorkspace", focusWS)
-    liteDataCreationAlgo.setPropertyValue("LiteInstrumentDefinitionFile", liteInstrumentFile)
-    liteDataCreationAlgo.setPropertyValue("Ingredients", instrumentState.model_dump_json())
-    liteDataCreationAlgo.execute()
+        # run the algorithm
+        liteDataCreationAlgo = LiteDataCreationAlgo()
+        liteDataCreationAlgo.initialize()
+        liteDataCreationAlgo.setPropertyValue("InputWorkspace", fullInstrumentWS)
+        liteDataCreationAlgo.setPropertyValue("OutputWorkspace", liteInstrumentWS)
+        liteDataCreationAlgo.setPropertyValue("LiteDataMapWorkspace", focusWS)
+        liteDataCreationAlgo.setPropertyValue("LiteInstrumentDefinitionFile", liteInstrumentFile)
+        liteDataCreationAlgo.setPropertyValue("Ingredients", ingredients.model_dump_json())
+        liteDataCreationAlgo.execute()
 
     # check that the lite data is correct
     # 1. check the lite data has four histograms
@@ -112,75 +114,129 @@ def test_fakeInstrument():
     # check that the data has been flagged as lite
     assert "Lite" in liteWS.getComment()
 
-    # clean up
-    DeleteWorkspace(fullInstrumentWS)
-    DeleteWorkspace(liteInstrumentWS)
-    DeleteWorkspace(focusWS)
-
 
 def test_fail_with_no_output():
-    from mantid.simpleapi import (
-        ConvertToEventWorkspace,
-        CreateWorkspace,
-        DeleteWorkspace,
-        LoadDetectorsGroupingFile,
-        LoadInstrument,
-    )
-
+    # 'OutputWorkspace' must be specified.
+    
     fullInstrumentWS = "_test_lite_algo_native"
     focusWS = "_test_lite_data_map"
 
     fullInstrumentFile = Resource.getPath("inputs/testInstrument/fakeSNAP_Definition.xml")
     liteInstrumentFile = Resource.getPath("inputs/testInstrument/fakeSNAPLite.xml")
     liteInstrumentMap = Resource.getPath("inputs/testInstrument/fakeSNAPLiteGroupMap.xml")
+    ingredients = LiteDataCreationIngredients(
+        instrumentState=DAOFactory.synthetic_instrument_state.copy()
+    )
 
     fullResolution: int = 16
+    liteResolution: int = 4
 
-    # create simple event data with a different number in each pixel
-    CreateWorkspace(
-        OutputWorkspace=fullInstrumentWS,
-        DataX=[0.5, 1.5] * fullResolution,
-        DataY=range(fullResolution),
-        DataE=[0.01] * fullResolution,
-        NSpec=fullResolution,
+    with (
+        Config_override("instrument.native.pixelResolution", fullResolution),
+        Config_override("instrument.lite.pixelResolution", liteResolution)
+    ):
+        # create simple event data with a different number in each pixel
+        CreateWorkspace(
+            OutputWorkspace=fullInstrumentWS,
+            DataX=[0.5, 1.5] * fullResolution,
+            DataY=range(fullResolution),
+            DataE=[0.01] * fullResolution,
+            NSpec=fullResolution,
+        )
+        ConvertToEventWorkspace(
+            InputWorkspace=fullInstrumentWS,
+            OutputWorkspace=fullInstrumentWS,
+        )
+        # load the instrument, and load the grouping file
+        LoadInstrument(
+            Workspace=fullInstrumentWS,
+            Filename=fullInstrumentFile,
+            RewriteSpectraMap=True,
+        )
+        LoadDetectorsGroupingFile(
+            InputFile=liteInstrumentMap,
+            InputWorkspace=fullInstrumentWS,
+            OutputWorkspace=focusWS,
+        )
+
+        # will fail with no output
+        liteDataCreationAlgo = LiteDataCreationAlgo()
+        liteDataCreationAlgo.initialize()
+        liteDataCreationAlgo.setPropertyValue("InputWorkspace", fullInstrumentWS)
+        liteDataCreationAlgo.setPropertyValue("LiteDataMapWorkspace", focusWS)
+        liteDataCreationAlgo.setPropertyValue("LiteInstrumentDefinitionFile", liteInstrumentFile)
+        liteDataCreationAlgo.setPropertyValue("Ingredients", ingredients.model_dump_json())
+        with pytest.raises(RuntimeError) as e:
+            liteDataCreationAlgo.execute()
+        assert "invalid Properties" in str(e.value)
+
+
+def test_fail_to_validate_missing_properties():
+    # 'InputWorkspace' must be specified.
+    # 'LiteDataMapWorkspace' must be specified.
+    
+    instrumentWorkspace: str = "_test_lite_idf"
+    liteInstrumentWS: str = "_test_lite_algo_lite"
+    focusWS = "_test_lite_data_map"
+
+    fullInstrumentFile = Resource.getPath("inputs/testInstrument/fakeSNAP_Definition.xml")
+    liteInstrumentFile = Resource.getPath("inputs/testInstrument/fakeSNAPLite.xml")
+    liteInstrumentMap = Resource.getPath("inputs/testInstrument/fakeSNAPLiteGroupMap.xml")
+    ingredients = LiteDataCreationIngredients(
+        instrumentState=DAOFactory.synthetic_instrument_state.copy()
     )
-    ConvertToEventWorkspace(
-        InputWorkspace=fullInstrumentWS,
-        OutputWorkspace=fullInstrumentWS,
-    )
+    
     # load the instrument, and load the grouping file
-    LoadInstrument(
-        Workspace=fullInstrumentWS,
+    LoadEmptyInstrument(
+        OutputWorkspace=instrumentWorkspace,
         Filename=fullInstrumentFile,
-        RewriteSpectraMap=True,
     )
     LoadDetectorsGroupingFile(
         InputFile=liteInstrumentMap,
-        InputWorkspace=fullInstrumentWS,
+        InputWorkspace=instrumentWorkspace,
         OutputWorkspace=focusWS,
     )
 
-    # will fail with no output
-    liteDataCreationAlgo = LiteDataCreationAlgo()
-    liteDataCreationAlgo.initialize()
-    liteDataCreationAlgo.setPropertyValue("InputWorkspace", fullInstrumentWS)
-    liteDataCreationAlgo.setPropertyValue("LiteDataMapWorkspace", focusWS)
-    liteDataCreationAlgo.setPropertyValue("LiteInstrumentDefinitionFile", liteInstrumentFile)
-    with pytest.raises(RuntimeError) as e:
-        liteDataCreationAlgo.execute()
-    assert "invalid Properties" in str(e.value)
 
-    DeleteWorkspace(fullInstrumentWS)
-    DeleteWorkspace(focusWS)
+    fullResolution: int = 16
+    liteResolution: int = 4
+
+    with (
+        Config_override("instrument.native.pixelResolution", fullResolution),
+        Config_override("instrument.lite.pixelResolution", liteResolution)
+    ):
+        # setup the algorithm
+        liteDataCreationAlgo = LiteDataCreationAlgo()
+        liteDataCreationAlgo.initialize()
+        liteDataCreationAlgo.setPropertyValue("OutputWorkspace", liteInstrumentWS)
+        liteDataCreationAlgo.setPropertyValue("LiteInstrumentDefinitionFile", liteInstrumentFile)
+        liteDataCreationAlgo.setPropertyValue("Ingredients", ingredients.model_dump_json())
+
+        # try executing without an input workspace -- should complain
+        with pytest.raises(RuntimeError) as e:
+            liteDataCreationAlgo.execute()
+        assert "some invalid properties found" in str(e.value).lower()
+        
+
+    with (
+        Config_override("instrument.native.pixelResolution", fullResolution),
+        Config_override("instrument.lite.pixelResolution", liteResolution)
+    ):
+        # setup the algorithm
+        liteDataCreationAlgo = LiteDataCreationAlgo()
+        liteDataCreationAlgo.initialize()
+        liteDataCreationAlgo.setPropertyValue("OutputWorkspace", liteInstrumentWS)
+        liteDataCreationAlgo.setPropertyValue("LiteInstrumentDefinitionFile", liteInstrumentFile)
+        liteDataCreationAlgo.setPropertyValue("Ingredients", ingredients.model_dump_json())
+        
+        # try executing without a map workspace -- should complain
+        with pytest.raises(RuntimeError) as e:
+            liteDataCreationAlgo.execute()
+        assert "some invalid properties found" in str(e.value).lower()
 
 
-def test_fail_to_validate():
-    from mantid.simpleapi import (
-        CreateWorkspace,
-        DeleteWorkspace,
-        LoadDetectorsGroupingFile,
-        LoadEmptyInstrument,
-    )
+def test_fail_to_validate_input_format():
+    # 'InputWorkspace' must have the correct number of spectra.
 
     instrumentWorkspace: str = "_test_lite_idf"
     invalidWorkspace: str = "_test_lite_algo_invalid"
@@ -190,6 +246,10 @@ def test_fail_to_validate():
     fullInstrumentFile = Resource.getPath("inputs/testInstrument/fakeSNAP_Definition.xml")
     liteInstrumentFile = Resource.getPath("inputs/testInstrument/fakeSNAPLite.xml")
     liteInstrumentMap = Resource.getPath("inputs/testInstrument/fakeSNAPLiteGroupMap.xml")
+    instrumentState = DAOFactory.synthetic_instrument_state.copy()
+    ingredients = LiteDataCreationIngredients(
+        instrumentState=DAOFactory.synthetic_instrument_state.copy()
+    )
 
     # load the instrument, and load the grouping file
     LoadEmptyInstrument(
@@ -202,63 +262,53 @@ def test_fail_to_validate():
         OutputWorkspace=focusWS,
     )
 
+
     fullResolution: int = 16
     liteResolution: int = 4
 
-    # setup the algorithm
-    liteDataCreationAlgo = LiteDataCreationAlgo()
-    liteDataCreationAlgo.initialize()
-    liteDataCreationAlgo.setPropertyValue("OutputWorkspace", liteInstrumentWS)
-    liteDataCreationAlgo.setPropertyValue("LiteInstrumentDefinitionFile", liteInstrumentFile)
+    with (
+        Config_override("instrument.native.pixelResolution", fullResolution),
+        Config_override("instrument.lite.pixelResolution", liteResolution)
+    ):
+        # setup the algorithm
+        liteDataCreationAlgo = LiteDataCreationAlgo()
+        liteDataCreationAlgo.initialize()
+        liteDataCreationAlgo.setPropertyValue("OutputWorkspace", liteInstrumentWS)
+        liteDataCreationAlgo.setPropertyValue("LiteInstrumentDefinitionFile", liteInstrumentFile)
+        liteDataCreationAlgo.setPropertyValue("Ingredients", ingredients.model_dump_json())
 
-    # try executing without an input workspace -- should complain
-    with pytest.raises(RuntimeError) as e:
-        liteDataCreationAlgo.execute()
-    assert "some invalid properties found" in str(e.value).lower()
+        # Create an event workspace with an incorrect number of spectra.
+        invalidResolution = fullResolution + 1
+        CreateWorkspace(
+            OutputWorkspace=invalidWorkspace,
+            DataX=[0.5, 1.5] * invalidResolution,
+            DataY=range(invalidResolution),
+            DataE=[0.01] * invalidResolution,
+            NSpec=invalidResolution
+        )
+        ConvertToEventWorkspace(
+            InputWorkspace=invalidWorkspace,
+            OutputWorkspace=invalidWorkspace
+        )
+        LoadInstrument(
+            Workspace=invalidWorkspace,
+            Filename=fullInstrumentFile,
+            RewriteSpectraMap=True
+        )
+        
+        liteDataCreationAlgo.setPropertyValue("InputWorkspace", invalidWorkspace)
 
-    # try running with the incorrect number of spectra
-    invalidResolution: int = fullResolution + 1
-    CreateWorkspace(
-        OutputWorkspace=invalidWorkspace,
-        DataX=[1] * invalidResolution,
-        DataY=[1] * invalidResolution,
-        DataE=[1] * invalidResolution,
-        NSpec=invalidResolution,
-    )
-    liteDataCreationAlgo.setPropertyValue("InputWorkspace", invalidWorkspace)
-    # try executing without a map workspace -- should complain
-    with pytest.raises(RuntimeError) as e:
-        liteDataCreationAlgo.execute()
-    assert "some invalid properties found" in str(e.value).lower()
-
-    # should complain inconsistent resolution with lite data map
-    liteDataCreationAlgo.setPropertyValue("LiteDataMapWorkspace", focusWS)
-    with pytest.raises(RuntimeError) as e:
-        liteDataCreationAlgo.execute()
-    print(str(e))
-    assert "InputWorkspace" in str(e.value)
-    assert "LiteDataMapWorkspace" in str(e.value)
-    assert invalidWorkspace in str(e.value)
-    assert focusWS in str(e.value)
-    assert liteDataCreationAlgo._liteModeResolution == liteResolution
-
-    # cleanup
-    DeleteWorkspace(invalidWorkspace)
-    DeleteWorkspace(instrumentWorkspace)
-    DeleteWorkspace(focusWS)
+        # should complain inconsistent resolution with lite data map
+        liteDataCreationAlgo.setPropertyValue("LiteDataMapWorkspace", focusWS)
+        with pytest.raises(RuntimeError, match=r".*one spectrum per non-monitor pixel.*"):
+            liteDataCreationAlgo.execute()
 
 
-def test_no_run_twice():
-    from mantid.simpleapi import (
-        CloneWorkspace,
-        ConvertToEventWorkspace,
-        CreateWorkspace,
-        DeleteWorkspace,
-        LoadDetectorsGroupingFile,
-        LoadEmptyInstrument,
-        LoadInstrument,
-    )
-
+def test_input_format_already_lite():
+    # Test: converted to lite-mode data is marked correctly as 'Lite'.
+    # Test: Usage error: input data already in lite-mode and marked as such.
+    # Test: Usage error: input data already in lite-mode and not marked.
+    
     instrumentWorkspace: str = "_test_lite_idf"
     inputWorkspace: str = "_test_lite_algo_input"
     outputWorkspace: str = "_test_lite_algo_output"
@@ -268,6 +318,9 @@ def test_no_run_twice():
     liteInstrumentFile = Resource.getPath("inputs/testInstrument/fakeSNAPLite.xml")
     liteInstrumentMap = Resource.getPath("inputs/testInstrument/fakeSNAPLiteGroupMap.xml")
     instrumentState = DAOFactory.synthetic_instrument_state.copy()
+    ingredients = LiteDataCreationIngredients(
+        instrumentState=DAOFactory.synthetic_instrument_state.copy()
+    )
 
     LoadEmptyInstrument(
         OutputWorkspace=instrumentWorkspace,
@@ -279,129 +332,76 @@ def test_no_run_twice():
         OutputWorkspace=focusWS,
     )
 
+
     fullResolution: int = 16
     liteResolution: int = 4
 
-    # setup the algorithm
-    liteDataCreationAlgo = LiteDataCreationAlgo()
-    liteDataCreationAlgo.initialize()
-    liteDataCreationAlgo.setPropertyValue("OutputWorkspace", outputWorkspace)
-    liteDataCreationAlgo.setPropertyValue("LiteDataMapWorkspace", focusWS)
-    liteDataCreationAlgo.setPropertyValue("LiteInstrumentDefinitionFile", liteInstrumentFile)
-    liteDataCreationAlgo.setPropertyValue("Ingredients", instrumentState.model_dump_json())
+    with (
+        Config_override("instrument.native.pixelResolution", fullResolution),
+        Config_override("instrument.lite.pixelResolution", liteResolution)
+    ):
+        # setup the algorithm
+        liteDataCreationAlgo = LiteDataCreationAlgo()
+        liteDataCreationAlgo.initialize()
+        liteDataCreationAlgo.setPropertyValue("OutputWorkspace", outputWorkspace)
+        liteDataCreationAlgo.setPropertyValue("LiteDataMapWorkspace", focusWS)
+        liteDataCreationAlgo.setPropertyValue("LiteInstrumentDefinitionFile", liteInstrumentFile)
+        liteDataCreationAlgo.setPropertyValue("Ingredients", ingredients.model_dump_json())
 
-    # try reducing native resolution, then running again with the Lite output
-    CreateWorkspace(
-        OutputWorkspace=inputWorkspace,
-        DataX=[0.5, 1.5] * fullResolution,
-        DataY=[1] * fullResolution,
-        DataE=[1] * fullResolution,
-        NSpec=fullResolution,
-    )
-    ConvertToEventWorkspace(
-        InputWorkspace=inputWorkspace,
-        OutputWorkspace=inputWorkspace,
-    )
-    LoadInstrument(
-        Workspace=inputWorkspace,
-        Filename=fullInstrumentFile,
-        RewriteSpectraMap=True,
-    )
-    # check that it runs
-    liteDataCreationAlgo.setPropertyValue("InputWorkspace", inputWorkspace)
-    assert liteDataCreationAlgo.execute()
-    assert liteDataCreationAlgo._liteModeResolution == liteResolution
+        # try reducing native resolution, then running again with the Lite output
+        CreateWorkspace(
+            OutputWorkspace=inputWorkspace,
+            DataX=[0.5, 1.5] * fullResolution,
+            DataY=[1] * fullResolution,
+            DataE=[1] * fullResolution,
+            NSpec=fullResolution,
+        )
+        ConvertToEventWorkspace(
+            InputWorkspace=inputWorkspace,
+            OutputWorkspace=inputWorkspace,
+        )
+        LoadInstrument(
+            Workspace=inputWorkspace,
+            Filename=fullInstrumentFile,
+            RewriteSpectraMap=True,
+        )
+        # check that it runs
+        liteDataCreationAlgo.setPropertyValue("InputWorkspace", inputWorkspace)
+        assert liteDataCreationAlgo.execute()
+        assert liteDataCreationAlgo._liteModeResolution == liteResolution
 
-    # check the data is reduced and marked as lite
-    liteWS = mtd[outputWorkspace]
-    assert liteWS.getNumberHistograms() == liteResolution
-    assert "Lite" in liteWS.getComment()
+        # check the data is reduced and marked as lite
+        liteWS = mtd[outputWorkspace]
+        assert liteWS.getNumberHistograms() == liteResolution
+        assert "Lite" in liteWS.getComment()
 
-    # copy the reduced data, and run it again as the input
-    CloneWorkspace(
-        InputWorkspace=outputWorkspace,
-        outputWorkspace=inputWorkspace,
-    )
+        # copy the reduced data, and run it again as the input
+        CloneWorkspace(
+            InputWorkspace=outputWorkspace,
+            outputWorkspace=inputWorkspace,
+        )
 
-    # ensure it is reduced data being sent as the input
-    liteWS = mtd[inputWorkspace]
-    assert liteWS.getNumberHistograms() == liteResolution
-    assert "Lite" in liteWS.getComment()
+        # ensure it is lite-mode data being sent as the input
+        liteWS = mtd[inputWorkspace]
+        assert liteWS.getNumberHistograms() == liteResolution
+        assert "Lite" in liteWS.getComment()
 
-    # mock GroupDetectors -- should never be reached
-    liteDataCreationAlgo.mantidSnapper.GroupDetectors = mock.Mock()
+        # run the algo with this lite-mode workspace
+        liteDataCreationAlgo.setPropertyValue("InputWorkspace", inputWorkspace)        
+        with pytest.raises(RuntimeError, match="Usage error: the input workspace has already been converted to lite mode."):
+            liteDataCreationAlgo.execute()
 
-    # run the algo with this reduced workspace and check it never got to GroupDetectors
-    liteDataCreationAlgo.setPropertyValue("InputWorkspace", inputWorkspace)
-    assert liteDataCreationAlgo.execute()
-    assert liteDataCreationAlgo._liteModeResolution == liteResolution
-    liteWS = mtd[outputWorkspace]
-    assert liteWS.getNumberHistograms() == liteResolution
-    assert "Lite" in liteWS.getComment()
-    liteDataCreationAlgo.mantidSnapper.GroupDetectors.assert_not_called()
-
-    # reset the comment so it does not have the word "Lite"
-    # but it does have lite resolution
-    # run, and make sure not further reduced
-    liteWS.setComment("No comment")
-    assert "Lite" not in liteWS.getComment()
-    CloneWorkspace(
-        InputWorkspace=liteWS,
-        OutputWorkspace=inputWorkspace,
-    )
-    liteDataCreationAlgo.setPropertyValue("InputWorkspace", inputWorkspace)
-    assert liteDataCreationAlgo.execute()
-    assert liteDataCreationAlgo._liteModeResolution == liteResolution
-    liteDataCreationAlgo.mantidSnapper.GroupDetectors.assert_not_called()
-
-    # try running with data already at Lite resolution
-    CreateWorkspace(
-        OutputWorkspace=inputWorkspace,
-        DataX=[1] * liteResolution,
-        DataY=[1] * liteResolution,
-        DataE=[1] * liteResolution,
-        NSpec=liteResolution,
-    )
-    #
-    liteDataCreationAlgo.setPropertyValue("InputWorkspace", inputWorkspace)
-    assert liteDataCreationAlgo.execute()
-    assert liteDataCreationAlgo._liteModeResolution == liteResolution
-    liteDataCreationAlgo.mantidSnapper.GroupDetectors.assert_not_called()
-
-    # to make sure the issue isn't some error caused before GroupDetectors
-    # run with full resolution data and make sure it executes the whole thing
-    CreateWorkspace(
-        OutputWorkspace=inputWorkspace,
-        DataX=[0.5, 1.5] * fullResolution,
-        DataY=[1] * fullResolution,
-        DataE=[1] * fullResolution,
-        NSpec=fullResolution,
-    )
-    ConvertToEventWorkspace(
-        InputWorkspace=inputWorkspace,
-        OutputWorkspace=inputWorkspace,
-    )
-    LoadInstrument(
-        Workspace=inputWorkspace,
-        Filename=fullInstrumentFile,
-        RewriteSpectraMap=True,
-    )
-    #
-    liteDataCreationAlgo.mantidSnapper = mock.MagicMock()
-    liteDataCreationAlgo = LiteDataCreationAlgo()
-    liteDataCreationAlgo.initialize()
-    liteDataCreationAlgo.setPropertyValue("OutputWorkspace", outputWorkspace)
-    liteDataCreationAlgo.setPropertyValue("LiteDataMapWorkspace", focusWS)
-    liteDataCreationAlgo.setPropertyValue("LiteInstrumentDefinitionFile", liteInstrumentFile)
-    liteDataCreationAlgo.setPropertyValue("Ingredients", instrumentState.model_dump_json())
-    liteDataCreationAlgo.setPropertyValue("InputWorkspace", inputWorkspace)
-    assert liteDataCreationAlgo.execute()
-
-    # cleanup
-    DeleteWorkspace(inputWorkspace)
-    DeleteWorkspace(outputWorkspace)
-    DeleteWorkspace(instrumentWorkspace)
-    DeleteWorkspace(focusWS)
+        # try running with data already at Lite resolution
+        CreateWorkspace(
+            OutputWorkspace=inputWorkspace,
+            DataX=[1] * liteResolution,
+            DataY=[1] * liteResolution,
+            DataE=[1] * liteResolution,
+            NSpec=liteResolution,
+        )
+        liteDataCreationAlgo.setPropertyValue("InputWorkspace", inputWorkspace)
+        with pytest.raises(RuntimeError, match="Usage error: the input workspace has already been converted to lite mode."):
+            liteDataCreationAlgo.execute()
 
 
 def getWorkspaceMetrics(workspace):
@@ -435,79 +435,81 @@ def testLiteDataCreationAlgoWithCompressionCheck():
     liteInstrumentFile = Resource.getPath("inputs/testInstrument/fakeSNAPLite.xml")
     liteInstrumentMap = Resource.getPath("inputs/testInstrument/fakeSNAPLiteGroupMap.xml")
     instrumentState = DAOFactory.synthetic_instrument_state.copy()
+    ingredients = LiteDataCreationIngredients(
+        instrumentState=DAOFactory.synthetic_instrument_state.copy()
+    )
 
     fullResolution: int = 16
     liteResolution: int = 4
 
-    # create simple event data with a different number in each pixel
-    CreateWorkspace(
-        OutputWorkspace=fullInstrumentWS,
-        DataX=[0.5, 1.5] * fullResolution,
-        DataY=range(fullResolution),
-        DataE=[0.01] * fullResolution,
-        NSpec=fullResolution,
-    )
-    ConvertToEventWorkspace(
-        InputWorkspace=fullInstrumentWS,
-        OutputWorkspace=fullInstrumentWS,
-    )
-    # load the instrument, and load the grouping file
-    LoadInstrument(
-        Workspace=fullInstrumentWS,
-        Filename=fullInstrumentFile,
-        RewriteSpectraMap=True,
-    )
-    LoadDetectorsGroupingFile(
-        InputFile=liteInstrumentMap,
-        InputWorkspace=fullInstrumentWS,
-        OutputWorkspace=focusWS,
-    )
+    with (
+        Config_override("instrument.native.pixelResolution", fullResolution),
+        Config_override("instrument.lite.pixelResolution", liteResolution)
+    ):
+        # create simple event data with a different number in each pixel
+        CreateWorkspace(
+            OutputWorkspace=fullInstrumentWS,
+            DataX=[0.5, 1.5] * fullResolution,
+            DataY=range(fullResolution),
+            DataE=[0.01] * fullResolution,
+            NSpec=fullResolution,
+        )
+        ConvertToEventWorkspace(
+            InputWorkspace=fullInstrumentWS,
+            OutputWorkspace=fullInstrumentWS,
+        )
+        # load the instrument, and load the grouping file
+        LoadInstrument(
+            Workspace=fullInstrumentWS,
+            Filename=fullInstrumentFile,
+            RewriteSpectraMap=True,
+        )
+        LoadDetectorsGroupingFile(
+            InputFile=liteInstrumentMap,
+            InputWorkspace=fullInstrumentWS,
+            OutputWorkspace=focusWS,
+        )
 
-    # Get initial metrics before compression
-    initialMetrics = getWorkspaceMetrics(mtd[fullInstrumentWS])
+        # Get initial metrics before compression
+        initialMetrics = getWorkspaceMetrics(mtd[fullInstrumentWS])
 
-    # run the algorithm
-    liteDataCreationAlgo = LiteDataCreationAlgo()
-    liteDataCreationAlgo.initialize()
-    liteDataCreationAlgo.setPropertyValue("InputWorkspace", fullInstrumentWS)
-    liteDataCreationAlgo.setPropertyValue("OutputWorkspace", liteInstrumentWS)
-    liteDataCreationAlgo.setPropertyValue("LiteDataMapWorkspace", focusWS)
-    liteDataCreationAlgo.setPropertyValue("LiteInstrumentDefinitionFile", liteInstrumentFile)
-    liteDataCreationAlgo.setPropertyValue("Ingredients", instrumentState.model_dump_json())
-    liteDataCreationAlgo.execute()
+        # run the algorithm
+        liteDataCreationAlgo = LiteDataCreationAlgo()
+        liteDataCreationAlgo.initialize()
+        liteDataCreationAlgo.setPropertyValue("InputWorkspace", fullInstrumentWS)
+        liteDataCreationAlgo.setPropertyValue("OutputWorkspace", liteInstrumentWS)
+        liteDataCreationAlgo.setPropertyValue("LiteDataMapWorkspace", focusWS)
+        liteDataCreationAlgo.setPropertyValue("LiteInstrumentDefinitionFile", liteInstrumentFile)
+        liteDataCreationAlgo.setPropertyValue("Ingredients", ingredients.model_dump_json())
+        liteDataCreationAlgo.execute()
 
-    # Get final metrics after compression
-    finalMetrics = getWorkspaceMetrics(mtd[liteInstrumentWS])
+        # Get final metrics after compression
+        finalMetrics = getWorkspaceMetrics(mtd[liteInstrumentWS])
 
-    # Compare metrics to verify compression effectiveness
-    assert compareMetrics(initialMetrics, finalMetrics), "Compression was not effective"
+        # Compare metrics to verify compression effectiveness
+        assert compareMetrics(initialMetrics, finalMetrics), "Compression was not effective"
 
-    # check that the lite data is correct
-    # 1. check the lite data has four histograms
-    # 2. check each histograms has a single pixel
-    # 3. check the pixel ids of histograms are 0, 1, 2, 3 in order
-    # 4. check each superpixel has the sum corresponding to the four banks
-    liteWS = mtd[liteInstrumentWS]
-    fullWS = mtd[fullInstrumentWS]
-    assert liteWS.getNumberHistograms() == liteResolution
-    assert liteWS.getSpectrumNumbers() == list(range(1, liteResolution + 1))
-    for i in range(liteResolution):
-        el = liteWS.getSpectrum(i)
-        assert list(el.getDetectorIDs()) == [i]
+        # check that the lite data is correct
+        # 1. check the lite data has four histograms
+        # 2. check each histograms has a single pixel
+        # 3. check the pixel ids of histograms are 0, 1, 2, 3 in order
+        # 4. check each superpixel has the sum corresponding to the four banks
+        liteWS = mtd[liteInstrumentWS]
+        fullWS = mtd[fullInstrumentWS]
+        assert liteWS.getNumberHistograms() == liteResolution
+        assert liteWS.getSpectrumNumbers() == list(range(1, liteResolution + 1))
+        for i in range(liteResolution):
+            el = liteWS.getSpectrum(i)
+            assert list(el.getDetectorIDs()) == [i]
 
-    for i in range(liteResolution):
-        assert liteWS.getDetector(i).getID() == i
+        for i in range(liteResolution):
+            assert liteWS.getDetector(i).getID() == i
 
-    summedPixels = [0] * liteResolution
-    for i in range(liteResolution):
-        for j in range(liteResolution):
-            summedPixels[i] += fullWS.readY(liteResolution * i + j)[0]
-        assert summedPixels[i] == liteWS.readY(i)[0]
+        summedPixels = [0] * liteResolution
+        for i in range(liteResolution):
+            for j in range(liteResolution):
+                summedPixels[i] += fullWS.readY(liteResolution * i + j)[0]
+            assert summedPixels[i] == liteWS.readY(i)[0]
 
-    # check that the data has been flagged as lite
-    assert "Lite" in liteWS.getComment()
-
-    # clean up
-    DeleteWorkspace(fullInstrumentWS)
-    DeleteWorkspace(liteInstrumentWS)
-    DeleteWorkspace(focusWS)
+        # check that the data has been flagged as lite
+        assert "Lite" in liteWS.getComment()

--- a/tests/unit/backend/service/test_LiteDataService.py
+++ b/tests/unit/backend/service/test_LiteDataService.py
@@ -1,20 +1,22 @@
-import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest import mock
-from unittest.mock import Mock, patch
 
-import pytest
 from mantid.simpleapi import CloneWorkspace, CreateSingleValuedWorkspace
-from util.Config_helpers import Config_override
-from util.dao import DAOFactory
 
+from snapred.backend.dao.ingredients.LiteDataCreationIngredients import LiteDataCreationIngredients
+from snapred.backend.dao.state.InstrumentState import InstrumentState
 from snapred.backend.service.LiteDataService import LiteDataService
 from snapred.meta.Config import Resource
 
+import unittest
+from unittest import mock
+import pytest
+from util.Config_helpers import Config_override
+from util.dao import DAOFactory
+
 
 class TestLiteDataService(unittest.TestCase):
-    @patch("snapred.backend.service.LiteDataService.Recipe.executeRecipe")
+    @mock.patch("snapred.backend.service.LiteDataService.LiteDataRecipe.executeRecipe")
     def test_createLiteData_calls_executeRecipe_with_correct_arguments(
         self,
         executeRecipe,
@@ -33,15 +35,17 @@ class TestLiteDataService(unittest.TestCase):
         CreateSingleValuedWorkspace(OutputWorkspace=inputWorkspace)
 
         liteDataService = LiteDataService()
-        liteDataService._ensureLiteDataMap = Mock(return_value="lite_map")
+        liteDataService._ensureLiteDataMap = mock.Mock(return_value="lite_map")
         liteDataService.dataFactoryService.constructStateId = mock.Mock(
             return_value=(DAOFactory.real_state_id.hex, DAOFactory.real_detector_state)
         )
-        liteDataService.sousChef.prepInstrumentState = Mock()
-        liteDataService.sousChef.prepInstrumentState.return_value = Mock()
-        liteDataService.sousChef.prepInstrumentState.return_value.model_dump_json.return_value = "{}"  # noqa: E501
-        liteDataService.dataFactoryService = Mock()
-        liteDataService.dataFactoryService.constructStateId = Mock(return_value=("state_id", "state"))
+        liteDataService.sousChef.prepInstrumentState = mock.Mock()
+        liteDataService.sousChef.prepInstrumentState.return_value = DAOFactory.default_instrument_state.model_copy()
+        liteDataService.dataFactoryService = mock.Mock()
+        liteDataService.dataFactoryService.constructStateId = mock.Mock(return_value=(DAOFactory.magical_state_id.hex, None))
+        expectedIngredients = LiteDataCreationIngredients(
+            instrumentState=liteDataService.sousChef.prepInstrumentState.return_value
+        )
 
         with TemporaryDirectory(dir=Resource.getPath("outputs"), suffix="/") as tmpdir:
             outputPath = Path(tmpdir, "555.nxs.h5")
@@ -56,36 +60,39 @@ class TestLiteDataService(unittest.TestCase):
             OutputWorkspace=outputWorkspace,
             LiteDataMapWorkspace="lite_map",
             LiteInstrumentDefinitionFile=None,
-            Ingredients="{}",
+            Ingredients=expectedIngredients.model_dump_json()
         )
 
-        liteDataService.dataExportService = Mock()
+        liteDataService.dataExportService = mock.Mock()
         with Config_override("constants.LiteDataCreationAlgo.toggleCompressionTolerance", True):
+            expectedIngredients = LiteDataCreationIngredients(
+                instrumentState=liteDataService.sousChef.prepInstrumentState.return_value,
+                toleranceOverride=-0.123
+            )
+            
             liteDataService.createLiteData(inputWorkspace, outputWorkspace)
             executeRecipe.assert_called_with(
                 InputWorkspace=inputWorkspace,
                 OutputWorkspace=outputWorkspace,
                 LiteDataMapWorkspace="lite_map",
                 LiteInstrumentDefinitionFile=None,
-                Ingredients="{}",
-                ToleranceOverride=-0.123,
+                Ingredients=expectedIngredients.model_dump_json()
             )
 
-    @patch("snapred.backend.recipe.GenericRecipe.GenericRecipe.executeRecipe")
+    @mock.patch("snapred.backend.recipe.GenericRecipe.GenericRecipe.executeRecipe")
     def test_createLiteData_fails(self, mock_executeRecipe):
         mock_executeRecipe.return_value = {}
         mock_executeRecipe.side_effect = RuntimeError("oops!")
 
         liteDataService = LiteDataService()
-        liteDataService._ensureLiteDataMap = Mock(return_value="lite map")
+        liteDataService._ensureLiteDataMap = mock.Mock(return_value="lite map")
         liteDataService.dataFactoryService.constructStateId = mock.Mock(
             return_value=(DAOFactory.real_state_id.hex, DAOFactory.real_detector_state)
         )
-        liteDataService.sousChef.prepInstrumentState = Mock()
-        liteDataService.sousChef.prepInstrumentState.return_value = Mock()
-        liteDataService.sousChef.prepInstrumentState.return_value.model_dump_json.return_value = "{}"  # noqa: E501
-        liteDataService.dataFactoryService = Mock()
-        liteDataService.dataFactoryService.constructStateId = Mock(return_value=("state_id", "state"))
+        liteDataService.sousChef.prepInstrumentState = mock.Mock()
+        liteDataService.sousChef.prepInstrumentState.return_value = DAOFactory.default_instrument_state.model_copy()
+        liteDataService.dataFactoryService = mock.Mock()
+        liteDataService.dataFactoryService.constructStateId = mock.Mock(return_value=(DAOFactory.magical_state_id.hex, None))
 
         inputWorkspace = "_test_liteservice_555"
         outputWorkspace = "_test_output_lite_"

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -34,8 +34,7 @@ class TestSousChef(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        for ws in mtd.getObjectNames():
-            DeleteWorkspace(ws)
+        mtd.clear()
 
     def test_name(self):
         assert SousChef.name() == "souschef"
@@ -209,6 +208,7 @@ class TestSousChef(unittest.TestCase):
         # make necessary assertions
         PixelGroupingIngredients.assert_called_once_with(
             instrumentState=self.instance.prepCalibration.return_value.instrumentState,
+            groupingScheme=self.ingredients.focusGroup.name,
             nBinsAcrossPeakWidth=self.ingredients.nBinsAcrossPeakWidth,
         )
         PixelGroupingParametersCalculationRecipe.return_value.executeRecipe.assert_called_once_with(


### PR DESCRIPTION



## Description of work
A `GroupingWorkspace` in Mantid consists of single-valued spectra, with each spectrum's value representing a subgroup-Id.  The spectrum-to-detector map of the workspace's instrument then associates these spectra to sets of pixel-Ids.  In the general case, each spectrum will have multiple pixel-Ids associated with it, and further, multiple spectra may share a subgroup-Id, but usually with disjoint sets of pixel-Ids.  When methods of `GroupingWorkspace` are employed, all of this should work transparently.

The changes of this PR ensure that SNAPRed is applying these `GroupingWorkspace` methods everywhere, and that the most general representation of the grouping-workspace format is supported.  Primarily this support consists of not overly constraining the format of input grouping-workspaces during validation.  For example, previously it was implicitly assumed that each grouping-workspace had a format which included only one pixel-Id per spectrum.

## Explanation of work

This commit includes the following changes:

  * Update the validation for `LiteDataCreationAlgo`.  Allow a more general grouping-workspace format, and in addition validate the required _instrument_ specifics on both the grouping-workspace and the input-data workspace.

  * Update `LiteDataCreationAlgo` and its associated `Recipe` to be more pythonic, and thereby to be more consistent with the rest of the codebase. Remove the auto-delete flag from `LiteDataCreationAlgo` as being out of the domain of responsibility of the algorithm.  Combine all non-workspace input arguments into a new `LiteDataCreationIngredients`.  Support a no-compression case when neither `<ingredients>.instrumentState` nor `<ingredients>.toleranceOverride` are specified.  Note that almost certainly, neither compression nor data export should have been part of this algorithm.  These should have been implemented as separate `LiteDataService` endpoints; however, this change was considered to be out-of-scope of the present PR.  Finally, the possibility that the input-data could already be in lite-mode, and not trigger an error has been removed -- this is a clear _developer_-usage error, and supporting it simply masks other defects.

  * Update the validation for 'FocusSpectraAlgorithm'.  Allow a more general grouping-workspace format, and as above, validate the required _instrument_ specifics where possible.  Overall the objective of the validation is as before -- to ensure that the grouping-workspace can be used successfully to focus the input-data workspace.

  * `GroupedDetectorIDs`, `GroupDiffCalRecipe`: provide more efficient conversion from `numpy.ndarray` of `numpy.int64` to `List[int]`.  Since several of these lists have a length of `10^6` or even larger -- this should speed things up a bit where these algorithms are used.

  * Improve `PixelGroupingParametersCalculation` log messages so that the name of the grouping-scheme is included when it is known.

## To test

### Dev testing
**These changes should not affect the results from any of the workflows.**  New unit tests have been added where required, although we are not yet actually testing grouping-workspaces with a more general format -- most of that is left to _future_ requirements.  **I am very interested, for example, in comparing the speed of the lite-mode conversion  using different lite-data map formats.**

### CIS testing

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#10464](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=10464)

### Verification

- [ ] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] acceptance criterion 1
- [ ] acceptance criterion 2
