### PR TITLE
Suppress the annoying `np.datetime64` errors

### DIFF
--- a/src/snapred/meta/Time.py
+++ b/src/snapred/meta/Time.py
@@ -24,9 +24,8 @@ def parseTimestamp(ts: float | str | int) -> float:
         # the warning is purely a nuissance and can be ignored
         # note there is an alternative solutiob using the python-dateutil library to handle strings
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=Warning)
-            time = np.datetime64(ts).astype(int) / 1e9  # convert to seconds
-        return time
+            warnings.filterwarnings("ignore", category=UserWarning)
+            return np.datetime64(ts).astype(int) / 1e9  # convert to seconds
     if isinstance(ts, int):
         # DEPRECIATED: support legacy integer encoding
         return float(ts) / 1000.0
@@ -41,7 +40,7 @@ def isoFromTimestamp(ts: float) -> str:
     # NOTE np.datetime64 throws an obnoxious warning if there is a timezone offset
     # it likely does not occur in this method, but it is safe to ignore it just in case
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=Warning)
+        warnings.filterwarnings("ignore", category=UserWarning)
         npDatetime = np.datetime64(ts_ns, "ns")
     iso = np.datetime_as_string(npDatetime, timezone="local", unit="ns")
     return iso

--- a/src/snapred/meta/Time.py
+++ b/src/snapred/meta/Time.py
@@ -25,7 +25,7 @@ def parseTimestamp(ts: float | str | int) -> float:
         # note there is an alternative solutiob using the python-dateutil library to handle strings
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning)
-            return np.datetime64(ts).astype(int) / 1e9  # convert to seconds
+            return float(np.datetime64(ts).astype(int) / 1e9)  # convert to seconds
     if isinstance(ts, int):
         # DEPRECIATED: support legacy integer encoding
         return float(ts) / 1000.0
@@ -42,5 +42,4 @@ def isoFromTimestamp(ts: float) -> str:
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=UserWarning)
         npDatetime = np.datetime64(ts_ns, "ns")
-    iso = np.datetime_as_string(npDatetime, timezone="local", unit="ns")
-    return iso
+    return str(np.datetime_as_string(npDatetime, timezone="local", unit="ns"))

--- a/src/snapred/meta/Time.py
+++ b/src/snapred/meta/Time.py
@@ -1,6 +1,7 @@
 import time
 
 import numpy as np
+import warnings
 
 
 def timestamp(ensureUnique: bool = False) -> float:
@@ -18,8 +19,14 @@ def timestamp(ensureUnique: bool = False) -> float:
 
 def parseTimestamp(ts: float | str | int) -> float:
     if isinstance(ts, str):
-        # Convert ISO format string to timestamp
-        return np.datetime64(ts).astype(int) / 1e9  # convert to seconds
+        # Convert string to timestamp -- the strings into this method are not always ISO format
+        # NOTE np.datetime64 throws an obnoxious warning if there is a timezone offset
+        # the warning is purely a nuissance and can be ignored
+        # note there is an alternative solutiob using the python-dateutil library to handle strings
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=Warning)
+            time = np.datetime64(ts).astype(int) / 1e9  # convert to seconds
+        return time
     if isinstance(ts, int):
         # DEPRECIATED: support legacy integer encoding
         return float(ts) / 1000.0
@@ -31,6 +38,10 @@ def parseTimestamp(ts: float | str | int) -> float:
 def isoFromTimestamp(ts: float) -> str:
     # Convert float timestamp (seconds) to integer nanoseconds
     ts_ns = int(ts * 1e9)
-    npDatetime = np.datetime64(ts_ns, "ns")
+    # NOTE np.datetime64 throws an obnoxious warning if there is a timezone offset
+    # it likely does not occur in this method, but it is safe to ignore it just in case
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=Warning)
+        npDatetime = np.datetime64(ts_ns, "ns")
     iso = np.datetime_as_string(npDatetime, timezone="local", unit="ns")
     return iso

--- a/src/snapred/meta/Time.py
+++ b/src/snapred/meta/Time.py
@@ -1,7 +1,7 @@
 import time
+import warnings
 
 import numpy as np
-import warnings
 
 
 def timestamp(ensureUnique: bool = False) -> float:

--- a/tests/unit/meta/test_Time.py
+++ b/tests/unit/meta/test_Time.py
@@ -1,3 +1,5 @@
+
+import time
 from unittest import TestCase
 
 from snapred.meta.Time import isoFromTimestamp, parseTimestamp, timestamp
@@ -25,7 +27,17 @@ class TestTime(TestCase):
         expected = 1717227296.789012
         assert parseTimestamp(ts) == expected
 
+    def test_parseTimestamp_error(self):
+        with self.assertRaises(ValueError):
+            parseTimestamp(None)
+        with self.assertRaises(ValueError):
+            parseTimestamp("invalid timestamp")
+        obj = ["x": 2]
+        with self.assertRaises(ValueError):
+            parseTimestamp(obj)
+
     def test_isoFromTimestamp(self):
         ts = 1717227296.789012
-        expected = "2024-06-01T03:34:56.789011968-0400"
+        localTimeZone = time.strftime("%z", time.localtime())
+        expected = "2024-06-01T03:34:56.789011968" + localTimeZone
         assert isoFromTimestamp(ts) == expected

--- a/tests/unit/meta/test_Time.py
+++ b/tests/unit/meta/test_Time.py
@@ -29,12 +29,12 @@ class TestTime(TestCase):
         assert parseTimestamp(ts) == expected
 
     def test_parseTimestamp_error(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Timestamp must be a float, int, or ISO format string"):
             parseTimestamp(None)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Error parsing datetime string"):
             parseTimestamp("invalid timestamp")
         obj = {"x": 2}
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Timestamp must be a float, int, or ISO format string"):
             parseTimestamp(obj)
 
     def test_isoFromTimestamp(self):

--- a/tests/unit/meta/test_Time.py
+++ b/tests/unit/meta/test_Time.py
@@ -38,5 +38,7 @@ class TestTime(TestCase):
     def test_isoFromTimestamp(self):
         ts = 1717227296.789012
         localTimeZone = time.strftime("%z", time.localtime())
-        expected = "2024-06-01T03:34:56.789011968" + localTimeZone
+        offsetHours = int(localTimeZone[:3])
+        print("offset Hours: ", offsetHours)
+        expected = f"2024-06-01T{(7 + offsetHours):02d}:34:56.789011968" + localTimeZone
         assert isoFromTimestamp(ts) == expected

--- a/tests/unit/meta/test_Time.py
+++ b/tests/unit/meta/test_Time.py
@@ -1,5 +1,6 @@
 import time
 from unittest import TestCase
+
 import pytest
 
 from snapred.meta.Time import isoFromTimestamp, parseTimestamp, timestamp

--- a/tests/unit/meta/test_Time.py
+++ b/tests/unit/meta/test_Time.py
@@ -1,5 +1,6 @@
 import time
 from unittest import TestCase
+import pytest
 
 from snapred.meta.Time import isoFromTimestamp, parseTimestamp, timestamp
 
@@ -27,18 +28,17 @@ class TestTime(TestCase):
         assert parseTimestamp(ts) == expected
 
     def test_parseTimestamp_error(self):
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             parseTimestamp(None)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             parseTimestamp("invalid timestamp")
         obj = {"x": 2}
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             parseTimestamp(obj)
 
     def test_isoFromTimestamp(self):
         ts = 1717227296.789012
         localTimeZone = time.strftime("%z", time.localtime())
         offsetHours = int(localTimeZone[:3])
-        print("offset Hours: ", offsetHours)
         expected = f"2024-06-01T{(7 + offsetHours):02d}:34:56.789011968" + localTimeZone
         assert isoFromTimestamp(ts) == expected

--- a/tests/unit/meta/test_Time.py
+++ b/tests/unit/meta/test_Time.py
@@ -1,4 +1,3 @@
-
 import time
 from unittest import TestCase
 

--- a/tests/unit/meta/test_Time.py
+++ b/tests/unit/meta/test_Time.py
@@ -1,0 +1,32 @@
+import os
+from typing import List
+from unittest import TestCase
+
+from snapred.meta.Time import timestamp, parseTimestamp, isoFromTimestamp
+
+class TestTime(TestCase):
+    def test_timestamp(self):
+        t1 = timestamp()
+        iso = isoFromTimestamp(t1)
+        t2 = parseTimestamp(iso)
+        assert t1 == t2
+
+    def test_timestamp_order(self):
+        t1 = timestamp()
+        t2 = timestamp()
+        assert t2 >= t1
+
+    def test_timestamp_ensureUnique(self):
+        t1 = timestamp(ensureUnique=True)
+        t2 = timestamp(ensureUnique=True)
+        assert t2 > t1
+
+    def test_parseTimestamp(self):
+        ts = "2024-06-01T03:34:56.789011968-0400"
+        expected = 1717227296.789012
+        assert parseTimestamp(ts) == expected
+
+    def test_isoFromTimestamp(self):
+        ts = 1717227296.789012
+        expected = "2024-06-01T03:34:56.789011968-0400"
+        assert isoFromTimestamp(ts) == expected

--- a/tests/unit/meta/test_Time.py
+++ b/tests/unit/meta/test_Time.py
@@ -1,8 +1,7 @@
-import os
-from typing import List
 from unittest import TestCase
 
-from snapred.meta.Time import timestamp, parseTimestamp, isoFromTimestamp
+from snapred.meta.Time import isoFromTimestamp, parseTimestamp, timestamp
+
 
 class TestTime(TestCase):
     def test_timestamp(self):

--- a/tests/unit/meta/test_Time.py
+++ b/tests/unit/meta/test_Time.py
@@ -32,7 +32,7 @@ class TestTime(TestCase):
             parseTimestamp(None)
         with self.assertRaises(ValueError):
             parseTimestamp("invalid timestamp")
-        obj = ["x": 2]
+        obj = {"x": 2}
         with self.assertRaises(ValueError):
             parseTimestamp(obj)
 


### PR DESCRIPTION
## Description of work

Recently, `numpy` fully deprecated the use of timezone offsets in `np,datetime64` constructor from strings.  This was throwing useless errors that confused users and made it seem that every SNAPRed reduction was failing.

These were handled by suppressing the errors inside of the central `Time.py` module.

## Explanation of work

This context manager successfully removes the error:
```python
with warnings.catch_warnings():
  warnings.filterwarnings("ignore", category=Warning)
  time = np.datetime64(ts).astype(int) / 1e9  # convert to seconds
```

## To test

### Dev testing

Open, and try running a complete calibration run.

### CIS testing

Please run an entire reduction run for a suitable file.

## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#14998](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=14998)

### Verification

- [x] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] acceptance criterion 1
- [ ] acceptance criterion 2
