### PR TITLE
env overrides snapred-user.yml existing

### DIFF
--- a/src/snapred/meta/Config.py
+++ b/src/snapred/meta/Config.py
@@ -126,9 +126,14 @@ class _Config:
 
         self.reload()
         # if snapred-user.yml exists, then load it by default
-        if (self._userHome() / "snapred-user.yml").exists() and not isTestEnv():
+        if self.shouldSwapToUserYml():
             self._logger.info("Found user configuration file, swapping to it")
             self.swapToUserYml()
+
+    def shouldSwapToUserYml(self) -> bool:
+        isExplicitEnv = "env" in os.environ
+        isUserYmlExists = (self._userHome() / "snapred-user.yml").exists()
+        return isUserYmlExists and not isExplicitEnv and not isTestEnv()
 
     def _fix_directory_properties(self):
         """Some developers set instrument.home to use ~/ and this fixes that"""

--- a/tests/unit/meta/test_Config.py
+++ b/tests/unit/meta/test_Config.py
@@ -368,6 +368,27 @@ def test_swapToUserYml():
                 assert yml["instrument"]["calibration"]["home"] is not None
 
 
+def test_shouldSwapToUserYml():
+    # Test that the method returns True when the user configuration file exists and is not in a test environment
+    with mock.patch.object(Config, "_userHome") as mockHome, mock.patch.dict(os.environ, values={}, clear=True):
+        mockHome.return_value = Path("/tmp/snapred")
+        (mockHome.return_value / "snapred-user.yml").touch()
+        assert "env" not in os.environ
+        assert Config.shouldSwapToUserYml()
+
+    # Test that the method returns False when the user configuration file does not exist
+    with mock.patch.object(Config, "_userHome") as mockHome:
+        mockHome.return_value = Path("/tmp/snapred")
+        assert not Config.shouldSwapToUserYml()
+
+    # Test that the method returns False when the environment variable 'env' is set
+    with mock.patch.object(Config, "_userHome") as mockHome, mock.patch.dict(os.environ, {"env": "test"}):
+        mockHome.return_value = Path("/tmp/snapred")
+        (mockHome.return_value / "snapred-user.yml").touch()
+
+        assert not Config.shouldSwapToUserYml()
+
+
 def test_swapToUserYml_error():
     # setup temp dir
     with mock.patch.object(Config, "_userHome") as mockHome:


### PR DESCRIPTION
## Description of work

As the title states, this fixes the defect where an explicitly set env gets overridden  if a snapred-user.yml exists.
NOTE: Since it was mentioned in the ticket to double check, it should only generate a new snapred-user.yml if there is a version mismatch, i.e. snapred upgraded.  It does archive the old one before doing so.

## To test

1. Create `~/.snapred/snapred-user.yml`
2. Launch snapred with `env=dev` or your preferred yml override
3. Observe that it is correctly configured
4. Launch snapred without `env` set
5. Observe either a. it errors out because you have an ill formed `snapred-user.yml` or b. a log message from `Config` informs you that it found a `snapred-user.yml` and will override the config with it.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#11851](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=11851)

### Verification

- [ ] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [x] env takes precedence over snapred-user.yml
