### PR TITLE
Snaplite load and normalization group masking

### DIFF
--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -822,6 +822,7 @@ class GroceryService:
                 RewriteSpectraMap=False,
             )
             self.mantidSnapper.executeQueue()
+            self.mantidSnapper.mtd[workspace].populateInstrumentParameters()
 
     def _fetchNeutronDataSingleUse(self, item: GroceryListItem, missingDataHandler: Callable) -> Dict[str, Any]:
         """

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -1293,7 +1293,7 @@ class GroceryService:
             # Note: 'LoadNexusProcessed' neither requires nor makes use of an instrument donor.
             data = self.grocer.executeRecipe(filename=filePath, workspace=workspaceName, loader=loader)
             if useLiteMode:
-                self.updateInstrument(item, workspaceName)
+                self.updateInstrument(workspaceName)
             self._processNeutronDataCopy(item, workspaceName)
             self.normalizationCache.add(workspaceName)
         return data

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -1156,15 +1156,6 @@ class GroceryService:
                 "All 'difc' values must be positive floats."
             )
 
-    def validateInstrument(self, workspace: str) -> None:
-        ws = self.getWorkspaceForName(workspace)
-        instName = ws.getInstrument().getName().lower()
-        if ws.getNumberHistograms() == Config["instrument.lite.pixelResolution"] and "snaplite" not in instName:
-            raise RuntimeError(
-                f"Workspace {workspace} does not have the expected number of histograms for the instrument: "
-                f"{Config['instrument.lite.pixelResolution']}, but has {ws.getNumberHistograms()}"
-            )
-
     def _validateWorkspaceInstrument(self, item: GroceryListItem, workspaceName: str):
         targetPixelCount = (
             Config["instrument.lite.pixelResolution"]

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -1174,24 +1174,21 @@ class GroceryService:
         targetInstrumentName = (
             Config["instrument.lite.name"].lower() if item.useLiteMode else Config["instrument.native.name"].lower()
         )
-        otherInstrumentName = (
-            Config["instrument.native.name"].lower() if item.useLiteMode else Config["instrument.lite.name"].lower()
-        )
-        liteStr = "lite" if item.useLiteMode else "native"
+        resolutionName = "lite" if item.useLiteMode else "native"
         ws = self.mantidSnapper.mtd[workspaceName]
         numHistos = ws.getNumberHistograms()
         instrumentName = ws.getInstrument().getName().lower()
         if numHistos != targetPixelCount:
             raise RuntimeError(
                 f"Workspace '{workspaceName}' has {numHistos} histograms"
-                f"\nExpected {targetPixelCount} histograms for the {liteStr} resolution."
+                f"\nExpected {targetPixelCount} spectra for the {resolutionName} resolution."
                 f"\ni.e. one histogram per pixel of the instrument."
                 f"\nPlease contact your IS or CIS for assistance."
             )
-        if targetInstrumentName not in instrumentName and otherInstrumentName in instrumentName:
+        if targetInstrumentName != instrumentName:
             raise RuntimeError(
                 f"Workspace '{workspaceName}' has an instrument with name '{instrumentName}'"
-                f"\nExpected {targetInstrumentName} for the {liteStr} resolution."
+                f"\nExpected instrument to be {targetInstrumentName} for the {resolutionName} resolution."
                 f"\nPlease contact your IS or CIS for assistance."
             )
 

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 import numpy as np
-from mantid.api import FileLoaderRegistry, MatrixWorkspace
+from mantid.api import FileLoaderRegistry
 from mantid.dataobjects import MaskWorkspace
 from pydantic import validate_call
 
@@ -1512,9 +1512,12 @@ class GroceryService:
                     result = self.fetchReductionPixelMask(item)
                 case _:
                     raise RuntimeError(f"unrecognized 'workspaceType': '{item.workspaceType}'")
-            ws = self.getWorkspaceForName(result["workspace"])
-            if isinstance(ws, MatrixWorkspace):
-                # If the workspace is a MatrixWorkspace, we can safely assume it is a neutron workspace.
+
+            if item.workspaceType in ["neutron", "normalization"] and result["loader"] in [
+                "LoadEventNexus",
+                "LoadNexusProcessed",
+            ]:
+                # The loader is not always set but *should* be at least for neutron/norm data.
                 # Validate the instrument and pixel count.
                 self._validateWorkspaceInstrument(item, result["workspace"])
             # check that the fetch operation succeeded and if so append the workspace

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -97,7 +97,6 @@ class NormalizationService(Service):
             crystalDBounds=request.crystalDBounds,
             state=state,
         )
-        detectorPeaks = self.sousChef.prepDetectorPeaks(farmFresh, purgePeaks=False)
 
         # prepare and check focus group workspaces -- see if grouping already calculated
         correctedVanadium = wng.rawVanadium().runNumber(request.runNumber).build()
@@ -119,6 +118,7 @@ class NormalizationService(Service):
                 self.groceryClerk.buildDict(),
             )
             maskWorkspace = groceries["maskWorkspace"]
+            # NOTE: It needs to be checked with Malcolm if peaks should be purged
             detectorPeaks = self.sousChef.prepDetectorPeaks(farmFresh, purgePeaks=False, pixelMask=maskWorkspace)
             return NormalizationResponse(
                 correctedVanadium=correctedVanadium,

--- a/src/snapred/backend/service/NormalizationService.py
+++ b/src/snapred/backend/service/NormalizationService.py
@@ -97,7 +97,7 @@ class NormalizationService(Service):
             crystalDBounds=request.crystalDBounds,
             state=state,
         )
-        ingredients = self.sousChef.prepNormalizationIngredients(farmFresh)
+        detectorPeaks = self.sousChef.prepDetectorPeaks(farmFresh, purgePeaks=False)
 
         # prepare and check focus group workspaces -- see if grouping already calculated
         correctedVanadium = wng.rawVanadium().runNumber(request.runNumber).build()
@@ -109,11 +109,22 @@ class NormalizationService(Service):
             and self.groceryService.workspaceDoesExist(focusedVanadium)
             and self.groceryService.workspaceDoesExist(smoothedVanadium)
         ):
+            calVersion = self.dataFactoryService.getLatestApplicableCalibrationVersion(
+                request.runNumber, request.useLiteMode, state
+            )
+            self.groceryClerk.name("maskWorkspace").diffcal_mask(state, calVersion, request.runNumber).useLiteMode(
+                request.useLiteMode
+            ).add()
+            groceries = self.groceryService.fetchGroceryDict(
+                self.groceryClerk.buildDict(),
+            )
+            maskWorkspace = groceries["maskWorkspace"]
+            detectorPeaks = self.sousChef.prepDetectorPeaks(farmFresh, purgePeaks=False, pixelMask=maskWorkspace)
             return NormalizationResponse(
                 correctedVanadium=correctedVanadium,
                 focusedVanadium=focusedVanadium,
                 smoothedVanadium=smoothedVanadium,
-                detectorPeaks=ingredients.detectorPeaks,
+                detectorPeaks=detectorPeaks,
             ).dict()
         calVersion = self.dataFactoryService.getLatestApplicableCalibrationVersion(
             request.runNumber, request.useLiteMode, state
@@ -153,7 +164,7 @@ class NormalizationService(Service):
         groceries = self.groceryService.fetchGroceryDict(
             self.groceryClerk.buildDict(),
         )
-
+        ingredients = self.sousChef.prepNormalizationIngredients(farmFresh, groceries["maskWorkspace"])
         if request.correctedVanadiumWs is None:
             self._markWorkspaceMetadata(request, groceries["inputWorkspace"])
             # NOTE: This used to point at other methods in this service to accomplish the same thing

--- a/src/snapred/backend/service/ReductionService.py
+++ b/src/snapred/backend/service/ReductionService.py
@@ -556,7 +556,6 @@ class ReductionService(Service):
         self.groceryService.writeWorkspaceMetadataAsTags(workspace, metadata)
 
     def saveReduction(self, request: ReductionExportRequest):
-        raise RuntimeError("test")
         self.dataExportService.exportReductionRecord(request.record)
         self.dataExportService.exportReductionData(request.record)
 

--- a/src/snapred/backend/service/ReductionService.py
+++ b/src/snapred/backend/service/ReductionService.py
@@ -556,6 +556,7 @@ class ReductionService(Service):
         self.groceryService.writeWorkspaceMetadataAsTags(workspace, metadata)
 
     def saveReduction(self, request: ReductionExportRequest):
+        raise RuntimeError("test")
         self.dataExportService.exportReductionRecord(request.record)
         self.dataExportService.exportReductionData(request.record)
 

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -322,14 +322,16 @@ class SousChef(Service):
                 data=recoveryData,
             )
 
-    def prepNormalizationIngredients(self, ingredients: FarmFreshIngredients) -> NormalizationIngredients:
+    def prepNormalizationIngredients(
+        self, ingredients: FarmFreshIngredients, combinedPixelMask: Optional[WorkspaceName] = None
+    ) -> NormalizationIngredients:
         # The calibration folder at the very least should be initialized with a default calibration
         self.verifyCalibrationExists(ingredients.runNumber, ingredients.useLiteMode)
 
         return NormalizationIngredients(
-            pixelGroup=self.prepPixelGroup(ingredients),
+            pixelGroup=self.prepPixelGroup(ingredients, pixelMask=combinedPixelMask),
             calibrantSample=self.prepCalibrantSample(ingredients.calibrantSamplePath),
-            detectorPeaks=self.prepDetectorPeaks(ingredients, purgePeaks=False),
+            detectorPeaks=self.prepDetectorPeaks(ingredients, purgePeaks=False, pixelMask=combinedPixelMask),
         )
 
     def prepDiffractionCalibrationIngredients(

--- a/src/snapred/backend/service/SousChef.py
+++ b/src/snapred/backend/service/SousChef.py
@@ -331,6 +331,7 @@ class SousChef(Service):
         return NormalizationIngredients(
             pixelGroup=self.prepPixelGroup(ingredients, pixelMask=combinedPixelMask),
             calibrantSample=self.prepCalibrantSample(ingredients.calibrantSamplePath),
+            # NOTE: It needs to be checked with Malcolm if peaks should be purged
             detectorPeaks=self.prepDetectorPeaks(ingredients, purgePeaks=False, pixelMask=combinedPixelMask),
         )
 

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -37,12 +37,14 @@ instrument:
   parameters:
     home: ${instrument.calibration.home}/SNAPInstPrm
   native:
+    name: SNAP
     pixelResolution: 1179648
     # pixelResolution: 72
     definition:
       file: ${module.root}/resources/SNAP_Definition.xml
       # file: ${module.root}/resources/ultralite/CRACKLE_Definition.xml
   lite:
+    name: SNAPLite
     pixelResolution: 18432
     # pixelResolution: 18
     definition:

--- a/tests/integration/test_versions_in_order.py
+++ b/tests/integration/test_versions_in_order.py
@@ -36,6 +36,7 @@ from mantid.simpleapi import (
     LoadEmptyInstrument,
     mtd,
 )
+from util.Config_helpers import Config_override
 from util.dao import DAOFactory
 from util.diffraction_calibration_synthetic_data import SyntheticData
 
@@ -382,7 +383,11 @@ class TestVersioning(TestCase):
             "removeBackground": False,
         }
         request = SNAPRequest(path="calibration/diffraction", payload=json.dumps(payload))
-        response = self.api.executeRequest(request)
+        with (
+            Config_override("instrument.native.pixelResolution", 16),
+            Config_override("instrument.native.name", "fakesnap"),
+        ):
+            response = self.api.executeRequest(request)
         assert response.code <= ResponseCode.MAX_OK
         return response.data
 

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -40,11 +40,13 @@ instrument:
   parameters:
     home: ${instrument.calibration.home}/SNAPInstPrm
   native:
+    name: SNAP
     pixelResolution: 1179648
     # "instrument.native.definition" is overridden in "test.yml":
     definition:
       file: ${module.root}/resources/inputs/pixel_grouping/SNAP_Definition.xml
   lite:
+    name: SNAPLite
     pixelResolution: 18432
     # "instrument.lite.definition" is overridden in "test.yml":
     definition:

--- a/tests/resources/integration_test.yml
+++ b/tests/resources/integration_test.yml
@@ -25,10 +25,12 @@ constants:
 
 instrument:
   native:
+    name: crackle
     pixelResolution: 72
     definition:
       file: ${module.root}/resources/ultralite/CRACKLE_Definition.xml
   lite:
+    name: pop
     pixelResolution: 18
     definition:
       file: ${module.root}/resources/ultralite/CRACKLELite_Definition.xml

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -3065,9 +3065,10 @@ class TestGroceryService(unittest.TestCase):
         with state_root_redirect(self.instance.dataService) as tmpRoot:
             self.instance.dataService.normalizationIndexer = self.mockIndexer(tmpRoot.path(), "normalization")
             groceryList = (
-                GroceryListItem.builder().native().normalization(self.runNumber1, "statId", self.version).buildList()
+                GroceryListItem.builder().lite().normalization(self.runNumber1, "statId", self.version).buildList()
             )
             self.instance._processNeutronDataCopy = mock.Mock()
+            self.instance.updateInstrument = mock.Mock()
             self.instance.dataService.generateInstrumentState = mock.Mock(
                 return_value=DAOFactory.default_instrument_state
             )
@@ -3089,6 +3090,7 @@ class TestGroceryService(unittest.TestCase):
             assert items[0] == normalizationWorkspaceName
             assert mtd.doesExist(normalizationWorkspaceName)
             self.instance._processNeutronDataCopy.assert_called_once_with(groceryList[0], normalizationWorkspaceName)
+            self.instance.updateInstrument.assert_called_once_with(normalizationWorkspaceName)
 
             mockLogger.info.assert_any_call(
                 f"Fetching normalization workspace for run {self.runNumber1}, version {self.version}"

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -2809,7 +2809,10 @@ class TestGroceryService(unittest.TestCase):
             # fetch the workspace
             assert not mtd.doesExist(diffCalTableName)
 
-            with Config_override("instrument.native.pixelResolution", 16):
+            with (
+                Config_override("instrument.native.pixelResolution", 16),
+                Config_override("instrument.native.name", "fakesnap"),
+            ):
                 items = self.instance.fetchGroceryList(groceryList)
             assert items[0] == diffCalTableName
             assert mtd.doesExist(diffCalTableName)
@@ -2829,7 +2832,7 @@ class TestGroceryService(unittest.TestCase):
             mockWs.getNumberHistograms.return_value = 1337
             with pytest.raises(
                 RuntimeError,
-                match="Expected 16 histograms for the native resolution.",
+                match="Expected 16 spectra for the native resolution.",
             ):
                 self.instance._validateWorkspaceInstrument(item, "someMask")
 
@@ -2929,7 +2932,10 @@ class TestGroceryService(unittest.TestCase):
             )
             assert mtd.doesExist(diffCalTableName)
             assert not mtd.doesExist(diffCalMaskName)
-            with Config_override("instrument.native.pixelResolution", 16):
+            with (
+                Config_override("instrument.native.pixelResolution", 16),
+                Config_override("instrument.native.name", "fakesnap"),
+            ):
                 wss = self.instance.fetchGroceryList(groceryList)  # noqa: F841
             assert mtd.doesExist(diffCalTableName)
             assert mtd.doesExist(diffCalMaskName)
@@ -2957,7 +2963,10 @@ class TestGroceryService(unittest.TestCase):
 
             assert not mtd.doesExist(diffCalTableName)
             assert not mtd.doesExist(diffCalMaskName)
-            with Config_override("instrument.native.pixelResolution", 16):
+            with (
+                Config_override("instrument.native.pixelResolution", 16),
+                Config_override("instrument.native.name", "fakesnap"),
+            ):
                 items = self.instance.fetchGroceryList(groceryList)
             assert items[0] == diffCalTableName
             assert mtd.doesExist(diffCalTableName)
@@ -2986,7 +2995,10 @@ class TestGroceryService(unittest.TestCase):
 
             assert not mtd.doesExist(diffCalMaskName)
             self.instance._lookupDiffCalWorkspaceNames = mock.Mock(return_value=(diffCalTableName, diffCalMaskName))
-            with Config_override("instrument.native.pixelResolution", 16):
+            with (
+                Config_override("instrument.native.pixelResolution", 16),
+                Config_override("instrument.native.name", "fakesnap"),
+            ):
                 items = self.instance.fetchGroceryList(groceryList)
             assert items[0] == diffCalMaskName
             assert mtd.doesExist(diffCalMaskName)
@@ -3062,7 +3074,10 @@ class TestGroceryService(unittest.TestCase):
 
             assert not mtd.doesExist(diffCalMaskName)
             assert not mtd.doesExist(diffCalTableName)
-            with Config_override("instrument.native.pixelResolution", 16):
+            with (
+                Config_override("instrument.native.pixelResolution", 16),
+                Config_override("instrument.native.name", "fakesnap"),
+            ):
                 items = self.instance.fetchGroceryList(groceryList)
             assert items[0] == diffCalMaskName
             assert mtd.doesExist(diffCalMaskName)

--- a/tests/unit/backend/service/test_CalibrationService.py
+++ b/tests/unit/backend/service/test_CalibrationService.py
@@ -540,7 +540,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
                 checkExistent=False,
             )
             self.instance.groceryService._fetchInstrumentDonor = mock.Mock(return_value=self.sampleWS)
-            self.instance.groceryService._validateCalibrationMask = mock.Mock(return_value=True)
+            self.instance.groceryService._validateWorkspaceInstrument = mock.Mock(return_value=True)
 
             with Config_override("instrument.lite.pixelResolution", 16):
                 # Load the assessment workspaces:
@@ -578,7 +578,7 @@ class TestCalibrationServiceMethods(unittest.TestCase):
                 checkExistent=False,
             )
             self.instance.groceryService._fetchInstrumentDonor = mock.Mock(return_value=self.sampleWS)
-            self.instance.groceryService._validateCalibrationMask = mock.Mock(return_value=True)
+            self.instance.groceryService._validateWorkspaceInstrument = mock.Mock(return_value=True)
 
             with Config_override("instrument.lite.pixelResolution", 16):
                 self.instance.loadQualityAssessment(mockRequest)

--- a/tests/unit/backend/service/test_NormalizationService.py
+++ b/tests/unit/backend/service/test_NormalizationService.py
@@ -411,6 +411,16 @@ class TestNormalizationService(unittest.TestCase):
         self.instance._sameStates = mock.Mock(return_value=True)
         self.instance.sousChef = SculleryBoy()
         self.instance.groceryService = mock.Mock()
+        self.instance.groceryService.fetchGroceryDict = mock.Mock(
+            return_value={
+                "backgroundWorkspace": "bg_ws",
+                "inputWorkspace": "input_ws",
+                "groupingWorkspace": "grouping_ws",
+                "outputWorkspace": "output_ws",
+                "diffcalWorkspace": "diffcal_ws",
+                "maskWorkspace": "mask_ws",
+            }
+        )
         self.instance.groceryService.workSpaceDoesExist = mock.Mock(return_value=True)
         self.instance.dataFactoryService.getCifFilePath = mock.Mock(return_value="path/to/cif")
         self.instance.dataFactoryService.constructStateId = mock.Mock(return_value=("12345", None))

--- a/tests/unit/backend/service/test_ReductionService.py
+++ b/tests/unit/backend/service/test_ReductionService.py
@@ -157,6 +157,7 @@ class TestReductionService(unittest.TestCase):
         self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
         self.instance.dataFactoryService.getLatestApplicableNormalizationVersion = mock.Mock(return_value=1)
         self.instance.groceryService._processNeutronDataCopy = mock.Mock()
+        self.instance.groceryService._validateWorkspaceInstrument = mock.Mock()
         self.instance.groceryService._lookupNormcalRunNumber = mock.Mock(return_value="123456")
         self.instance._markWorkspaceMetadata = mock.Mock()
         self.request.continueFlags = ContinueWarning.Type.UNSET
@@ -171,6 +172,7 @@ class TestReductionService(unittest.TestCase):
         self.instance.dataFactoryService.getLatestApplicableNormalizationVersion = mock.Mock(return_value=1)
         self.instance.dataFactoryService.constructStateId = mock.Mock(return_value=("state", None))
         self.instance.groceryService._processNeutronDataCopy = mock.Mock()
+        self.instance.groceryService._validateWorkspaceInstrument = mock.Mock()
         self.instance.groceryService._lookupNormcalRunNumber = mock.Mock(return_value="123456")
         self.instance._markWorkspaceMetadata = mock.Mock()
         self.instance.groceryService.dataService.hasLiveDataConnection = mock.Mock(return_value=True)
@@ -200,6 +202,7 @@ class TestReductionService(unittest.TestCase):
         self.instance.dataFactoryService.getLatestApplicableCalibrationVersion = mock.Mock(return_value=1)
         self.instance.dataFactoryService.getLatestApplicableNormalizationVersion = mock.Mock(return_value=1)
         self.instance.groceryService._processNeutronDataCopy = mock.Mock()
+        self.instance.groceryService._validateWorkspaceInstrument = mock.Mock()
         self.instance.groceryService._lookupNormcalRunNumber = mock.Mock(return_value="123456")
         self.instance._markWorkspaceMetadata = mock.Mock()
         self.instance.prepCombinedMask = mock.Mock(return_value=mock.sentinel.mask)
@@ -236,6 +239,7 @@ class TestReductionService(unittest.TestCase):
         self.instance.dataFactoryService.normalizationExists = mock.Mock(return_value=True)
         self.instance.dataFactoryService.constructStateId = mock.Mock(return_value=("state", None))
         self.instance.groceryService._processNeutronDataCopy = mock.Mock()
+        self.instance.groceryService._validateWorkspaceInstrument = mock.Mock()
         self.instance.groceryService._lookupNormcalRunNumber = mock.Mock(return_value="123456")
         self.instance._markWorkspaceMetadata = mock.Mock()
 

--- a/tests/unit/backend/service/test_ReductionService.py
+++ b/tests/unit/backend/service/test_ReductionService.py
@@ -20,6 +20,7 @@ from mantid.simpleapi import (
     mtd,
 )
 from mantid.testing import assert_almost_equal as assert_wksp_almost_equal
+from util.Config_helpers import Config_override
 from util.helpers import arrayFromMask, createCompatibleMask, maskFromArray
 from util.InstaEats import InstaEats
 from util.SculleryBoy import SculleryBoy
@@ -943,10 +944,14 @@ class TestReductionServiceMasks:
         )
 
         # call code and check result
-        with mock.patch.object(
-            self.service.dataFactoryService,
-            "getLatestApplicableCalibrationVersion",
-            return_value=None,
+        with (
+            mock.patch.object(
+                self.service.dataFactoryService,
+                "getLatestApplicableCalibrationVersion",
+                return_value=None,
+            ),
+            Config_override("instrument.lite.pixelResolution", 4),
+            Config_override("instrument.lite.name", "fakesnaplite"),
         ):
             combinedMask = self.service.prepCombinedMask(request)
         actual = arrayFromMask(combinedMask)

--- a/tests/unit/backend/service/test_SousChef.py
+++ b/tests/unit/backend/service/test_SousChef.py
@@ -492,8 +492,8 @@ class TestSousChef(unittest.TestCase):
         res = self.instance.prepNormalizationIngredients(self.ingredients)
 
         self.instance.prepCalibrantSample.assert_called_once_with(self.ingredients.calibrantSamplePath)
-        self.instance.prepPixelGroup.assert_called_once_with(self.ingredients)
-        self.instance.prepDetectorPeaks.assert_called_once_with(self.ingredients, purgePeaks=False)
+        self.instance.prepPixelGroup.assert_called_once_with(self.ingredients, pixelMask=None)
+        self.instance.prepDetectorPeaks.assert_called_once_with(self.ingredients, purgePeaks=False, pixelMask=None)
         NormalizationIngredients.assert_called_once_with(
             pixelGroup=self.instance.prepPixelGroup.return_value,
             calibrantSample=self.instance.prepCalibrantSample.return_value,

--- a/tests/util/SculleryBoy.py
+++ b/tests/util/SculleryBoy.py
@@ -64,7 +64,7 @@ class SculleryBoy:
     def prepFocusGroup(self, ingredients: FarmFreshIngredients) -> FocusGroup:  # noqa ARG002
         return DAOFactory.focus_group_SNAP_column_lite.copy()
 
-    def prepPixelGroup(self, ingredients: FarmFreshIngredients = None):  # noqa ARG002
+    def prepPixelGroup(self, ingredients: FarmFreshIngredients = None, pixelMask=None):  # noqa ARG002
         params = PixelGroupingParameters(
             groupID=1,
             isMasked=False,
@@ -92,7 +92,12 @@ class SculleryBoy:
         else:
             return DAOFactory.fake_peak_ingredients.copy()
 
-    def prepDetectorPeaks(self, ingredients: FarmFreshIngredients, purgePeaks=False) -> List[GroupPeakList]:  # noqa: ARG002
+    def prepDetectorPeaks(
+        self,
+        ingredients: FarmFreshIngredients,
+        purgePeaks=False,  # noqa: ARG002
+        pixelMask=None,  # noqa: ARG002
+    ) -> List[GroupPeakList]:
         try:
             peakList = DetectorPeakPredictorRecipe().executeRecipe(
                 Ingredients=self.prepPeakIngredients(ingredients),
@@ -108,7 +113,11 @@ class SculleryBoy:
         path = Resource.getPath("/inputs/calibration/ReductionIngredients.json")
         return parse_file_as(ReductionIngredients, path)
 
-    def prepNormalizationIngredients(self, ingredients: FarmFreshIngredients) -> NormalizationIngredients:
+    def prepNormalizationIngredients(
+        self,
+        ingredients: FarmFreshIngredients,
+        pixelMask=None,  # noqa: ARG002
+    ) -> NormalizationIngredients:
         return NormalizationIngredients(
             pixelGroup=self.prepPixelGroup(ingredients),
             calibrantSample=self.prepCalibrantSample("123"),


### PR DESCRIPTION
## Description of work

This pr addresses two case I came across while testing another pr fixing nan issues in the diffractionfocussing call.

1. Explicitly checking the instrument on load
  a. Due to some external meddling of datafiles on disk, there are at least 1 lite rundata file and 1 lite normalization file on disk without the correct instrument, this pr explicitly catches this error and recommends a user contacts an IS or CIS (to regenerate the file).
2. Masking from a diffcal causes pixelgroup/detector mismatch during the normalization workflow.
  a. this can be caused by creating a terrible calibration that masks half the expected spectra and then running an applicable runnumber through normalization 


## To test

### Instrument Check

1. save a data file with incorrect spectra and/or incorrect instrument to the location of a normally valid lite data file
2. attempt to run a workflow that would load said file
3. observe exception message tailor to this specific case.

`64412` is a good example

### Normalization Masking
run on `next` then on this pr to observe change in behavior
1. Run diffcal with `46680`, diamond, bank, default pixel masking threshold ( 0.15), skip pixel calibration
2. Attempt to run normalization with `59039` + `58813`, LaB6, Column
3. `next` Observe an error denoting a mismatch of groups to parameters for diffraction focussing 
4. `this pr` Observe a successful normalization.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#12188](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=12188)

### Verification

- [ ] the author has read the EWM story and acceptance critera
- [x] the reviewer has read the EWM story and acceptance criteria
- [x] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] acceptance criterion 1
- [x] acceptance criterion 2
