### PR TITLE
ContinueWarning for DEFAULT_DIFFRACTION_CALIBRATION

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -169,14 +169,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.1-gpl_h98cc613_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.25.1-h3f43e3d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-33_h59b9bed_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-34_h59b9bed_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.88.0-h6c02f8c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.88.0-py311h5b7b71f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.75-h39aace5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-33_he106b2a_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-34_he106b2a_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp15-15.0.7-default_h127d8a8_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-20.1.8-default_ha444ac7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-hb8b1518_5.conda
@@ -211,7 +211,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h4ce23a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.8-ha4ef2c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.0-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-33_h7ac8fdf_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-34_h7ac8fdf_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblief-0.12.3-h27087fc_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-ha7bfdaf_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.8-hecd9e04_0.conda
@@ -300,7 +300,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py311h1322bbf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pint-0.24.4-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h537e5f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
@@ -340,7 +340,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.1.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.11.13-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-libarchive-c-5.3-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-libarchive-c-5.3-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h2dc5d0c_2.conda
@@ -373,7 +373,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.14-py311h9ecbd09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.8-py311h9ecbd09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel_yaml-0.15.80-py311h459d7ec_1009.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.12.7-hf9daec2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.12.8-hf9daec2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.0-py311h2d3ef60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.3.3-py311h38be061_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/seekpath-2.1.0-pyhd8ed1ab_1.conda
@@ -591,14 +591,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.1-gpl_h98cc613_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.25.1-h3f43e3d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-33_h59b9bed_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-34_h59b9bed_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.88.0-h6c02f8c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.88.0-py311h5b7b71f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.75-h39aace5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-33_he106b2a_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-34_he106b2a_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp15-15.0.7-default_h127d8a8_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-20.1.8-default_ha444ac7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-hb8b1518_5.conda
@@ -633,7 +633,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h4ce23a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.8-ha4ef2c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.0-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-33_h7ac8fdf_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-34_h7ac8fdf_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-ha7bfdaf_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.8-hecd9e04_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
@@ -710,7 +710,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py311h1322bbf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pint-0.24.4-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h537e5f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/poco-1.14.2-h0a6e815_0.conda
@@ -953,14 +953,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.1-gpl_h98cc613_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.25.1-h3f43e3d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.25.1-h3f43e3d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-33_h59b9bed_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-34_h59b9bed_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.88.0-h6c02f8c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.88.0-py311h5b7b71f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.75-h39aace5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-33_he106b2a_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-34_he106b2a_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp15-15.0.7-default_h127d8a8_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp19.1-19.1.7-default_hb5137d0_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-20.1.8-default_ha444ac7_0.conda
@@ -995,7 +995,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h4ce23a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.8-ha4ef2c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.0-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-33_h7ac8fdf_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-34_h7ac8fdf_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-ha7bfdaf_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm19-19.1.7-ha7bfdaf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.8-hecd9e04_0.conda
@@ -1072,7 +1072,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py311h1322bbf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pint-0.24.4-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h537e5f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
@@ -1121,7 +1121,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.14-py311h9ecbd09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.8-py311h9ecbd09_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.12.7-hf9daec2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.12.8-hf9daec2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.0-py311h2d3ef60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/seekpath-2.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
@@ -2050,7 +2050,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/distlib?source=compressed-mapping
+  - pkg:pypi/distlib?source=hash-mapping
   size: 275642
   timestamp: 1752823081585
 - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
@@ -3504,24 +3504,23 @@ packages:
   purls: []
   size: 34734
   timestamp: 1753342921605
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-33_h59b9bed_openblas.conda
-  build_number: 33
-  sha256: 18b165b45f3cea3892fee25a91b231abf29f521df76c8fcc0c92f6cf5071a911
-  md5: b43d5de8fe73c2a5fb2b43f45301285b
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-34_h59b9bed_openblas.conda
+  build_number: 34
+  sha256: 08a394ba934f68f102298259b150eb5c17a97c30c6da618e1baab4247366eab3
+  md5: 064c22bac20fecf2a99838f9b979374c
   depends:
   - libopenblas >=0.3.30,<0.3.31.0a0
   - libopenblas >=0.3.30,<1.0a0
   constrains:
   - mkl <2025
-  - liblapack  3.9.0   33*_openblas
-  - blas 2.133   openblas
-  - liblapacke 3.9.0   33*_openblas
-  - libcblas   3.9.0   33*_openblas
+  - blas 2.134   openblas
+  - liblapacke 3.9.0   34*_openblas
+  - libcblas   3.9.0   34*_openblas
+  - liblapack  3.9.0   34*_openblas
   license: BSD-3-Clause
-  license_family: BSD
   purls: []
-  size: 18778
-  timestamp: 1754412356514
+  size: 19306
+  timestamp: 1754678416811
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.88.0-h6c02f8c_0.conda
   sha256: 0f51eada581974dbaab5c763c2f26664d7c41fce441083c87d2204d55cb767da
   md5: e0afbff39e5218b5ccdac40ad3cbc5cf
@@ -3604,21 +3603,20 @@ packages:
   purls: []
   size: 120375
   timestamp: 1741176638215
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-33_he106b2a_openblas.conda
-  build_number: 33
-  sha256: b34271bb9c3b2377ac23c3fb1ecf45c08f8d09675ff8aad860f4e3c547b126a7
-  md5: 28052b5e6ea5bd283ac343c5c064b950
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-34_he106b2a_openblas.conda
+  build_number: 34
+  sha256: edde454897c7889c0323216516abb570a593de728c585b14ef41eda2b08ddf3a
+  md5: 148b531b5457ad666ed76ceb4c766505
   depends:
-  - libblas 3.9.0 33_h59b9bed_openblas
+  - libblas 3.9.0 34_h59b9bed_openblas
   constrains:
-  - liblapack  3.9.0   33*_openblas
-  - liblapacke 3.9.0   33*_openblas
-  - blas 2.133   openblas
+  - liblapacke 3.9.0   34*_openblas
+  - blas 2.134   openblas
+  - liblapack  3.9.0   34*_openblas
   license: BSD-3-Clause
-  license_family: BSD
   purls: []
-  size: 18748
-  timestamp: 1754412369555
+  size: 19313
+  timestamp: 1754678426220
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp15-15.0.7-default_h127d8a8_5.conda
   sha256: 9b0238e705a33da74ca82efd03974f499550f7dada1340cc9cb7c35a92411ed8
   md5: d0a9633b53cdc319b8a1a532ae7822b8
@@ -4068,21 +4066,20 @@ packages:
   purls: []
   size: 628947
   timestamp: 1745268527144
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-33_h7ac8fdf_openblas.conda
-  build_number: 33
-  sha256: 60c2ccdfa181bc304b5162c73cdecb5b4c3972da71758472c71fefb33965cde3
-  md5: e598bb54c4a4b45c3d83c72984f79dbb
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-34_h7ac8fdf_openblas.conda
+  build_number: 34
+  sha256: 9c941d5da239f614b53065bc5f8a705899326c60c9f349d9fbd7bd78298f13ab
+  md5: f05a31377b4d9a8d8740f47d1e70b70e
   depends:
-  - libblas 3.9.0 33_h59b9bed_openblas
+  - libblas 3.9.0 34_h59b9bed_openblas
   constrains:
-  - liblapacke 3.9.0   33*_openblas
-  - blas 2.133   openblas
-  - libcblas   3.9.0   33*_openblas
+  - liblapacke 3.9.0   34*_openblas
+  - libcblas   3.9.0   34*_openblas
+  - blas 2.134   openblas
   license: BSD-3-Clause
-  license_family: BSD
   purls: []
-  size: 18785
-  timestamp: 1754412383434
+  size: 19324
+  timestamp: 1754678435277
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblief-0.12.3-h27087fc_0.tar.bz2
   sha256: d7e5b39bcbc144463ca938c8cdb1dc73d2d204fb78c5aea200c07037517aebba
   md5: 2ed926c822a091c21d467429d1eaa92c
@@ -5458,7 +5455,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pint?source=compressed-mapping
+  - pkg:pypi/pint?source=hash-mapping
   size: 240361
   timestamp: 1753127340588
 - conda: https://conda.anaconda.org/conda-forge/noarch/pip-25.2-pyh8b19718_0.conda
@@ -5474,18 +5471,18 @@ packages:
   - pkg:pypi/pip?source=compressed-mapping
   size: 1177168
   timestamp: 1753924973872
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h537e5f6_0.conda
-  sha256: f1a4bed536f8860b4e67fcd17662884dfa364e515c195c6d2e41dbf70f19263b
-  md5: b0674781beef9e302a17c330213ec41a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+  sha256: 43d37bc9ca3b257c5dd7bf76a8426addbdec381f6786ff441dc90b1a49143b6a
+  md5: c01af13bdc553d1a8fbfff6e8db075f0
   depends:
-  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   license: MIT
-  license_family: MIT
   purls: []
-  size: 410140
-  timestamp: 1753105399719
+  size: 450960
+  timestamp: 1754665235234
 - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
   sha256: 353fd5a2c3ce31811a6272cd328874eb0d327b1eafd32a1e19001c4ad137ad3a
   md5: dc702b2fae7ebe770aff3c83adb16b63
@@ -6063,9 +6060,9 @@ packages:
   purls: []
   size: 47472
   timestamp: 1749048180043
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-libarchive-c-5.3-pyhe01879c_0.conda
-  sha256: 916fa14bc3a810dd9d8c295da941c160f61e2a7d93f67b676707c5a9ee719605
-  md5: 62f88e1e404f84d3ff7f68746ced7f0f
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-libarchive-c-5.3-pyhe01879c_1.conda
+  sha256: 1d95b449b0574dc9905ba575a7c1e2fdf8b42129b488407a95afa80fde97c9c8
+  md5: c0c03ce8d0b7809ba5d2b89ebb10bd42
   depends:
   - libarchive
   - python >=3.9
@@ -6073,8 +6070,8 @@ packages:
   license: CC0-1.0
   purls:
   - pkg:pypi/libarchive-c?source=hash-mapping
-  size: 28823
-  timestamp: 1747927321421
+  size: 29627
+  timestamp: 1754663558440
 - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
   build_number: 8
   sha256: fddf123692aa4b1fc48f0471e346400d9852d96eeed77dbfdd746fa50a8ff894
@@ -6655,22 +6652,21 @@ packages:
   - pkg:pypi/ruamel-yaml-conda?source=hash-mapping
   size: 325700
   timestamp: 1695546344673
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.12.7-hf9daec2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.12.8-hf9daec2_0.conda
   noarch: python
-  sha256: be3eb69d5f1bff60743289252dd37fc4369db01763cd0fb48e5cb0e340f665f9
-  md5: e1775b6c7aae7ea99b3677b6bb8fcf1d
+  sha256: a1489605292241b0f1d52cca9eab762e92ac8d37ed26ee7472b6637cc591889d
+  md5: cdd4c26d70310431c77a530174e4fe8e
   depends:
   - python
-  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   constrains:
   - __glibc >=2.17
   license: MIT
-  license_family: MIT
   purls:
-  - pkg:pypi/ruff?source=compressed-mapping
-  size: 10481171
-  timestamp: 1753906136472
+  - pkg:pypi/ruff?source=hash-mapping
+  size: 10492379
+  timestamp: 1754600833195
 - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.0-py311h2d3ef60_0.conda
   sha256: 52352d0f9388cf215c79690732e560bc6a33fb463a9176f6d2af6df84da8f4f7
   md5: 87f6abadb59e4b17fc3a7b666faa721f
@@ -6776,7 +6772,7 @@ packages:
   timestamp: 1753199211006
 - pypi: ./
   name: snapred
-  version: 1.4.0.dev33+d202508072046
+  version: 1.4.0.dev36
   sha256: aeb1e7dd9444a0d94a2c7d5897077353d93a9b58f4579937082d4ee8d92cfd7c
   requires_dist:
   - pyoncat~=1.6

--- a/src/snapred/backend/dao/WorkspaceMetadata.py
+++ b/src/snapred/backend/dao/WorkspaceMetadata.py
@@ -11,17 +11,17 @@ class DiffcalStateMetadata(StrEnum):
     """Class to hold tags related to a workspace"""
 
     UNSET: str = UNSET  # the default condition before any settings
-    DEFAULT: str = "default"  # the default condition before any settings
-    EXISTS: str = "exists"  # the state exists and the corresponding .h5 file located
+    EXISTS: str = "exists"  # the state exists and the corresponding .h5 file has been located
     ALTERNATE: str = "alternate"  # the user supplied an alternate .h5 that they believe is usable.
-    NONE: str = "none"  # proceed using the defaul (IDF) geometry.
+    # Note: `MISSING_DIFFRACTION_CALIBRATION` is now the same as the former `DEFAULT_DIFFRACTION_CALIBRATION`.
+    NONE: str = "none"  # proceed using the default (IDF + parameter values) geometry.
 
 
 class NormalizationStateMetadata(StrEnum):
     """Class to hold tags related to a workspace"""
 
     UNSET: str = UNSET  # the default condition before any settings
-    EXISTS: str = "exists"  # the state exists and the corresponding .h5 file located
+    EXISTS: str = "exists"  # the state exists and the corresponding .h5 file has been located
     ALTERNATE: str = "alternate"  # the user supplied an alternate .h5 that they believe is usable
     NONE: str = "none"  # proceed without applying any normalization
     FAKE: str = "fake"  # proceed by creating a "fake vanadium"
@@ -31,7 +31,7 @@ class ParticleNormalizationMethod(StrEnum):
     """Class to hold tags related to a workspace"""
 
     UNSET: str = UNSET  # the default condition before any settings
-    PROTON_CHARGE: str = "proton_charge"  # the state exists and the corresponding .h5 file located
+    PROTON_CHARGE: str = "proton_charge"  # the state exists and the corresponding .h5 file has been located
     MONITOR_COUNTS: str = "monitor_counts"  # the user supplied an alternate .h5 that they believe is usable
     NONE: str = "none"  # proceed without applying any normalization
 

--- a/src/snapred/backend/dao/indexing/Versioning.py
+++ b/src/snapred/backend/dao/indexing/Versioning.py
@@ -2,8 +2,12 @@ from snapred.meta.Config import Config
 from snapred.meta.Enum import StrEnum
 
 
-# NOTE: This should probably not be reconfigurable at runtime.
-#       This would be liable to only cause indexing issues.
+# NOTES:
+#   * This should probably not be reconfigurable at runtime.
+#     This would be liable to only cause indexing issues.
+#   * `VERSION_START` is used as the DEFAULT version number.
+#     For example, when diffraction calibration would otherwise
+#     be missing and the default diffraction calibration is used.
 def VERSION_START():
     return Config["version.start"]
 
@@ -16,7 +20,9 @@ class VersionState(StrEnum):
     LEGACY_INST_PRM = "1.4"
 
 
+""" TODO: remove this.
 # I'm not sure why ci is failing without this, it doesn't seem to be used anywhere
 VERSION_DEFAULT = VersionState.DEFAULT
+"""
 
 Version = int | VersionState

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -1090,6 +1090,8 @@ class LocalDataService:
         grocer.deleteWorkspaceUnconditional(outWS)
 
     def generateInstrumentState(self, runId: str):
+        # Generate a default instrument state.
+
         # Read the detector state from the PV data file,
         #   and generate the stateID SHA.
         stateId, detectorState = self.generateStateId(runId)

--- a/src/snapred/backend/error/ContinueWarning.py
+++ b/src/snapred/backend/error/ContinueWarning.py
@@ -13,9 +13,9 @@ class ContinueWarning(Exception):
 
     class Type(Flag):
         UNSET = 0
+        # Note: `MISSING_DIFFRACTION_CALIBRATION` is now the same as the former `DEFAULT_DIFFRACTION_CALIBRATION`.
         MISSING_DIFFRACTION_CALIBRATION = auto()
         ALTERNATE_DIFFRACTION_CALIBRATION = auto()
-        DEFAULT_DIFFRACTION_CALIBRATION = auto()
         MISSING_NORMALIZATION = auto()
         LOW_PEAK_COUNT = auto()
         NO_WRITE_PERMISSIONS = auto()

--- a/src/snapred/backend/recipe/algorithm/CreateArtificialNormalizationAlgo.py
+++ b/src/snapred/backend/recipe/algorithm/CreateArtificialNormalizationAlgo.py
@@ -149,11 +149,9 @@ class CreateArtificialNormalizationAlgo(PythonAlgorithm):
             )
 
         self.mantidSnapper.executeQueue()
-        self.outputWorkspace = self.mantidSnapper.mtd[self.outputWorkspaceName]
 
-        # Apply peak clipping to each histogram in the workspace
-        for i in range(self.outputWorkspace.getNumberHistograms()):
-            dataY = self.outputWorkspace.readY(i)
+        for i in range(self.mantidSnapper.mtd[self.outputWorkspaceName].getNumberHistograms()):
+            dataY = self.mantidSnapper.mtd[self.outputWorkspaceName].readY(i)
             clippedData = self.peakClip(
                 data=dataY,
                 winSize=self.peakWindowClippingSize,
@@ -161,7 +159,7 @@ class CreateArtificialNormalizationAlgo(PythonAlgorithm):
                 LLS=self.LSS,
                 smoothing=self.smoothingParameter,
             )
-            self.outputWorkspace.setY(i, clippedData)
+            self.mantidSnapper.mtd[self.outputWorkspaceName].setY(i, clippedData)
 
         # Set the output workspace property
         self.setProperty("OutputWorkspace", self.outputWorkspaceName)

--- a/src/snapred/meta/mantid/WorkspaceNameGenerator.py
+++ b/src/snapred/meta/mantid/WorkspaceNameGenerator.py
@@ -9,7 +9,6 @@ from pydantic import WithJsonSchema
 from pydantic.functional_validators import BeforeValidator
 from typing_extensions import Annotated, Self
 
-# *** DEBUG *** : CIRCULAR IMPORT?!
 from snapred.backend.dao.indexing.Versioning import VERSION_START, VersionState
 from snapred.meta.Config import Config
 from snapred.meta.decorators.classproperty import classproperty
@@ -223,9 +222,6 @@ class ValueFormatter:
     def formatVersion(cls, version: Optional[int], fmt=ValueFormat.versionFormat.WORKSPACE):
         # handle two special cases of unassigned or default version
         # in those cases, format will be a user-specified string
-
-        # *** DEBUG *** : CIRCULAR IMPORT?!
-        from snapred.backend.dao.indexing.Versioning import VersionState
 
         formattedVersion = ""
         if version == VersionState.DEFAULT:

--- a/src/snapred/ui/workflow/ReductionWorkflow.py
+++ b/src/snapred/ui/workflow/ReductionWorkflow.py
@@ -499,6 +499,7 @@ class ReductionWorkflow(WorkflowImplementer):
                     "Currently, Artificial Normalization can only be performed on a "
                     "single run at a time.  Please clear your run list and try again."
                 )
+
             for runNumber in self.runNumbers:
                 # Set status to indicate that the artificial normalization is being calculated.
                 self.setStatus(ReductionStatus.CALCULATING_NORM)

--- a/tests/integration/test_normalization.py
+++ b/tests/integration/test_normalization.py
@@ -8,9 +8,7 @@ import pytest
 from mantid.kernel import amend_config
 from qtpy import QtCore
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import (
-    QTabWidget,
-)
+from qtpy.QtWidgets import QTabWidget
 from util.pytest_helpers import calibration_home_from_mirror, handleStateInit  # noqa: F401
 from util.qt_mock_util import MockQMessageBox
 from util.TestSummary import TestSummary
@@ -31,12 +29,6 @@ class InterruptWithBlock(BaseException):
 class TestNormalizationPanels:
     @pytest.fixture(scope="function", autouse=True)  # noqa: PT003
     def _setup_gui(self, qapp):
-        testMock = MockQMessageBox()
-        msg = "No valid FocusGroups were specified for mode: 'lite'"
-        print(self)
-        self._logWarningsMessageBox = testMock.exec(msg)
-        self._logWarningsMessageBox[0].start()
-
         # Automatically continue at the end of each workflow.
         self._actionPrompt = mock.patch(
             "qtpy.QtWidgets.QMessageBox.information",
@@ -62,8 +54,8 @@ class TestNormalizationPanels:
                 self.testSummary.FAILURE()
             if self.testSummary.isFailure():
                 pytest.fail(f"Test Summary (-vv for full table): {self.testSummary}")
+
         # # teardown...
-        # self._logWarningsMessageBox.stop()
         self._actionPrompt.stop()
         self.exitStack.close()
 
@@ -159,10 +151,9 @@ class TestNormalizationPanels:
             # and verify the 2 corresponding msg boxes show up.
             # Repeat for Background Run number box
 
-            self._logWarningsMessageBox[0].stop()
             qtbot.wait(100)
 
-            msg = "Invalid run number: -1"
+            msg = ".*Invalid run number: -1.*"
             mp = MockQMessageBox().critical(msg)
             with mp[0]:
                 requestView.runNumberField.setText("-1")
@@ -171,7 +162,7 @@ class TestNormalizationPanels:
                 assert len(exceptions) == 0
                 assert mp[1].call_count == 1
 
-            msg = "Invalid run number: 1"
+            msg = ".*Invalid run number: 1.*"
             mp = MockQMessageBox().critical(msg)
             with mp[0]:
                 requestView.runNumberField.setText("1")
@@ -180,7 +171,7 @@ class TestNormalizationPanels:
                 assert len(exceptions) == 0
                 assert mp[1].call_count == 1
 
-            msg = "Invalid run number: -1"
+            msg = ".*Invalid run number: -1.*"
             mp = MockQMessageBox().critical(msg)
             with mp[0]:
                 requestView.backgroundRunNumberField.setText("-1")
@@ -189,7 +180,7 @@ class TestNormalizationPanels:
                 assert len(exceptions) == 0
                 assert mp[1].call_count == 1
 
-            msg = "Invalid run number: 1"
+            msg = ".*Invalid run number: 1.*"
             mp = MockQMessageBox().critical(msg)
             with mp[0]:
                 requestView.backgroundRunNumberField.setText("1")
@@ -199,7 +190,7 @@ class TestNormalizationPanels:
                 assert mp[1].call_count == 1
 
             # Enter 58810 for run number and 58813 for background and click continue
-            msg = "Please select a sample"
+            msg = ".*Please select a sample.*"
             mpCrit = MockQMessageBox().critical(msg)
             with mpCrit[0]:
                 requestView.runNumberField.setText("58810")
@@ -215,7 +206,7 @@ class TestNormalizationPanels:
                 assert mpCrit[1].call_count == 1
 
             # Select Vanadium Cylinder as sample and click continue
-            msg = "Please select a grouping file"
+            msg = ".*Please select a grouping file.*"
             mpCrit = MockQMessageBox().critical(msg)
             with mpCrit[0]:
                 requestView.sampleDropdown.setCurrentIndex(3)
@@ -243,12 +234,12 @@ class TestNormalizationPanels:
 
             handleStateInit(waitForStateInit, stateId, qtbot, qapp, actionCompleted, workflowNodeTabs)
 
-            msg = "No valid FocusGroups were specified for mode: 'lite'"
-            mp = MockQMessageBox().exec(msg, moduleRoot="snapred.ui.handler.SNAPResponseHandler")
+            msg = r".*Diffraction calibration is missing.*Would you like to continue anyway?.*"
+            mp = MockQMessageBox().exec(msg)
             mp[0].start()
+
             with qtbot.waitSignal(actionCompleted, timeout=60000):
                 qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
-
             qtbot.waitUntil(
                 lambda: isinstance(workflowNodeTabs.currentWidget().view, NormalizationTweakPeakView), timeout=60000
             )
@@ -257,9 +248,10 @@ class TestNormalizationPanels:
 
             # On tweak peaks tab, test each text field(3 of these) by putting non numeric chars and verify error msg
             tweakPeakView = workflowNodeTabs.currentWidget().view
+
             mp[0].stop()
 
-            msg = "Smoothing parameter must be a numerical value"
+            msg = ".*Smoothing parameter must be a numerical value.*"
             mpWarn = MockQMessageBox().warning(msg)
             with mpWarn[0]:
                 tweakPeakView.smoothingSlider.field.setValue("a")
@@ -268,8 +260,8 @@ class TestNormalizationPanels:
                 assert mpWarn[1].call_count == 1
 
             msg = (
-                "One of xtal dMin, xtal dMax, smoothing, or peak threshold is invalid: "
-                + "could not convert string to float: 'a'"
+                r".*One of xtal dMin, xtal dMax, smoothing, or peak threshold is invalid\: "
+                r"could not convert string to float: \'a\'.*"
             )
             mpWarn = MockQMessageBox().warning(msg)
             with mpWarn[0]:
@@ -281,8 +273,8 @@ class TestNormalizationPanels:
                 assert mpWarn[1].call_count == 1
 
             msg = (
-                "One of xtal dMin, xtal dMax, smoothing, or peak threshold is invalid: "
-                + "could not convert string to float: 'a'"
+                r".*One of xtal dMin, xtal dMax, smoothing, or peak threshold is invalid\: "
+                r"could not convert string to float: \'a\'.*"
             )
             mpWarn = MockQMessageBox().warning(msg)
             with mpWarn[0]:
@@ -294,8 +286,8 @@ class TestNormalizationPanels:
                 assert mpWarn[1].call_count == 1
 
             msg = (
-                "One of xtal dMin, xtal dMax, smoothing, or peak threshold is invalid: "
-                + "could not convert string to float: 'a'"
+                r".*One of xtal dMin, xtal dMax, smoothing, or peak threshold is invalid\: "
+                r"could not convert string to float: \'a\'.*"
             )
             mpWarn = MockQMessageBox().warning(msg)
             with mpWarn[0]:
@@ -305,7 +297,7 @@ class TestNormalizationPanels:
                 assert mpWarn[1].call_count == 1
 
             # Then set negative values and verify errors on recalculate
-            msg = "Smoothing parameter must be a nonnegative number"
+            msg = ".*Smoothing parameter must be a nonnegative number.*"
             mpWarn = MockQMessageBox().warning(msg)
             with mpWarn[0]:
                 tweakPeakView.fieldXtalDMax.setText("1")
@@ -315,11 +307,11 @@ class TestNormalizationPanels:
                 assert mpWarn[1].call_count == 1
 
             msg = (
-                "Are you sure you want to do this?"
-                + " This may cause memory overflow or may take a long time to compute."
+                r".*Are you sure you want to do this\?"
+                " This may cause memory overflow or may take a long time to compute.*"
             )
             mpWarn = MockQMessageBox().warning(msg)
-            msgCrit = "CrystallographicInfoAlgorithm  -- has failed -- dMin cannot be <= 0."
+            msgCrit = ".*CrystallographicInfoAlgorithm  -- has failed -- dMin cannot be <= 0.*"
             mpCrit = MockQMessageBox().critical(msgCrit)
             with mpWarn[0], mpCrit[0]:
                 tweakPeakView.fieldXtalDMin.setText("-1")
@@ -328,7 +320,7 @@ class TestNormalizationPanels:
                 assert len(exceptions) == 0
                 assert mpWarn[1].call_count == 1, mpWarn[1].call_args
 
-            msg = "The minimum crystal d-spacing exceeds the maximum (-1.0). Please enter a smaller value"
+            msg = r".*The minimum crystal d-spacing exceeds the maximum \(-1\.0\)\. Please enter a smaller value.*"
             mpWarn = MockQMessageBox().warning(msg)
             with mpWarn[0]:
                 tweakPeakView.fieldXtalDMin.setText("0.1")
@@ -339,10 +331,11 @@ class TestNormalizationPanels:
                 assert mpWarn[1].call_count == 1
 
             msgWarn = (
-                "Are you sure you want to do this? This may cause memory overflow or may take a long time to compute."
+                r".*Are you sure you want to do this\? "
+                r"This may cause memory overflow or may take a long time to compute.*"
             )
             mpWarn = MockQMessageBox().warning(msgWarn)
-            msgCrit = "CrystallographicInfoAlgorithm  -- has failed -- dMin cannot be <= 0."
+            msgCrit = ".*CrystallographicInfoAlgorithm  -- has failed -- dMin cannot be <= 0.*"
             mpCrit = MockQMessageBox().critical(msgCrit)
             with mpWarn[0], mpCrit[0]:
                 tweakPeakView.fieldXtalDMin.setText("-1")
@@ -394,8 +387,8 @@ class TestNormalizationPanels:
 
             # Do error checking on all text fields
 
-            # Set author to "Test"You must specify the author
-            msg = "You must specify the author"
+            # Set author to "Test" You must specify the author
+            msg = ".*You must specify the author.*"
             mpCrit = MockQMessageBox().critical(msg)
             with mpCrit[0]:
                 qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)
@@ -405,7 +398,7 @@ class TestNormalizationPanels:
             saveView.fieldAuthor.setText("Test")
 
             # Set Comments to "This is a test"You must add comments
-            msg = "You must add comments"
+            msg = ".*You must add comments.*"
             mpCrit = MockQMessageBox().critical(msg)
             with mpCrit[0]:
                 qtbot.mouseClick(workflowNodeTabs.currentWidget().continueButton, Qt.MouseButton.LeftButton)

--- a/tests/integration/test_reduction.py
+++ b/tests/integration/test_reduction.py
@@ -66,10 +66,7 @@ class TestGUIPanels:
             lambda self, *args, **kwargs: QMessageBox.Ok
             if (
                 "The backend has encountered warning(s)" in self.text()
-                and (
-                    "InstrumentDonor will only be used if GroupingFilename is in XML format." in self.detailedText()
-                    or "No valid FocusGroups were specified for mode: 'lite'" in self.detailedText()
-                )
+                and "InstrumentDonor will only be used if GroupingFilename is in XML format." in self.detailedText()
             )
             else pytest.fail(
                 "unexpected QMessageBox.exec:"
@@ -113,7 +110,7 @@ class TestGUIPanels:
         # teardown...
         self._warningMessageBox.stop()
         self._criticalMessageBox.stop()
-        # self._logWarningsMessageBox.stop()
+        self._logWarningsMessageBox.stop()
         self._actionPrompt.stop()
         self.exitStack.close()
 
@@ -236,8 +233,8 @@ class TestGUIPanels:
 
             # # Test case of using non numeric
             msg = (
-                "Reduction run numbers were incorrectly formatted: please read mantid docs"
-                + " for `IntArrayProperty` on how to format input"
+                ".*Reduction run numbers were incorrectly formatted: please read mantid docs"
+                " for `IntArrayProperty` on how to format input.*"
             )
             mp = MockQMessageBox().warning(msg)
             with mp[0]:
@@ -248,11 +245,12 @@ class TestGUIPanels:
                 assert mp[1].call_count == 1
 
             # # Test case of using low run number
-            msg = (
-                "Value error, Run number -1 is below the minimum value or data does not exist."
-                + "Please enter a valid run number"
+            msg = r".*There are issues with some run\(s\).*"
+            details = (
+                r".*Value error, Run number -1 is below the minimum value or data does not exist\."
+                r".*Please enter a valid run number.*"
             )
-            mp = MockQMessageBox().exec(msg)
+            mp = MockQMessageBox().exec(msg, detailedText_regex=details)
             with mp[0]:
                 requestView._requestView.runNumberInput.setText("-1")
                 qtbot.mouseClick(requestView._requestView.enterRunNumberButton, Qt.MouseButton.LeftButton)
@@ -367,9 +365,10 @@ class TestGUIPanels:
                 handleStateInit(waitForStateInit, reductionStateId, qtbot, qapp, actionCompleted, workflowNodeTabs)
 
                 msg = (
-                    "Warning: Reduction is missing normalization data."
-                    + " Artificial normalization will be created in place of actual normalization."
-                    + " Would you like to continue?"
+                    r"<p><b>Both normalization and diffraction calibrations are missing\.</b></p>"
+                    r"<p>Default calibration will be used in place of actual calibration\.</p>"
+                    r"<p>Artificial normalization will be created in place of actual normalization\.</p>"
+                    r"<p>Would you like to continue anyway\?</p>"
                 )
                 mp = MockQMessageBox().continueWarning(msg, moduleRoot="snapred.ui.handler.SNAPResponseHandler")
                 mb = MockQMessageBox().continueButton("Yes")
@@ -385,7 +384,7 @@ class TestGUIPanels:
                 )
                 artNormView = workflowNodeTabs.currentWidget().view
 
-                msg = "Smoothing or peak window clipping size is invalid: could not convert string to float: 'a'"
+                msg = r".*Smoothing or peak window clipping size is invalid: could not convert string to float: 'a'.*"
                 mp = MockQMessageBox().warning(msg)
                 with mp[0]:
                     artNormView.smoothingSlider.field.setText("a")
@@ -395,7 +394,10 @@ class TestGUIPanels:
                     assert mp[1].call_count == 1
                 artNormView.smoothingSlider.field.setText("5")
 
-                msg = "Smoothing or peak window clipping size is invalid: invalid literal for int() with base 10: 'a'"
+                msg = (
+                    r".*Smoothing or peak window clipping size is invalid: "
+                    r"invalid literal for int\(\) with base 10: 'a'.*"
+                )
                 mp = MockQMessageBox().warning(msg)
                 with mp[0]:
                     artNormView.peakWindowClippingSize.field.setText("a")
@@ -435,9 +437,10 @@ class TestGUIPanels:
                 handleStateInit(waitForStateInit, reductionStateId, qtbot, qapp, actionCompleted, workflowNodeTabs)
 
                 msg = (
-                    "Warning: Reduction is missing normalization data."
-                    + " Artificial normalization will be created in place of actual normalization."
-                    + " Would you like to continue?"
+                    r"<p><b>Both normalization and diffraction calibrations are missing\.</b></p>"
+                    r"<p>Default calibration will be used in place of actual calibration\.</p>"
+                    r"<p>Artificial normalization will be created in place of actual normalization\.</p>"
+                    r"<p>Would you like to continue anyway\?</p>"
                 )
                 mp = MockQMessageBox().continueWarning(msg)
                 mb = MockQMessageBox().continueButton("Continue without Normalization")
@@ -482,7 +485,7 @@ class TestGUIPanels:
                     return False
 
                 with patch.object(ReductionService, "checkReductionWritePermissions", denyPerm):
-                    msg2 = "<p>It looks like you don't have permissions to write to <br><b>"
+                    msg2 = ".*<p>It looks like you don't have permissions to write to <br><b>.*"
                     mp2 = MockQMessageBox().continueWarning(msg2)
                     mb = MockQMessageBox().continueButton("Yes")
                     with mp2[0], mb[0]:
@@ -566,13 +569,14 @@ class TestGUIPanels:
                 qtbot.wait(1000)
 
                 msg = (
-                    "Warning: Reduction is missing normalization data."
-                    + " Artificial normalization will be created in place of actual normalization."
-                    + " Would you like to continue?"
+                    r"<p><b>Both normalization and diffraction calibrations are missing\.</b></p>"
+                    r"<p>Default calibration will be used in place of actual calibration\.</p>"
+                    r"<p>Artificial normalization will be created in place of actual normalization\.</p>"
+                    r"<p>Would you like to continue anyway\?</p>"
                 )
                 critMsg = (
-                    "Error 500: Currently, Artificial Normalization can only be performed"
-                    + " on a single run at a time.  Please clear your run list and try again."
+                    r".*Error 500: Currently, Artificial Normalization can only be performed"
+                    r" on a single run at a time\.  Please clear your run list and try again.*"
                 )
                 mp = MockQMessageBox().continueWarning(msg)
                 mc = MockQMessageBox().critical(critMsg)

--- a/tests/unit/backend/dao/test_RunMetadata.py
+++ b/tests/unit/backend/dao/test_RunMetadata.py
@@ -209,10 +209,6 @@ class TestRunMetadata(unittest.TestCase):
         self._test_get_item(map_)
 
     def test_get_item_fromNeXusLogs(self):
-        # *** DEBUG ***
-        h5 = mockH5File(self.DASlogs, **self.specialValues)
-        print(f"++++++++++++>>> root: {h5['entry'].keys()}, logs: {h5['entry/DASlogs'].keys()}")
-
         map_ = RunMetadata.fromNeXusLogs(mockH5File(self.DASlogs, **self.specialValues))
         self._test_get_item(map_)
 

--- a/tests/unit/meta/test_LockFile.py
+++ b/tests/unit/meta/test_LockFile.py
@@ -72,9 +72,15 @@ class TestLockFile:
         with TemporaryDirectory() as temp_dir:
             lockedPath = Path(temp_dir)
             lockedPath_str = str(lockedPath)
-
-            with multiprocessing.Pool(processes=2) as pool:
-                lockFilePaths = pool.map(create_lock_file, [lockedPath_str, lockedPath_str])
+            lockFilePaths = []
+            with (Config_override("lockfile.ttl", 0), 
+                  Config_override("lockfile.checkFrequency", 0.1), 
+                  Config_override("lockfile.timeout", 1)):
+                with multiprocessing.Pool(processes=1) as pool:
+                    lockFilePaths.extend(pool.map(create_lock_file, [lockedPath_str]))
+                    
+                with multiprocessing.Pool(processes=1) as pool:
+                    lockFilePaths.extend(pool.map(create_lock_file, [lockedPath_str]))
 
             assert len(lockFilePaths) == 2
             assert lockFilePaths[0] != lockFilePaths[1]

--- a/tests/unit/meta/test_LockFile.py
+++ b/tests/unit/meta/test_LockFile.py
@@ -73,12 +73,14 @@ class TestLockFile:
             lockedPath = Path(temp_dir)
             lockedPath_str = str(lockedPath)
             lockFilePaths = []
-            with (Config_override("lockfile.ttl", 0), 
-                  Config_override("lockfile.checkFrequency", 0.1), 
-                  Config_override("lockfile.timeout", 1)):
+            with (
+                Config_override("lockfile.ttl", 0),
+                Config_override("lockfile.checkFrequency", 0.1),
+                Config_override("lockfile.timeout", 1),
+            ):
                 with multiprocessing.Pool(processes=1) as pool:
                     lockFilePaths.extend(pool.map(create_lock_file, [lockedPath_str]))
-                    
+
                 with multiprocessing.Pool(processes=1) as pool:
                     lockFilePaths.extend(pool.map(create_lock_file, [lockedPath_str]))
 


### PR DESCRIPTION
## Description of work
Previously the `ReductionWorkflow` only recognized the distinction between a _missing_ diffraction calibration, and any existing diffraction calibration including the default.  In reality, the workflow was never entered with an _actual_ missing diffraction calibration, as it always required the state to be initialized.  From the beginning, It had been intended that the default diffraction calibration be identified with the missing diffraction calibration case, but these issues were confused during the implementation.  With the changes of this PR, there is now only `MISSING_DIFFRACTION_CALIBRATION`, both in `ContinueWarning.Type`, and in the workspace-metadata markers.  Both the reduction and normalization workflows now warn the user that the diffraction calibration is _missing_, when only the default diffraction calibration exists.

## Explanation of work

**This PR includes the following changes:**
    
  * Equate `ContinueWarning.Type.MISSING_DIFFRACTION_CALIBRATION` with `ContinueWarning.Type.DEFAULT_DIFFRACTION_CALIBRATION`.  Remove alternate code paths, and metadata markers.  From this point on, only `MISSING_DIFFRACTION_CALIBRATION` should be used.
    
   * Add new exception checks: when called in any workflow, `getLatestApplicableCalibrationVersion` should never return `None`.  At present, it is required that the state be initialized, so if `None` is returned it indicates a developer error.  Since returning `None` actually has a valid meaning -- no diffraction calibration exists, even the default -- these checks are placed in the workflow validators, and not in the method itself.
    
  * Rework `ReductionService.validateReduction` so that it gives the appropriate warning when the calibration is missing -- it now warns the user that a default calibration will be used.
    
  * In `NormalizationService._validateDiffractionCalibration`, give the same warning.
    
  * For both workflows: update the metadata marking accordingly.
    
  * Make the continue-warning messages in normalization workflow and reduction workflow as similar as possible.
    
  * Cleanup the logic flow in `SNAPResponseHandler._handleContinueWarning` to use standard Qt practices.  Specifically, `QMessageBox.exec()` returns the _default_ codes, but for non-default buttons, the recommended practice is to test against the \<button instance\>, rather than the \<button text\>.  It would be preferable if somehow this case were moved to the `ReductionWorkflow`, but I did not attempt to do that.

**Misc. related defects fixed:**
    
  * 'MockQMessageBox': remove 'No valid FocusGroups were specified for mode: 'lite'' hack; rework to use regular expressions for expected 'text' and 'detailedText'.
    
  * snapred-data: add lite-mode groupings to the grouping maps -- for the moment, these are just the native-mode groupings, but with changed names.  If they are ever used, we will need to adjust the contents accordingly.
    
  * Fix intermittent failure in 'CreateArtificialNormalizationAlgo.py' (vanishing 'weakPtr' reference to workspace): 'Variable invalidated, data has been deleted.'.


## To test

### Dev testing

**[Compare the behavior on "next" and on this branch]:**

1. Move any existing calibration _state_ directory out of the way.
2. Initialize a state so that only the _default_ calibration is available.
3. Run a reduction using a run in this state.
4. In both the normalizaton and the reduction workflows:  while observing the sequence of `ContinueWarning` messages, step by step, continue until both a non-default calibration, and a _real_ normalization are available.  (Remember to set your "appliesTo" correctly when you save the calibrations!)

### CIS testing

As for "Dev testing".


## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#12331](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=12331)

