### PR TITLE
populate instrument parameters: workspace groups

### DIFF
--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -615,9 +615,9 @@ class GroceryService:
 
     def _fetchInstrumentDonor(self, runNumber: str, useLiteMode: bool) -> WorkspaceName:
         """
-        The grouping workspaces require an instrument definition, and do not have their own instrument definition
-        saved with them.  Therefore, when loading groupings, it is necessary to match them to
-        the proper instrument definition *with the proper instrument state params*.
+        Grouping and mask workspaces require an instrument definition, and do not have their own instrument definition
+        saved with them.  Therefore, for these workspace types, it is necessary to match them to
+        the proper instrument definition *with the proper instrument state parameters*.
         This uses the run number (and lite mode) to locate the proper state, and from that the proper instrument
         definition with instrument params for that state.
 

--- a/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
@@ -390,7 +390,10 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.setPropertyValue("OutputWorkspace", test_ws)
         with (
             mock.patch.object(algo, "mantidSnapper", mockSnapper_) as mockSnapper,
-            mock.patch.object(TestFetchGroceriesAlgorithm._MockMtd, "populateInstrumentParameters") as populateInstrumentParameters
+            mock.patch.object(
+                TestFetchGroceriesAlgorithm._MockMtd,
+                "populateInstrumentParameters"
+            ) as populateInstrumentParameters
         ):
             assert algo.execute()
             
@@ -422,10 +425,14 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.setPropertyValue("OutputWorkspace", "")
         with (
             mock.patch.object(algo, "mantidSnapper", mockSnapper_) as mockSnapper,
-            mock.patch.object(TestFetchGroceriesAlgorithm._MockMtd, "populateInstrumentParameters") as populateInstrumentParameters
+            mock.patch.object(
+                TestFetchGroceriesAlgorithm._MockMtd,
+                "populateInstrumentParameters"
+            ) as populateInstrumentParameters
         ):
             assert algo.execute()            
             populateInstrumentParameters.assert_not_called()
+            mockSnapper.executeQueue.assert_called_once()
     
     def test_populateInstrumentParameters_single_mask_workspace(self):
         # Test that `populateInstrumentParameters` is NOT called by `FetchGroceriesAlgorithm`
@@ -457,17 +464,23 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.setPropertyValue("OutputWorkspace", test_mask_ws)
         with (
             mock.patch.object(algo, "mantidSnapper", mockSnapper_) as mockSnapper,
-            mock.patch.object(TestFetchGroceriesAlgorithm._MockMtd, "populateInstrumentParameters") as populateInstrumentParameters
+            mock.patch.object(
+                TestFetchGroceriesAlgorithm._MockMtd,
+                "populateInstrumentParameters"
+            ) as populateInstrumentParameters
         ):
             assert algo.execute()            
             populateInstrumentParameters.assert_not_called()
+            mockSnapper.executeQueue.assert_called_once()
 
     def test_populateInstrumentParameters_group_workspace(self):
         # Test that `populateInstrumentParameters` is called for each workspace when a `WorkspaceGroup` is loaded.
         test_ws = "test_PIP_group"
         mockSnapper_ = mock.Mock()
         mockSnapper_.Load=mock.Mock(return_value=(None, "LoadNexusProcessed", None))
-        mockSnapper_.mtd = TestFetchGroceriesAlgorithm._MockMtd(wsNames=["ws1", "ws2", "ws3", "ws4", "ws5"])
+        mockSnapper_.mtd = TestFetchGroceriesAlgorithm._MockMtd(
+                               wsNames=["ws1", "ws2", "ws3", "ws4", "ws5"]
+                           )
         mockSnapper_.mtd.doesExist = mock.Mock(return_value=False)
         assert isinstance(mockSnapper_.mtd[test_ws], WorkspaceGroup)
         N_wss = len(mockSnapper_.mtd[test_ws].getNames())
@@ -479,7 +492,10 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.setPropertyValue("OutputWorkspace", test_ws)
         with (
             mock.patch.object(algo, "mantidSnapper", mockSnapper_) as mockSnapper,
-            mock.patch.object(TestFetchGroceriesAlgorithm._MockMtd, "populateInstrumentParameters") as populateInstrumentParameters
+            mock.patch.object(
+                TestFetchGroceriesAlgorithm._MockMtd,
+                "populateInstrumentParameters"
+            ) as populateInstrumentParameters
         ):
             assert algo.execute()
             assert populateInstrumentParameters.call_count == N_wss
@@ -488,11 +504,13 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
 
     def test_populateInstrumentParameters_group_workspace_with_table(self):
         # Test that `populateInstrumentParameters` is called for any `TableWorkspace` within a `WorkspaceGroup`.        
-        #   * Question: can `LoadNexusProcessed` actually deal with this type of workspace group?
+        #   * Question: can `LoadNexusProcessed` actually ever load a workspace group like this?
         test_ws = "test_PIP_group_with_table"
         mockSnapper_ = mock.Mock()
         mockSnapper_.Load=mock.Mock(return_value=(None, "LoadNexusProcessed", None))
-        mockSnapper_.mtd = TestFetchGroceriesAlgorithm._MockMtd(wsNames=["ws1", "ws2", "table_ws3", "ws4", "ws5"])
+        mockSnapper_.mtd = TestFetchGroceriesAlgorithm._MockMtd(
+                               wsNames=["ws1", "ws2", "table_ws3", "ws4", "ws5"]
+                           )
         mockSnapper_.mtd.doesExist = mock.Mock(return_value=False)
         assert isinstance(mockSnapper_.mtd[test_ws], WorkspaceGroup)
         N_wss = len(mockSnapper_.mtd[test_ws].getNames())
@@ -503,19 +521,25 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.setPropertyValue("OutputWorkspace", test_ws)
         with (
             mock.patch.object(algo, "mantidSnapper", mockSnapper_) as mockSnapper,
-            mock.patch.object(TestFetchGroceriesAlgorithm._MockMtd, "populateInstrumentParameters") as populateInstrumentParameters
+            mock.patch.object(
+                TestFetchGroceriesAlgorithm._MockMtd,
+                "populateInstrumentParameters"
+            ) as populateInstrumentParameters
         ):
             assert algo.execute()
             assert populateInstrumentParameters.call_count == N_wss - 1
             mockSnapper.executeQueue.assert_called_once()
 
     def test_populateInstrumentParameters_group_workspace_all_tables(self):
-        # Test that `populateInstrumentParameters` is NOT called for a `WorkspaceGroup` consisting entirely of `TableWorkspace`s.
-        #   * Question: can `LoadNexusProcessed` actually deal with this type of workspace group?
+        # Test that `populateInstrumentParameters` is NOT called for a `WorkspaceGroup`
+        # consisting entirely of `TableWorkspace`s.
+        #   * Question: can `LoadNexusProcessed` ever actually load a workspace group like this?
         test_ws = "test_PIP_group_all_tables"
         mockSnapper_ = mock.Mock()
         mockSnapper_.Load=mock.Mock(return_value=(None, "LoadNexusProcessed", None))
-        mockSnapper_.mtd = TestFetchGroceriesAlgorithm._MockMtd(wsNames=["table_ws1", "table_ws2", "table_ws3", "table_ws4", "table_ws5"])
+        mockSnapper_.mtd = TestFetchGroceriesAlgorithm._MockMtd(
+                               wsNames=["table_ws1", "table_ws2", "table_ws3", "table_ws4", "table_ws5"]
+                           )
         mockSnapper_.mtd.doesExist = mock.Mock(return_value=False)
         assert isinstance(mockSnapper_.mtd[test_ws], WorkspaceGroup)
         
@@ -525,7 +549,10 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.setPropertyValue("OutputWorkspace", test_ws)
         with (
             mock.patch.object(algo, "mantidSnapper", mockSnapper_) as mockSnapper,
-            mock.patch.object(TestFetchGroceriesAlgorithm._MockMtd, "populateInstrumentParameters") as populateInstrumentParameters
+            mock.patch.object(
+                TestFetchGroceriesAlgorithm._MockMtd,
+                "populateInstrumentParameters"
+            ) as populateInstrumentParameters
         ):
             assert algo.execute()
             populateInstrumentParameters.assert_not_called()


### PR DESCRIPTION
## Description of work
Recently `ExperimentInfo.populateInstrumentParameters` was exposed in Mantid's python api.  The effect of calling this method is _essential_ when loading any workspace which includes an instrument.  By default, when loading a workspace Mantid initializes the instrument-parameter values by reading from a single \<parameter map\> string, which _historically_ has not been written at full floating-point precision.  On calling `populateInstrumentParameters` the instrument parameter values are recalculated from the PV-logs, and reapplied to the detectors, thereby making the detector _positions_ and _rotations_ consistent.

In SNAPRed, for workspaces loaded from nexus format, `populateInstrumentParameters` is called within `FetchGroceriesAlgorithm`.  However, for grouping workspaces and mask workspaces, the corresponding call occurs within `LoadCalibrationWorkspaces`.  Since `FetchGroceriesAlgorithm` is also used to load diagnostic workspace groups, it's important to _recursively_ call `populateInstrumentParameters` for each workspace in a group (that has a type for which the call applies).

Formerly, there was a fallback implementation accomplishing the same effect as `populateInstrumentParameters` in `PV_logs_util`.  When the method was then exposed in Mantid's Python API, the translation between the two implementations wasn't performed correctly, and `populateInstrumentParameters` ended up being called _directly_ on `WorkspaceGroup`, which has no such method.

## Explanation of work
When `FetchGroceriesAlgorithm` uses `LoadNexusProcessed` to load a \<workspace group\>, all of the workspaces within that group are checked, and `populateInstrumentParameters` is called as appropriate.  

## To test

### Dev testing

The analogous unit tests from `PV_logs_util` have been updated and applied to test the current changes.  Note that the fallback utility method has not been removed from the codebase -- it should still be useful for diagnostic applications. In order to verify that this defect has been fixed, it's sufficient to compare the behavior between "next" and this branch.  **On "next", at the calibration assessment panel, this defect is triggered when one attempts to load a diagnostic `WorkspaceGroup` for comparison.**

### CIS testing


## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#12569](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=12569)

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->
