### PR TITLE
Progress reporting for workflows

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
   apt_packages:
     - graphviz
   jobs:

--- a/docs/source/developer/implementation_notes/grouping_workspaces.rst
+++ b/docs/source/developer/implementation_notes/grouping_workspaces.rst
@@ -1,5 +1,5 @@
-Grouping Workspace Fine Points:
--------------------------------
+Grouping Workspace Fine Points
+------------------------------
 
 A `GroupingWorkspace` represents a one-to-many mapping between integer subgroup-IDs, and corresponding sets of pixel-IDs.  As implemented in the Mantid codebase, `GroupingWorkspace` s can be more complex than they initially seem.  Most of the subtlety relates to the fact that there are *multiple* ways to represent any specific subgroup-id to pixel-ids grouping.
 

--- a/docs/source/developer/implementation_notes/index.rst
+++ b/docs/source/developer/implementation_notes/index.rst
@@ -13,3 +13,4 @@ provide additional information that will be useful during SNAPRed development.
    :caption: Index
 
    grouping_workspaces.rst
+   profiling_and_progress_recording.rst

--- a/docs/source/developer/implementation_notes/profiling_and_progress_recording.rst
+++ b/docs/source/developer/implementation_notes/profiling_and_progress_recording.rst
@@ -1,0 +1,195 @@
+Execution Time Estimator for Computational Processes
+====================================================
+
+Background
+----------
+
+It is straightforward to mathematically estimate the execution time for a computational process. However, when such an estimate is applied in the real world, it may often end up being *almost useless*. This is typically because:
+
+- The effects of constant terms are neglected at short timescales.
+- Processing-system related issues are ignored at long timescales.
+
+For this reason, the current system for execution-time estimation is based on:
+
+- The specification of a computational order, combined with a set of **empirical measurements** of the process behavior.
+
+In combination, these are then used to construct an **estimator function**, which is applied to predict execution-time behavior.
+
+Each measurement consists of:
+
+- A single scalar reference value ``N_ref``, combined with the associated wall-clock execution time for the process step under consideration ``dt``.
+
+An *a priori* computational order (selected from ``O_0``, ``O_N``, ``O_LOGN``, ``O_N2``, ...) is used to convert this ``N_ref`` into a value ``N``, which is then used to construct the estimator function as ``dt(N)``. This construction uses a spline-fitting technique, with a constrained maximum degree.  Such an estimator will produce highly accurate values for ``N_ref`` falling within the interval of the measurements used in its construction, but somewhat less accurate values for ``N_ref`` falling outside of that interval.
+
+----
+
+Design objectives
+-----------------
+
+Use an efficient technique to obtain empirical timing measurements from relevant subsections of the running code. This technique should:
+
+- Be as *flexible* and *non-intrusive* as possible
+
+  - Easy for a developer to apply initially
+  - Easy to modify where it is applied.
+
+- Provide *automatic* identification of which section of code a measurement comes from.
+- Provide *automatic* detection of changes to the ``N_ref`` function used to produce the estimator.  This allows the user to be notified when the existing set of empirical measurements is no longer valid, and should be discarded.
+
+  - Note that detecting changes to the selected *order* is not a requirement, as the estimator can easily be reconstructed from existing measurements when the order is modified.
+
+The technique must work with:
+
+- Methods in a ``Service`` class.
+- Methods in a ``Recipe`` class.
+- Any subsections of code within those methods.
+
+Both a **decorator form** and **context-manager form** of the ``WallClockTime`` profiler should be provided.
+
+- The decorator must decorate either a class or a function (in the discussion, ``Recipe`` and ``Service.method`` are used as examples).
+- When a class is decorated, the method to profile must be specified *explicitly*.  For example ``Recipe.cook`` is usually specified when a ``Recipe`` class is decorated.
+- For context-manager application, the local stack frame determines the calling method *automatically*, but this is insufficient to identify the precise location in the code.  This creates the additional requirement to specify an *explicit* step name in this case.
+- In all cases, an explicit step name (optional for decorator application) *may* be specified, and in general doing this will provide additional
+  clarity to a developer attempting to read and understand the recorded measurement values.
+
+Time estimates should be available whenever required for any *running* process step. The estimated completion time for each step should be **logged**.
+
+- Process steps may be arbitrarily nested.  Logging from process substeps should be *abbreviated*.
+- Customized display of in-progress process steps should be facilitated by deriving from the ``Logging.Handler`` class.  For example, in this manner the existing
+  logging updates might be used to control a progress bar.  Any required numerical information for such use should be entered into the ``LogRecord.extra`` ``dict`` so that it can be accessed by such a derived ``Handler``.
+
+----
+
+Implementation details
+----------------------
+
+The primary class implementing both timing measurement and execution-time estimation is ``ProgressRecorder``.
+
+- Applied by calling ``record()`` at the start of an execution step, and ``stop()`` at the end.
+- Exposed via its decorator / context-manager ``WallClockTime``.  This is what should **normally** be used; ``record()`` and ``stop()`` should not be called directly.
+
+Timing data from ``ProgressRecorder`` is **persistent**:
+
+- Stored at: ``${user.application.data.home}/workflows_data/timing``
+- Retained timing data is:
+
+  - limited by the number of retained files
+  - limited by the size of each file.
+
+Progress-recording steps are automatically named using details from the scope of the decorated function / class, or from the local scope where the context manager is applied. When used as a context manager, an explicit step name must be provided (but this is optional when used as a decorator).
+
+- Explicit and implicit step-name information is *combined* to generate a step key to identify the progress-recording step.
+- Steps must be unique under this keying system, but otherwise they may be arbitrarily nested.
+- A stack keeps track of which steps are currently being recorded ("active steps").  Steps that become active while others are also active are called "substeps".
+
+----
+
+Logging and estimation
+~~~~~~~~~~~~~~~~~~~~~~
+
+For each application, either as a decorator or a context manager, a suitable ``N_ref`` function must be specified.  At the start of each execution step, the current estimator instance is used to predict execution time.  In order to compute this prediction, the current value of ``N_ref`` is required. Often, special cases occur during the calculation of ``N_ref`` which indicate that no estimate can be calculated.  For example, when running the reduction workflow in ``live_data`` mode, no time estimate is presently possible.
+
+- In such cases, the ``N_ref`` function should return ``None``, and the logging for the step will display simply *no data available*.
+
+For a step that is not a substep, an **automatic logging chain** is initiated:
+
+- This chain reports progress of execution at regular intervals, until either the step completes, or the step exceeds its time estimate.
+- Logging from substeps is much reduced (no automatic logging chain starts).
+
+Each generated ``LogRecord`` includes details (step key, time estimate, remaining time) in its ``extra`` ``dict`` that will be useful for an ergonomic display.  For example, a class might be derived from ``Logging.Handler``, and then connected to a GUI progress bar.
+
+----
+
+Updating the estimator
+~~~~~~~~~~~~~~~~~~~~~~
+
+At successful completion of a step:
+
+- The current measurement is recorded.
+
+  - If an exception occurs, the step is marked as completed (and therefore *inactive*), but no measurement is recorded.
+
+- The current estimate is compared to the actual execution time.
+
+  - If the disparity is above a certain threshold, the estimator updates.
+
+- The estimator function updates only if enough measurements are available (usually this will require at least three).
+- Preferably, measurements should be at *distinct* ``N_ref`` values (although this is not strictly required).
+- Over time, estimator quality improves rapidly.
+
+----
+
+Known issues and what to expect when testing
+--------------------------------------------
+
+- Only primary workflows and a few key recipes have been decorated so far.  It would be possible to decorate all recipes automatically, but this has not been attempted due to the discrepancy between the derivation of ``Recipe`` and ``GenericRecipe``.
+- Progress logging is only *activated* for selected target steps.  This means that obtaining as much useful profiling data as possible does not necessarily increase the logging output.
+
+To facilitate testing, a new IPC-based logging feature is provided which allows logging output to be viewed in separate terminal windows:
+
+- IPC-handler names are specified in ``application.yml``.
+- Each handler has a list of logger names that are associated with it.
+
+  - Example: the ``ProgressRecorder`` logger associated with the ``SNAPRed-progress`` IPC handler.
+
+- For security reasons, IPC-based logging uses Unix-domain sockets (``UDS``), and not localhost.
+
+At present, the provided logging output for progress recording is not particularly *ergonomic*:
+
+- When displayed in a separate terminal window, the current output might be adequate for some use cases (e.g ``SNAPWrap``).
+- A better method to display this data is almost certainly needed for both:
+
+  - ``SNAPRed`` GUI panel
+  - ``SNAPRed`` backend via ``SNAPWrap``.
+
+For testing, it may help if you **already have** a diffraction calibration and a normalization calibration for the run numbers you intend to use.  Due to the required ``N_ref`` treatment of *special-cases* mentioned above:
+
+- At present, profiling only covers the case where both a diffraction calibration and a normalization calibration are available.
+
+----
+
+To test - Dev testing
+~~~~~~~~~~~~~~~~~~~~~
+
+1. Remove any data files at ``${user.application.data.home}/workflows_data/timing``.
+
+   - These may have been auto-generated.
+   - It's OK to simply delete these JSON files, whenever required.
+
+2. Start ``SNAPRed`` (either as ``env=dev python -m snapred``, or from ``mantid_workbench``).
+3. Make a note of the process id (PID) using ``ps -u USER | grep python``.  Note here that ``mantid_workbench`` may have launched multiple python processes; use the first one.
+4. In a separate terminal (activate the ``SNAPRed`` conda environment), start an IPC-server for the ``SNAPRed-progress`` handler:
+
+   - ``python tests/cis_tests/util/logging/IPC_server.py -n SNAPRed-progress -p ${PID}``
+
+5. Run any workflow, e.g., reduction. Start by reducing data for one run.
+6. Exit. In an IPC-logging terminal, type CNTL-C to exit.  Look at the JSON in ``${user.application.data.home}/workflows_data/timing``.  Details of ``dt`` and estimated ``dt_est`` should have been recorded for several service steps and possibly from various recipes, depending on which workflow was executed.  Note that the *default* estimator is linear: 1GB in 3.0s -- this default instance should still be current after running only one workflow.  Check the *automatically* generated step keys.
+7. Repeat steps 1-3 to start a new process with an IPC-logger.
+8. Run the reduction workflow for several distinct runs (e.g., 58810, 58812, 58813, 59039).
+9. Somewhere in the middle of step 8, note that the time estimates indicated in the log will become much more accurate.
+10. Exit as before. Inspect the latest JSON files -- estimates should reflect improved accuracy, and you can see that the applied spline degree has increased.
+
+----
+
+Notes on estimator accuracy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- The default linear estimator is not very accurate.  It will update automatically when enough timing measurements are available.
+- The effect of this update can be seen in the JSON data at ``${user.application.data.home}/workflows_data/timing``.
+- If *distinct* ``N_ref`` values are not used, the estimator may become accurate for those run numbers only; extrapolation to other run numbers will be less accurate.
+
+  - Regardless, automatic updating continues as needed.
+
+- Given enough distinct ``N_ref`` values, the estimator will quickly become accurate, even when extrapolation is required.
+
+Definition of the ``N_ref`` function
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Special cases in workflows complicate the definition of the ``N_ref`` function.  For example, in the normalization workflow, the distinction between cylindrical / spherical samples has not yet been treated.
+
+- The system presently identifies but does not attempt to estimate such special cases.
+- When defining an ``N_ref`` method, it's important to return ``None`` if a case is identified that should not be estimated.  This ensures that any recorded measurement can be effectively used to create a *useful* time estimate for the workflow.
+
+  - If every single measurement were recorded, certainly the estimate would be able to predict the *average* execution time for any workflow, but that average might be over cases including so many *special* parameter combinations that it would not be useful to the end user.
+
+The ideal way to fix this issue of special casing the ``N_ref``, in order to allow these estimators to function more broadly, is probably to move such special cases out of the service layer and up to workflow level.  Alternatively, the step *keying* system could be made more elaborate.

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -221,7 +221,7 @@ class GroceryService:
         """
         return self.dataService.getIPTS(runNumber, instrumentName)
 
-    def _createNeutronFilePath(self, runNumber: str, useLiteMode: bool) -> Path | None:
+    def createNeutronFilePath(self, runNumber: str, useLiteMode: bool) -> Path | None:
         return self.dataService.createNeutronFilePath(runNumber, useLiteMode)
 
     @validate_call
@@ -819,7 +819,7 @@ class GroceryService:
 
         # Warning: `filePath` will be `None` if no IPTS directory exists!
         #   This situation occurs during diagnostic runs in live-data mode.
-        filePath = self._createNeutronFilePath(runNumber, useLiteMode)
+        filePath = self.createNeutronFilePath(runNumber, useLiteMode)
 
         # This checks to make sure existing cache is valid
         self._updateNeutronCacheFromADS(runNumber, useLiteMode)
@@ -1378,7 +1378,7 @@ class GroceryService:
 
         # Warning: `filePath` will be `None` if no IPTS directory exists!
         #   This situation occurs during diagnostic runs in live-data mode.
-        filePath = self._createNeutronFilePath(runNumber, useLiteMode)
+        filePath = self.createNeutronFilePath(runNumber, useLiteMode)
         if not bool(filePath):
             raise RuntimeError(f"Cannot find IPTS directory for run '{runNumber}'")
 

--- a/src/snapred/backend/profiling/ProgressRecorder.py
+++ b/src/snapred/backend/profiling/ProgressRecorder.py
@@ -1,0 +1,985 @@
+import atexit
+import functools
+import inspect
+import sys
+from datetime import datetime, timezone
+from enum import StrEnum
+from hashlib import sha256
+from threading import Timer
+from types import FrameType, FunctionType, MethodType
+from typing import Any, Callable, ClassVar, Dict, List, Self, Tuple
+
+import numpy as np
+from pydantic import BaseModel, field_serializer, field_validator
+from scipy.interpolate import BSpline, make_splrep
+
+from snapred.backend.data.LocalDataService import LocalDataService
+from snapred.backend.log.logger import snapredLogger
+from snapred.meta.Config import Config
+from snapred.meta.decorators.classproperty import classproperty
+
+logger = snapredLogger.getLogger(__name__)
+
+
+class ComputationalOrder(StrEnum):
+    O_0 = "O_0"
+    O_LOG_N = "O_LOG_N"
+    O_N = "O_N"
+    O_N_LOG_N = "O_N_LOG_N"
+    O_N_2 = "O_N_2"
+    O_N_3 = "O_N_3"
+
+    def __call__(self, N_ref: float) -> float:
+        # Incoming 'N_ref' must always have a value:
+        #   even in the case of `O_0`.
+        if N_ref is None:
+            raise RuntimeError("Usage error: incoming 'N_ref' must have a value.")
+        N = None
+        match self:
+            case ComputationalOrder.O_0:
+                N = 1.0
+            case ComputationalOrder.O_LOG_N:
+                N = np.log(N_ref)
+            case ComputationalOrder.O_N:
+                N = N_ref
+            case ComputationalOrder.O_N_LOG_N:
+                N = N_ref * np.log(N_ref)
+            case ComputationalOrder.O_N_2:
+                N = N_ref ** (2.0)
+            case ComputationalOrder.O_N_3:
+                N = N_ref ** (3.0)
+            case _:
+                raise RuntimeError(f"unrecognized `ComputationalOrder`: {self}")
+        return N
+
+
+class _Step(BaseModel):
+    # Class holding details
+    #   about how to calculate the execution-time estimate
+    #    for a process (either workflow or recipe) step.
+
+    # The key used to uniquely identify this process step.
+    # At present this is `(<module name> or <file name>, <class name>, <method name> [, <step name>])`.
+    key: Tuple[str | None, ...]
+
+    # Hex digest of `_N_ref` `Callable`:
+    #   this allows accounting for changes in how `N_ref` is computed,
+    #   but doesn't have the problems associated with making an
+    #   `N_ref`-callable persistent.
+    N_ref_hash: str | None
+
+    # Standard computational-order is used to normalize `N_ref`, from the as-saved measurement,
+    #   to `N`, as used by the estimate's spline fit.
+    order: ComputationalOrder | None
+
+    ##
+    ## PRIVATE attributes:
+    ##
+
+    # `_N_ref`, `_N_ref_args`:
+    # The actual `N_ref` function corresponding to this process step, and its `(args, kwargs)` tuple.
+    #   `N_ref` computes the scalar value to be used as input to the computational-order calculation:
+    #   `dt = <order>(N_ref(*args, **kwargs))`, where `<order>` is a standard process order, e.g. `N_log_N`,
+    #   and `dt` is the estimated execution time.
+
+    def __init__(
+        self,
+        key: Tuple[str | None, ...],
+        *,
+        N_ref_hash: str | None = None,
+        N_ref: Callable[..., float] | None = None,
+        N_ref_args: Tuple[Tuple[Any, ...], Dict[str, Any]] = ((), {}),
+        order: ComputationalOrder = None,
+    ):
+        # The persistent part of the `Step` retains the hash digest of the `N_ref`-callable,
+        #   but not the callable itself.
+
+        # In expected usage: during `__init__` only ONE of these would be specified.
+        if N_ref is not None:
+            if N_ref_hash is not None:
+                raise RuntimeError(
+                    f"Usage error: step {key} initialization should specify "
+                    + "either `N_ref` or `N_ref_hash`, but not both."
+                )
+            N_ref_hash = _Step._callable_hash(N_ref)
+
+        super().__init__(key=key, N_ref_hash=N_ref_hash, order=order)
+        self._N_ref = N_ref
+        self._N_ref_args = N_ref_args
+
+    # A factory method to produce default instances of `_Step`.
+    @classmethod
+    def default(cls, key: Tuple[str, ...]) -> Self:
+        return _Step(
+            key=key
+            # Default values for `N_ref` and `order` are set
+            #   at `WallClockTime`.  They should not be set here.
+        )
+
+    def setDetails(
+        self,
+        *,
+        N_ref: Callable[..., float] = None,
+        N_ref_args: Tuple[Tuple[Any, ...], Dict[str, Any]] = None,
+        order: ComputationalOrder = None,
+    ):
+        # Notes:
+        #   * Values will only be modified when their incoming args are not `None`.
+        #   * For steps registered using the decorator, all values except for the
+        #     `N_ref_args` will be set at the decorator `__init__`.
+        #     `N_ref_args` will then be set when the wrapped function is actually called.
+        #   * For explicitly-named steps, registered using the context manager, or by calling
+        #     `record` directly, all values must be set at the initial call.
+        #
+        if N_ref is not None:
+            self._N_ref = N_ref
+            previousHash = self.N_ref_hash
+            self.N_ref_hash = _Step._callable_hash(N_ref)
+            if previousHash is not None and self.N_ref_hash != previousHash:
+                logger.warning(
+                    f"`N_ref` for step {self.key} has been modified from that used in previously-saved data.\n"
+                    + "  In this case, usually the previous timing measurements for the step should be discarded."
+                )
+
+        if N_ref_args is not None:
+            self._N_ref_args = N_ref_args
+        if order is not None:
+            self.order = order
+
+    def N_ref(self) -> float | None:
+        # Access the reference value
+        N_ref = None
+        if self._N_ref is not None:
+            N_ref = self._N_ref(*self._N_ref_args[0], **self._N_ref_args[1])
+        return N_ref
+
+    @staticmethod
+    def _callable_hash(func: FunctionType) -> str:
+        # IMPORTANT: generate a hex digest based on the callable's code, rather than its id!
+        #   This then can be used to determine if the `N_ref` callable has changed, between
+        # different instances of the persistent `_Step` data.
+        if not isinstance(func, FunctionType):
+            raise RuntimeError(f"Usage error: expecting `FunctionType` not {type(func)}.")
+        sha = sha256()
+        sha.update(func.__code__.co_code)
+        return sha.hexdigest()[0:16]
+
+
+class _Measurement(BaseModel):
+    # Contains post-execution timing data from a specific workflow step.
+
+    # elapsed wall-clock time in seconds
+    dt: float
+
+    # estimate of elapsed wall-clock time
+    dt_est: float | None
+
+    # Non-normalized reference value:
+    #   as the data point itself: only the original value should be saved.
+    # In the case that this value is `None`, this `_Measurement` only includes timing data.
+    N_ref: float | None
+
+
+class _Estimate(BaseModel):
+    # A tuple summarizing the information used during the last call to `update`.
+    # (<Number of distinct contributing `_Measurement` records>,
+    #    <Total number of contributing records>)
+    count: Tuple[int, int] | None = None
+
+    # Spline-fit args from most recent "update" calculation.
+    #   Possible spline orders can be anything from constant (k == 0),
+    #   up to a maximum order  of `Config["application.workflows_data.timing.spline_order"]`,
+    #   which is typically cubic (k == 3).  The order used by the fit is determined
+    #   by the number of distinct measurement points available.
+    tck: Tuple[List[float], List[float], int] = None
+
+    # A singleton of the default `_Estimate` instance.
+    _default: ClassVar[Self] = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._spl = None
+        if self.tck is not None:
+            # Note that this _does_ allow degree `k == 0`:
+            #   but any construction of the actual `BSpline` not using `construct_fast` will
+            #   prohibit that.  (See comments at `_update` below.)
+            _tck = (np.array(self.tck[0]), np.array(self.tck[1]), self.tck[2])
+            self._spl = BSpline.construct_fast(*_tck, extrapolate=True)
+
+    @classproperty
+    def SPLINE_DEGREE(cls):
+        return Config["application.workflows_data.timing.spline_order"]
+
+    # A factory method to produce a default instance of the `_Estimate`.
+    @classmethod
+    def default(cls) -> Self:
+        # A factory method to produce default instances of `_Estimate`.
+
+        # Implementation notes:
+        # * As this method may eventually depend on arguments,
+        #   default args should not be used to implement this value.
+        # * This caches the `_default` value of `_Estimate` as a class attribute.
+
+        if cls._default is None:
+            # A linear estimator:
+            #   based on: 3.0s to process 1GB of data.
+            Ns = np.array([0.0, 1.0e9])
+            dts = np.array([0.0, 3.0])
+            cls._default = _Estimate()
+            cls._default._update(Ns, dts, len(Ns))
+
+        # IMPORTANT: we need to return a _copy_ here.
+        #   To ensure that the `__init__` is called `model_copy` cannot be used.
+        return _Estimate(count=cls._default.count, tck=cls._default.tck)
+
+    # Estimate elapsed wall-clock time for a specific workflow step.
+    def dt(self, N: float) -> float:
+        # Estimate elapsed wall-clock time `dt` for a specific workflow step.
+        # `dt` is estimated from normalized 'N'.
+        if self._spl is None:
+            raise RuntimeError("Usage error: `dt` called before `update`.")
+        return float(self._spl(N))
+
+    def update(self, measurements: List[_Measurement], order: Callable[[float], float]):
+        # Update the spline model of the time dependence.
+        Ns, dts = self._prepareData(measurements, order)
+        self._update(Ns, dts, len(measurements))
+
+    def _update(self, Ns: np.ndarray, dts: np.ndarray, dataCount: int):
+        # Until there are enough distinct measurement points to generate the full spline order,
+        #   construct lower-order splines.
+        splineOrder = min(len(Ns) - 1, self.SPLINE_DEGREE)
+        if splineOrder >= 0:
+            # retain counts contributing to the estimate: (|<distinct points>|, |<all points>|)
+            self.count = (len(Ns), dataCount)
+
+            # Compute an interpolating `BSpline` instance (i.e with `s=0.0`).
+            # Implementation notes:
+            #   * TODO: Optionally, the smoothing parameter 's' can be changed from 0.0.; but that wasn't
+            #     explored during this first-pass implementation;
+            #   * This treatment also works for degree `k==0` (i.e. a spline representing a _constant_ value),
+            #     however constructing a `BSpline` from the resulting `tck` requires the use of
+            #     `BSpline.construct_fast(*tck)`, otherwise the knot vector will be judged to be too short.
+            self._spl = make_splrep(Ns if Ns[0] is not None else np.array([0.0]), dts, k=splineOrder)
+            self.tck = (list(self._spl.tck[0]), list(self._spl.tck[1]), self._spl.tck[2])
+
+    def _prepareData(
+        self, measurements: List[_Measurement], order: Callable[[float], float]
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        # Sort and accumulate the measurement data.
+
+        ts = [
+            (order(measurement.N_ref) if measurement.N_ref is not None else None, measurement.dt)
+            for measurement in measurements
+        ]
+
+        # Either all of the `N_ref` will be `float`, or all will be `None`.
+        if any(t[0] is None for t in ts) and not all(t[0] is None for t in ts):
+            raise RuntimeError("Either all of the `N_ref` values should be `float`, or all should be `None`.")
+
+        if ts[0][0] is not None:
+            ts = sorted(ts, key=lambda t: t[0])
+            if ts[0][0] != 0.0:
+                # Insert a "tie" point at (N==0.0, dt==0.0).
+                ts.insert(0, (0.0, 0.0))
+        Ns, dts = self._accumulateDuplicates(ts)
+        return np.array(Ns), np.array(dts)
+
+    def _accumulateDuplicates(self, ps: List[Tuple[float, float]]) -> Tuple[List[float], List[float]]:
+        Ns_, dts_ = [], []
+        i = 0
+        while i < len(ps):
+            n_group, dt_values = ps[i][0], [ps[i][1]]
+            j = i + 1
+            while j < len(ps):
+                n_curr = ps[j][0]
+                if (n_group is None and n_curr is None) or np.isclose(n_group, n_curr):
+                    dt_values.append(ps[j][1])
+                    j += 1
+                else:
+                    break
+            Ns_.append(n_group)
+            dts_.append(np.mean(dt_values))
+            i = j
+        return Ns_, dts_
+
+    @field_validator("tck", mode="before")
+    @classmethod
+    def _validate_tck(cls, v: Any) -> Tuple[List[float], List[float], int]:
+        if v is not None:
+            if v[2] > cls.SPLINE_DEGREE:
+                raise ValueError(f"In `tck`, specified spline degree `k` must be <= {_Estimate.SPLINE_DEGREE}.")
+        return v
+
+
+class ProgressStep(BaseModel):
+    # Progress-recording information for a single process step.
+
+    # Information about how to calculate the execution-time estimate
+    details: _Step
+
+    # Elapsed wall-clock time measurements for previous executions of this step.
+    measurements: List[_Measurement] = []
+
+    # An execution-time estimator for this step.
+    estimate: _Estimate = _Estimate.default()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._isSubstep = False
+        self._startTime: datetime | None = None
+        self._N_ref: float | None = None
+        self._dt: float | None = None
+        self._loggingEnabled = False
+        self._timer: Timer | None = None
+
+    def setDetails(
+        self,
+        *,
+        N_ref: Callable[..., Any] = None,
+        N_ref_args: Tuple[Tuple[Any, ...], Dict[str, Any]] = None,
+        order: ComputationalOrder = None,
+        enableLogging: bool = False,
+    ):
+        self.details.setDetails(N_ref=N_ref, N_ref_args=N_ref_args, order=order)
+        self._loggingEnabled = enableLogging
+
+    def start(self, isSubstep: bool):
+        self._isSubstep = isSubstep
+        self._startTime = datetime.now(timezone.utc)
+
+        # Set the expected execution-time duration:
+        #   it is IMPORTANT that this be the only place where this estimate is calculated.
+        #   For example, it should not be recalculated prior to logging.
+        self._N_ref = self.details.N_ref()
+        if self._N_ref is not None:
+            self._dt = self.estimate.dt(self.details.order(self._N_ref))
+
+    def stop(self):
+        if not self.isActive:
+            raise RuntimeError(f"Usage error: attempt to `stop` unstarted step {self.name}.")
+        self._isSubstep = False
+        self._startTime = None
+        self._N_ref = None
+        self._dt = None
+        if self._timer is not None:
+            self._timer.cancel()
+            self._timer = None
+
+    def recordMeasurement(self, dt_elapsed: float, dt_est: float, N_ref: float):
+        # Record a measurement in the `measurements` list.
+
+        # The possibility of active exceptions, or of an `N_ref` value of `None` should have been treated
+        #   outside of this method.
+        self.measurements.append(_Measurement(dt=dt_elapsed, dt_est=dt_est, N_ref=N_ref))
+
+        # Restrict the maximum length of the measurements list.
+        max_measurements = Config["application.workflows_data.timing.max_measurements"]
+        if len(self.measurements) > max_measurements:
+            # Forget the oldest measurements
+            self.measurements = self.measurements[-max_measurements:]
+
+        # If necessary, update the estimate for the step.
+        if len(self.measurements) >= Config["application.workflows_data.timing.update_minimum_count"]:
+            # Enough data points are available to perform an update.
+            if abs(dt_est - dt_elapsed) / dt_elapsed > Config["application.workflows_data.timing.update_threshold"]:
+                # The relative error from the current estimate is greater than the threshold.
+                self.estimate.update(self.measurements, self.details.order)
+
+    @property
+    def name(self) -> str:
+        # A human-readable name for the step.
+        return self.humanReadableName(self.details.key)
+
+    @classmethod
+    def humanReadableName(cls, key: Tuple[str, ...]) -> str:
+        return ".".join(filter(lambda s: bool(s), key))
+
+    @classmethod
+    def shortName(cls, key: Tuple[str, ...], isSubstep: bool) -> str:
+        # Return an abbreviated name for the step, retaining only the strictly necessary components.
+        if isSubstep:
+            # the substep name
+            return key[-1]
+        name = key[-1] if bool(key[-1]) else ""
+        qualname = key[-2]
+        # the <step name> appended to the last component of the `qualname`
+        return ": ".join(filter(None, (qualname.split(".")[-1], name)))
+
+    @property
+    def isActive(self) -> bool:
+        return self._isActive()
+
+    def _isActive(self) -> bool:
+        # separate method for testing
+        return bool(self._startTime)
+
+    @property
+    def startTime(self) -> datetime:
+        if self._startTime is None:
+            raise RuntimeError("Usage error: attempt to read `startTime` for unstarted step '{self.details.name}'.")
+        return self._startTime
+
+    @property
+    def N_ref(self) -> float | None:
+        # The reference value used to estimate the execution time for an active step:
+        #   a value of `None` indicates that an estimate could not be calculated.
+        if not self.isActive:
+            raise RuntimeError("Usage error: attempt to read `N_ref` for unstarted step '{self.details.name}'.")
+        return self._N_ref
+
+    @property
+    def dt(self) -> float | None:
+        # The estimated execution-time duration for an active step (in seconds):
+        #   a value of `None` indicates that an estimate could not be calculated.
+        if not self.isActive:
+            raise RuntimeError("Usage error: attempt to read `dt` for unstarted step '{self.details.name}'.")
+        return self._dt
+
+    @property
+    def loggingEnabled(self) -> bool:
+        return self._loggingEnabled
+
+    @property
+    def isSubstep(self) -> bool:
+        return self._isSubstep
+
+
+class _ProgressRecorder(BaseModel):
+    # Map from <step key> to progress steps.
+    #   * `Dict[Tuple[str | None, ...], ProgressStep]` is the primary class,
+    #        the `List[ProgressStep]` is only used for serialization, to work around the fact
+    #        that JSON `dict` require string keys.
+    #   * A fully-scoped step key includes
+    #       (<module name>, <the fully-qualified function name of the caller>, <step name>)
+    #       any element of the tuple may be `None`.  For example, the <step name> is usually `None`
+    #       when the step is associated with the `WallClockTime` used as a decorator.
+    #   * Both workflow scope and recipe scope may be nested,
+    #       and a step can be identified as a substep if there are already steps on the active-step stack
+    #       when it begins execution.
+    steps: Dict[Tuple[str | None, ...], ProgressStep] | List[ProgressStep] = {}
+
+    def __new__(cls, *_args, **_kwargs):
+        # This is declared as a pass-through method, to be used during testing.
+        return super().__new__(cls)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._activeSteps: List[ProgressStep] = []
+
+    @classmethod
+    @functools.lru_cache(maxsize=None)
+    def _loggable_qualname_roots(cls):
+        # TODO: PROBLEM -- this bypasses `Config` reload!
+        # Convert this `Config` value to a set, so that it won't scanned each time it's used
+        return set(Config["application.workflows_data.timing.logging.qualname_roots"])
+
+    @classproperty
+    def enabled(cls):
+        return Config["application.workflows_data.timing.enabled"]
+
+    @classmethod
+    @functools.lru_cache(maxsize=None)
+    def instance(cls) -> Self:
+        # TODO: PROBLEM -- this bypasses `Config` reload!
+        if cls.enabled:
+            if Config["application.workflows_data.timing.persistent_data"]:
+                # Automatically persist the progress data at application exit.
+                atexit.register(_ProgressRecorder._unloadResident)
+
+            return cls.model_validate_json(LocalDataService().readProgressRecords())
+
+        # When not enabled, we still need to return an "empty" instance.
+        return cls()
+
+    @classmethod
+    def _unloadResident(cls):
+        # Unload method to register with `atexit`.
+        try:
+            if cls.enabled:
+                LocalDataService().writeProgressRecords(cls.instance().model_dump_json(indent=2))
+        except BaseException:  # noqa: BLE001
+            # This method is registered with `atexit`: it must not raise any exceptions.
+            pass
+
+    @classmethod
+    def _getCallerFullyQualifiedName(cls, callerObjectOrStackFrame) -> Tuple[str | None, ...]:
+        # Caller key based on its (<module>, <fully-qualified name>).
+        # args:
+        #   'callerObjectOrStackFrame': this will be either a reference to the caller itself
+        #      as a `class`, `<class instance>`, `method`, or `function,
+        #      OR it will be the stack frame to look at to examine and obtain the caller's information.
+        # Note that the only requirement here for progress-step scoping,
+        # is that the information determined about the caller be
+        # suitably unique, when combined with the [optional] explicit <step name>.
+
+        module_name = None
+        qualified_name = None
+        if not isinstance(callerObjectOrStackFrame, FrameType):
+            caller = callerObjectOrStackFrame
+            if isinstance(caller, FunctionType):
+                qualified_name = caller.__qualname__
+            elif isinstance(caller, type):
+                qualified_name = caller.__qualname__
+            else:
+                raise RuntimeError(
+                    f"Not implemented: fully-qualified name for object of type {type(caller)}.\n"
+                    + "  Expecting object of type `FrameType`, `FunctionType`, or `type` only."
+                )
+            module_name = caller.__module__
+        else:
+            frame = callerObjectOrStackFrame
+            module = inspect.getmodule(frame.f_code)
+            module_name = module.__name__ if module is not None else ""
+
+            qualified_name = None
+            if sys.version_info >= (3, 11, 0):
+                qualified_name = frame.f_code.co_qualname
+            else:
+                # Required if Python version < 3.11.
+
+                # Get the function name
+                func_name = frame.f_code.co_name
+
+                # If the function is a method within a class, try to find the class name
+                class_name = None
+                if "self" in frame.f_locals:
+                    class_name = frame.f_locals["self"].__class__.__qualname__
+                elif "cls" in frame.f_locals:
+                    class_name = frame.f_locals["cls"].__qualname__
+
+                qualified_name = class_name + "." + func_name if bool(class_name) else func_name
+
+        return (module_name, qualified_name)
+
+    @classmethod
+    def isLoggingEnabledForStep(cls, key: Tuple[str, ...]) -> bool:
+        # Determine whether or not to log a step, based on the qualified name of its scope.
+
+        # key components: (<module name>, <fully-qualified scope name>, <explicit step name>)
+        qualname = key[-2]
+        if qualname is not None:
+            _root = qualname.split(".")[0]
+            return _root in cls._loggable_qualname_roots()
+        return False
+
+    @classmethod
+    def getStepKey(
+        cls, *, callerOrStackFrameOverride: FunctionType | FrameType | type = None, stepName=None
+    ) -> Tuple[str | None, ...]:
+        # Compute a unique key for the current process step.
+
+        # Notes:
+        #   * In general, the key tuple will be
+        #     `(<module name>, <fully qualified class or method name>, <explicit step name>)`.
+        #   * `None` is a valid entry for any tuple component;
+        #   * Note that the caller's stack frame is actually two-frames up from the current frame.
+
+        if bool(callerOrStackFrameOverride) and not isinstance(
+            callerOrStackFrameOverride, (FunctionType, FrameType, type)
+        ):
+            raise RuntimeError(
+                "Usage error: when `callerOrStackFrameOverride` is set, it must be either "
+                + "a function, the local stack-frame of a function, or a <class> type."
+            )
+
+        # The choice of stack frame in the fallback here allows `ProgressRecorder.record` to be called directly
+        # in the scope of a function of interest.  Any other usage should supply the <caller function>
+        # or <local stack-frame of caller function> directly.
+        # TODO: maybe there shouldn't be any fallback?
+        callerObjectOrStackFrame = (
+            callerOrStackFrameOverride
+            if callerOrStackFrameOverride is not None
+            else inspect.currentframe().f_back.f_back
+        )
+        key = cls._getCallerFullyQualifiedName(callerObjectOrStackFrame) + (stepName,)
+        return key
+
+    def getStep(self, key: Tuple[str | None, ...], create: bool = False) -> ProgressStep:
+        # Get the `ProgressStep` corresponding to the specified step key.
+        step = self.steps.get(key)
+        if step is None:
+            if not create:
+                raise RuntimeError(f"Usage error: progress-recording step {key} does not exist.")
+            step = ProgressStep(details=_Step(key=key))
+            self.steps[key] = step
+        return step
+
+    def record(
+        self,
+        *,
+        callerOrStackFrameOverride: MethodType | FunctionType | FrameType = None,
+        stepName: str = None,
+        N_ref: Callable[..., float] = None,
+        N_ref_args: Tuple[Tuple[Any, ...], Dict[str, Any]] = None,
+        order: ComputationalOrder = None,
+        enableLogging=False,
+    ) -> Tuple[str | None, ...]:
+        # Initialize the elapsed wall-clock time measurement for a processing step.
+        # args:
+        #   'stepName': [optional] if provided this is an additional suffix key added to
+        #      the step key generated from the _local_ (e.g. <class instance>, <method>, <function>, or <module>) scope.
+        #   'N_ref': an optional callable
+        #   'N_ref_args': the args to be used when calling `N_ref` as `(args, kwargs)`
+        #   'order': the computational order of the step.
+        #     This will be used to _normalize_ the `N_ref` value prior to estimating the step.
+        # returns:
+        #   the tuple of str keys used to uniquely identify the step
+
+        # Usage notes:
+        # -- Each call to `record` _must_ have a corresponding call to `stop`:
+        #    these calls are matched using the step key.
+        # -- Calls to `record` may be nested as required by the process being profiled.
+        # -- IMPORTANT: any call to `stop` should only record the measurement if no exception has been raised.
+        #    Mis-recorded measurements affect future estimates!
+        # -- There are several important details relating to the definition and behavior of the `N_ref`
+        #    function.  Please see:
+        #    `snapred.readthedocs.io/en/latest/developer/implementation_notes/profiling_and_progress_recording.html`.
+
+        if not _ProgressRecorder.enabled:
+            return None
+
+        key = self.getStepKey(callerOrStackFrameOverride=callerOrStackFrameOverride, stepName=stepName)
+        step = self.getStep(key, create=True)
+
+        # Logging is either enabled by explicit request,
+        #   or is enabled depending on the specifics of the scope of the step's key.
+        enableLogging |= ProgressRecorder.isLoggingEnabledForStep(key)
+
+        step.setDetails(N_ref=N_ref, N_ref_args=N_ref_args, order=order, enableLogging=enableLogging)
+        step.start(isSubstep=len(self._activeSteps) > 0)
+
+        # Push to the active steps stack.
+        self._activeSteps.append(step)
+
+        if step.loggingEnabled:
+            self._chainLogTimeRemaining(step)
+
+        # Return the key
+        return key
+
+    def stop(self, key: Tuple[str | None, ...]):
+        if not _ProgressRecorder.enabled:
+            return
+
+        step = self.getStep(key)
+
+        # retain timing-property values while the step is still active
+        startTime = step.startTime
+        N_ref = step.N_ref
+        dt = step.dt
+        isSubstep = step.isSubstep
+
+        # all cached step properties are cleared beyond this point
+        step.stop()
+
+        # Pop from the active steps stack.
+        if not bool(self._activeSteps):
+            raise RuntimeError("Usage error: `_activeSteps` stack underflow.")
+        self._activeSteps.pop()
+
+        # Do not output anything to the log, or record the measurement,
+        #   if any exception has been raised.
+        if sys.exc_info()[0] is None:
+            if step.loggingEnabled:
+                self._logCompletion(step.details.key, isSubstep)
+
+            stopTime = datetime.now(timezone.utc)
+            elapsed = float((stopTime - startTime).total_seconds())
+
+            # Do not record the measurement if `N_ref` could not be calculated.
+            if N_ref is not None:
+                step.recordMeasurement(dt_elapsed=elapsed, dt_est=dt, N_ref=N_ref)
+
+    def logTimeRemaining(self, key: Tuple[str | None, ...]):
+        # user-facing method to log the step time remaining
+        step = self.getStep(key)
+        self._logTimeRemaining(step)
+
+    def _chainLogTimeRemaining(self, step: ProgressStep):
+        # Log the time remaining for the step, continue to log at regular intervals
+        continueToLog = self._logTimeRemaining(step)
+
+        if continueToLog:
+            updateInterval = Config["application.workflows_data.timing.logging.log_update_interval"]
+            if updateInterval > 0.0:
+                # if it isn't a substep, log again at regular time intervals
+                if not step.isSubstep:
+                    step._timer = Timer(updateInterval, self._chainLogTimeRemaining, args=[step])
+                    step._timer.start()
+        elif step._timer is not None:
+            step._timer.cancel()
+            step._timer = None
+
+    def _logTimeRemaining(self, step: ProgressStep) -> bool:
+        # Log the time remaining for an in-progress step.
+        # -- returns a flag indicating whether any further logging should occur for this step.
+
+        # The logger kwarg `extra` is used to allow precise timing information to be accessed
+        #   from the generated log records when necessary.
+        if step.isActive:
+            continueToLog = True
+            loggableName = self._loggableStepName(step.details.key, step.isSubstep)
+            indent = ""
+            if step.isSubstep:
+                # indent substeps by the current stack depth:
+                #   substeps do not "chain", so this will be the substep's stack depth.
+                indent = Config["application.workflows_data.timing.logging.indent"] * (len(self._activeSteps) - 1)
+            remainder = self._stepTimeRemaining(step)
+            if remainder is not None:
+                if remainder > 0.0:
+                    logger.log(
+                        Config["application.workflows_data.timing.logging.loglevel"],
+                        f"{indent}{loggableName} -- estimated completion in {remainder:.1f} seconds.",
+                        extra={"key": step.details.key, "dt_est": step.dt, "dt_rem": remainder},
+                    )
+                else:
+                    logger.log(
+                        Config["application.workflows_data.timing.logging.loglevel"],
+                        f"{indent}{loggableName} -- is taking longer than expected.",
+                        extra={"key": step.details.key, "dt_est": step.dt, "dt_rem": 0.0},
+                    )
+                    # Log this message only once.
+                    continueToLog = False
+            else:
+                logger.log(
+                    Config["application.workflows_data.timing.logging.loglevel"],
+                    f"{indent}{loggableName} -- <no timing data is available>.",
+                    extra={"key": step.details.key, "dt_est": None, "dt_rem": None},
+                )
+                # Log this message only once.
+                continueToLog = False
+            return continueToLog
+        return False
+
+    def _logCompletion(self, key: Tuple[str, ...], isSubstep: bool):
+        loggableName = self._loggableStepName(key, isSubstep)
+        indent = Config["application.workflows_data.timing.logging.indent"] * len(self._activeSteps)
+        logger.log(Config["application.workflows_data.timing.logging.loglevel"], f"{indent}{loggableName} -- complete.")
+
+    def _loggableStepName(self, key: Tuple[str, ...], isSubstep: bool) -> str:
+        # Remove prefix information from the logged step name when this step is a substep
+        #   of another in-progress step.
+        return ProgressStep.shortName(key, isSubstep)
+
+    def stepTimeRemaining(self, key: Tuple[str | None, ...]) -> float | None:
+        # Estimate the time remaining for the specified step,
+        # or return `None` if not enough data is available yet to create an estimate,
+        step = self.getStep(key)
+        return self._stepTimeRemaining(step)
+
+    @classmethod
+    def _stepTimeRemaining(cls, step: ProgressStep) -> float | None:
+        elapsed = float((datetime.now(timezone.utc) - step.startTime).total_seconds())
+        remainder = None
+        dt = step.dt
+        if dt is not None:
+            remainder = dt - elapsed
+            if remainder < 0.0:
+                remainder = 0.0
+        return remainder
+
+    """
+    @field_validator("steps", mode="before")
+    @classmethod
+    def _validate_steps(cls, values: Any):
+        # incoming values:
+        #   either: from python: `Dict[Tuple[str, ...], ProgressStep]
+        #   or:    from json: `List[Dict[<progress-step items>], ...]`: here `key: List[str, ...]`
+        if isinstance(values, list):
+            return {tuple(step["details"]["key"]): step for step in values}
+        return values
+    """
+
+    @field_validator("steps", mode="after")
+    @classmethod
+    def _validate_steps(cls, steps: Any):
+        # Dict[Tuple[str, ...], ProgressStep] <- List[ProgressStep] | Dict[Tuple[str | None, ...], ProgressStep]
+        if isinstance(steps, list):
+            return {step.details.key: step for step in steps}
+        return steps
+
+    @field_serializer("steps")
+    def _serialize_steps(self, steps: Dict[Tuple[str, ...], ProgressStep], _info) -> List[ProgressStep]:
+        # By default `Tuple[str, ...]` keys don't serialize correctly to JSON.
+        return list(steps.values())  # *** DEBUG *** vs. `self.steps.values()` ? Which is correct?!
+
+
+# The `ProgressRecorder` singleton.
+ProgressRecorder = _ProgressRecorder.instance()
+
+
+class WallClockTime:
+    # A decorator or context manager to register a process-recording step for any method, function, or class.
+
+    def __init__(
+        self,
+        stepName: str = None,
+        *,
+        callerOverride: FunctionType | str = None,
+        N_ref: Callable[..., float] | str = lambda *_args, **_kwargs: 1.0,
+        N_ref_args: Tuple[Tuple[Any, ...], Dict[str, Any]] = ((), {}),
+        order: ComputationalOrder = ComputationalOrder.O_0,
+        enableLogging: bool = False,
+    ):
+        # When used as a decorator:
+        #   -- `callerOverride` is specified _only_ if the decoratee is a class:
+        #      in this case it is the _name_ of the class method to be profiled;
+        #   -- `stepName` may optionally be specified;
+        #   -- `N_ref` may optionally be specified:
+        #      it may be either a `FunctionType`, or the _name_ of a method within the
+        #      decorated class;
+        #   -- `N_ref_args` must not be specified;
+        #   -- `order` may optionally be be specified.
+        # When used as a context manager:
+        #   -- `callerOverride` should not be specified;
+        #   -- `stepName` must be specified;
+        #   -- `N_ref`, `N_ref_args` and `order` may optionally be specified:
+        #      when specified: `N_ref` must be a `FunctionType`.
+        # In either case:
+        #   -- when `N_ref`, `N_ref_args`, and `order` are left as `None`:
+        #      at time of execution, a constant-time estimate will be used.
+        # For discussion of these details, please see:
+        #    `snapred.readthedocs.io/en/latest/developer/implementation_notes/profiling_and_progress_recording.html`.
+
+        self.callerOverride = callerOverride
+
+        # One stack frame up from the current frame: only required for use as a context manager.
+        self._callingFrame: FrameType = inspect.currentframe().f_back
+
+        self.stepName = stepName
+        self.N_ref = N_ref
+        self.N_ref_args = N_ref_args
+        self.order = order
+        self._stepKey = None
+        self._enableLogging = enableLogging
+
+    @classmethod
+    def _progressRecorder(cls):
+        # This is provided as a separate method to facilitate testing.
+        return ProgressRecorder
+
+    def __call__(self, decoratee: type | FunctionType) -> type | FunctionType:
+        # Apply as a decorator
+
+        # Important: the behavior of this decorator should not depend on `_ProgressRecorder.enabled`,
+        #   otherwise it unnecessarily complicates any `Config` reload!
+        if self.N_ref_args != ((), {}):
+            raise RuntimeError(
+                "Usage error: when `WallClockTime` is used as a decorator: `N_ref_args` must not be specified:\n"
+                + "  these will be initialized when the decorated function is called."
+            )
+
+        func = decoratee
+        if isinstance(decoratee, type):
+            if not bool(self.callerOverride):
+                raise RuntimeError(
+                    "Usage error: on a `WallClockTime` decorated class: `callerOverride` must be specified: \n"
+                    + "  this should be the name of the to-be-profiled method of the decorated class."
+                )
+            if not isinstance(self.callerOverride, str) or not hasattr(decoratee, self.callerOverride):
+                raise RuntimeError(
+                    "Usage error: on a `WallClockTime` decorated class:\n"
+                    + "  `callerOverride` must be the name of a method of the decorated class."
+                )
+
+            func = getattr(decoratee, self.callerOverride)
+            if not isinstance(func, FunctionType):
+                raise RuntimeError(
+                    "Usage error: on a `WallClockTime` decorated class:\n"
+                    + "  `callerOverride` must be the name of a method of the decorated class."
+                )
+            # Check if `N_ref` was also given as the _name_ of a class method.
+            if isinstance(self.N_ref, str):
+                # Replace the N_ref name with the actual class method.
+                if not hasattr(decoratee, self.N_ref):
+                    raise RuntimeError(
+                        "Usage error: on a `WallClockTime` decorated class:\n"
+                        + "  when specified, `N_ref` may be a function,\n"
+                        + "  or the the name of a method of the decorated class."
+                    )
+                self.N_ref = getattr(decoratee, self.N_ref)
+
+        elif isinstance(decoratee, FunctionType):
+            if bool(self.callerOverride):
+                raise RuntimeError(
+                    "Usage error: on a `WallClockTime` decorated function:\n"
+                    + "  `callerOverride` must not be specified."
+                )
+            if isinstance(self.N_ref, str):
+                raise RuntimeError(
+                    "Usage error: on a `WallClockTime` decorated function:\n"
+                    + "  when specified, `N_ref` must be a function."
+                )
+        else:
+            raise RuntimeError(
+                "Usage error: `WallClockTime` used as decorator:\n"
+                + "  only `FunctionType` or `type` can be decorated."
+            )
+
+        @functools.wraps(func)  # Retain metadata from the wrapped `func`.
+        def _wrapper(*args, **kwargs):
+            # This wrapper profiles the call to the wrapped function using `_ProgressRecorder.record`,
+            #   and `_ProgressRecorder.stop`.  In addition, it allows the `args`, and `kwargs`
+            #   used by the wrapped function to be available to the `N_ref` used by the progress-reporting step.
+            #   This means that in expected usage, the signature for `N_ref` should be the same as that of
+            #   the wrapped function.
+
+            try:
+                if self._stepKey is not None:
+                    raise RuntimeError("Usage error: a `WallClockTime` decorated function is not re-entrant.")
+                self._stepKey = self._progressRecorder().record(
+                    stepName=self.stepName,
+                    # the decorated `FunctionType` or `type` should be used to generate the step key,
+                    #   not the <class method> passed in via the `callerOverride`!
+                    callerOrStackFrameOverride=decoratee,
+                    N_ref=self.N_ref,
+                    N_ref_args=(args, kwargs),
+                    order=self.order,
+                    enableLogging=self._enableLogging,
+                )
+
+                result = func(*args, **kwargs)
+            finally:
+                if self._stepKey is not None:
+                    # IMPORTANT: `stop` needs to be called regardless of the state of `sys.exc_info()`.
+                    self._progressRecorder().stop(self._stepKey)
+                    self._stepKey = None
+            return result
+
+        if isinstance(decoratee, type):
+            setattr(decoratee, self.callerOverride, _wrapper)
+            # return the wrapped <class>
+            return decoratee
+        # return the wrapped <function>
+        return _wrapper
+
+    def __enter__(self):
+        if not _ProgressRecorder.enabled:
+            return None
+
+        if bool(self.callerOverride) or not bool(self.stepName):
+            raise RuntimeError(
+                "Usage error: `WallClockTime` as context manager:\n"
+                + "  `callerOverride` must not be specified;\n"
+                + "  `stepName` must be specified."
+            )
+        if self._stepKey is not None:
+            raise RuntimeError("Usage error: a `WallClockTime` context manager cannot be re-used.")
+
+        self._stepKey = self._progressRecorder().record(
+            stepName=self.stepName,
+            callerOrStackFrameOverride=self._callingFrame,
+            N_ref=self.N_ref,
+            N_ref_args=self.N_ref_args,
+            order=self.order,
+            enableLogging=self._enableLogging,
+        )
+        return self._stepKey
+
+    def __exit__(self, *exc):
+        if not _ProgressRecorder.enabled:
+            return
+
+        if self._stepKey is not None:
+            self._progressRecorder().stop(self._stepKey)

--- a/src/snapred/backend/recipe/PixelDiffCalRecipe.py
+++ b/src/snapred/backend/recipe/PixelDiffCalRecipe.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from snapred.backend.dao.ingredients import DiffractionCalibrationIngredients as Ingredients
 from snapred.backend.log.logger import snapredLogger
+from snapred.backend.profiling.ProgressRecorder import ComputationalOrder, WallClockTime
 from snapred.backend.recipe.algorithm.Utensils import Utensils
 from snapred.backend.recipe.Recipe import Recipe, WorkspaceName
 from snapred.meta.Config import Config
@@ -22,6 +23,11 @@ class PixelDiffCalServing(BaseModel):
     outputWorkspace: str
 
 
+# Decorating with the `WallClockTime` profiler here somewhat duplicates the objective of the decoration
+#   at `CalibrationService.pixelCalibration`.  However, by default, there will be no logging output from this instance.
+#   This duplication allows both verification of this alternative decorator signature, and comparison of the
+#   profiling measurements and estimate initialization from the two instances.
+@WallClockTime(callerOverride="cook", N_ref="_pixelDiffCal_N_ref", order=ComputationalOrder.O_N)
 class PixelDiffCalRecipe(Recipe[Ingredients]):
     """
     Calculate the offset-corrected DIFC associated with a given workspace.
@@ -317,6 +323,35 @@ class PixelDiffCalRecipe(Recipe[Ingredients]):
         self.mantidSnapper.executeQueue()
         # return
         return self.medianOffsets[-1] > self.threshold and newOffset <= self.medianOffsets[-1]
+
+    def _pixelDiffCal_N_ref(self, _ingredients: Ingredients, groceries: Dict[str, str]) -> float | None:
+        # Calculate the reference value to use during the estimation of execution time for the
+        # `pixelDiffCalRecipe.cook` method.
+
+        # -- This method must have the same calling signature as `cook`.
+        # -- Returning `None` means that the `N_ref` value cannot be calculated, or alternatively,
+        #    that it should not be used.
+        # -- Please see:
+        #    `snapred.readthedocs.io/en/latest/developer/implementation_notes/profiling_and_progress_recording.html`.
+
+        # This method is largely the same as `CalibrationService._calibration_substep_N_ref`.
+        # It is declared separately here so that it can be modified, depending on requirements
+        # when more profiling data becomes available.
+
+        inputWorkspace = groceries["inputWorkspace"]
+        N_ref = None
+        if self.mantidSnapper.mtd.doesExist(inputWorkspace):
+            # Notes:
+            #   -- Scaling will also probably have a sub-linear dependence on the number of subgroups in the grouping,
+            #      however, that should be accounted for during the estimator's spline fit.
+            #   -- `getMemorySize` appears to return bytes (, which contradicts what the Mantid docs say).
+            #      Note that the default estimator instance is designed assuming its `N_ref` input will be in bytes.
+            #      It's important that these match, so that the transition between the default estimator,
+            #      and the first updated estimator will be as transparent as possible.
+            dataSize = float(self.mantidSnapper.mtd[inputWorkspace].getMemorySize())
+            N_ref = dataSize
+
+        return N_ref
 
     def cook(self, ingredients: Ingredients, groceries: Dict[str, str]) -> Dict[str, Any]:
         """

--- a/src/snapred/meta/Config.py
+++ b/src/snapred/meta/Config.py
@@ -200,6 +200,20 @@ class _Config:
 
         self._config["version"] = self._config.get("version", {})
         self._config["version"]["default"] = -1
+
+        # allow paths relative to user's home directory to be entered
+        #   using "${user.home}".
+        self._config["user"] = {"home": str(Path.home())}
+
+        # Automatically set the path to "${user.application.data.home}":
+        self._config["user"]["application"] = {}
+        self._config["user"]["application"]["data"] = {}
+        if not isTestEnv():
+            self._config["user"]["application"]["data"]["home"] = str(Path.home() / ".snapred")
+        else:
+            self._config["user"]["application"]["data"]["home"] = str(
+                Path(self._config["module"]["root"]) / "data" / "snapred-data" / "user.application.data.home"
+            )
         # ---------- end: internal values: -----------------------------
 
         watchedProperties = {}
@@ -223,8 +237,7 @@ class _Config:
 
     @property
     def userApplicationDataHome(self) -> Path:
-        userApplicationDataHome = Path.home() / ".snapred"
-        return userApplicationDataHome
+        return Path(self["user.application.data.home"])
 
     def persistBackup(self) -> None:
         self.userApplicationDataHome.mkdir(parents=True, exist_ok=True)

--- a/src/snapred/meta/decorators/classproperty.py
+++ b/src/snapred/meta/decorators/classproperty.py
@@ -1,4 +1,4 @@
-# https://stackoverflow.com/questions/1697501/staticmethod-with-property
+# (See: https://stackoverflow.com/questions/1697501/staticmethod-with-property)
 
 
 class classproperty(property):

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -2,7 +2,7 @@ import re
 import sys
 from copy import deepcopy
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any, List, NamedTuple, Optional, Tuple
 
 from pydantic import WithJsonSchema
@@ -14,7 +14,7 @@ from snapred.meta.Config import Config
 from snapred.meta.decorators.classproperty import classproperty
 
 
-class WorkspaceType(str, Enum):
+class WorkspaceType(StrEnum):
     # TODO: not yet completely connected: should be a mixin to the WNG class itself...
     #   For the moment: the <enum>.value will be `_WorkspaceNameGenerator` method name
     RUN = "run"

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -266,14 +266,31 @@ logging:
     stream:
       level: "WARNING"
       format: 'MANTID %(levelname)-8s - %(asctime)s - %(message)s'
+      datefmt: '%Y-%m-%d %H:%M:%S'
     file:
       level: "INFO"
       format: ${logging.SNAP.stream.format}
+      datefmt: '%Y-%m-%d %H:%M:%S'
       output: "mantidlog.txt"
   SNAP:
     stream:
+      handler:
+        name: 'SNAPRed_handler'
       level: "INFO"
-      format: '%(asctime)s - %(levelname)-8s - %(name)s - %(message)s'
+      format: '%(hostname)s - %(asctime)s - %(levelname)-8s - %(name)s - %(message)s'
+      datefmt: '%Y-%m-%d %H:%M:%S'
+  IPC:
+    socket_path: '{XDG_RUNTIME_DIR}/sock-{name}-{PID}'
+    handlers:
+      # handler names
+      SNAPRed-progress:
+        level: "INFO"
+        # Abbreviated format for progress reporting:
+        format: '%(asctime)s - %(message)s'
+        datefmt: '%Y-%m-%d %H:%M:%S'
+        # attached loggers
+        loggers:
+        - 'snapred.backend.profiling.ProgressRecorder'
 
 samples:
   home: ${instrument.calibration.sample.home}
@@ -329,15 +346,46 @@ docs:
 metadata:
   tagPrefix: SNAPRed_
 
+application:
+  workflows_data:
+    timing:
+      enabled: true
+
+      home: ${user.application.data.home}/workflows_data/timing
+
+      # save new timing data at application exit:
+      persistent_data: true
+
+      max_files: 5
+      max_measurements: 50
+
+      # spline order for time estimates
+      spline_order: 3
+
+      # update estimates if off by 20%
+      update_threshold: 0.2
+      # update only when sufficient data points are available
+      update_minimum_count: 3
+
+      # logging of execution-time information:
+      logging:
+        # in order to enable logging:
+        #   the first part of the fully-qualified name of the progress-recording step must be in this list:
+        qualname_roots:
+          - "ReductionService"
+          - "CalibrationService"
+          - "NormalizationService"
+
+        loglevel: 20 # logging.INFO
+        log_update_interval: 10 # in seconds, 0 => no count-down logging: explicit logging only
+        indent: "  " # string to be used for indenting sub-levels
+
 ui:
   default:
     reduction:
       smoothing: 5
     workflow:
       completionMessage: "‧₊‧₊The workflow has been completed successfully!‧₊‧₊"
-
-system:
-  max_hdf5_descriptors: 5
 
 lockfile:
   ttl: 120 # seconds

--- a/tests/cis_tests/util/logging/IPC_server.py
+++ b/tests/cis_tests/util/logging/IPC_server.py
@@ -1,0 +1,89 @@
+import argparse
+from pathlib import Path
+import socket
+import os
+import pickle
+import struct
+import logging
+
+from snapred.backend.log.logger import snapredLogger, CustomFormatter, getIPCSocketPath
+from snapred.meta.Config import Config
+
+class ClientDisconnected(Exception):
+    pass
+
+class IPCServer:
+    _SNAPRed_handler_name = Config["logging.SNAP.stream.handler.name"]
+    
+    def __init__(self, name: str, PID: int | str):
+        self._socket_path: Path = getIPCSocketPath(name, PID)
+        self._logger = snapredLogger.getLogger(name)
+        
+        # Associate a logger with this server _instance_, not with its _module_!
+        formatter = CustomFormatter(name=f"IPC.handlers.{name}")
+        for handler in self._logger.handlers:
+            if handler.name == self._SNAPRed_handler_name:
+                handler.setFormatter(formatter)
+
+    @property
+    def socket_path(self) -> Path:
+        return self._socket_path
+                
+    def receive_exact(self, conn, count):
+        buf = b''
+        while len(buf) < count:
+            chunk = conn.recv(count - len(buf))
+            if not chunk:
+                raise ClientDisconnected('Client disconnected')
+            buf += chunk
+        return buf
+
+    def run(self):
+        # Clean up any existing socket
+        if self.socket_path.exists():
+            self._logger.warning(f"Removing existing socket at '{self.socket_path}'.")
+            socketPath.unlink()
+            
+        server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server_sock.bind(str(self.socket_path))
+        server_sock.listen(1)
+        self._logger.info(f"Listening on {self.socket_path}")
+
+        try:
+            while True:
+                conn, _ = server_sock.accept()
+                print("Client connected.")
+                try:
+                    while True:
+                        # First, read 4-byte length prefix
+                        length_bytes = self.receive_exact(conn, 4)
+                        slen = struct.unpack('>L', length_bytes)[0]
+                        # Then, read the pickled LogRecord
+                        pickled_data = self.receive_exact(conn, slen)
+                        log_record_dict = pickle.loads(pickled_data)
+                        record = logging.makeLogRecord(log_record_dict)
+                        self._logger.handle(record)
+                except ClientDisconnected:
+                    self._logger.info("Client disconnected.")
+                except (struct.error, pickle.UnpicklingError):
+                    self._logger.error("Protocol error.")
+                finally:
+                    conn.close()
+        finally:
+            server_sock.close()
+            self.socket_path.unlink()
+
+if __name__ == "__main__":
+    try:
+        # Parse the command line arguments.
+        parser = argparse.ArgumentParser()
+        parser.add_argument("-n", "--name", help="the name of the SNAPRed IPC-handler to log: see 'application.yml'")
+        parser.add_argument("-p", "--pid", help="the PID of the SNAPRed process")
+        args = parser.parse_args()
+        name, PID = args.name, args.pid
+        
+        # Create and start the IPC server.
+        server = IPCServer(name, PID)
+        server.run()
+    except KeyboardInterrupt:
+        print("\nServer shutting down.")

--- a/tests/integration/test_workflow_panels_happy_path.py
+++ b/tests/integration/test_workflow_panels_happy_path.py
@@ -735,6 +735,7 @@ class TestGUIPanels:
 
             calibrationPanel.widget.close()
             gui.close()
+
             self.testSummary.SUCCESS()
 
         #####################################################################

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -267,18 +267,34 @@ logging:
     stream:
       level: 40
       format: 'MANTID %(levelname)s - %(message)s'
+      datefmt: '%Y-%m-%d %H:%M:%S'
     file:
       level: 40
       format: 'MANTID FILE %(levelname)s - %(message)s'
+      datefmt: '%Y-%m-%d %H:%M:%S'
       output: '/dev/null'
   SNAP:
     stream:
+      handler:
+        name: 'SNAPRed_handler'
       level: 40
-      format: '%(asctime)s - %(levelname)-8s - %(name)s - %(message)s'
+      format: '%(hostname)s - %(asctime)s - %(levelname)-8s - %(name)s - %(message)s'
+      datefmt: '%Y-%m-%d %H:%M:%S'
+  IPC:
+    socket_path: '{XDG_RUNTIME_DIR}/sock-{name}-{PID}'
+    handlers:
+      # handler names
+      SNAPRed-progress:
+        level: "INFO"
+        # Abbreviated format for progress reporting:
+        format: '%(asctime)s - %(message)s'
+        datefmt: '%Y-%m-%d %H:%M:%S'
+        # attached loggers
+        loggers:
+        - 'snapred.backend.profiling.ProgressRecorder'
 
 samples:
   home: ${instrument.calibration.sample.home}
-
 
 test:
   config:
@@ -344,16 +360,49 @@ constants:
 metadata:
   tagPrefix: testSNAPfuntime_
 
+application:
+  workflows_data:
+    timing:
+      # Enable the `ProgressRecorder`.
+      # IMPORTANT: by default this must remain disabled for tests!
+      #   Otherwise the `ProgressRecorder` will still load and unload persistent data.
+      enabled: false
+
+      home: ${user.application.data.home}/workflows_data/timing
+
+      # save new timing data at application exit
+      persistent_data: false
+
+      max_files: 5
+      max_measurements: 50
+
+      # spline order for time estimates
+      spline_order: 3
+
+      # update estimates if off by 20%
+      update_threshold: 0.2
+      # update only when sufficient data points are available
+      update_minimum_count: 3
+
+      # logging of execution-time information:
+      logging:
+        # in order to enable logging:
+        #   the first part of the fully-qualified name of the progress-recording step must be in this list:
+        qualname_roots:
+          - "ReductionService"
+          - "CalibrationService"
+          - "NormalizationService"
+
+        loglevel: 20 # logging.INFO
+        log_update_interval: 0 # in seconds, 0 => no count-down logging: explicit logging only
+        indent: "  " # string to be used for indenting sub-levels
+
 ui:
   default:
     reduction:
       smoothing: 5
     workflow:
       completionMessage: "‧₊‧₊The workflow has been completed successfully!‧₊‧₊"
-
-system:
-  max_hdf5_descriptors: 5
-
 
 lockfile:
   ttl: 10 # seconds

--- a/tests/resources/inputs/workflows_data/execution_timing_2025-07-20T03:46:43.913617+00:00.json
+++ b/tests/resources/inputs/workflows_data/execution_timing_2025-07-20T03:46:43.913617+00:00.json
@@ -1,0 +1,103 @@
+{
+  "steps": [
+    {
+      "details": {
+        "key": [
+          "snapred.backend.service.ReductionService",
+          "ReductionService.fetchReductionGroupings",
+          null
+        ],
+        "N_ref_hash": "0e20bf8b3c169c8b",
+        "order": "O_N"
+      },
+      "measurements": [
+      ],
+      "estimate": {
+        "count": [
+          1,
+          20
+        ],
+        "tck": [
+          [
+            0.0,
+            0.0
+          ],
+          [
+            0.007214550000000002
+          ],
+          0
+        ]
+      }
+    },
+    {
+      "details": {
+        "key": [
+          "snapred.backend.service.ReductionService",
+          "ReductionService.reduction",
+          null
+        ],
+        "N_ref_hash": "32530ac37e38c4d5",
+        "order": "O_N"
+      },
+      "measurements": [
+      ],
+      "estimate": {
+        "count": [
+          3,
+          6
+        ],
+        "tck": [
+          [
+            0.0,
+            0.0,
+            0.0,
+            22118475.0,
+            22118475.0,
+            22118475.0
+          ],
+          [
+            0.0,
+            4.225078881560582,
+            0.7177178
+          ],
+          2
+        ]
+      }
+    },
+    {
+      "details": {
+        "key": [
+          "snapred.backend.service.ReductionService",
+          "ReductionService.reduction",
+          "load-and-prepare-data"
+        ],
+        "N_ref_hash": "32530ac37e38c4d5",
+        "order": "O_N"
+      },
+      "measurements": [
+      ],
+      "estimate": {
+        "count": [
+          3,
+          6
+        ],
+        "tck": [
+          [
+            0.0,
+            0.0,
+            0.0,
+            22118475.0,
+            22118475.0,
+            22118475.0
+          ],
+          [
+            0.0,
+            -2.66333201812769,
+            0.454993
+          ],
+          2
+        ]
+      }
+    }
+  ]
+}

--- a/tests/resources/integration_test.yml
+++ b/tests/resources/integration_test.yml
@@ -9,20 +9,6 @@ IPTS:
   # For the moment, each developer needs to set this individually to their local path.
   root: ${module.root}/data/snapred-data/SNS
 
-constants:
-  # For tests with '46680' this seems to be necessary.
-  maskedPixelThreshold: 1.0
-
-  DetectorPeakPredictor:
-    fwhm: 1.17741002252 # used to convert gaussian to fwhm (2 * log_e(2))
-  CropFactors:
-    lowWavelengthCrop: 0.05
-    lowdSpacingCrop: 0.1
-    highdSpacingCrop: 0.15
-  RawVanadiumCorrection:
-    numberOfSlices: 1
-    numberOfAnnuli: 1
-
 instrument:
   native:
     name: crackle
@@ -53,6 +39,21 @@ instrument:
     - "det_lin1"
     - "det_lin2"
 
+calibration:
+  parameters:
+    default:
+      alpha: 0.1
+      # alpha: 1.1
+      beta:
+        - 0.02
+        - 0.05
+      # beta:
+      #   - 1
+      #   - 2
+  fitting:
+    # minSignal2Noise: 0.0
+    minSignal2Noise: 10
+
 mantid:
   workspace:
     nameTemplate:
@@ -72,17 +73,53 @@ mantid:
           focusedRawVanadium: "{unit},{group},{runNumber},raw_van_corr,{version}"
           smoothedFocusedRawVanadium: "{unit},{group},{runNumber},fitted_van_corr,{version}"
 
-calibration:
-  parameters:
-    default:
-      alpha: 0.1
-      # alpha: 1.1
-      beta:
-        - 0.02
-        - 0.05
-      # beta:
-      #   - 1
-      #   - 2
-  fitting:
-    # minSignal2Noise: 0.0
-    minSignal2Noise: 10
+constants:
+  # For tests with '46680' this seems to be necessary.
+  maskedPixelThreshold: 1.0
+
+  DetectorPeakPredictor:
+    fwhm: 1.17741002252 # used to convert gaussian to fwhm (2 * log_e(2))
+  CropFactors:
+    lowWavelengthCrop: 0.05
+    lowdSpacingCrop: 0.1
+    highdSpacingCrop: 0.15
+  RawVanadiumCorrection:
+    numberOfSlices: 1
+    numberOfAnnuli: 1
+
+application:
+  workflows_data:
+    timing:
+      # Enable the `ProgressRecorder`.
+      # IMPORTANT: by default this must remain disabled for tests!
+      #   Otherwise the `ProgressRecorder` will still load and unload persistent data.
+      enabled: true
+
+      home: ${user.application.data.home}/workflows_data/timing
+
+      # save new timing data at application exit
+      persistent_data: true
+
+      max_files: 5
+      max_measurements: 50
+
+      # spline order for time estimates
+      spline_order: 3
+
+      # update estimates if off by 20%
+      update_threshold: 0.2
+      # update only when sufficient data points are available
+      update_minimum_count: 5
+
+      # logging of execution-time information:
+      logging:
+        # in order to enable logging:
+        #   the first part of the fully-qualified name of the progress-recording step must be in this list:
+        qualname_roots:
+          - "ReductionService"
+          - "CalibrationService"
+          - "NormalizationService"
+
+        loglevel: 20 # logging.INFO
+        log_update_interval: 0 # in seconds, 0 => explicit logging only
+        indent: "  " # string to be used for indenting sub-levels

--- a/tests/unit/backend/data/test_NexusHDF5Metadata.py
+++ b/tests/unit/backend/data/test_NexusHDF5Metadata.py
@@ -1,6 +1,6 @@
 import tempfile
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 
 import h5py
@@ -94,7 +94,7 @@ dict_of_StringDerived_reconstruct = {"one": {"one": "s_one", "two": 2}, "two": {
 dict_of_StringDerived_inputs = (dict_of_StringDerived, dict_of_StringDerived_reconstruct)
 
 
-class tags(str, Enum):
+class tags(StrEnum):
     ONE = "one"
     TWO = "two"
     THREE = "three"

--- a/tests/unit/backend/profiling/test_ProgressRecorder.py
+++ b/tests/unit/backend/profiling/test_ProgressRecorder.py
@@ -1,0 +1,2262 @@
+import inspect
+import logging
+import re
+import sys
+import tempfile
+import threading
+from collections import namedtuple
+from datetime import datetime, timedelta, timezone
+from time import sleep
+from types import FrameType, FunctionType, LambdaType
+from unittest import mock
+
+import numpy as np
+import pytest
+from scipy.interpolate import make_splrep
+from util.Config_helpers import Config_override
+
+from snapred.backend.profiling.ProgressRecorder import (
+    ComputationalOrder,
+    # The `ProgressRecorder` singleton:
+    ProgressRecorder,
+    ProgressStep,
+    # The decorator / context manager:
+    WallClockTime,
+    _Estimate,
+    _Measurement,
+    # The corresponding class:
+    _ProgressRecorder,
+    _Step,
+)
+from snapred.meta.Config import Config, Resource
+
+
+class TestComputationalOrder:
+    def test___call__(self):
+        for order in ComputationalOrder:
+            expected = None
+            N_ref = 1.0e9 * np.random.random()
+            match order:
+                case ComputationalOrder.O_0:
+                    expected = 1.0
+                case ComputationalOrder.O_LOG_N:
+                    expected = np.log(N_ref)
+                case ComputationalOrder.O_N:
+                    expected = N_ref
+                case ComputationalOrder.O_N_LOG_N:
+                    expected = N_ref * np.log(N_ref)
+                case ComputationalOrder.O_N_2:
+                    expected = N_ref ** (2.0)
+                case ComputationalOrder.O_N_3:
+                    expected = N_ref ** (3.0)
+
+            actual = order(N_ref)
+            assert actual == pytest.approx(expected, rel=1.0e-9)
+
+
+class Test_Step:
+    class _Class:
+        def method(self):
+            pass
+
+        def another_method(self):
+            # do something besides `pass`:
+            self._two = 1 + 1
+
+        def same_as_another_method(self):
+            # match bytecode from `another_method`
+            self._two = 1 + 1
+
+    def test__callable_hash(self):
+        # Only allow hashes for `FunctionType`:
+
+        def _function():
+            pass
+
+        _class = Test_Step._Class()
+
+        # `FunctionType`
+        h0 = _Step._callable_hash(_function)  # `FunctionType`
+        assert isinstance(h0, str)
+        assert len(h0) == 16
+
+        # `FunctionType` <- `LambdaType`
+        h1 = _Step._callable_hash(lambda *args, **_kwargs: args[1] * args[1])  # `FunctionType`
+        assert isinstance(h1, str)
+        assert len(h1) == 16
+
+        # `FunctionType`
+        h2 = _Step._callable_hash(Test_Step._Class.method)
+        assert isinstance(h2, str)
+        assert len(h2) == 16
+
+        # `MethodType`
+        with pytest.raises(RuntimeError, match="Usage error: expecting `FunctionType`.*"):
+            _Step._callable_hash(_class.method)  # the _bound_ method
+
+        # type `Test_Step._Class`
+        with pytest.raises(RuntimeError, match="Usage error: expecting `FunctionType`.*"):
+            _Step._callable_hash(_class)  # a class instance
+
+        # `type`
+        with pytest.raises(RuntimeError, match="Usage error: expecting `FunctionType`.*"):
+            _Step._callable_hash(Test_Step._Class)  # a class
+
+    def test__callable_hash_hashes_persist(self):
+        # hash values don't change
+
+        def _function():
+            pass
+
+        _class = Test_Step._Class()
+
+        h0 = _Step._callable_hash(_function)  # `FunctionType`
+        h1 = _Step._callable_hash(lambda *args, **_kwargs: args[1] * args[1])  # `FunctionType`
+        h2 = _Step._callable_hash(Test_Step._Class.method)
+
+        assert h0 == _Step._callable_hash(_function)
+        assert h1 == _Step._callable_hash(lambda *args, **_kwargs: args[1] * args[1])
+        assert h2 == _Step._callable_hash(Test_Step._Class.method)
+
+    def test__callable_hash_hashes_distinct(self):
+        # hash values are distinct
+
+        def _function():
+            pass
+
+        _class = Test_Step._Class()
+
+        h0 = _Step._callable_hash(_function)  # `FunctionType`
+        h1 = _Step._callable_hash(lambda *args, **_kwargs: args[1] * args[1])  # `FunctionType`
+        h2 = _Step._callable_hash(Test_Step._Class.method)
+
+        assert h0 != h1
+        assert h1 != h2
+        # Note here that `h0 == h2`, because their bytecodes match.
+
+    def test__callable_hash_same_bytecodes(self):
+        # hash values from matching bytecodes are the same
+
+        def _function():
+            pass
+
+        _class = Test_Step._Class()
+
+        assert _Step._callable_hash(_function) == _Step._callable_hash(Test_Step._Class.method)
+        assert _Step._callable_hash(Test_Step._Class.another_method) == _Step._callable_hash(
+            Test_Step._Class.same_as_another_method
+        )
+        assert _Step._callable_hash(_function) != _Step._callable_hash(Test_Step._Class.another_method)
+
+    def test_init(self):
+        key = ("one.two.three", "four.five", None)
+
+        def N_ref(*args, **kwargs):
+            return args[0] * args[1] * len(kwargs)
+
+        N_ref_hash = _Step._callable_hash(N_ref)
+
+        # `key` arg is required, all others are optional
+        s0 = _Step(key)
+        with pytest.raises(TypeError, match=".*missing 1 required positional argument: 'key'.*"):
+            s0 = _Step()
+
+        # No default values should be set:
+        # -- it's important that this happens after the `__init__`,
+        #    otherwise there's no way to determine if `N_ref` for a `_Step`
+        #    has been changed!
+        s0 = _Step(key)
+        assert s0._N_ref is None
+        assert s0.N_ref_hash is None
+        assert s0._N_ref_args == ((), {})
+        assert s0.order is None
+
+        # Setting `N_ref` should set `N_ref_hash`.
+        s1 = _Step(key, N_ref=N_ref)
+        assert s1._N_ref == N_ref
+        assert isinstance(s1.N_ref_hash, str)
+        assert len(s1.N_ref_hash) == 16
+        assert s1.N_ref_hash == N_ref_hash
+
+        # Both shouldn't be passed in at the same time.
+        with pytest.raises(RuntimeError, match="Usage error:.*specify either `N_ref` or `N_ref_hash`, but not both."):
+            s2 = _Step(key, N_ref=N_ref, N_ref_hash="abcdeeeeffff0000")  # noqa: F841
+
+        # Both shouldn't be passed in at the same time, even if they are consistent.
+        with pytest.raises(RuntimeError, match="Usage error:.*specify either `N_ref` or `N_ref_hash`, but not both."):
+            s3 = _Step(key, N_ref=N_ref, N_ref_hash=s1.N_ref_hash)  # noqa: F841
+
+    def test_default(self):
+        key = ("one.two.three", "four.five", None)
+        # No default values should be set:
+        # -- it's important that this happens after the `__init__`,
+        #    otherwise there's no way to determine if `N_ref` for a `_Step`
+        #    has been changed!
+        s0 = _Step.default(key)
+        assert s0._N_ref is None
+        assert s0.N_ref_hash is None
+        assert s0._N_ref_args == ((), {})
+        assert s0.order is None
+
+    def test_setDetails(self, caplog):
+        key = ("one.two.three", "four.five", None)
+
+        # Attributes should only be set when the corresponding arg is not `None`.
+        # N_ref, N_ref_args, order
+        s = _Step(key)
+        assert s._N_ref is None
+        assert s._N_ref_args == ((), {})
+        assert s.order is None
+
+        # Attributes should only be set when the corresponding arg is not `None`.
+        # .. set `_N_ref` => `_N_ref_args` and `order` remain the same.
+        s = _Step(key)
+        original_args = ((1, 2), {"1": "one", "2": "two"})
+        original_order = ComputationalOrder.O_N
+        s._N_ref_args = original_args
+        s.order = original_order
+        s.setDetails(N_ref=lambda *_args, **_kwargs: 1.0)
+        assert s._N_ref is not None
+        assert s._N_ref_args == original_args
+        assert s.order == original_order
+
+        # .. set `order` => `_N_ref` and `N_ref_args` remain the same.
+        s = _Step(
+            key,
+            N_ref=lambda *args, **kwargs: args[0] * args[1] * len(kwargs),
+            N_ref_args=((1.0, 2.0), {"one": 1, "two": 2}),
+        )
+        original_hash = s.N_ref_hash
+        original_args = s._N_ref_args
+        s.setDetails(order=ComputationalOrder.O_N_2)
+        assert s.order is ComputationalOrder.O_N_2
+        assert s.N_ref_hash == original_hash
+        assert s._N_ref_args == original_args
+
+        # When `N_ref_hash` had a previous value, log a message when it changes.
+        original_N_ref = lambda *args, **kwargs: args[0] * args[1] * len(kwargs)  # noqa: E731
+        original_hash = _Step._callable_hash(original_N_ref)
+        new_N_ref = lambda *args, **kwargs: float(len(args)) * len(kwargs)  # noqa: E731
+        new_hash = _Step._callable_hash(new_N_ref)
+
+        # .. if a step has been loaded from persistent data: only its `N_ref_hash` will be set.
+        s = _Step(key, N_ref_hash=original_hash)
+        assert s._N_ref is None
+        assert s.N_ref_hash == original_hash
+        with caplog.at_level(logging.WARNING, logger=inspect.getmodule(ProgressRecorder).__name__):
+            s.setDetails(N_ref=new_N_ref)
+        assert f"`N_ref` for step {key} has been modified" in caplog.text
+        assert s.N_ref_hash == new_hash
+
+        # In other situations, both `_N_ref` and `N_ref_hash` will be set.
+        s = _Step(key, N_ref=original_N_ref)
+        assert s.N_ref_hash == original_hash
+        assert s._N_ref is not None
+        with caplog.at_level(logging.WARNING, logger=inspect.getmodule(ProgressRecorder).__name__):
+            s.setDetails(N_ref=new_N_ref)
+        assert f"`N_ref` for step {key} has been modified" in caplog.text
+        assert s.N_ref_hash == new_hash
+
+
+class Test_Estimate:
+    def test_init(self):
+        SPLINE_DEGREE = _Estimate.SPLINE_DEGREE
+        assert SPLINE_DEGREE == Config["application.workflows_data.timing.spline_order"]
+
+        # all args are optional
+        e = _Estimate()
+        assert e.count is None
+        assert e.tck is None
+
+        # `tck` `k` arg must be <= SPLINE_DEGREE.
+        Ns = np.linspace(0.0, 1.0e9, 20)
+        dts = np.linspace(0.0, 60.0, 20)
+        spl = make_splrep(Ns, dts**2.7, k=SPLINE_DEGREE + 1)
+        with pytest.raises(ValueError, match=f"In `tck`, specified spline degree `k` must be <= {SPLINE_DEGREE}."):
+            e = _Estimate(tck=(list(spl.tck[0]), list(spl.tck[1]), spl.tck[2]))
+
+        # `tck` `k` arg may be _zero_ => a constant-time estimate will be applied.
+        Ns = np.linspace(0.0, 1.0e9, 20)
+        dts = np.ones_like(Ns)
+        spl = make_splrep(Ns, dts, k=0)
+        e = _Estimate(tck=(list(spl.tck[0]), list(spl.tck[1]), spl.tck[2]))
+
+    def test_default(self):
+        # returns a _linear_ estimator (degree `k == 1`):
+        e = _Estimate.default()
+        assert e._spl is not None
+        assert e.tck[2] == 1
+
+        # verify estimate at `N == 1.0e-9`: should be 3.0s
+        assert 3.0 == pytest.approx(e.dt(1.0e9), rel=1.0e-3)
+        # verify estimate at `N == 5.0e-9`: should be 15.0s
+        assert 15.0 == pytest.approx(e.dt(5.0e9), rel=1.0e-3)
+
+    def test_dt(self):
+        # check update before evaluation usage exception
+        e = _Estimate()
+        with pytest.raises(RuntimeError, match="Usage error: `dt` called before `update`."):
+            e.dt(1.0e9)
+
+        # returns `float`, not `np.float64` or `np.ndarray`:
+        e = _Estimate.default()
+        isinstance(e.dt(1.0e9), float)
+
+    def test_update(self):
+        Ns = np.linspace(0.0, 1.0e9, 20)
+        dts = Ns ** (2.7)
+        measurements = [_Measurement(dt=dts[n], dt_est=dts[n] * 2.0, N_ref=Ns[n]) for n in range(len(Ns))]
+        instance = _Estimate.default()
+
+        # `update` calls `_prepareData` and `_update`
+        with (
+            mock.patch.object(instance, "_prepareData") as mock_prepareData,
+            mock.patch.object(instance, "_update") as mock_update,
+        ):
+            mock_prepareData.return_value = (Ns, dts)
+            instance.update(measurements, ComputationalOrder.O_N_2)
+            mock_prepareData.assert_called_once_with(measurements, ComputationalOrder.O_N_2)
+            mock_update.assert_called_once_with(Ns, dts, len(measurements))
+
+    def test__update(self):
+        # doesn't do anything if there are no data points
+        e = _Estimate.default()
+        with mock.patch.object(inspect.getmodule(ProgressRecorder), "make_splrep") as mock_make_splrep:
+            e._update(np.array([]), np.array([]), 0)
+            mock_make_splrep.assert_not_called()
+
+        with Config_override("application.workflows_data.timing.spline_order", 3):
+            # provides constant-time estimate when necessary (only one measurement):
+            e = _Estimate.default()
+            Ns, dts = np.array([1.0e9]), np.array([60.0])
+            e._update(Ns, dts, len(Ns))
+            assert e.tck[2] == 0
+
+            # provides linear estimate when necessary (only two measurements):
+            e = _Estimate.default()
+            Ns, dts = np.array([1.0e9, 2.0e9]), np.array([60.0, 120.0])
+            e._update(Ns, dts, len(Ns))
+            assert e.tck[2] == 1
+
+            # .. quadratic estimate:
+            e = _Estimate.default()
+            Ns, dts = np.array([1.0e9, 2.0e9, 2.2e9]), np.array([60.0, 120.0, 180.0])
+            e._update(Ns, dts, len(Ns))
+            assert e.tck[2] == 2
+
+            # .. cubic estimate:
+            e = _Estimate.default()
+            Ns, dts = np.array([1.0e9, 2.0e9, 2.2e9, 3.0e9]), np.array([60.0, 120.0, 180.0, 240.0])
+            e._update(Ns, dts, len(Ns))
+            assert e.tck[2] == 3
+
+            # When more data points are available, limits degree of estimate to SPLINE_DEGREE.
+            e = _Estimate.default()
+            Ns, dts = np.array([1.0e9, 2.0e9, 2.2e9, 3.0e9, 3.5e9]), np.array([60.0, 120.0, 180.0, 240.0, 300.0])
+            e._update(Ns, dts, len(Ns))
+            assert e.tck[2] == 3
+
+    def test__prepareData(self):
+        # either all `measurement.N_ref` are `None` or all are `float`:
+        Ns = np.linspace(0.0, 1.0e9, 20)
+        dts = Ns ** (2.7)
+        #   convert `Ns` to list, so that it can have `None` elements
+        Ns = list(Ns)
+        Ns[3], Ns[10], Ns[11] = None, None, None
+        measurements = [_Measurement(dt=dts[n], dt_est=dts[n] * 2.0, N_ref=Ns[n]) for n in range(len(Ns))]
+
+        with pytest.raises(  # noqa: PT012
+            RuntimeError, match="Either all of the `N_ref` values should be `float`, or all should be `None`."
+        ):
+            e = _Estimate.default()
+            e._prepareData(measurements, ComputationalOrder.O_N_2)
+
+        # inserts "tie point" at (0.0, 0.0) when required:
+        Ns = np.linspace(10.0, 1.0e9, 20)
+        dts = Ns ** (2.7)
+        assert Ns[0] != 0.0
+        assert dts[0] != 0.0
+        measurements = [_Measurement(dt=dts[n], dt_est=dts[n] * 2.0, N_ref=Ns[n]) for n in range(len(Ns))]
+        e = _Estimate.default()
+        Ns_, dts_ = e._prepareData(measurements, ComputationalOrder.O_N_2)
+        assert len(Ns_) == len(Ns) + 1
+        assert len(dts_) == len(dts) + 1
+        assert Ns_[0] == 0.0
+        assert dts_[0] == 0.0
+
+        # calls _accumulateDuplicates
+        Ns = np.linspace(0.0, 1.0e9, 20)
+        dts = Ns ** (2.7)
+        measurements = [_Measurement(dt=dts[n], dt_est=dts[n] * 2.0, N_ref=Ns[n]) for n in range(len(Ns))]
+        instance = _Estimate.default()
+        with mock.patch.object(instance, "_accumulateDuplicates") as mock_accumulateDuplicates:
+            mock_accumulateDuplicates.return_value = (Ns, dts)
+            Ns_, dts_ = instance._prepareData(measurements, ComputationalOrder.O_N_2)
+            mock_accumulateDuplicates.assert_called_once()
+
+        # .. returns `np.ndarray, np.ndarray`
+        assert isinstance(Ns_, np.ndarray)
+        assert isinstance(dts_, np.ndarray)
+
+    def test__accumulateDuplicates(self):
+        # works with `[(None, dt), ...]`:
+        Ns = np.linspace(0.0, 1.0e9, 20)
+        dts = Ns ** (2.7)
+        ps = [(None, dt) for dt in dts]
+        e = _Estimate.default()
+        Ns_, dts_ = e._accumulateDuplicates(ps)
+        assert len(Ns_) == len(dts_)
+        assert Ns_ == [None]
+        assert len(dts_) == 1
+        # `N_ref is None` => constant-time estimate, so `_accumulateDuplicates` will return the mean.
+        assert dts_[0] == pytest.approx(sum(dts) / len(dts), rel=1.0e-3)
+
+        # when there are no duplicates: it doesn't change the data
+        Ns = np.linspace(0.0, 1.0e9, 20)
+        dts = Ns ** (2.7)
+        ps = [(N, dt) for N, dt in zip(Ns, dts)]
+        e = _Estimate.default()
+        Ns_, dts_ = e._accumulateDuplicates(ps)
+        assert len(Ns_) == len(dts_)
+        assert Ns.tolist() == list(Ns_)
+        # values should be unmodified: use exact comparison
+        assert dts_ == list(dts_)
+
+        # accumulates duplicates as expected
+        Ns = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 3.0, 3.0])
+        dts = Ns**2.5 + 0.1 * np.random.random(size=Ns.shape)
+        ps = [(N, dt) for N, dt in zip(Ns, dts)]
+        e = _Estimate.default()
+        Ns_, dts_ = e._accumulateDuplicates(ps)
+        assert len(Ns_) == len(dts_)
+        assert [1.0, 2.0, 3.0] == list(Ns_)
+        assert [dts[0:3].mean(), dts[3:5].mean(), dts[5:].mean()] == pytest.approx(list(dts_), rel=1.0e-6)
+
+        # works with mixtures of duplicated and non-duplicated values
+        Ns = np.array([1.0, 1.0, 1.0, 2.0, 3.0, 4.0, 5.0, 5.0, 5.0])
+        dts = Ns**0.8 + 0.5 * np.random.random(size=Ns.shape)
+        ps = [(N, dt) for N, dt in zip(Ns, dts)]
+        e = _Estimate.default()
+        Ns_, dts_ = e._accumulateDuplicates(ps)
+        assert len(Ns_) == len(dts_)
+        assert [1.0, 2.0, 3.0, 4.0, 5.0] == list(Ns_)
+        assert [dts[0:3].mean(), dts[3], dts[4], dts[5], dts[6:].mean()] == pytest.approx(list(dts_), rel=1.0e-6)
+
+        Ns = np.array([1.0, 2.0, 3.0, 4.0, 4.0, 4.0, 5.0, 6.0, 7.0])
+        dts = Ns**3.1 + 0.01 * np.random.random(size=Ns.shape)
+        ps = [(N, dt) for N, dt in zip(Ns, dts)]
+        e = _Estimate.default()
+        Ns_, dts_ = e._accumulateDuplicates(ps)
+        assert len(Ns_) == len(dts_)
+        assert [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0] == list(Ns_)
+        assert [dts[0], dts[1], dts[2], dts[3:6].mean(), dts[6], dts[7], dts[8]] == pytest.approx(
+            list(dts_), rel=1.0e-6
+        )
+
+
+class TestProgressStep:
+    @pytest.fixture(autouse=True)
+    def _setUpTest(self):
+        # setup:
+
+        self.key = ("module.name", "qualified.function.name", "step-name")
+        Ns = [1.0, 2.0, 3.0]
+        dts = [45.0, 75.0, 85.2]
+        measurements = [_Measurement(dt=dts[n], dt_est=dts[n] * 2.0, N_ref=Ns[n]) for n in range(len(Ns))]
+        self.s = ProgressStep(details=_Step(self.key), measurements=measurements, estimate=_Estimate.default())
+        yield
+
+        # teardown
+        pass
+
+    def test_init(self):
+        # verify that private attributes have been initialized correctly
+        assert self.s._isSubstep == False  # noqa: E712
+        assert self.s._startTime is None
+        assert self.s._loggingEnabled == False  # noqa: E712
+        assert self.s._timer is None
+
+    def test_setDetails(self):
+        # verify that `setDetails` works correctly
+        N_ref = lambda *args, **kwargs: args[0] * args[1] * len(kwargs)  # noqa: E731
+        N_ref_args = ((1, 2), {"three": 3})
+        order = ComputationalOrder.O_N_3
+        enableLogging = True
+
+        with mock.patch.object(self.s, "details") as mockDetails:
+            # sets `_loggingEnabled`
+            assert not self.s._loggingEnabled
+            self.s.setDetails(N_ref=N_ref, N_ref_args=N_ref_args, order=order, enableLogging=enableLogging)
+            assert self.s._loggingEnabled == enableLogging
+
+            # calls `self.details.setDetails`
+            mockDetails.setDetails.assert_called_once_with(N_ref=N_ref, N_ref_args=N_ref_args, order=order)
+
+    def test_setDetails_defaults(self):
+        # verify that `setDetails` works correctly RE default args
+        assert not self.s._loggingEnabled
+        with mock.patch.object(self.s, "details") as mockDetails:
+            self.s.setDetails()
+            mockDetails.setDetails.assert_called_once_with(N_ref=None, N_ref_args=None, order=None)
+            assert not self.s._loggingEnabled
+
+    def test_setDetails_enable_logging(self):
+        # verify that `setDetails(enableLogging=<flag>)` works correctly
+        assert not self.s._loggingEnabled
+        with mock.patch.object(self.s, "details") as mockDetails:
+            self.s.setDetails(enableLogging=True)
+            mockDetails.setDetails.assert_called_once_with(
+                N_ref=None,
+                N_ref_args=None,
+                order=None,
+            )
+            assert self.s._loggingEnabled
+
+            self.s.setDetails(enableLogging=False)
+            assert not self.s._loggingEnabled
+
+    def test_start(self):
+        _now = datetime.now(timezone.utc)
+        with (
+            mock.patch.object(inspect.getmodule(ProgressRecorder), "datetime") as mock_datetime,
+            mock.patch.object(_Step, "N_ref", return_value=mock.sentinel.N_ref) as mock_N_ref,
+            mock.patch.object(_Estimate, "dt") as mock_dt,
+        ):
+            mock_order = mock.Mock(return_value=mock.sentinel.N)  # placed here to patch the `BaseModel` attribute
+            self.s.details.order = mock_order
+            mock_datetime.now = mock.Mock(return_value=_now)
+            mock_N_ref.return_value = mock.sentinel.N_ref
+            mock_dt.return_value = mock.sentinel.dt
+
+            assert not self.s._loggingEnabled
+            self.s.start(isSubstep=False)
+
+            # verify that the utc-timezone is used
+            mock_datetime.now.assert_called_once_with(timezone.utc)
+
+            # verify that _isSubstep is not set
+            assert self.s._isSubstep == False  # noqa: E712
+
+            # verify that _startTime is set
+            assert self.s._startTime == _now
+
+            # verify that the timing properties have been initialized correctly
+            assert self.s._N_ref == mock.sentinel.N_ref
+            assert self.s._dt == mock.sentinel.dt
+            mock_order.assert_called_once_with(mock.sentinel.N_ref)
+            mock_dt.assert_called_once_with(mock.sentinel.N)
+
+            # verify that other args aren't affected
+            assert self.s._timer is None
+            assert not self.s._loggingEnabled
+
+    def test_start_substep(self):
+        _now = datetime.now(timezone.utc)
+        with (
+            mock.patch.object(inspect.getmodule(ProgressRecorder), "datetime") as mock_datetime,
+            mock.patch.object(_Step, "N_ref", return_value=mock.sentinel.N_ref) as mock_N_ref,
+            mock.patch.object(_Estimate, "dt") as mock_dt,
+        ):
+            mock_order = mock.Mock(return_value=mock.sentinel.N)  # placed here to patch the `BaseModel` attribute
+            self.s.details.order = mock_order
+            mock_datetime.now = mock.Mock(return_value=_now)
+            mock_N_ref.return_value = mock.sentinel.N_ref
+            mock_dt.return_value = mock.sentinel.dt
+
+            assert not self.s._loggingEnabled
+            self.s.start(isSubstep=True)
+
+            # verify that the utc-timezone is used
+            mock_datetime.now.assert_called_once_with(timezone.utc)
+
+            # verify that _isSubstep is set
+            assert self.s._isSubstep == True  # noqa: E712
+
+            # verify that _startTime is set
+            assert self.s._startTime == _now
+
+            # verify that the timing properties have been initialized correctly
+            assert self.s._N_ref == mock.sentinel.N_ref
+            assert self.s._dt == mock.sentinel.dt
+            mock_order.assert_called_once_with(mock.sentinel.N_ref)
+            mock_dt.assert_called_once_with(mock.sentinel.N)
+
+            # verify that other args aren't affected
+            assert self.s._timer is None
+            assert not self.s._loggingEnabled
+
+    def test_stop(self):
+        self.s._isSubstep = True
+        self.s._startTime = mock.sentinel.startTime
+        self.s._N_ref = mock.sentinel.N_ref
+        self.s._dt = mock.sentinel.dt
+        mockTimer = mock.Mock(spec=threading.Timer)
+        self.s._timer = mockTimer
+
+        self.s.stop()
+
+        # clears `_isSubstep`, `_startTime`, `_N_ref`, `_dt` and `_timer`:
+        assert self.s._isSubstep == False  # noqa: E712
+        assert self.s._startTime is None
+        assert self.s._N_ref is None
+        assert self.s._dt is None
+        assert self.s._timer is None
+
+        # cancels the `_timer`
+        mockTimer.cancel.assert_called_once()
+
+    def test_stop_no_timer(self):
+        self.s._isSubstep = True
+        self.s._startTime = mock.sentinel.startTime
+        self.s._N_ref = mock.sentinel.N_ref
+        self.s._dt = mock.sentinel.dt
+        assert self.s._timer is None
+
+        self.s.stop()
+
+        # clears `_isSubstep`, `_startTime`, `_N_ref`, `_dt` and `_timer`:
+        assert self.s._isSubstep == False  # noqa: E712
+        assert self.s._startTime is None
+        assert self.s._N_ref is None
+        assert self.s._dt is None
+        assert self.s._timer is None
+
+    def test_stop_not_started(self):
+        # checks that the step has been started
+        assert self.s._startTime is None
+        with pytest.raises(RuntimeError, match="Usage error: attempt to `stop` unstarted step.*"):
+            self.s.stop()
+
+    def test_recordMeasurement(self):
+        # records the measurement
+        with (
+            Config_override("application.workflows_data.timing.enabled", True),
+            Config_override("application.workflows_data.timing.max_measurements", 500),
+            Config_override("application.workflows_data.timing.update_minimum_count", 5),
+            Config_override("application.workflows_data.timing.update_threshold", 0.2),
+        ):
+            _step = self.s.model_copy(deep=True)
+            _step.estimate = mock.Mock()
+
+            currentLength = len(_step.measurements)
+            assert currentLength + 1 < Config["application.workflows_data.timing.update_minimum_count"]
+            _step.recordMeasurement(dt_elapsed=100.0, dt_est=2 * 100.0, N_ref=4.0)
+            assert len(_step.measurements) == currentLength + 1
+            _step.estimate.update.assert_not_called()
+
+        # updates the estimate when enough measurements are available
+        with (
+            Config_override("application.workflows_data.timing.enabled", True),
+            Config_override("application.workflows_data.timing.max_measurements", 500),
+            Config_override("application.workflows_data.timing.update_minimum_count", 3),
+            Config_override("application.workflows_data.timing.update_threshold", 0.2),
+        ):
+            _step = self.s.model_copy(deep=True)
+            _step.details = mock.Mock()
+            _step.estimate = mock.Mock()
+
+            assert len(_step.measurements) >= Config["application.workflows_data.timing.update_minimum_count"]
+            _step.recordMeasurement(dt_elapsed=100.0, dt_est=2 * 100.0, N_ref=4.0)
+            assert len(_step.measurements) == 4
+
+            # only the cached properties `step.N_ref`, `step.dt` should be used in `update`
+            _step.details.N_ref.assert_not_called()
+            _step.details.order.assert_not_called()
+            _step.estimate.dt.assert_not_called()
+            _step.estimate.update.assert_called_once_with(_step.measurements, _step.details.order)
+
+        # only updates the estimate when the current estimate is bad
+        with (
+            Config_override("application.workflows_data.timing.enabled", True),
+            Config_override("application.workflows_data.timing.max_measurements", 500),
+            Config_override("application.workflows_data.timing.update_minimum_count", 3),
+            Config_override("application.workflows_data.timing.update_threshold", 0.2),
+        ):
+            _step = self.s.model_copy(deep=True)
+            _step.estimate = mock.Mock()
+
+            assert len(_step.measurements) >= Config["application.workflows_data.timing.update_minimum_count"]
+            # record a measurement that has a _perfect_ estimate
+            _step.recordMeasurement(dt_elapsed=100.0, dt_est=100.0, N_ref=4.0)
+            assert len(_step.measurements) == 4
+            _step.estimate.update.assert_not_called()
+
+        # restricts maximum length of the `measurements` list
+        with (
+            Config_override("application.workflows_data.timing.enabled", True),
+            Config_override("application.workflows_data.timing.max_measurements", 25),
+            Config_override("application.workflows_data.timing.update_minimum_count", 500),
+            Config_override("application.workflows_data.timing.update_threshold", 0.2),
+        ):
+            _step = self.s.model_copy(deep=True)
+            _step.measurements.extend([_step.measurements[-1] for n in range(25)])
+            assert len(_step.measurements) > Config["application.workflows_data.timing.max_measurements"]
+            _step.recordMeasurement(dt_elapsed=100.0, dt_est=100.0, N_ref=4.0)
+            assert len(_step.measurements) == Config["application.workflows_data.timing.max_measurements"]
+
+    def test_name(self):
+        # calls `humanReadableName`
+        with mock.patch.object(
+            ProgressStep, "humanReadableName", return_value="module.class.func"
+        ) as mockHumanReadableName:
+            name = self.s.name
+            assert isinstance(name, str)
+            mockHumanReadableName.assert_called_once_with(self.key)
+
+    def test_humanReadableName(self):
+        # excludes `None` fields
+        key = (None, "lah.dee.dah", None)
+        assert ProgressStep.humanReadableName(key) == key[1]
+
+        key = ("fiddle", None, "dee.dee")
+        assert ProgressStep.humanReadableName(key) == ".".join((key[0], key[2]))
+
+        # includes all non-trivial fields
+        key = ("one.two.three", "four.five", "six")
+        assert ProgressStep.humanReadableName(key) == ".".join(key)
+
+    def test_isActive(self):
+        _now = datetime.now(timezone.utc)
+
+        # returns False if step hasn't been started
+        assert self.s._startTime is None
+        assert not self.s.isActive
+
+        # returns True if step has been started
+        self.s._startTime = _now
+        assert self.s.isActive
+
+    def test_startTime(self):
+        _now = datetime.now(timezone.utc)
+
+        # exception if the step hasn't been started
+        with pytest.raises(RuntimeError, match="Usage error: attempt to read `startTime` for unstarted step.*"):
+            _time = self.s.startTime
+
+        # returns `_startTime`
+        self.s._startTime = _now
+        assert self.s.startTime == _now
+
+    def test_N_ref(self):
+        _now = datetime.now(timezone.utc)
+
+        # exception if the step hasn't been started
+        with pytest.raises(RuntimeError, match="Usage error: attempt to read `N_ref` for unstarted step.*"):
+            _N_ref = self.s.N_ref
+
+        # returns `_N_ref`
+        self.s._startTime = _now
+        self.s._N_ref = mock.sentinel.N_ref
+        assert self.s.N_ref == mock.sentinel.N_ref
+
+    def test_dt(self):
+        _now = datetime.now(timezone.utc)
+
+        # exception if the step hasn't been started
+        with pytest.raises(RuntimeError, match="Usage error: attempt to read `dt` for unstarted step.*"):
+            _dt = self.s.dt
+
+        # returns `_N_ref`
+        self.s._startTime = _now
+        self.s._dt = mock.sentinel.dt
+        assert self.s.dt == mock.sentinel.dt
+
+    def test_loggingEnabled(self):
+        _now = datetime.now(timezone.utc)
+
+        # returns _loggingEnabled
+        assert not self.s._loggingEnabled
+        assert not self.s.loggingEnabled
+
+        self.s._loggingEnabled = True
+        assert self.s.loggingEnabled
+
+    def test_isSubstep(self):
+        # returns _isSubstep
+        assert not self.s._isSubstep
+        assert not self.s.isSubstep
+
+        self.s._isSubstep = True
+        assert self.s.isSubstep
+
+
+# a function in module scope
+def _function_in_module_scope():
+    pass
+
+
+class Test_ProgressRecorder:
+    # pytest-style: uses fixtures
+
+    @pytest.fixture(autouse=True, scope="class")
+    @classmethod
+    def _setup_test_class(cls):
+        # setup
+        yield
+
+        # teardown
+        pass
+
+    @pytest.fixture(autouse=True)
+    def _setup_test(self, Config_override_fixture):
+        # setup
+
+        """
+        # The `ProgressRecorder` singleton has been created at import of its module.
+        #   Since it is by-default _disabled_ in the test environment, it contains
+        #   no persistent data; however, for all of these tests it now needs to be enabled:
+        Config_override_fixture("application.workflows_data.timing.enable", True)
+        """
+
+        # Use a temporary directory for "user.application.data.home":
+        Config_override_fixture(
+            "user.application.data.home",
+            tempfile.TemporaryDirectory(prefix=Resource.getPath("outputs/user.application.data.home_")),
+        )
+        yield
+
+        # teardown
+
+        # Re-initialize the `ProgressRecorder` at the end of each test.
+        ProgressRecorder.steps.clear()
+
+    @pytest.fixture
+    def _init_with_data(self, data: str) -> mock.MagicMock:
+        # Initialize the `ProgressRecorder` singleton from its JSON representation.
+        # returns: a wrapped version of the `ProgressRecorder` instance.
+
+        def _init() -> mock.MagicMock:
+            # setup
+
+            instance = _ProgressRecorder.model_validate_json(data)
+            mockSingleton = mock.patch.object(inspect.getmodule(ProgressRecorder), "ProgressRecorder", instance)
+            mockSingleton.start()
+            yield mockSingleton
+
+            # teardown
+            mockSingleton.stop()
+
+        return _init()
+
+    @pytest.fixture(autouse=True)
+    def _clear_instance_cache(self):
+        # This fixture re-initializes `_ProgressRecorder.instance` `lru_cache` before and after each test.
+
+        # setup
+        _ProgressRecorder.instance.cache_clear()
+        yield
+
+        # teardown:
+        _ProgressRecorder.instance.cache_clear()
+
+    def test_init(self):
+        # default init:
+        recorder = _ProgressRecorder()
+        assert recorder.steps == {}
+
+    def test_enabled(self):
+        # `enabled` classproperty tracks `Config`
+        for flag in (False, True):
+            with Config_override("application.workflows_data.timing.enabled", flag):
+                assert _ProgressRecorder.enabled == flag
+
+    def test_instance(self):
+        # `_ProgressRecorder.instance()` uses `lru_cache`:
+        #   for each of these subtests, we need to re-initialize it.
+
+        # enabled => load persistent data
+        with (
+            Config_override("application.workflows_data.timing.enabled", True),
+            Config_override("application.workflows_data.timing.persistent_data", True),
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "LocalDataService") as mockLocalDataService,
+            mock.patch.object(_ProgressRecorder, "model_validate_json") as mockModelValidate,
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "atexit") as mock_atexit,
+        ):
+            _ProgressRecorder.instance.cache_clear()
+            mockLocalDataService.return_value.readProgressRecords.return_value = mock.sentinel.json_data
+            mockModelValidate.return_value = mock.sentinel.instance1
+            actual = _ProgressRecorder.instance()
+            assert actual == mock.sentinel.instance1
+            mockModelValidate.assert_called_once_with(mock.sentinel.json_data)
+            mockLocalDataService.return_value.readProgressRecords.assert_called_once()
+            mock_atexit.register.assert_called_once_with(_ProgressRecorder._unloadResident)
+
+            # call it again => returns the cached value
+            mockLocalDataService.reset_mock()
+            mockModelValidate.reset_mock()
+            mock_atexit.reset_mock()
+            mockModelValidate.return_value = mock.sentinel.instance2
+            actual = _ProgressRecorder.instance()
+            assert actual == mock.sentinel.instance1
+            mockModelValidate.assert_not_called()
+            mockLocalDataService.return_value.readProgressRecords.assert_not_called()
+            mock_atexit.register.assert_not_called()
+
+        # enabled (not 'persistent_data') => load persistent data, but don't register to unload it
+        with (
+            Config_override("application.workflows_data.timing.enabled", True),
+            Config_override("application.workflows_data.timing.persistent_data", False),
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "LocalDataService") as mockLocalDataService,
+            mock.patch.object(_ProgressRecorder, "model_validate_json") as mockModelValidate,
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "atexit") as mock_atexit,
+        ):
+            _ProgressRecorder.instance.cache_clear()
+            mockLocalDataService.return_value.readProgressRecords.return_value = mock.sentinel.json_data
+            mockModelValidate.return_value = mock.sentinel.instance1
+            actual = _ProgressRecorder.instance()
+            assert actual == mock.sentinel.instance1
+            mockModelValidate.assert_called_once_with(mock.sentinel.json_data)
+            mockLocalDataService.return_value.readProgressRecords.assert_called_once()
+            mock_atexit.register.assert_not_called()
+
+        # disabled => do not load persistent data
+        with (
+            Config_override("application.workflows_data.timing.enabled", False),
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "LocalDataService") as mockLocalDataService,
+            mock.patch.object(_ProgressRecorder, "model_validate_json") as mockModelValidate,
+            mock.patch.object(_ProgressRecorder, "__new__") as mock_new,
+            mock.patch.object(_ProgressRecorder, "__init__") as mock_init,
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "atexit") as mock_atexit,
+        ):
+            _ProgressRecorder.instance.cache_clear()
+            mockLocalDataService.return_value.readProgressRecords.side_effect = RuntimeError(
+                "this method should not be called"
+            )
+            mockModelValidate.side_effect = RuntimeError("this method should not be called")
+            mock_atexit.register.side_effect = RuntimeError("this function should not be called")
+            mock_new.return_value = mock.sentinel.instance3
+            actual = _ProgressRecorder.instance()
+            assert actual == mock.sentinel.instance3
+            mock_new.assert_called_once_with(_ProgressRecorder)
+
+            # call it again => returns the cached value
+            mockLocalDataService.reset_mock()
+            mockModelValidate.reset_mock()
+            mock_atexit.reset_mock()
+            mock_init.reset_mock()
+            mock_new.reset_mock()
+            mock_new.return_value = mock.sentinel.instance4
+            actual = _ProgressRecorder.instance()
+            assert actual == mock.sentinel.instance3
+            mock_new.assert_not_called()
+
+    def test__unloadResident(self):
+        # `_ProgressRecorder.instance()` uses `lru_cache`:
+        #   for each of these subtests, we need to re-initialize it.
+
+        # enabled: saves persistent data
+        with (
+            Config_override("application.workflows_data.timing.enabled", True),
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "LocalDataService") as mockLocalDataService,
+            mock.patch.object(_ProgressRecorder, "instance") as mockInstance,
+        ):
+            _ProgressRecorder.instance.cache_clear()
+            mockInstance.return_value.model_dump_json.return_value = mock.sentinel.json_data
+            _ProgressRecorder._unloadResident()
+            mockInstance.assert_called_once()
+            mockLocalDataService.return_value.writeProgressRecords.assert_called_once_with(mock.sentinel.json_data)
+
+        # disabled: does not save any data
+        with (
+            Config_override("application.workflows_data.timing.enabled", False),
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "LocalDataService") as mockLocalDataService,
+            mock.patch.object(_ProgressRecorder, "instance") as mockInstance,
+        ):
+            _ProgressRecorder.instance.cache_clear()
+            mockInstance.return_value.model_dump_json.return_value = mock.sentinel.json_data
+            _ProgressRecorder._unloadResident()
+            mockInstance.return_value.model_dump_json.assert_not_called()
+            mockLocalDataService.return_value.writeProgressRecords.assert_not_called()
+
+        # enabled: exceptions raised at exit do not propagate
+        with (
+            Config_override("application.workflows_data.timing.enabled", True),
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "LocalDataService") as mockLocalDataService,
+            mock.patch.object(_ProgressRecorder, "instance") as mockInstance,
+        ):
+            mockLocalDataService.return_value.writeProgressRecords.side_effect = RuntimeError("any exception")
+            _ProgressRecorder.instance.cache_clear()
+            mockInstance.return_value.model_dump_json.return_value = mock.sentinel.json_data
+            _ProgressRecorder._unloadResident()
+            mockInstance.assert_called_once()
+            mockLocalDataService.return_value.writeProgressRecords.assert_called_once_with(mock.sentinel.json_data)
+
+    def test__getCallerFullyQualifiedName(self):
+        # function in local scope
+        def _function():
+            pass
+
+        # object of type `type`
+        class _Class:
+            def method(self):
+                pass
+
+        # object of type `_Class`
+        instanceType = _Class()
+
+        # `FunctionType` <- `LambdaType` in local scope
+        lambdaType = lambda *_args, **_kwargs: None  # noqa: E731
+
+        # function in local scope
+        expected = (__name__, "Test_ProgressRecorder.test__getCallerFullyQualifiedName.<locals>._function")
+        actual = _ProgressRecorder._getCallerFullyQualifiedName(_function)
+        assert actual == expected
+
+        # function in module scope
+        expected = (__name__, "_function_in_module_scope")
+        actual = _ProgressRecorder._getCallerFullyQualifiedName(_function_in_module_scope)
+        assert actual == expected
+
+        # unbound class method
+        expected = (__name__, "Test_ProgressRecorder.test__getCallerFullyQualifiedName")
+        actual = _ProgressRecorder._getCallerFullyQualifiedName(Test_ProgressRecorder.test__getCallerFullyQualifiedName)
+        assert actual == expected
+
+        # lambda function
+        #   (Note: generally this would not be used, but it _is_ allowed.)
+        expected = (__name__, "Test_ProgressRecorder.test__getCallerFullyQualifiedName.<locals>.<lambda>")
+        actual = _ProgressRecorder._getCallerFullyQualifiedName(lambda *_args, **_kwargs: None)
+        assert actual == expected
+
+        # reference to a lambda function
+        expected = (__name__, "Test_ProgressRecorder.test__getCallerFullyQualifiedName.<locals>.<lambda>")
+        actual = _ProgressRecorder._getCallerFullyQualifiedName(lambdaType)
+        assert actual == expected
+
+        # a class
+        expected = (__name__, "Test_ProgressRecorder.test__getCallerFullyQualifiedName.<locals>._Class")
+        actual = _ProgressRecorder._getCallerFullyQualifiedName(_Class)
+        assert actual == expected
+
+        # the current stack frame
+        expected = (__name__, "Test_ProgressRecorder.test__getCallerFullyQualifiedName")
+        actual = _ProgressRecorder._getCallerFullyQualifiedName(inspect.currentframe())
+        assert actual == expected
+
+        # one stack frame up from the current frame
+        expected = ("_pytest.python", "pytest_pyfunc_call")
+        actual = _ProgressRecorder._getCallerFullyQualifiedName(inspect.currentframe().f_back)
+        assert actual == expected
+
+        # anything else should raise an exception
+        for caller in (instanceType, instanceType.method, "string", None):
+            with pytest.raises(
+                RuntimeError, match=".*Expecting object of type `FrameType`, `FunctionType`, or `type` only.*"
+            ):
+                _ProgressRecorder._getCallerFullyQualifiedName(caller)
+
+    def test__getCallerFullyQualifiedName_python_version(self):
+        # function in local scope
+        def _function():
+            pass
+
+        # object of type `type`
+        class _Class:
+            def method(self):
+                pass
+
+        # object of type `_Class`
+        _instanceType = _Class()
+
+        # `FunctionType` <- `LambdaType` in local scope
+        _lambdaType = lambda *_args, **_kwargs: None  # noqa: E731
+
+        VersionInfo = namedtuple("VersionInfo", ["major", "minor", "micro", "releaselevel", "serial"])
+        with mock.patch.object(sys, "version_info", VersionInfo(3, 10, 0, "final", 0)):
+            # the current stack frame
+            expected = (__name__, "Test_ProgressRecorder.test__getCallerFullyQualifiedName_python_version")
+            actual = _ProgressRecorder._getCallerFullyQualifiedName(inspect.currentframe())
+            assert actual == expected
+
+            # one stack frame up from the current frame
+            expected = ("_pytest.python", "pytest_pyfunc_call")
+            actual = _ProgressRecorder._getCallerFullyQualifiedName(inspect.currentframe().f_back)
+            assert actual == expected
+
+    def test_isLoggingEnabledForStep(self):
+        test_qualname_roots = ["joe", "sam", "sally"]
+        _ProgressRecorder._loggable_qualname_roots.cache_clear()
+        with Config_override("application.workflows_data.timing.logging.qualname_roots", test_qualname_roots):
+            # key ::= (<module name> | None, <fully-qualified function name> | None, <step name> | None)
+
+            # trivial key returns False
+            assert not _ProgressRecorder.isLoggingEnabledForStep((None, None, None))
+
+            # key with matching <qualified name> returns True
+            assert _ProgressRecorder.isLoggingEnabledForStep(("module", "joe.blah.blah", "step-name"))
+
+            # key with non-matching <qualified name> returns False
+            assert not _ProgressRecorder.isLoggingEnabledForStep(("module", "ted.blah.blah", "step-name"))
+
+            # key with None elements and match returns True
+            assert _ProgressRecorder.isLoggingEnabledForStep((None, "sam.blah.blah", None))
+
+            # key with None elements and non-matching <qualified name> returns False
+            assert not _ProgressRecorder.isLoggingEnabledForStep((None, "fred.blah.blah", None))
+
+    def test_getStepKey(self):
+        # object of type `type`
+        class _Class:
+            pass
+
+        # object of type `FunctionType`
+        def _function():
+            pass
+
+        # object of type `FrameType`:
+        #   the caller of this test method's stack frame
+        default_frame = inspect.currentframe().f_back
+
+        # returns result from `_getCallerFullyQualifiedName` + (<step name>,)
+        with mock.patch.object(_ProgressRecorder, "_getCallerFullyQualifiedName") as mock_getFullyQualifiedName:
+            stepName = "the-step"
+            qualified_name = ("module.name", "qualified.function.name")
+            mock_getFullyQualifiedName.return_value = qualified_name
+            expected = qualified_name + (stepName,)
+
+            # works with `FunctionType`
+            actual = _ProgressRecorder.getStepKey(callerOrStackFrameOverride=_function, stepName=stepName)
+            assert actual == expected
+            mock_getFullyQualifiedName.assert_called_once_with(_function)
+
+            # works with `FrameType`
+            mock_getFullyQualifiedName.reset_mock()
+            actual = _ProgressRecorder.getStepKey(callerOrStackFrameOverride=default_frame, stepName=stepName)
+            assert actual == expected
+            mock_getFullyQualifiedName.assert_called_once_with(default_frame)
+
+            # no <step name> adds `None` in the <step name> position
+            mock_getFullyQualifiedName.reset_mock()
+            expected = qualified_name + (None,)
+            actual = _ProgressRecorder.getStepKey(callerOrStackFrameOverride=_function)
+            assert actual == expected
+            mock_getFullyQualifiedName.assert_called_once_with(_function)
+
+        # only allows `FunctionType`, `FrameType`, or `type`
+        with mock.patch.object(_ProgressRecorder, "_getCallerFullyQualifiedName") as mock_getFullyQualifiedName:
+            with pytest.raises(  # noqa: PT012
+                RuntimeError,
+                match=".*it must be either a function, the local stack-frame of a function, or a <class> type.*",
+            ):
+                _class = _Class()  # an instance of `_Class`
+                _ProgressRecorder.getStepKey(callerOrStackFrameOverride=_class)
+
+        # By default `_getStepKey` uses the stack frame _one_ frame up from the current frame:
+        #   this allows `_ProgressRecorder.record` to use `_getStepKey` and obtain the step for
+        #     the scope of its _caller_.
+        with mock.patch.object(_ProgressRecorder, "_getCallerFullyQualifiedName") as mock_getFullyQualifiedName:
+            stepName = "the-step"
+            qualified_name = ("module.name", "qualified.function.name")
+            mock_getFullyQualifiedName.return_value = qualified_name
+            expected = qualified_name + (stepName,)
+            actual = _ProgressRecorder.getStepKey(stepName=stepName)
+            assert actual == expected
+            mock_getFullyQualifiedName.assert_called_once_with(default_frame)
+
+    def test_getStep(self):
+        instance = _ProgressRecorder()
+        key = (__name__, "test_ProgressRecorder.test_getStep", None)
+        step = ProgressStep(details=_Step(key))
+
+        # step is in <instance>.steps
+        assert instance.steps == {}
+        with mock.patch.dict(instance.steps, {key: step}, clear=True):
+            assert key in instance.steps
+            assert instance.getStep(key, create=False) == step
+
+        # step not in <instance>.steps: create=False
+        with pytest.raises(  # noqa: PT012
+            RuntimeError, match=re.escape(f"Usage error: progress-recording step {key} does not exist.")
+        ):
+            assert key not in instance.steps
+            instance.getStep(key, create=False)
+
+        # step not in <instance>.steps, create=True =>
+        #   creates the step when it doesn't exist,
+        #   fills in its default values,
+        #   and enters it in `steps`
+        with mock.patch.dict(instance.steps, {}, clear=True):
+            assert key not in instance.steps
+            newStep = instance.getStep(key, create=True)
+            assert instance.steps[key] == newStep
+            # they have the same key, but they should be distinct objects
+            assert id(newStep) != id(step)
+            # they should have the same attributes
+            assert newStep == step
+
+    def test_logTimeRemaining(self):
+        key = (__name__, "test_ProgressRecorder.test_logTimeRemaining", None)
+        step = ProgressStep(details=_Step(key))
+        instance = _ProgressRecorder(steps={key: step})
+
+        # calls `getStep`, `_logTimeRemaining`
+        with (
+            mock.patch.object(_ProgressRecorder, "getStep", return_value=step) as mockGetStep,
+            mock.patch.object(_ProgressRecorder, "_logTimeRemaining") as mock_logTimeRemaining,
+        ):
+            instance.logTimeRemaining(key)
+            mockGetStep.assert_called_once_with(key)
+            mock_logTimeRemaining.assert_called_once_with(step)
+
+    def test__chainLogTimeRemaining(self):
+        update_interval = 10.0
+        instance = _ProgressRecorder()
+        key = (__name__, "test_ProgressRecorder.test__chainLogTimeRemaining", None)
+        substepKey = (__name__, "test_ProgressRecorder.test__chainLogTimeRemaining", "a-substep")
+
+        # calls `_logTimeRemaining`
+        with mock.patch.object(_ProgressRecorder, "_logTimeRemaining") as mock_logTimeRemaining:
+            mock_logTimeRemaining.return_value = False
+            step = ProgressStep(details=_Step(key))
+            substep = ProgressStep(details=_Step(substepKey))
+            substep._isSubstep = True
+            instance = _ProgressRecorder(steps={key: step, substepKey: substep})
+
+            assert step._timer is None
+            instance._chainLogTimeRemaining(step)
+            mock_logTimeRemaining.assert_called_once_with(step)
+
+        # `_logTimeRemaining` returns True:
+        #    'log_update_interval' > 0.0: set a `Timer`
+        with (
+            Config_override("application.workflows_data.timing.logging.log_update_interval", update_interval),
+            mock.patch.object(_ProgressRecorder, "_logTimeRemaining") as mock_logTimeRemaining,
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "Timer") as mockTimer,
+        ):
+            mock_logTimeRemaining.return_value = True
+            step = ProgressStep(details=_Step(key))
+            substep = ProgressStep(details=_Step(substepKey))
+            substep._isSubstep = True
+            instance = _ProgressRecorder(steps={key: step, substepKey: substep})
+
+            assert step._timer is None
+            assert instance._logTimeRemaining()
+            instance._logTimeRemaining.reset_mock()
+            instance._chainLogTimeRemaining(step)
+            assert step._timer is not None
+            mockTimer.assert_called_once_with(update_interval, instance._chainLogTimeRemaining, args=[step])
+
+        # `_logTimeRemaining` returns True:
+        #    'log_update_interval' == 0.0: do not set a `Timer`
+        with (
+            Config_override("application.workflows_data.timing.logging.log_update_interval", 0.0),
+            mock.patch.object(_ProgressRecorder, "_logTimeRemaining") as mock_logTimeRemaining,
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "Timer") as mockTimer,
+        ):
+            mock_logTimeRemaining.return_value = True
+            step = ProgressStep(details=_Step(key))
+            substep = ProgressStep(details=_Step(substepKey))
+            substep._isSubstep = True
+            instance = _ProgressRecorder(steps={key: step, substepKey: substep})
+
+            assert step._timer is None
+            assert instance._logTimeRemaining()
+            instance._logTimeRemaining.reset_mock()
+            instance._chainLogTimeRemaining(step)
+            assert step._timer is None
+            mockTimer.assert_not_called()
+
+        # `_logTimeRemaining` returns True:
+        #    'log_update_interval' > 0.0: is a substep: do not set a `Timer`
+        with (
+            Config_override("application.workflows_data.timing.logging.log_update_interval", update_interval),
+            mock.patch.object(_ProgressRecorder, "_logTimeRemaining") as mock_logTimeRemaining,
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "Timer") as mockTimer,
+        ):
+            mock_logTimeRemaining.return_value = True
+            step = ProgressStep(details=_Step(key))
+            substep = ProgressStep(details=_Step(substepKey))
+            substep._isSubstep = True
+            instance = _ProgressRecorder(steps={key: step, substepKey: substep})
+
+            assert substep._timer is None
+            assert instance._logTimeRemaining()
+            instance._logTimeRemaining.reset_mock()
+            instance._chainLogTimeRemaining(substep)
+            assert substep._timer is None
+            mockTimer.assert_not_called()
+
+        # `_logTimeRemaining` returns False:
+        #    if `step._timer is not None`: `cancel` and set to `None`
+        with (
+            Config_override("application.workflows_data.timing.logging.log_update_interval", update_interval),
+            mock.patch.object(_ProgressRecorder, "_logTimeRemaining") as mock_logTimeRemaining,
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "Timer") as mockTimer,
+        ):
+            mock_logTimeRemaining.return_value = False
+            step = ProgressStep(details=_Step(key))
+            substep = ProgressStep(details=_Step(substepKey))
+            substep._isSubstep = True
+            instance = _ProgressRecorder(steps={key: step, substepKey: substep})
+            mock_step__timer = mock.Mock()
+            step._timer = mock_step__timer
+
+            assert not instance._logTimeRemaining()
+            instance._logTimeRemaining.reset_mock()
+            instance._chainLogTimeRemaining(step)
+            # the `step._timer` has been cancelled and set to `None`
+            assert step._timer is None
+            mock_step__timer.cancel.assert_called_once()
+            mockTimer.assert_not_called()
+
+    def test__logTimeRemaining(self, caplog):
+        instance = _ProgressRecorder()
+        key = (__name__, "test_ProgressRecorder.test__logTimeRemaining", None)
+        substepKey = (__name__, "test_ProgressRecorder.test__logTimeRemaining", "a-substep")
+        step = ProgressStep(details=_Step(key))
+        substep = ProgressStep(details=_Step(substepKey))
+        substep._isSubstep = True
+
+        # for active step:
+        #   calls `_loggableStepName`, `_stepTimeRemaining`
+        with (
+            mock.patch.object(step, "_isActive", return_value=True) as mock_isActive,
+            mock.patch.dict(instance.steps, {key: step, substepKey: substep}, clear=True),
+            mock.patch.object(_ProgressRecorder, "_loggableStepName") as mock_loggableStepName,
+            mock.patch.object(_ProgressRecorder, "_stepTimeRemaining") as mock_stepTimeRemaining,
+        ):
+            remainder = 10.0
+            mock_loggableStepName.return_value = "test__logTimeRemaining"
+            mock_stepTimeRemaining.return_value = remainder
+
+            assert step.isActive
+            mock_isActive.reset_mock()
+            assert instance._stepTimeRemaining(step) == remainder
+            instance._stepTimeRemaining.reset_mock()
+
+            instance._logTimeRemaining(step)
+            mock_loggableStepName.assert_called_once_with(step.details.key, False)
+            mock_stepTimeRemaining.assert_called_once_with(step)
+
+        # for inactive step: does nothing: returns False
+        with (
+            mock.patch.object(step, "_isActive", return_value=False) as mock_isActive,
+            mock.patch.dict(instance.steps, {key: step, substepKey: substep}, clear=True),
+            mock.patch.object(_ProgressRecorder, "_loggableStepName") as mock_loggableStepName,
+            mock.patch.object(_ProgressRecorder, "_stepTimeRemaining") as mock_stepTimeRemaining,
+        ):
+            remainder = 10.0
+            mock_loggableStepName.return_value = "test__logTimeRemaining"
+            mock_stepTimeRemaining.return_value = remainder
+
+            assert not step.isActive
+            mock_isActive.reset_mock()
+            continueToLog = instance._logTimeRemaining(step)
+            mock_loggableStepName.assert_not_called()
+            mock_stepTimeRemaining.assert_not_called()
+            assert not continueToLog
+
+        # for active step:
+        #   remainder is `None`: log "<no timing data available>": returns False
+        with (
+            mock.patch.object(step, "_isActive", return_value=True) as mock_isActive,
+            mock.patch.dict(instance.steps, {key: step, substepKey: substep}, clear=True),
+            mock.patch.object(_ProgressRecorder, "_loggableStepName") as mock_loggableStepName,
+            mock.patch.object(_ProgressRecorder, "_stepTimeRemaining") as mock_stepTimeRemaining,
+        ):
+            remainder = None
+            mock_loggableStepName.return_value = "test__logTimeRemaining"
+            mock_stepTimeRemaining.return_value = remainder
+
+            assert step.isActive
+            mock_isActive.reset_mock()
+            assert instance._stepTimeRemaining(step) == remainder
+            mock_stepTimeRemaining.reset_mock()
+            with caplog.at_level(
+                Config["application.workflows_data.timing.logging.loglevel"],
+                logger=inspect.getmodule(ProgressRecorder).__name__,
+            ):
+                continueToLog = instance._logTimeRemaining(step)
+                assert not continueToLog
+            assert "<no timing data is available>" in caplog.text
+            assert mock_loggableStepName.return_value in caplog.text
+        caplog.clear()
+
+        # for active step:
+        #   remainder > 0.0: log time-remaning message: returns True
+        with (
+            mock.patch.object(step, "_isActive", return_value=True) as mock_isActive,
+            mock.patch.dict(instance.steps, {key: step, substepKey: substep}, clear=True),
+            mock.patch.object(_ProgressRecorder, "_loggableStepName") as mock_loggableStepName,
+            mock.patch.object(_ProgressRecorder, "_stepTimeRemaining") as mock_stepTimeRemaining,
+        ):
+            remainder = 10.0
+            mock_loggableStepName.return_value = "test__logTimeRemaining"
+            mock_stepTimeRemaining.return_value = remainder
+
+            assert step.isActive
+            mock_isActive.reset_mock()
+            assert instance._stepTimeRemaining(step) == remainder
+            mock_stepTimeRemaining.reset_mock()
+            with caplog.at_level(
+                Config["application.workflows_data.timing.logging.loglevel"],
+                logger=inspect.getmodule(ProgressRecorder).__name__,
+            ):
+                continueToLog = instance._logTimeRemaining(step)
+                assert continueToLog
+            assert f"estimated completion in {remainder} seconds" in caplog.text
+            assert mock_loggableStepName.return_value in caplog.text
+        caplog.clear()
+
+        # for active step:
+        #   remainder == 0.0: log "is taking longer than expected" message: returns False
+        with (
+            mock.patch.object(step, "_isActive", return_value=True) as mock_isActive,
+            mock.patch.dict(instance.steps, {key: step, substepKey: substep}, clear=True),
+            mock.patch.object(instance, "_loggableStepName") as mock_loggableStepName,
+            mock.patch.object(instance, "_stepTimeRemaining") as mock_stepTimeRemaining,
+        ):
+            remainder = 0.0
+            mock_loggableStepName.return_value = "test__logTimeRemaining"
+            mock_stepTimeRemaining.return_value = remainder
+
+            assert step.isActive
+            mock_isActive.reset_mock()
+            assert instance._stepTimeRemaining(step) == remainder
+            mock_stepTimeRemaining.reset_mock()
+            with caplog.at_level(
+                Config["application.workflows_data.timing.logging.loglevel"],
+                logger=inspect.getmodule(ProgressRecorder).__name__,
+            ):
+                continueToLog = instance._logTimeRemaining(step)
+                assert not continueToLog
+            assert "taking longer than expected" in caplog.text
+            assert mock_loggableStepName.return_value in caplog.text
+        caplog.clear()
+
+    def test__logCompletion(self, caplog):
+        instance = _ProgressRecorder()
+        key = (__name__, "test_ProgressRecorder.test__logCompletion", None)
+        substepKey = (__name__, "test_ProgressRecorder.test__logCompletion", "a-substep")
+        step = ProgressStep(details=_Step(key))
+        substep = ProgressStep(details=_Step(substepKey))
+        substep._isSubstep = True
+        with (
+            mock.patch.dict(instance.steps, {key: step, substepKey: substep}, clear=True),
+            mock.patch.object(instance, "_loggableStepName", wraps=instance._loggableStepName) as mock_loggableStepName,
+        ):
+            # calls `_loggableStepName`
+            instance._logCompletion(step.details.key, False)
+            mock_loggableStepName.assert_called_once_with(step.details.key, False)
+
+        with mock.patch.dict(instance.steps, {key: step, substepKey: substep}, clear=True):
+            # logs at the level of `Config["application.workflows_data.timing.logging.loglevel"]`
+            expectedName = instance._loggableStepName(step.details.key, False)
+            with caplog.at_level(
+                Config["application.workflows_data.timing.logging.loglevel"],
+                logger=inspect.getmodule(ProgressRecorder).__name__,
+            ):
+                instance._logCompletion(step.details.key, False)
+            # logs a completion message
+            assert "complete" in caplog.text.lower()
+            # includes the step name
+            assert expectedName in caplog.text
+
+            caplog.clear()
+            expectedName = instance._loggableStepName(substep.details.key, True)
+            with caplog.at_level(
+                Config["application.workflows_data.timing.logging.loglevel"],
+                logger=inspect.getmodule(ProgressRecorder).__name__,
+            ):
+                instance._logCompletion(substep.details.key, True)
+            assert "complete" in caplog.text.lower()
+            # or includes the <short name>, as appropriate.
+            assert expectedName in caplog.text
+
+    def test__loggableStepName(self):
+        instance = _ProgressRecorder()
+        key = (__name__, "test_ProgressRecorder.test__loggableStepName", "main-step")
+        substepKey = (__name__, "test_ProgressRecorder.test__loggableStepName", "a-substep")
+        step = ProgressStep(details=_Step(key))
+        substep = ProgressStep(details=_Step(substepKey))
+        substep._isSubstep = True
+
+        with mock.patch.dict(instance.steps, {key: step, substepKey: substep}, clear=True):
+            # the step is not a substep => use its full name
+            assert instance._loggableStepName(step.details.key, False) == "test__loggableStepName: main-step"
+
+            # the step is a substep => use a shorter name
+            shortName = instance._loggableStepName(substep.details.key, True)
+            #   the <short name> is actually shorter
+            assert len(shortName) < len(step.name)
+            #   the substep's name is in the <short name>
+            assert substepKey[-1] in shortName
+
+    def test_stepTimeRemaining(self):
+        key = (__name__, "test_ProgressRecorder.test_stepTimeRemaining", None)
+        step = ProgressStep(details=_Step(key))
+
+        # calls `getStep`, `_stepTimeRemaining`: returns `_stepTimeRemaining`
+        with (
+            mock.patch.object(_ProgressRecorder, "getStep", return_value=step) as mockGetStep,
+            mock.patch.object(
+                _ProgressRecorder, "_stepTimeRemaining", return_value=mock.sentinel.remainder
+            ) as mock_stepTimeRemaining,
+        ):
+            instance = _ProgressRecorder(steps={key: step})
+            assert instance.stepTimeRemaining(key) == mock.sentinel.remainder
+            mockGetStep.assert_called_once_with(key)
+            mock_stepTimeRemaining.assert_called_once_with(step)
+
+    def test__stepTimeRemaining(self):
+        _now = datetime.now(timezone.utc)
+        _start = _now - timedelta(seconds=120.0)
+        _elapsed = (_now - _start).total_seconds()
+        # estimated dt > elapsed time:
+        _dt_continues = 180.0
+        # estimated dt < elapsed time:
+        _dt_finished = 60.0
+        key = (__name__, "test_ProgressRecorder.test__stepTimeRemaining", None)
+
+        # does NOT call `step.N_ref`, `step.order`, `step.estimate.dt`: returns the `step.dt` value
+        with (
+            mock.patch.object(_Step, "N_ref", return_value=mock.sentinel.N_ref) as mock_N_ref,
+            mock.patch.object(_Estimate, "dt", return_value=mock.sentinel.dt) as mock_dt,
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "datetime") as mock_datetime,
+        ):
+            mock_datetime.now = mock.Mock(return_value=_now)
+            step = ProgressStep(details=_Step(key))
+            step._startTime = _start
+            step._N_ref = mock.sentinel.N_ref
+            step._dt = _dt_continues
+            mock_order = mock.Mock(return_value=mock.sentinel.N)
+            step.details.order = mock_order
+
+            expected = _dt_continues - _elapsed
+            actual = _ProgressRecorder._stepTimeRemaining(step)
+            assert actual == pytest.approx(expected, rel=1.0e-3)
+            mock_N_ref.assert_not_called()
+            mock_order.assert_not_called()
+            mock_dt.assert_not_called()
+
+        # remaining time < 0.0: returns 0.0
+        with (
+            mock.patch.object(_Step, "N_ref", return_value=mock.sentinel.N_ref) as mock_N_ref,
+            mock.patch.object(_Estimate, "dt", return_value=mock.sentinel.dt) as mock_dt,
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "datetime") as mock_datetime,
+        ):
+            mock_datetime.now = mock.Mock(return_value=_now)
+            step = ProgressStep(details=_Step(key))
+            step._startTime = _start
+            step._N_ref = mock.sentinel.N_ref
+            step._dt = _dt_finished
+            mock_order = mock.Mock(return_value=mock.sentinel.N)
+            step.details.order = mock_order
+
+            expected = 0.0
+            actual = _ProgressRecorder._stepTimeRemaining(step)
+            assert actual == expected
+            mock_N_ref.assert_not_called()
+            mock_order.assert_not_called()
+            mock_dt.assert_not_called()
+
+        # `step.details.N_ref() is None`: returns `None`
+        with (
+            mock.patch.object(_Step, "N_ref", return_value=mock.sentinel.N_ref) as mock_N_ref,
+            mock.patch.object(_Estimate, "dt", return_value=mock.sentinel.dt) as mock_dt,
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "datetime") as mock_datetime,
+        ):
+            mock_datetime.now = mock.Mock(return_value=_now)
+            step = ProgressStep(details=_Step(key))
+            step._startTime = _start
+            step._N_ref = None
+            step._dt = None
+            mock_order = mock.Mock(return_value=mock.sentinel.N)
+            step.details.order = mock_order
+
+            expected = None
+            actual = _ProgressRecorder._stepTimeRemaining(step)
+            assert actual == expected
+            mock_N_ref.assert_not_called()
+            mock_order.assert_not_called()
+            mock_dt.assert_not_called()
+
+    def test__validate_steps(self):
+        stepsList = [ProgressStep(details=_Step(key=(__name__, f"function_{n}", None))) for n in range(20)]
+        stepsDict = {s.details.key: s for s in stepsList}
+
+        # `Dict[Tuple[str, ...], <ProgressStep dict>]` <- `List[ProgressStep]`
+        assert _ProgressRecorder._validate_steps(stepsList) == stepsDict
+
+        # `Dict[Tuple[str, ...], ProgressStep]` remains unchanged
+        assert _ProgressRecorder._validate_steps(stepsDict) == stepsDict
+
+        # works as expected when called via `model_validate_json`
+        jsonData = Resource.read("inputs/workflows_data/execution_timing_2025-07-20T03:46:43.913617+00:00.json")
+        _ProgressRecorder.model_validate_json(jsonData)
+
+    def test__serialize_steps(self):
+        stepsList = [ProgressStep(details=_Step(key=(__name__, f"function_{n}", None))) for n in range(20)]
+        stepsDict = {s.details.key: s for s in stepsList}
+        instance = _ProgressRecorder(steps=stepsDict)
+
+        # `List[ProgressStep]` <- `Dict[Tuple[str, ...], ProgressStep]`
+        assert instance._serialize_steps(instance.steps, mock.sentinel._info) == stepsList
+
+    def test_record(self):
+        caller = mock.sentinel.caller
+        N_ref = mock.sentinel.N_ref
+        N_ref_args = (mock.sentinel.N_ref_args,)
+        order = mock.sentinel.order
+        stepName = mock.sentinel.stepName
+        key0 = mock.sentinel.key0
+        key1 = mock.sentinel.key1
+
+        # enabled: gets (or creates) the step, sets its details, calls step start,
+        #   starts the logging chain: returns the step key
+        with (
+            Config_override("application.workflows_data.timing.enabled", True),
+            mock.patch.object(_ProgressRecorder, "getStepKey") as mockGetStepKey,
+            mock.patch.object(_ProgressRecorder, "getStep") as mockGetStep,
+            mock.patch.object(_ProgressRecorder, "isLoggingEnabledForStep") as mockIsLoggingEnabledForStep,
+            mock.patch.object(_ProgressRecorder, "_chainLogTimeRemaining") as mock_chainLogTimeRemaining,
+        ):
+            mockGetStepKey.return_value = key0
+            step0 = mock.Mock(spec=ProgressStep, details=mock.Mock(spec=_Step, key=key0))
+            mockGetStep.return_value = step0
+            mockIsLoggingEnabledForStep.return_value = True
+
+            instance = _ProgressRecorder.model_construct(steps={key0: step0})
+            instance._activeSteps = []
+
+            returnValue = instance.record(
+                callerOrStackFrameOverride=caller, stepName=stepName, N_ref=N_ref, N_ref_args=N_ref_args, order=order
+            )
+            assert returnValue == key0
+            assert instance._activeSteps == [step0]
+
+            mockGetStepKey.assert_called_once_with(callerOrStackFrameOverride=caller, stepName=stepName)
+            mockGetStep.assert_called_once_with(key0, create=True)
+            mockIsLoggingEnabledForStep.assert_called_once_with(key0)
+            step0.setDetails.assert_called_once_with(
+                N_ref=N_ref, N_ref_args=N_ref_args, order=order, enableLogging=True
+            )
+            step0.start.assert_called_once_with(isSubstep=False)
+            mock_chainLogTimeRemaining.assert_called_once_with(step0)
+
+        # enabled (substep): gets (or creates) the step, sets its details, calls step start,
+        #   starts the logging chain: returns the step key
+        with (
+            Config_override("application.workflows_data.timing.enabled", True),
+            mock.patch.object(_ProgressRecorder, "getStepKey") as mockGetStepKey,
+            mock.patch.object(_ProgressRecorder, "getStep") as mockGetStep,
+            mock.patch.object(_ProgressRecorder, "isLoggingEnabledForStep") as mockIsLoggingEnabledForStep,
+            mock.patch.object(_ProgressRecorder, "_chainLogTimeRemaining") as mock_chainLogTimeRemaining,
+        ):
+            mockGetStepKey.return_value = key0
+            step0 = mock.Mock(spec=ProgressStep, details=mock.Mock(spec=_Step, key=key0))
+            step1 = mock.Mock(spec=ProgressStep, details=mock.Mock(spec=_Step, key=key1))
+            mockGetStep.return_value = step0
+            mockIsLoggingEnabledForStep.return_value = True
+
+            instance = _ProgressRecorder.model_construct(steps={key0: step0, key1: step1})
+            # a substep is identified when `_activeSteps` isn't empty
+            instance._activeSteps = [step1]
+
+            returnValue = instance.record(
+                callerOrStackFrameOverride=caller, stepName=stepName, N_ref=N_ref, N_ref_args=N_ref_args, order=order
+            )
+            assert returnValue == key0
+            assert instance._activeSteps == [step1, step0]
+
+            mockGetStepKey.assert_called_once_with(callerOrStackFrameOverride=caller, stepName=stepName)
+            mockGetStep.assert_called_once_with(key0, create=True)
+            mockIsLoggingEnabledForStep.assert_called_once_with(key0)
+            step0.setDetails.assert_called_once_with(
+                N_ref=N_ref, N_ref_args=N_ref_args, order=order, enableLogging=True
+            )
+            step0.start.assert_called_once_with(isSubstep=True)
+            mock_chainLogTimeRemaining.assert_called_once_with(step0)
+
+        # disabled: returns None
+        with (
+            Config_override("application.workflows_data.timing.enabled", False),
+            mock.patch.object(_ProgressRecorder, "getStepKey") as mockGetStepKey,
+            mock.patch.object(_ProgressRecorder, "getStep") as mockGetStep,
+            mock.patch.object(_ProgressRecorder, "isLoggingEnabledForStep") as mockIsLoggingEnabledForStep,
+            mock.patch.object(_ProgressRecorder, "_chainLogTimeRemaining") as mock_chainLogTimeRemaining,
+        ):
+            mockGetStepKey.return_value = key0
+            step0 = mock.Mock(spec=ProgressStep, details=mock.Mock(spec=_Step, key=key0))
+            mockGetStep.return_value = step0
+            mockIsLoggingEnabledForStep.return_value = True
+
+            instance = _ProgressRecorder.model_construct(steps={key0: step0})
+            returnValue = instance.record(
+                callerOrStackFrameOverride=caller, stepName=stepName, N_ref=N_ref, N_ref_args=N_ref_args, order=order
+            )
+            assert returnValue is None
+
+            mockGetStepKey.assert_not_called()
+            mockGetStep.assert_not_called()
+            mockIsLoggingEnabledForStep.assert_not_called()
+            mock_chainLogTimeRemaining.assert_not_called()
+
+    def test_stop(self):
+        _now = datetime.now(timezone.utc)
+        _start = _now - timedelta(seconds=120.0)
+        _elapsed = (_now - _start).total_seconds()
+        key0 = mock.sentinel.key0
+        N_ref = 4096.0
+        N = N_ref**2
+
+        # enabled: gets the step, checks the stop time, calls `step.stop`,
+        #   logs the completion
+        with (
+            Config_override("application.workflows_data.timing.enabled", True),
+            Config_override("application.workflows_data.timing.max_measurements", 50),
+            Config_override("application.workflows_data.timing.update_minimum_count", 10),
+            Config_override("application.workflows_data.timing.update_threshold", 0.2),
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "datetime") as mock_datetime,
+            mock.patch.object(inspect.getmodule(_ProgressRecorder).sys, "exc_info") as mock_exc_info,
+            mock.patch.object(_ProgressRecorder, "getStep") as mockGetStep,
+            mock.patch.object(_ProgressRecorder, "_logCompletion") as mock_logCompletion,
+        ):
+            mock_datetime.now.return_value = _now
+            mock_exc_info.return_value = (None, None, None)
+            step0 = mock.Mock(
+                spec=ProgressStep,
+                details=mock.Mock(
+                    spec=_Step, key=key0, N_ref=mock.Mock(return_value=N_ref), order=mock.Mock(return_value=N)
+                ),
+                measurements=[],
+                estimate=mock.Mock(spec=_Estimate),
+                stop=mock.Mock(),
+                recordMeasurement=mock.Mock(),
+            )
+            # mock the `_Step` properties
+            mock_loggingEnabled = mock.PropertyMock(return_value=True)
+            mock_startTime = mock.PropertyMock(return_value=_start)
+            mock_N_ref = mock.PropertyMock(return_value=N_ref)
+            mock_dt = mock.PropertyMock(return_value=_elapsed)
+            mock_isSubstep = mock.PropertyMock(return_value=False)
+            type(step0).loggingEnabled = mock_loggingEnabled
+            type(step0).startTime = mock_startTime
+            type(step0).N_ref = mock_N_ref
+            type(step0).dt = mock_dt
+            type(step0).isSubstep = mock_isSubstep
+
+            mockGetStep.return_value = step0
+
+            instance = _ProgressRecorder.model_construct(steps={key0: step0})
+            instance._activeSteps = [step0]
+            instance.stop(key0)
+
+            assert not bool(instance._activeSteps)
+            mockGetStep.assert_called_once_with(key0)
+            step0.stop.assert_called_once()
+            mock_exc_info.assert_called_once()
+            mock_logCompletion.assert_called_once_with(key0, False)
+            mock_datetime.now.assert_called_once()
+            mock_startTime.assert_called_once()
+            mock_N_ref.assert_called_once()
+            mock_dt.assert_called_once()
+            mock_isSubstep.assert_called_once()
+            step0.details.N_ref.assert_not_called()
+            step0.details.order.assert_not_called()
+            step0.recordMeasurement.assert_called_once_with(dt_elapsed=_elapsed, dt_est=_elapsed, N_ref=N_ref)
+            step0.estimate.dt.assert_not_called()
+
+        # enabled: substep stack exception
+        with (
+            Config_override("application.workflows_data.timing.enabled", True),
+            Config_override("application.workflows_data.timing.max_measurements", 50),
+            Config_override("application.workflows_data.timing.update_minimum_count", 10),
+            Config_override("application.workflows_data.timing.update_threshold", 0.2),
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "datetime") as mock_datetime,
+            mock.patch.object(inspect.getmodule(_ProgressRecorder).sys, "exc_info") as mock_exc_info,
+            mock.patch.object(_ProgressRecorder, "getStep") as mockGetStep,
+            mock.patch.object(_ProgressRecorder, "_logCompletion") as mock_logCompletion,
+        ):
+            mock_datetime.now.return_value = _now
+            mock_exc_info.return_value = (None, None, None)
+            step0 = mock.Mock(
+                spec=ProgressStep,
+                details=mock.Mock(spec=_Step, key=key0, N_ref=mock.Mock(return_value=N_ref)),
+                measurements=[],
+                estimate=mock.Mock(spec=_Estimate),
+                stop=mock.Mock(),
+                recordMeasurement=mock.Mock(),
+            )
+            # mock the `_Step` properties
+            mock_loggingEnabled = mock.PropertyMock(return_value=True)
+            mock_startTime = mock.PropertyMock(return_value=_start)
+            mock_N_ref = mock.PropertyMock(return_value=N_ref)
+            mock_dt = mock.PropertyMock(return_value=_elapsed)
+            type(step0).loggingEnabled = mock_loggingEnabled
+            type(step0).startTime = mock_startTime
+            type(step0).N_ref = mock_N_ref
+            type(step0).dt = mock_dt
+            mockGetStep.return_value = step0
+
+            instance = _ProgressRecorder.model_construct(steps={key0: step0})
+            instance._activeSteps = []
+            with pytest.raises(RuntimeError, match="Usage error: `_activeSteps` stack underflow."):
+                instance.stop(key0)
+
+        # disabled: does nothing
+        with (
+            Config_override("application.workflows_data.timing.enabled", False),
+            Config_override("application.workflows_data.timing.max_measurements", 50),
+            Config_override("application.workflows_data.timing.update_minimum_count", 10),
+            Config_override("application.workflows_data.timing.update_threshold", 0.2),
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "datetime") as mock_datetime,
+            mock.patch.object(inspect.getmodule(_ProgressRecorder).sys, "exc_info") as mock_exc_info,
+            mock.patch.object(_ProgressRecorder, "getStep") as mockGetStep,
+            mock.patch.object(_ProgressRecorder, "_logCompletion") as mock_logCompletion,
+        ):
+            mock_datetime.now.return_value = _now
+            mock_exc_info.return_value = (None, None, None)
+            step0 = mock.Mock(
+                spec=ProgressStep,
+                details=mock.Mock(
+                    spec=_Step, key=key0, N_ref=mock.Mock(return_value=N_ref), order=mock.Mock(return_value=N)
+                ),
+                measurements=[],
+                estimate=mock.Mock(spec=_Estimate),
+                stop=mock.Mock(),
+                recordMeasurement=mock.Mock(),
+            )
+            # mock the `_Step` properties
+            mock_loggingEnabled = mock.PropertyMock(return_value=True)
+            mock_startTime = mock.PropertyMock(return_value=_start)
+            mock_N_ref = mock.PropertyMock(return_value=N_ref)
+            mock_dt = mock.PropertyMock(return_value=_elapsed)
+            type(step0).loggingEnabled = mock_loggingEnabled
+            type(step0).startTime = mock_startTime
+            type(step0).N_ref = mock_N_ref
+            type(step0).dt = mock_dt
+            mockGetStep.return_value = step0
+
+            instance = _ProgressRecorder.model_construct(steps={key0: step0})
+            instance.stop(key0)
+
+            mockGetStep.assert_not_called()
+            step0.stop.assert_not_called()
+            mock_exc_info.assert_not_called()
+            mock_logCompletion.assert_not_called()
+            mock_datetime.now.assert_not_called()
+            mock_startTime.assert_not_called()
+            mock_N_ref.assert_not_called()
+            mock_dt.assert_not_called()
+            step0.recordMeasurement.assert_not_called()
+            step0.details.N_ref.assert_not_called()
+            step0.details.order.assert_not_called()
+            step0.estimate.dt.assert_not_called()
+            step0.estimate.update.assert_not_called()
+
+        # does not record a measurement if `N_ref` could not be calculated
+        with (
+            Config_override("application.workflows_data.timing.enabled", True),
+            Config_override("application.workflows_data.timing.max_measurements", 50),
+            Config_override("application.workflows_data.timing.update_minimum_count", 5),
+            Config_override("application.workflows_data.timing.update_threshold", 0.2),
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "datetime") as mock_datetime,
+            mock.patch.object(inspect.getmodule(_ProgressRecorder).sys, "exc_info") as mock_exc_info,
+            mock.patch.object(_ProgressRecorder, "getStep") as mockGetStep,
+            mock.patch.object(_ProgressRecorder, "_logCompletion") as mock_logCompletion,
+        ):
+            mock_datetime.now.return_value = _now
+            mock_exc_info.return_value = (None, None, None)
+            step0 = mock.Mock(
+                spec=ProgressStep,
+                details=mock.Mock(
+                    spec=_Step,
+                    key=key0,
+                    # When `N_ref` cannot be calculated `N_ref()` returns `None`:
+                    #   however, what we care about for this test is the cached property value
+                    #   which is set via the property mock initialization below.
+                    N_ref=mock.Mock(return_value=mock.sentinel.N_ref),
+                    order=mock.Mock(return_value=mock.sentinel.N),
+                ),
+                measurements=[],
+                estimate=mock.Mock(spec=_Estimate),
+                stop=mock.Mock(),
+                recordMeasurement=mock.Mock(),
+            )
+            # mock the `_Step` properties
+            mock_loggingEnabled = mock.PropertyMock(return_value=True)
+            mock_startTime = mock.PropertyMock(return_value=_start)
+            # return `None` => `N_ref` could not be calculated
+            mock_N_ref = mock.PropertyMock(return_value=None)
+            # `N_ref is None` => `dt is None`
+            mock_dt = mock.PropertyMock(return_value=None)
+            mock_isSubstep = mock.PropertyMock(return_value=False)
+            type(step0).loggingEnabled = mock_loggingEnabled
+            type(step0).startTime = mock_startTime
+            type(step0).N_ref = mock_N_ref
+            type(step0).dt = mock_dt
+            type(step0).isSubstep = mock_isSubstep
+            mockGetStep.return_value = step0
+
+            instance = _ProgressRecorder.model_construct(steps={key0: step0})
+            instance._activeSteps = [step0]
+            instance.stop(key0)
+
+            assert not bool(instance._activeSteps)
+            mockGetStep.assert_called_once_with(key0)
+            step0.stop.assert_called_once()
+            mock_exc_info.assert_called_once()
+            mock_logCompletion.assert_called_once_with(key0, False)
+            mock_datetime.now.assert_called_once()
+            mock_startTime.assert_called_once()
+            mock_N_ref.assert_called_once()
+            mock_dt.assert_called_once()
+            step0.recordMeasurement.assert_not_called()
+            step0.details.N_ref.assert_not_called()
+            step0.details.order.assert_not_called()
+            step0.estimate.dt.assert_not_called()
+            step0.estimate.update.assert_not_called()
+
+        # exception in progress: gets the step, calls `step.stop`
+        with (
+            Config_override("application.workflows_data.timing.enabled", True),
+            Config_override("application.workflows_data.timing.max_measurements", 50),
+            Config_override("application.workflows_data.timing.update_minimum_count", 100),
+            Config_override("application.workflows_data.timing.update_threshold", 0.2),
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "datetime") as mock_datetime,
+            mock.patch.object(inspect.getmodule(_ProgressRecorder).sys, "exc_info") as mock_exc_info,
+            mock.patch.object(_ProgressRecorder, "getStep") as mockGetStep,
+            mock.patch.object(_ProgressRecorder, "_logCompletion") as mock_logCompletion,
+        ):
+            mock_datetime.now.return_value = _now
+            mock_exc_info.return_value = (RuntimeError, None, None)
+            step0 = mock.Mock(
+                spec=ProgressStep,
+                details=mock.Mock(
+                    spec=_Step,
+                    key=key0,
+                    N_ref=mock.Mock(return_value=mock.sentinel.N_ref),
+                    order=mock.Mock(return_value=mock.sentinel.N),
+                ),
+                measurements=[],
+                estimate=mock.Mock(spec=_Estimate),
+                stop=mock.Mock(),
+                recordMeasurement=mock.Mock(),
+            )
+            # mock the `_Step` properties
+            mock_loggingEnabled = mock.PropertyMock(return_value=True)
+            mock_startTime = mock.PropertyMock(return_value=_start)
+            mock_N_ref = mock.PropertyMock(return_value=N_ref)
+            mock_dt = mock.PropertyMock(return_value=_elapsed)
+            type(step0).loggingEnabled = mock_loggingEnabled
+            type(step0).startTime = mock_startTime
+            type(step0).N_ref = mock_N_ref
+            type(step0).dt = mock_dt
+            mockGetStep.return_value = step0
+
+            instance = _ProgressRecorder.model_construct(steps={key0: step0})
+            instance._activeSteps = [step0]
+            instance.stop(key0)
+
+            assert not bool(instance._activeSteps)
+            mockGetStep.assert_called_once_with(key0)
+            # timing properties are always called prior to `step.stop()`
+            mock_startTime.assert_called_once()
+            mock_N_ref.assert_called_once()
+            mock_dt.assert_called_once()
+            step0.stop.assert_called_once()
+            mock_exc_info.assert_called_once()
+            mock_logCompletion.assert_not_called()
+            mock_datetime.now.assert_not_called()
+            step0.recordMeasurement.assert_not_called()
+            step0.details.N_ref.assert_not_called()
+            step0.details.order.assert_not_called()
+            step0.estimate.dt.assert_not_called()
+            step0.estimate.update.assert_not_called()
+
+
+class TestWallClockTime:
+    class _Class:
+        attribute_one = 45.0
+
+        def N_ref(self):
+            pass
+
+        def method_one(self):
+            pass
+
+    class _Class2:
+        def method_two(self, *_args, **_kwargs):
+            pass
+
+    def test_decorator(self):
+        with mock.patch.object(inspect.getmodule(_ProgressRecorder), "ProgressRecorder") as mockProgressRecorder:
+            # `N_ref`, `order`, and `stepName` are optional
+            decorator = WallClockTime()
+            #   verify that default values are set
+            assert decorator.N_ref is not None
+            assert isinstance(decorator.N_ref, LambdaType)  # we can't compare a lambda directly
+            assert decorator.order == ComputationalOrder.O_0
+            assert decorator.stepName is None
+
+            # `N_ref_args` must not be specified
+            decorator = WallClockTime(
+                N_ref=lambda *args, **kwargs: args[0] * args[1] * len(kwargs), N_ref_args=((1.0, 2.0), {"one": 1.0})
+            )
+            with pytest.raises(RuntimeError, match=".*`N_ref_args` must not be specified.*"):
+                decorator(TestWallClockTime._Class.method_one)
+
+            ## decorating a class ##
+            decorator = WallClockTime(callerOverride="method_one")
+            decorator(TestWallClockTime._Class)
+
+            # -- specifying `N_ref` by name
+            decorator = WallClockTime(callerOverride="method_one", N_ref="N_ref")
+            decorator(TestWallClockTime._Class)
+
+            # -- `N_ref` by name, must be a method of the class
+            decorator = WallClockTime(callerOverride="method_one", N_ref="method_two")
+            with pytest.raises(
+                RuntimeError, match="Usage error.*\n.*N_ref.*\n.*the name of a method of the decorated class.*"
+            ):
+                decorator(TestWallClockTime._Class)
+
+            #  -- `callerOverride` must be specified
+            decorator = WallClockTime()
+            with pytest.raises(RuntimeError, match=".*`callerOverride` must be specified.*"):
+                decorator(TestWallClockTime._Class)
+
+            #  -- `callerOverride` must be a string
+            decorator = WallClockTime(callerOverride=TestWallClockTime._Class.method_one)
+            with pytest.raises(
+                RuntimeError, match=".*`callerOverride` must be the name of a method of the decorated class.*"
+            ):
+                decorator(TestWallClockTime._Class)
+
+            #  -- `callerOverride` must be a method (i.e. not some other attribute)
+            decorator = WallClockTime(callerOverride="attribute_one")
+            with pytest.raises(
+                RuntimeError, match=".*`callerOverride` must be the name of a method of the decorated class.*"
+            ):
+                decorator(TestWallClockTime._Class)
+
+            #  -- `callerOverride` must actually be a method of the decorated class
+            decorator = WallClockTime(callerOverride="method_two")
+            with pytest.raises(
+                RuntimeError, match=".*`callerOverride` must be the name of a method of the decorated class.*"
+            ):
+                decorator(TestWallClockTime._Class)
+
+            ## decorating a function ##
+            decorator = WallClockTime()
+            decorator(TestWallClockTime._Class.method_one)
+
+            # -- `N_ref` specified
+            decorator = WallClockTime(N_ref=TestWallClockTime._Class.N_ref)
+            decorator(TestWallClockTime._Class.method_one)
+
+            # -- `N_ref` specified as function, not by name
+            decorator = WallClockTime(N_ref="N_ref")
+            with pytest.raises(RuntimeError, match="Usage error.*\n.*N_ref.*must be a function.*"):
+                decorator(TestWallClockTime._Class.method_one)
+
+            #  -- `callerOverride` must not be specified
+            decorator = WallClockTime(callerOverride=TestWallClockTime._Class.method_one)
+            with pytest.raises(RuntimeError, match=".*`callerOverride` must not be specified.*"):
+                decorator(TestWallClockTime._Class.method_one)
+
+            ## only `FunctionType` or `type` can be decorated ##
+            decorator = WallClockTime()
+            with pytest.raises(RuntimeError, match=".*only `FunctionType` or `type` can be decorated.*"):  # noqa: PT012
+                # an attempt to decorate an instance
+                instance = TestWallClockTime._Class()
+                decorator(instance)
+
+            ## decorated function can not be re-entrant ##
+            decorator = WallClockTime()
+            wrapped = None
+
+            def _function(depth: int = 0):
+                if depth < 2:
+                    sleep(1)
+                    wrapped(depth + 1)
+
+            wrapped = decorator(_function)
+
+            # Question: CAN THIS EVEN HAPPEN with a decorator?
+            with pytest.raises(RuntimeError, match=".*decorated function is not re-entrant.*"):
+                wrapped()
+
+            ## verify that the wrapped function is profiled correctly
+            with mock.patch.object(inspect.getmodule(_ProgressRecorder), "functools") as mock_functools:
+                # disable `functools.wraps` decorator
+                mock_functools.wraps = mock.Mock(return_value=lambda func: func)
+
+                key = mock.sentinel.key
+                mockProgressRecorder.reset_mock()
+                mockProgressRecorder.record.return_value = key
+
+                def decoratee_(*_args, **_kwargs):
+                    sleep(1)
+
+                decoratee = mock.Mock(spec=FunctionType, side_effect=decoratee_)
+
+                decorator = WallClockTime(
+                    N_ref=mock.sentinel.N_ref, order=mock.sentinel.order, stepName=mock.sentinel.stepName
+                )
+                decorated = decorator(decoratee)
+                _args, _kwargs = ("one", "two"), {"three": "three", "four": "four"}
+                decorated(*_args, **_kwargs)
+
+                decoratee.assert_called_once_with(*_args, **_kwargs)
+                mockProgressRecorder.record.assert_called_once_with(
+                    stepName=mock.sentinel.stepName,
+                    callerOrStackFrameOverride=decoratee,
+                    N_ref=mock.sentinel.N_ref,
+                    N_ref_args=(_args, _kwargs),
+                    order=mock.sentinel.order,
+                    enableLogging=False,
+                )
+                mockProgressRecorder.stop.assert_called_once_with(key)
+
+            ## verify that a method of a class is profiled correctly
+            key = mock.sentinel.key
+            mockProgressRecorder.reset_mock()
+            mockProgressRecorder.record.return_value = key
+
+            with (
+                mock.patch.object(inspect.getmodule(_ProgressRecorder), "functools") as mock_functools,
+                mock.patch.object(
+                    TestWallClockTime._Class2, "method_two", spec=FunctionType, __name__="method_two"
+                ) as mock_method,
+            ):
+                # disable `functools.wraps` decorator
+                mock_functools.wraps = mock.Mock(return_value=lambda func: func)
+
+                decoratee = TestWallClockTime._Class2
+                decorator = WallClockTime(
+                    callerOverride="method_two",
+                    N_ref=mock.sentinel.N_ref,
+                    order=mock.sentinel.order,
+                    stepName=mock.sentinel.stepName,
+                )
+                decorated = decorator(decoratee)
+                instance = decorated()
+                _args, _kwargs = ("one", "two"), {"three": "three", "four": "four"}
+                instance.method_two(*_args, **_kwargs)
+
+                mock_method.assert_called_once_with(instance, *_args, **_kwargs)
+                mockProgressRecorder.record.assert_called_once_with(
+                    stepName=mock.sentinel.stepName,
+                    # step key is generated from the <class>, not from the <class method>
+                    callerOrStackFrameOverride=decoratee,
+                    N_ref=mock.sentinel.N_ref,
+                    N_ref_args=((instance, *_args), _kwargs),
+                    order=mock.sentinel.order,
+                    enableLogging=False,
+                )
+                mockProgressRecorder.stop.assert_called_once_with(key)
+
+    def test_context_manager(self):
+        with (
+            Config_override("application.workflows_data.timing.enabled", True),
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "ProgressRecorder") as mockProgressRecorder,
+        ):
+            key = mock.sentinel.key
+            mockProgressRecorder.record.return_value = key
+
+            # `N_ref` and `order` are optional
+            stepName = mock.sentinel.stepName
+            manager = WallClockTime(stepName=stepName)
+            assert manager.stepName == stepName
+
+            def _function(*_args, **_kwargs):
+                pass
+
+            # `N_ref` may be a function
+            stepName = mock.sentinel.stepName
+            manager = WallClockTime(stepName=stepName, N_ref=_function)
+            assert manager.stepName == stepName
+
+            # `N_ref` should not be a string
+            stepName = mock.sentinel.stepName
+            manager = WallClockTime(stepName=stepName, N_ref="_function")
+            assert manager.stepName == stepName
+
+            # `stepName` must be specified
+            mockProgressRecorder.reset_mock()
+
+            def _function():
+                with WallClockTime():
+                    sleep(1)
+
+            with pytest.raises(RuntimeError, match=".*`stepName` must be specified.*"):
+                _function()
+
+            # `callerOverride` must not be specified
+            mockProgressRecorder.reset_mock()
+
+            def _another_function():
+                pass
+
+            def _function():
+                with WallClockTime(stepName=stepName, callerOverride=_another_function):
+                    sleep(1)
+
+            with pytest.raises(RuntimeError, match=".*`callerOverride` must not be specified.*"):
+                _function()
+
+            # context manager cannot be re-used
+            mockProgressRecorder.reset_mock()
+
+            def _function():
+                manager = WallClockTime(stepName=stepName)
+                with manager:
+                    sleep(1)
+                with manager:
+                    sleep(1)
+
+            with pytest.raises(RuntimeError, match=".*context manager cannot be re-used.*"):
+                _function()
+
+            # correctly profiles the wrapped section
+            mockProgressRecorder.reset_mock()
+
+            def _N_ref(*_args, **_kwargs):
+                return mock.sentinel.N_ref
+
+            _N_ref_args = (mock.sentinel.args, mock.sentinel.kwargs)
+            _order = mock.sentinel.order
+
+            def _function():
+                with WallClockTime(stepName=stepName, N_ref=_N_ref, N_ref_args=_N_ref_args, order=_order):
+                    sleep(1)
+
+            _function()
+
+            class IsFrameType:
+                def __eq__(self, other):
+                    return isinstance(other, FrameType)
+
+            mockProgressRecorder.record.assert_called_once_with(
+                stepName=stepName,
+                # difficult to compare exactly: the calling stack frame was inside the `_function`
+                callerOrStackFrameOverride=IsFrameType(),
+                N_ref=_N_ref,
+                N_ref_args=_N_ref_args,
+                order=_order,
+                enableLogging=False,
+            )
+            mockProgressRecorder.stop.assert_called_once_with(key)
+
+        # disabled: does nothing
+        with (
+            Config_override("application.workflows_data.timing.enabled", False),
+            mock.patch.object(inspect.getmodule(_ProgressRecorder), "ProgressRecorder") as mockProgressRecorder,
+        ):
+
+            def _N_ref(*_args, **_kwargs):
+                return mock.sentinel.N_ref
+
+            _N_ref_args = (mock.sentinel.args, mock.sentinel.kwargs)
+            _order = mock.sentinel.order
+
+            def _function():
+                with WallClockTime(stepName=stepName, N_ref=_N_ref, N_ref_args=_N_ref_args, order=_order):
+                    sleep(1)
+
+            _function()
+
+            mockProgressRecorder.record.assert_not_called()
+            mockProgressRecorder.stop.assert_not_called()

--- a/tests/unit/backend/recipe/test_CrystallographicInfoRecipe.py
+++ b/tests/unit/backend/recipe/test_CrystallographicInfoRecipe.py
@@ -18,15 +18,18 @@ with mock.patch.dict(
         """Test success of crystal ingestion recipe with a good path name"""
         goodCIF = Resource.getPath("/inputs/crystalInfo/example.cif")
         assert Path(goodCIF).exists()
-
-        xtalRecipe = Recipe()
-        data = xtalRecipe.executeRecipe(goodCIF, 1.0, 10.0)
-        xtal = data["crystalInfo"]
-        assert isinstance(xtal, CrystallographicInfo)
-        assert xtal.hkl[0] == (1, 1, 1)
-        assert xtal.hkl[5] == (4, 0, 0)
-        assert xtal.dSpacing[0] == 3.13592994862768
-        assert xtal.dSpacing[4] == 1.0453099828758932
+        try:
+            xtalRecipe = Recipe()
+            data = xtalRecipe.executeRecipe(goodCIF, 1.0, 10.0)
+            xtal = data["crystalInfo"]
+        except BaseException:  # noqa: BLE001 E722
+            pytest.fail("valid file failed to open")
+        else:
+            assert isinstance(xtal, CrystallographicInfo)
+            assert xtal.hkl[0] == (1, 1, 1)
+            assert xtal.hkl[5] == (4, 0, 0)
+            assert xtal.dSpacing[0] == 3.13592994862768
+            assert xtal.dSpacing[4] == 1.0453099828758932
 
     def test_failed_path():
         """Test failure of crystal ingestion recipe with a bad path name"""
@@ -34,5 +37,5 @@ with mock.patch.dict(
         assert not Path(fakeCIF).exists()
 
         xtalRecipe = Recipe()
-        with pytest.raises(BaseException):  # noqa: PT011
+        with pytest.raises(Exception):  # noqa: PT011
             xtalRecipe.executeRecipe(fakeCIF)

--- a/tests/util/WhateversInTheFridge.py
+++ b/tests/util/WhateversInTheFridge.py
@@ -158,3 +158,13 @@ class WhateversInTheFridge(LocalDataService):
 
     def _readDefaultGroupingMap(self) -> GroupingMap:
         return DAOFactory.groupingMap_POP(stateId=DAOFactory.nonsense_state_id)
+
+    ### GENERALIZED PROGRESS REPORTING ###
+
+    def readProgressRecords(self) -> str:
+        # Returns the JSON representation of the current progress data.
+        return '{"steps": []}'
+
+    def writeProgressRecords(self, records: str):
+        # Writes the JSON representation of the current progress data.
+        pass


### PR DESCRIPTION
## Background

  It is straightforward to mathematically estimate the execution time for a computational process.  However, when such an estimate is applied in the real world, often it may end up being almost useless. This is usually because the effects of constant terms have been neglected at short timescales, and the effects of processing-system related issues have been neglected at long timescales.  For this reason, the current system for execution-time estimation is based on the specification of a computational order, combined with a set of empirical measurements of the process behavior.  In combination, these are then used to construct an estimator function, which may be applied to predict the execution-time behavior of the process.  Each measurement of the process consists of a single scalar reference value `N_ref`, combined with the associated wall-clock execution time.  An a priori computational order is selected from `{O_0, O_N, O_LOG_N, O_N_2, ...}` and is used to convert this `N_ref` into a value `N`, which is then used to construct the estimator function as `dt(N)`.  This latter construction uses a spline-fitting technique, with a constrained maximum degree.  Such an estimator will produce highly accurate values for `N_ref` falling within the interval of the measurements used in its construction, but somewhat less accurate values for `N_ref` falling outside of that interval.

## Design objectives

  * Use an efficient technique to obtain empirical timing measurements from relevant subsections of the running code.  This technique should be as flexible and non-intrusive as possible, both in terms of how a developer would apply it initially, but also in terms of the ease of making any required modifications to where it is applied.
  
  * As much as possible, the identification of which section of code a measurement comes from should be automatic.
  
  * Identifying when changes have been made to the `N_ref` function used to produce the estimator should also be automatic.  This allows the user to be notified that the existing set of empirical measurements is no longer valid, and should be discarded.  In this regard, note that the recorded measurements should include only the `N_ref` and the elapsed wall-clock time.  This means that detecting changes to the selected `order` is not a requirement, as for this case the estimator can simply be reconstructed from the existing measurements. 
  
  * The measurement technique must work with methods in a `Service` class, methods in a `Recipe` class, and any subsections within those methods.  To this end, both a decorator form and context-manager form of the `WallClockTime` profiler have been provided. Note that the actual requirement for the application of the decorator is that it is decorating either a \<class\> or a \<function\>, and the `Service` and `Recipe` are mentioned only as specific examples.  For application as a context manager, the local stack frame is used to determine the calling method.  In all cases an explicit step name (, which is optional for the decorator application), may be specified.
 
  * Time estimates should be available as required, for any _running_ process step.   The estimated completion time for each step should be logged.  As process-steps may be arbitrarily nested, logging from process substeps should be abbreviated.

## Implementation details

  * The primary class implementing both the timing measurement and the execution-time estimation is `ProgressRecorder`.  `ProgressRecorder` is applied by calling `record` at the start of an execution step, and `stop` at the end of the step.  
  
  * `ProgressRecorder` is exposed through its decorator / context-manager `WallClockTime`.  This is what should normally be used in application, and `record` and `stop` should not be called directly.
  
  *  Timing data produced by `ProgressRecorder` is persistent.  This data is stored at `${user.application.data.home}/workflows_data/timing`.  Retained timing data is limited both in the number of retained files, and also in the size of each of the files.
  
  * Progress-recording steps are automatically named using details from the scope of either the decorated function or class, or from the local scope of application of the context manager.  When used as a context-manager, an explicit step name must also be provided (, but this name is optional when used as a decorator).  In combination, this information is used to generate a step key in order to uniquely identify the progress-recording step.
  
  * Progress-recording steps must be unique, but otherwise may be arbitrarily nested.  A stack is used to keep track of which steps are currently being recorded.  Such steps are called _active_ steps.  Steps that become active while other steps are also active are called _substeps_.

  * At the start of each execution step, the current estimator for the step is used to predict the execution time.  There are special cases that may occur during this time calculation that will indicate that no such estimate can be calculated.  For example, we don't currently provide an estimate for `reduction` when `liveData` mode is active.  In these cases, the logging for the step will display simply "\<no data available\>". 
    
  * At the start of execution for a step which is not a substep, an automatic logging chain begins.  This logging chain reports on the progress of the execution at regular intervals, until either the step has completed execution, or the step has exceeded its time estimate.
  
  * Logging from any substep is much reduced.  For example, substep logging does not start an automatic logging chain.
  
  * At the successful completion of execution for each step, the measurement is recorded and the estimate is compared to the actual execution time.  If the disparity is above a threshold, and if there are enough data points available, the estimator will be updated.  If an exception occurs during the execution of a step, the system will properly enter that the step is no longer active, but no measurement data will be recorded.

  * When required, the estimator function is updated, but only if there are enough measurements available.  Usually this means that at least three (by default) measurements will be required.  If at all possible these measurements should be at distinct values of `N_ref`, but this is not a requirement.  Over time, the quality of the estimator should quickly improve.
    
  * When each `LogRecord` is generated, details of the \<step key\>, \<time estimate\> and the \<remaining time\> are added to the `extra` dict associated with the record.  This will in future allow a custom `Handler` to use these values as required to present a more ergonomic display of execution progress output.  For example, a separate pane which displays a set of progress bars for each in-progress step and substep might be implemented, based on this already available information.
  
  * To facilitate testing, a new IPC-based logging feature is provided which allows the viewing of logging output in separate terminal windows.  IPC-handler names are specified in "application.yml", and associated with each of these handlers is a list of logger names.  For example, the "application.yml" included with this PR associates the `ProgressRecorder` logger with a `SNAPRed-progress` IPC handler.  For security reasons, this IPC-based logging uses Unix-domain sockets (UDS), rather than localhost.  (See: "To test", below.)
     
## Known issues and what to expect when testing

  * The default (as initialized) linear estimator isn't very accurate.  It will automatically update when enough timing measurements are available (by default: 3 measurements).  The effect of this can be seen by looking over the JSON data, saved at `${user.application.data.home}/workflows_data/timing`, which should gradually become more accurate as new execution runs are added to the data.
  
  * In case distinct `N_ref` values are not used, the estimator will become accurate for those specific runs, but it won't be able to extrapolate very well to _different_ runs.  Regardless, it will continue to automatically update when it produces inaccurate estimates. Given enough distinct values it should quickly become accurate, even when extrapolation is required.
  
  * The treatment of `N_ref` can be quite complicated for workflows that are broken up into a lot of special cases.  For example, in the normalization workflow: maybe the grouping has already been calculated, or maybe such and such a required workspace is already in the ADS.  It's important to identify the primary case for profiling, and then to have the `N_ref` function return `None` when any special case occurs.  No attempt has been made to treat these special cases with the current system -- they are simply identified and the system does not attempt to estimate for those cases.  The simplest way to fix this issue is to move these special cases _out_ of the service, and up to the _workflow_ level.
  
  * For the normalization workflow: a cylindrical sample is assumed.  To treat the distinction between cylindrical and spherical samples probably will require the capability to enter multiple sets of measurements for each step, with multiple instances of the estimator.  This might be implemented for example, by having an additional subkey which depends on the `N_ref` args.

  * Only the primary workflows, and a few key recipes, have been decorated so far.  It would also be possible to decorate _all_ of the recipes.  In this regard, note that progress logging is only activated for a selected set of target steps.  This wouldn't necessarily increase logging output, but the increased amount of process data that we obtain could be quite useful.
  
  * Finally, the provided logging output is not at all an ergonomic way to provide progress reporting.  When displayed in a separate terminal window, it might be OK, but we definitely need a follow-on story to provide a better way to display this data.  A key requirement here is that any display method must work both with the SNAPRed GUI panel, but also when SNAPRed's backend is accessed via SNAPWrap.  Possibly, the initiation of the IPC-logging terminal window should be _automatic_.  For use by the end users, possibly the `IPC_server` might be launched as a `snapred` command-line option.

## To test

### Dev testing

For these tests, it will help if you already have a diffraction calibration, and a normalization-calibration for the runs to be used.

1. Remove any data files at `${HOME}/.snapred/workflows_data/timing/*.json`.  These might have been automatically generated when you ran any diffraction-calibration or normalization-calibration to prepare for these tests.  It's OK to simply delete these.

2. Start SNAPRed, either as `env=dev python -m snapred`, or from `mantidworkbench`.

3. Make a note of the process id (PID): `ps -u $USER | grep python`.  Note that `mantidworkbench` may have launched multiple `python` processes -- you need the first one.

4. In a separate terminal, in the SNAPRed environment, start an IPC-server for the `SNAPRed-progress` handler: `python tests/cis_tests/util/logging/IPC_server.py -n SNAPRed-progress -p ${PID}`

5. Run any workflow, but for example, let's use reduction.  Start by reducing data for one run.

6. Exit. (And also in the IPC-logging terminal, type CNTL-C to exit there!).  Now take a look at the JSON at `${HOME}/.snapred/workflows_data/timing`.  Especially note that both the `dt`, and the estimated `dt_est` have been recorded. Also note the details of the `estimate`: at this time this should still be the default estimator, which is linear: 1 GB in 3.0s.  Here you can also see how the  generated step keys work.

7. Repeat steps 1..3, to start a new SNAPRed process, with an associated IPC-logger.

8. Run the reduction workflow for several distinct runs: for example: "58810", "58812", "58813", and "59039".

9. Somewhere in the middle of the sequence "8", the reported estimates should become much more accurate. 

10. Exit (as in "6").  Again take a look at the latest data in `${HOME}/.snapred/workflows_data/timing` -- there should be two JSON files at this point.  Open the latest one, and note how the "estimate" values have changed to reflect the more accurate estimation of the execution time.

### CIS testing

As for "Dev testing".


## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#10717](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=10717)

### Verification

- [ ] the author has read the EWM story and acceptance criteria
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] acceptance criterion 1
- [ ] acceptance criterion 2
