### PR TITLE
live-data fixups: UDS sockets, run-status, and front-end reset sequence

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -26,7 +26,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.14.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.14.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-cli-base-0.8.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-client-1.14.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
@@ -61,7 +61,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-5.2.0-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-wheel-contents-0.6.3-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmarkgfm-2024.11.20-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
@@ -74,9 +74,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.5-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.5-py312ha4b625e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.7-py312ha4b625e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cyclopts-4.10.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cyclopts-4.10.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda
@@ -87,14 +87,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.1-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/elfutils-0.193-h849f50c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/erdantic-1.2.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/euphonic-1.6.0-py312h4f23490_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/euphonic-1.6.1-py312h4f23490_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.28.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flexcache-0.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flexparser-0.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.1.4-h07f6e7f_1.conda
@@ -126,12 +126,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.11-h651a532_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.11-hc37bda9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.17.0-h84d6215_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h0c6a113_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h021d004_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha4f8f14_101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-11.5.1-h15599e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha4f8f14_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.2.0-h15599e2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hatch-1.16.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.29.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
@@ -149,8 +149,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/imagesize-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.2.2-hde8ca8f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.5.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-7.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-7.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-7.2.0-pyha191276_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.12.0-pyhecfbec7_0.conda
@@ -223,12 +223,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.1-default_h3d81e11_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.8-hfac485b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblief-0.14.1-h5888daf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.8-hecd9e04_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm21-21.1.0-hecd9e04_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmamba-1.5.12-h44b872a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmambapy-1.5.12-py312h2549379_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmicrohttpd-1.0.2-hc2fc477_0.conda
@@ -241,15 +241,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.56-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.7-h5c52fec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.5-h074291d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librdkafka-2.13.2-he5e3081_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-he92a37e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-h49af25d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsolv-0.7.36-h9463b59_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-h0c1763c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
@@ -273,9 +273,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.4.5-py312h3d67a73_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-h280c20c_1002.conda
-      - conda: https://conda.anaconda.org/mantid/label/nightly/linux-64/mantid-6.15.20260331.2253-np21py312h62f99c1_0.conda
-      - conda: https://conda.anaconda.org/mantid/label/nightly/linux-64/mantidqt-6.15.20260331.2253-py312he48a509_0.conda
-      - conda: https://conda.anaconda.org/mantid/label/nightly/linux-64/mantidworkbench-6.15.20260331.2253-py312hc9b079f_0.conda
+      - conda: https://conda.anaconda.org/mantid/label/nightly/linux-64/mantid-6.15.20260413.1004-np21py312hf11577e_0.conda
+      - conda: https://conda.anaconda.org/mantid/label/nightly/linux-64/mantidqt-6.15.20260413.1004-py312he48a509_0.conda
+      - conda: https://conda.anaconda.org/mantid/label/nightly/linux-64/mantidworkbench-6.15.20260413.1004-py312h595221b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.9.4-py312h7900ff3_0.conda
@@ -283,7 +283,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/menuinst-2.4.2-py312h7900ff3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-11.0.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-11.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.2-py312hd9148b4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py312h8a5da7c_0.conda
@@ -304,10 +304,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.3-h8d634f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/orsopy-1.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.26.2-h3435931_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/patch-2.8-hb03c661_1002.conda
@@ -321,7 +321,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkce-1.0.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/poco-1.15.1-hbea8664_0.conda
@@ -344,8 +344,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyconify-0.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pycosat-0.6.6-py312h4c3975b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py312h868fb18_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.0-py312h868fb18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pygraphviz-1.14-py312hdfa1987_2.conda
@@ -358,11 +358,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.9.2-py312h5654102_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pystack-1.5.1-py312hf77101e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-qt-4.5.0-pyhdecd6ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-build-1.4.2-pyhc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-build-1.4.3-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
@@ -370,7 +370,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-libarchive-c-5.3-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.1.post1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyvista-0.47.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyvista-0.47.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyvistaqt-0.11.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
@@ -378,7 +378,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qscintilla2-2.14.1-py312h82c0db2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-gtk-platformtheme-5.15.15-h4e19bd6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h3a7ef08_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-webengine-5.15.15-h2da670d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-webengine-5.15.15-h0071231_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.9.2-h5bd77bc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/qtconsole-5.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/qtconsole-base-5.7.2-pyha770c72_0.conda
@@ -395,7 +395,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ripgrep-15.1.0-hdab8a38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/roman-numerals-4.1.0-pyhd8ed1ab_0.conda
@@ -403,7 +403,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.17-py312h5253ce2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py312h5253ce2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.9-h7805a7d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.10-h7805a7d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.3-py312h54fa4ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/scooby-0.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.4.1-py312h7900ff3_0.conda
@@ -430,7 +430,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-mermaid-2.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.52.0-hbc0de68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.0-hbc0de68_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/superqt-0.8.0-pyh9208f05_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-h8d10470_1.conda
@@ -449,7 +449,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/twine-6.2.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typenames-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.24.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20260408-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -460,7 +460,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/utfcpp-4.09-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.3-h0f56927_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.6-h0f56927_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/versioningit-3.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.39.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/vtk-base-9.4.2-py312h28cca35_1.conda
@@ -500,7 +500,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-cpp-0.8.0-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.23.0-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h387f397_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py312h5253ce2_1.conda
@@ -535,7 +535,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.14.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.14.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-cli-base-0.8.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-client-1.14.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
@@ -570,7 +570,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-5.2.0-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-wheel-contents-0.6.3-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmarkgfm-2024.11.20-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
@@ -583,9 +583,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.5-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.5-py312ha4b625e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.7-py312ha4b625e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cyclopts-4.10.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cyclopts-4.10.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda
@@ -596,14 +596,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.1-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/elfutils-0.193-h849f50c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/erdantic-1.2.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/euphonic-1.6.0-py312h4f23490_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/euphonic-1.6.1-py312h4f23490_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.28.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flexcache-0.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flexparser-0.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.1.4-h07f6e7f_1.conda
@@ -635,12 +635,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.11-h651a532_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.11-hc37bda9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.17.0-h84d6215_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h0c6a113_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h021d004_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha4f8f14_101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-11.5.1-h15599e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha4f8f14_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.2.0-h15599e2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hatch-1.16.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.29.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
@@ -658,8 +658,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/imagesize-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.2.2-hde8ca8f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.5.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-7.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-7.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-7.2.0-pyha191276_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.12.0-pyhecfbec7_0.conda
@@ -732,12 +732,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.1-default_h3d81e11_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.8-hfac485b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblief-0.14.1-h5888daf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.8-hecd9e04_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm21-21.1.0-hecd9e04_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmamba-1.5.12-h44b872a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmambapy-1.5.12-py312h2549379_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmicrohttpd-1.0.2-hc2fc477_0.conda
@@ -750,15 +750,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.56-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.7-h5c52fec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.5-h074291d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librdkafka-2.13.2-he5e3081_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-he92a37e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-h49af25d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsolv-0.7.36-h9463b59_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-h0c1763c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
@@ -782,9 +782,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.4.5-py312h3d67a73_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-h280c20c_1002.conda
-      - conda: https://conda.anaconda.org/mantid/label/nightly/linux-64/mantid-6.15.20260331.2253-np21py312h62f99c1_0.conda
-      - conda: https://conda.anaconda.org/mantid/label/nightly/linux-64/mantidqt-6.15.20260331.2253-py312he48a509_0.conda
-      - conda: https://conda.anaconda.org/mantid/label/nightly/linux-64/mantidworkbench-6.15.20260331.2253-py312hc9b079f_0.conda
+      - conda: https://conda.anaconda.org/mantid/label/nightly/linux-64/mantid-6.15.20260413.1004-np21py312hf11577e_0.conda
+      - conda: https://conda.anaconda.org/mantid/label/nightly/linux-64/mantidqt-6.15.20260413.1004-py312he48a509_0.conda
+      - conda: https://conda.anaconda.org/mantid/label/nightly/linux-64/mantidworkbench-6.15.20260413.1004-py312h595221b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.9.4-py312h7900ff3_0.conda
@@ -792,7 +792,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/menuinst-2.4.2-py312h7900ff3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-11.0.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-11.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.2-py312hd9148b4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py312h8a5da7c_0.conda
@@ -813,10 +813,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.3-h8d634f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/orsopy-1.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.26.2-h3435931_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/patch-2.8-hb03c661_1002.conda
@@ -830,7 +830,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkce-1.0.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/poco-1.15.1-hbea8664_0.conda
@@ -853,8 +853,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyconify-0.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pycosat-0.6.6-py312h4c3975b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py312h868fb18_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.0-py312h868fb18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pygraphviz-1.14-py312hdfa1987_2.conda
@@ -867,7 +867,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.9.2-py312h5654102_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pystack-1.5.1-py312hf77101e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-qt-4.5.0-pyhdecd6ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
@@ -878,7 +878,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-libarchive-c-5.3-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.1.post1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyvista-0.47.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyvista-0.47.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyvistaqt-0.11.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
@@ -886,7 +886,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qscintilla2-2.14.1-py312h82c0db2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-gtk-platformtheme-5.15.15-h4e19bd6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h3a7ef08_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-webengine-5.15.15-h2da670d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-webengine-5.15.15-h0071231_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.9.2-h5bd77bc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/qtconsole-5.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/qtconsole-base-5.7.2-pyha770c72_0.conda
@@ -903,7 +903,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ripgrep-15.1.0-hdab8a38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/roman-numerals-4.1.0-pyhd8ed1ab_0.conda
@@ -937,7 +937,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-mermaid-2.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.52.0-hbc0de68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.0-hbc0de68_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/superqt-0.8.0-pyh9208f05_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-h8d10470_1.conda
@@ -956,7 +956,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/twine-6.2.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typenames-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.24.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20260408-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -967,7 +967,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/utfcpp-4.09-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.3-h0f56927_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.6-h0f56927_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/versioningit-3.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.39.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/vtk-base-9.4.2-py312h28cca35_1.conda
@@ -1007,7 +1007,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-cpp-0.8.0-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.23.0-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h387f397_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py312h5253ce2_1.conda
@@ -1053,7 +1053,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py314h4a8dc5f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
@@ -1061,7 +1061,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/erdantic-1.2.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.28.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -1100,8 +1100,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-6_h4a7cf45_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-hd0affe5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-6_h0358290_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.0-default_h99862b1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.0-default_h746c552_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.3-default_h99862b1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.3-default_h746c552_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
@@ -1127,10 +1127,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h47877c9_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.2-hf7376ad_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.3-hf7376ad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
@@ -1138,11 +1138,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.56-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.3-h9abb657_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.1-h4c96295_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-hd0affe5_0.conda
@@ -1168,14 +1168,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.38-h29cc59b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.118-h445c969_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py314h2b28147_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-hbde042b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prettytable-3.17.0-pyhd8ed1ab_0.conda
@@ -1183,15 +1183,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pycifrw-5.0.1-py314h5bd0f2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py314h2e6c369_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.0-py314h2e6c369_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pygraphviz-1.14-py314h5b92a88_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.11-py314h92491ac_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.17.0-py314ha160325_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqtwebengine-5.15.11-py314hb4c45cb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_101_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.4-habeac84_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h0c412b5_8.conda
@@ -1199,7 +1199,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/qtpy-2.4.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/roman-numerals-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/roman-numerals-py-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
@@ -1225,7 +1225,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typenames-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.24.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20260408-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -1261,7 +1261,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: ./
   local-mantid:
@@ -1317,7 +1317,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.28.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -1336,7 +1336,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.26.10-h0363672_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.26.10-h17cb667_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py311hfef529e_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py311hfef529e_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.1.0-h6083320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
@@ -1361,8 +1361,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-hd0affe5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-6_h0358290_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp21.1-21.1.8-default_h99862b1_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.0-default_h99862b1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.0-default_h746c552_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.3-default_h99862b1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.3-default_h746c552_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.19.0-hcf29cc6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
@@ -1386,11 +1386,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm21-21.1.8-hf7376ad_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.2-hf7376ad_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.3-hf7376ad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
@@ -1399,10 +1399,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.56-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.3-h9abb657_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
@@ -1420,7 +1420,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.2-he237659_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.0.2-py311h8840267_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.0.4-py311h8840267_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.10.8-py311h38be061_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.8-py311h0f3be63_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
@@ -1432,15 +1432,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.118-h445c969_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py311h2e04523_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-hbde042b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.2.0-py311hf88fc01_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
@@ -1450,8 +1450,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pycifrw-5.0.1-py311h49ec1c0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py311h902ca64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.0-py311h902ca64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.11-py311h0580839_2.conda
@@ -1459,7 +1459,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqtwebengine-5.15.11-py311h1694d00_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.0-py311hf27b23e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-qt-4.5.0-pyhdecd6ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.15-hd63d673_0_cpython.conda
@@ -1475,7 +1475,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py311haee01d2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.9-h7805a7d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.10-h7805a7d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.1-h1cbb8d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py311hbe70eeb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
@@ -1520,7 +1520,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: ./
@@ -1550,7 +1550,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.14.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.14.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-cli-base-0.8.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-client-1.14.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
@@ -1585,7 +1585,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-5.2.0-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-wheel-contents-0.6.3-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmarkgfm-2024.11.20-py311h49ec1c0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
@@ -1598,9 +1598,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py311h724c32c_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.5-py311h3778330_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.15-py311hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.5-py311h2005dd1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.7-py311h2005dd1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cyclopts-4.10.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cyclopts-4.10.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.20-py311hc665b79_0.conda
@@ -1611,14 +1611,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.1-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/elfutils-0.193-h849f50c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/erdantic-1.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/euphonic-1.5.1-py311h0372a8f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.28.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flexcache-0.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flexparser-0.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.1.4-h07f6e7f_1.conda
@@ -1654,7 +1654,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py311h0b2f468_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py311h0b2f468_102.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-11.5.1-h15599e2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hatch-1.16.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.29.0-pyhcf101f3_0.conda
@@ -1673,8 +1673,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/imagesize-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.2.2-hde8ca8f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.5.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-7.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-7.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-7.2.0-pyha191276_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.10.1-pyh53cf698_0.conda
@@ -1728,8 +1728,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.5.0-ha770c72_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.5.0-h8f87c3e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.5.1-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.5.1-hf621623_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
@@ -1750,12 +1750,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.1-default_h3d81e11_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.8-hfac485b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblief-0.14.1-h5888daf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.8-hecd9e04_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm21-21.1.0-hecd9e04_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmamba-1.5.12-h44b872a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmambapy-1.5.12-py311h5f9230d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmicrohttpd-1.0.2-hc2fc477_0.conda
@@ -1769,7 +1769,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.56-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.7-h5c52fec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.5-h074291d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librdkafka-2.13.2-he5e3081_0.conda
@@ -1777,7 +1777,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsolv-0.7.36-h9463b59_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-h0c1763c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
@@ -1812,7 +1812,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/menuinst-2.4.2-py311h38be061_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-11.0.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-11.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mpi-1.0.1-mpich.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpi4py-4.1.1-py311h6c43bbb_103.conda
@@ -1836,10 +1836,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.3-h8d634f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/orsopy-1.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.26.2-h3435931_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/patch-2.8-hb03c661_1002.conda
@@ -1853,7 +1853,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkce-1.0.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/poco-1.15.0-hf15dec0_0.conda
@@ -1876,8 +1876,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyconify-0.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pycosat-0.6.6-py311h49ec1c0_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py311h902ca64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.0-py311h902ca64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pygraphviz-1.14-py311hf824169_2.conda
@@ -1890,7 +1890,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.9.2-py311h72d58bf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pystack-1.5.1-py311h50cc03b_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-qt-4.5.0-pyhdecd6ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.15-hd63d673_0_cpython.conda
@@ -1901,7 +1901,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-libarchive-c-5.3-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.1.post1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyvista-0.47.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyvista-0.47.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyvistaqt-0.11.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py311h3778330_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py311h57d2397_2.conda
@@ -1927,7 +1927,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ripgrep-15.1.0-hdab8a38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/roman-numerals-4.1.0-pyhd8ed1ab_0.conda
@@ -1961,7 +1961,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-mermaid-2.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.52.0-hbc0de68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.0-hbc0de68_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/superqt-0.8.0-pyh9208f05_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-h8d10470_1.conda
@@ -1980,7 +1980,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/twine-6.2.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typenames-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.24.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20260408-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -1992,7 +1992,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/utfcpp-4.09-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.3-h0f56927_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.6-h0f56927_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/versioningit-3.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.39.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/vtk-base-9.4.2-py311hc26c8ec_1.conda
@@ -2032,7 +2032,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-cpp-0.8.0-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.23.0-py311h3778330_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h387f397_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py311haee01d2_1.conda
@@ -2067,7 +2067,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.14.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.14.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-cli-base-0.8.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-client-1.14.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
@@ -2102,7 +2102,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/chardet-5.2.0-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-wheel-contents-0.6.3-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cmarkgfm-2024.11.20-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
@@ -2115,9 +2115,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.5-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.5-py312ha4b625e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.7-py312ha4b625e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cyclopts-4.10.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cyclopts-4.10.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda
@@ -2128,14 +2128,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.3.1-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/elfutils-0.193-h849f50c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/erdantic-1.2.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/euphonic-1.6.0-py312h4f23490_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/euphonic-1.6.1-py312h4f23490_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.28.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flexcache-0.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flexparser-0.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.1.4-h07f6e7f_1.conda
@@ -2167,12 +2167,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.11-h651a532_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.24.11-hc37bda9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gtest-1.17.0-h84d6215_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h0c6a113_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h021d004_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha4f8f14_101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-11.5.1-h15599e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha4f8f14_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.2.0-h15599e2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hatch-1.16.3-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.29.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
@@ -2190,8 +2190,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/imagesize-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.2.2-hde8ca8f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.5.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-7.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-7.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-7.2.0-pyha191276_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.12.0-pyhecfbec7_0.conda
@@ -2264,12 +2264,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.1-default_h3d81e11_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.8-hfac485b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblief-0.14.1-h5888daf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.8-hecd9e04_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm21-21.1.0-hecd9e04_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmamba-1.5.12-h44b872a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmambapy-1.5.12-py312h2549379_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmicrohttpd-1.0.2-hc2fc477_0.conda
@@ -2282,15 +2282,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.56-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.7-h5c52fec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.5-h074291d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librdkafka-2.13.2-he5e3081_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-he92a37e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-h49af25d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsolv-0.7.36-h9463b59_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-h0c1763c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
@@ -2324,7 +2324,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/menuinst-2.4.2-py312h7900ff3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-11.0.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-11.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.2-py312hd9148b4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py312h8a5da7c_0.conda
@@ -2345,10 +2345,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.3-h8d634f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/orsopy-1.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.26.2-h3435931_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/patch-2.8-hb03c661_1002.conda
@@ -2362,7 +2362,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkce-1.0.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkginfo-1.12.1.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/poco-1.15.1-hbea8664_0.conda
@@ -2385,8 +2385,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyconify-0.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pycosat-0.6.6-py312h4c3975b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py312h868fb18_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.0-py312h868fb18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pygraphviz-1.14-py312hdfa1987_2.conda
@@ -2399,7 +2399,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.9.2-py312h5654102_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pystack-1.5.1-py312hf77101e_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-qt-4.5.0-pyhdecd6ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
@@ -2410,7 +2410,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-libarchive-c-5.3-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.1.post1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyvista-0.47.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyvista-0.47.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyvistaqt-0.11.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
@@ -2418,7 +2418,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qscintilla2-2.14.1-py312h82c0db2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-gtk-platformtheme-5.15.15-h4e19bd6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-h3a7ef08_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-webengine-5.15.15-h2da670d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-webengine-5.15.15-h0071231_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.9.2-h5bd77bc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/qtconsole-5.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/qtconsole-base-5.7.2-pyha770c72_0.conda
@@ -2435,7 +2435,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-toolbelt-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ripgrep-15.1.0-hdab8a38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/roman-numerals-4.1.0-pyhd8ed1ab_0.conda
@@ -2469,7 +2469,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-mermaid-2.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.52.0-hbc0de68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.0-hbc0de68_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/superqt-0.8.0-pyh9208f05_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-h8d10470_1.conda
@@ -2488,7 +2488,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/twine-6.2.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typenames-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.24.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20260408-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -2499,7 +2499,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/utfcpp-4.09-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.3-h0f56927_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.6-h0f56927_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/versioningit-3.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.39.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/vtk-base-9.4.2-py312h28cca35_1.conda
@@ -2539,7 +2539,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-cpp-0.8.0-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.23.0-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h387f397_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py312h5253ce2_1.conda
@@ -2674,9 +2674,9 @@ packages:
   purls: []
   size: 584660
   timestamp: 1768327524772
-- conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.14.0-pyhd8ed1ab_0.conda
-  sha256: 402e5433ecc3d3ae06a9b43c3e45e769de86985ffd60e8355190802bba7ca3bb
-  md5: a60066d23ca609efbb14ada3e57fa98c
+- conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.14.1-pyhd8ed1ab_0.conda
+  sha256: d74184b93673483bbcee5319927ad522f059f291a0f1f2b00e8bff0badd995e2
+  md5: 18b8082600565ab922555ce01b785dc1
   depends:
   - anaconda-cli-base >=0.8.1
   - cryptography >=3.4.0
@@ -2690,15 +2690,15 @@ packages:
   - requests
   - semver <4
   constrains:
-  - conda >=23.9.0
-  - conda-token >=0.7.0
   - anaconda-cloud-auth >=0.8
+  - conda-token >=0.7.0
+  - conda >=23.9.0
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/anaconda-auth?source=hash-mapping
-  size: 52672
-  timestamp: 1774323340657
+  size: 53051
+  timestamp: 1775655411614
 - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-cli-base-0.8.2-pyhc364b38_0.conda
   sha256: a15e57650690f37bbe54f18e4ff429530b3bb54aa582ff9e3a9155921fec2804
   md5: af12e48f4d16dce2d160e3067930ad93
@@ -3325,7 +3325,7 @@ packages:
   - python >=3.10
   license: ISC
   purls:
-  - pkg:pypi/certifi?source=compressed-mapping
+  - pkg:pypi/certifi?source=hash-mapping
   size: 151445
   timestamp: 1772001170301
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py311h03d9500_1.conda
@@ -3427,19 +3427,19 @@ packages:
   - pkg:pypi/check-wheel-contents?source=hash-mapping
   size: 580700
   timestamp: 1754145812782
-- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
-  sha256: 38cfe1ee75b21a8361c8824f5544c3866f303af1762693a178266d7f198e8715
-  md5: ea8a6c3256897cc31263de9f455e25d9
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
+  sha256: 526d434cf5390310f40f34ea6ec4f0c225cdf1e419010e624d399b13b2059f0f
+  md5: 4d18bc3af7cfcea97bd817164672a08c
   depends:
-  - python >=3.10
   - __unix
   - python
+  - python >=3.10
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/click?source=hash-mapping
-  size: 97676
-  timestamp: 1764518652276
+  - pkg:pypi/click?source=compressed-mapping
+  size: 98253
+  timestamp: 1775578217828
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cmarkgfm-2024.11.20-py311h49ec1c0_1.conda
   sha256: 447b65e534b3104cbd55d98fcf06607d7d136f54be30577fbd654d9647717950
   md5: 59ff48e89b1a32ddfbe0d73de2498ec8
@@ -3707,7 +3707,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/contourpy?source=compressed-mapping
+  - pkg:pypi/contourpy?source=hash-mapping
   size: 320553
   timestamp: 1769155975008
 - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
@@ -3723,7 +3723,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/contourpy?source=compressed-mapping
+  - pkg:pypi/contourpy?source=hash-mapping
   size: 320386
   timestamp: 1769155979897
 - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.5-py311h3778330_0.conda
@@ -3738,7 +3738,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/coverage?source=compressed-mapping
+  - pkg:pypi/coverage?source=hash-mapping
   size: 399687
   timestamp: 1773761044419
 - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.5-py312h8a5da7c_0.conda
@@ -3753,7 +3753,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/coverage?source=compressed-mapping
+  - pkg:pypi/coverage?source=hash-mapping
   size: 387585
   timestamp: 1773761191371
 - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.15-py311hd8ed1ab_0.conda
@@ -3778,14 +3778,14 @@ packages:
   purls: []
   size: 46463
   timestamp: 1772728929620
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.5-py311h2005dd1_0.conda
-  sha256: 0b427b0f353ccf66a926360b6544ea18566e13099e661dcd35c61ffc9c0924e9
-  md5: f9c47968555906c9fe918f447d9abf1f
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.7-py311h2005dd1_0.conda
+  sha256: 4fea148d52c0408970a41aca41a0ea87675cc889f4d0387c21f39d3cf5ee6cde
+  md5: 62b09ad7f1907a1c91dd7226975ce4cd
   depends:
   - __glibc >=2.17,<3.0.a0
   - cffi >=1.14
   - libgcc >=14
-  - openssl >=3.5.5,<4.0a0
+  - openssl >=3.5.6,<4.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   constrains:
@@ -3793,17 +3793,17 @@ packages:
   license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
   license_family: BSD
   purls:
-  - pkg:pypi/cryptography?source=compressed-mapping
-  size: 1714583
-  timestamp: 1770772534804
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.5-py312ha4b625e_0.conda
-  sha256: 3a20020b7c9efbabfbfdd726ff303df81159e0c3a41a40ef8b37c3ce161a7849
-  md5: 4c69182866fcdd2fc335885b8f0ac192
+  - pkg:pypi/cryptography?source=hash-mapping
+  size: 2611406
+  timestamp: 1775637733645
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.7-py312ha4b625e_0.conda
+  sha256: ec1635e4c3016f85d170f9f8d060f8a615d352b55bb39255a12dd3a1903d476c
+  md5: ab9e1a0591be902a1707159b58460453
   depends:
   - __glibc >=2.17,<3.0.a0
   - cffi >=1.14
   - libgcc >=14
-  - openssl >=3.5.5,<4.0a0
+  - openssl >=3.5.6,<4.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   constrains:
@@ -3811,9 +3811,9 @@ packages:
   license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
   license_family: BSD
   purls:
-  - pkg:pypi/cryptography?source=hash-mapping
-  size: 1712251
-  timestamp: 1770772759286
+  - pkg:pypi/cryptography?source=compressed-mapping
+  size: 2534262
+  timestamp: 1775637873338
 - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
   sha256: bb47aec5338695ff8efbddbc669064a3b10fe34ad881fb8ad5d64fbfa6910ed1
   md5: 4c2a8fef270f6c69591889b93f9f55c1
@@ -3826,9 +3826,9 @@ packages:
   - pkg:pypi/cycler?source=hash-mapping
   size: 14778
   timestamp: 1764466758386
-- conda: https://conda.anaconda.org/conda-forge/noarch/cyclopts-4.10.1-pyhcf101f3_0.conda
-  sha256: aae95f265ed767d3ba490259bf9e14ec984f15aedf7e85a67da122a327f760ea
-  md5: 3718be965507e15f8c815e35b755600c
+- conda: https://conda.anaconda.org/conda-forge/noarch/cyclopts-4.10.2-pyhcf101f3_0.conda
+  sha256: ec17b8111ef1371452093931b1791156c00ff481e64e5a9e6e98817ca9f5d50d
+  md5: 2c07e2363c11ed772c045ef15bffe6bf
   depends:
   - python >=3.10
   - attrs >=23.1.0
@@ -3839,11 +3839,10 @@ packages:
   - tomli >=2.0.0
   - python
   license: Apache-2.0
-  license_family: APACHE
   purls:
   - pkg:pypi/cyclopts?source=hash-mapping
-  size: 163722
-  timestamp: 1774283230806
+  size: 163761
+  timestamp: 1776113754979
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
   sha256: 7684da83306bb69686c0506fb09aa7074e1a55ade50c3a879e4e5df6eebb1009
   md5: af491aae930edc096b58466c51c4126c
@@ -4009,17 +4008,17 @@ packages:
   purls: []
   size: 71809
   timestamp: 1765193127016
-- conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_1.conda
-  sha256: 8d4f908e670be360617d418c328213bc46e7100154c3742db085148141712f60
-  md5: 2cf824fe702d88e641eec9f9f653e170
+- conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.6-pyhcf101f3_0.conda
+  sha256: bb826ff403b8195467e7cd5f504bc14767b424dac27bb225508ca2c1852554b2
+  md5: 86b177231eecb011fe00e2117dbc3348
   depends:
-  - python >=3.9
+  - python >=3.10
+  - python
   license: MIT
-  license_family: MIT
   purls:
-  - pkg:pypi/editables?source=hash-mapping
-  size: 10828
-  timestamp: 1733208220327
+  - pkg:pypi/editables?source=compressed-mapping
+  size: 13160
+  timestamp: 1776172429816
 - conda: https://conda.anaconda.org/conda-forge/linux-64/elfutils-0.193-h849f50c_0.conda
   sha256: 21726a2d66cd76cac382311f63c26a56d3dad044be735666440f348a136f4588
   md5: c4548d6b94dde4ab418b1bb4cb583ecf
@@ -4106,9 +4105,9 @@ packages:
   - pkg:pypi/euphonic?source=hash-mapping
   size: 317596
   timestamp: 1767781349165
-- conda: https://conda.anaconda.org/conda-forge/linux-64/euphonic-1.6.0-py312h4f23490_0.conda
-  sha256: 6d82e6b7b259a337a31427c2880ac983479d955b5254b4f77c78c97381b9fa14
-  md5: 98e201681f3f75a6750b82b7285cfe45
+- conda: https://conda.anaconda.org/conda-forge/linux-64/euphonic-1.6.1-py312h4f23490_0.conda
+  sha256: c5902e19ba36741a970b61eceecad9875e2f8854ab19eb085d7a61ee478940b5
+  md5: 40d94395d8ceac2e0201bf717891a7bc
   depends:
   - __glibc >=2.17,<3.0.a0
   - _openmp_mutex >=4.5
@@ -4125,11 +4124,10 @@ packages:
   - threadpoolctl >=3.0.0
   - toolz >=0.12.1
   license: GPL-3.0-only
-  license_family: GPL
   purls:
   - pkg:pypi/euphonic?source=hash-mapping
-  size: 312625
-  timestamp: 1770757368164
+  size: 312551
+  timestamp: 1776193760939
 - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
   sha256: ee6cf346d017d954255bbcbdb424cddea4d14e4ed7e9813e429db1d795d01144
   md5: 8e662bd460bda79b1ea39194e3c4c9ab
@@ -4152,16 +4150,16 @@ packages:
   - pkg:pypi/executing?source=hash-mapping
   size: 30753
   timestamp: 1756729456476
-- conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.2-pyhd8ed1ab_0.conda
-  sha256: dddea9ec53d5e179de82c24569d41198f98db93314f0adae6b15195085d5567f
-  md5: f58064cec97b12a7136ebb8a6f8a129b
+- conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.28.0-pyhd8ed1ab_0.conda
+  sha256: d1151d785c346bc24bc19b4ee10f5cfd0b1963530e9ab6f7e4f3789640d1154e
+  md5: 60a871a0e893d6ec7083115beba05001
   depends:
   - python >=3.10
   license: Unlicense
   purls:
   - pkg:pypi/filelock?source=compressed-mapping
-  size: 25845
-  timestamp: 1773314012590
+  size: 33763
+  timestamp: 1776210480080
 - conda: https://conda.anaconda.org/conda-forge/noarch/flexcache-0.3-pyhd8ed1ab_1.conda
   sha256: acdb7b73d84268773fcc8192965994554411edc488ec3447925a62154e9d3baa
   md5: f1e618f2f783427019071b14a111b30d
@@ -4284,7 +4282,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/fonttools?source=compressed-mapping
+  - pkg:pypi/fonttools?source=hash-mapping
   size: 3018805
   timestamp: 1773137226454
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.62.0-py312h8a5da7c_0.conda
@@ -4301,7 +4299,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/fonttools?source=compressed-mapping
+  - pkg:pypi/fonttools?source=hash-mapping
   size: 2935817
   timestamp: 1773137546716
 - conda: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-ha6d2627_3.conda
@@ -4748,6 +4746,47 @@ packages:
   purls: []
   size: 416610
   timestamp: 1748320117187
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h021d004_4.conda
+  sha256: fc8abccb4b0d454891847bdd8163332ff8607aa33ea9cf1e43b3828fc88c42ce
+  md5: a891e341072432fafb853b3762957cbf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - at-spi2-atk >=2.38.0,<3.0a0
+  - atk-1.0 >=2.38.0
+  - cairo >=1.18.4,<2.0a0
+  - epoxy >=1.5.10,<1.6.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - fribidi >=1.0.10,<2.0a0
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - glib-tools
+  - harfbuzz >=10.4.0
+  - hicolor-icon-theme
+  - libcups >=2.3.3,<2.4.0a0
+  - libcups >=2.3.3,<3.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libglib >=2.82.2,<3.0a0
+  - liblzma >=5.6.4,<6.0a0
+  - libxkbcommon >=1.8.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pango >=1.56.1,<2.0a0
+  - wayland >=1.23.1,<2.0a0
+  - xorg-libx11 >=1.8.11,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxi >=1.8.2,<2.0a0
+  - xorg-libxinerama >=1.1.5,<1.2.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 5563940
+  timestamp: 1741694746664
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h0c6a113_5.conda
   sha256: d36263cbcbce34ec463ce92bd72efa198b55d987959eab6210cc256a0e79573b
   md5: 67d00e9cfe751cfe581726c5eff7c184
@@ -4870,9 +4909,9 @@ packages:
   - pkg:pypi/h2?source=hash-mapping
   size: 95967
   timestamp: 1756364871835
-- conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py311h0b2f468_101.conda
-  sha256: bc6f3f698839e83f594dee629b53c506de3a37595f4571c9b85d7464fe8e23e9
-  md5: 208b162b7be10f8398a88055190900f7
+- conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py311h0b2f468_102.conda
+  sha256: 61e3adb8218d57a2e7a91c7b4b4d338c3c0d23432ef0f2ed5bfc8d51f73735f3
+  md5: f476161e215ecee68daf16efbf209731
   depends:
   - __glibc >=2.17,<3.0.a0
   - cached-property
@@ -4884,12 +4923,12 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/h5py?source=compressed-mapping
-  size: 1356892
-  timestamp: 1774712270994
-- conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py311hfef529e_101.conda
-  sha256: 48be5eca81ff2f42a33801295eaa35efbefd95115339ca6b7b78f8cc7b7ac910
-  md5: fcde727bdcc518d0bef3754ed0bee07d
+  - pkg:pypi/h5py?source=hash-mapping
+  size: 1353682
+  timestamp: 1775581279300
+- conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py311hfef529e_102.conda
+  sha256: 9495b6fe2a7b1cf0fded3c53252e964d968fa1fc87cf1ce76c4d9c5e8ab22385
+  md5: 5737f2130791c91aee8374ee0d4465de
   depends:
   - __glibc >=2.17,<3.0.a0
   - cached-property
@@ -4902,11 +4941,11 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1362158
-  timestamp: 1774712273349
-- conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha4f8f14_101.conda
-  sha256: ea129e82173ea5841bc6ecf898ed03505252a7c0912c632d09c1b5ccffea6ca0
-  md5: 00cda48b891eb5189ec4ce1a469df0f6
+  size: 1359434
+  timestamp: 1775581283533
+- conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha4f8f14_102.conda
+  sha256: de9ec9b1b01b90f2da2d896a5835a2fd8049859aff0c6331ca4594327ec79a8b
+  md5: b270340809d19ae40ff9913f277b803a
   depends:
   - __glibc >=2.17,<3.0.a0
   - cached-property
@@ -4919,8 +4958,8 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/h5py?source=hash-mapping
-  size: 1334426
-  timestamp: 1774712279148
+  size: 1335314
+  timestamp: 1775581269364
 - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-11.5.1-h15599e2_0.conda
   sha256: 3bf149eab76768ed10f95eba015ca996cd6be7dc666996a004c4a8340a57cd60
   md5: b90a6ec73cc7d630981f78d4c7ca8fed
@@ -4941,6 +4980,26 @@ packages:
   purls: []
   size: 2427482
   timestamp: 1758640288422
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.2.0-h15599e2_0.conda
+  sha256: 6bd8b22beb7d40562b2889dc68232c589ff0d11a5ad3addd41a8570d11f039d9
+  md5: b8690f53007e9b5ee2c2178dd4ac778c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.14,<2.0a0
+  - icu >=75.1,<76.0a0
+  - libexpat >=2.7.1,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libglib >=2.86.1,<3.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 2411408
+  timestamp: 1762372726141
 - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.1.0-h6083320_0.conda
   sha256: 22c4f6df7eb4684a4b60e62de84211e7d80a0df2d7cfdbbd093a73650e3f2d45
   md5: ca8a94b613db5d805c3d2498a7c30997
@@ -5234,31 +5293,30 @@ packages:
   - pkg:pypi/importlib-metadata?source=compressed-mapping
   size: 34387
   timestamp: 1773931568510
-- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-6.5.2-pyhd8ed1ab_0.conda
-  sha256: a99a3dafdfff2bb648d2b10637c704400295cb2ba6dc929e2d814870cf9f6ae5
-  md5: e376ea42e9ae40f3278b0f79c9bf9826
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-resources-7.1.0-pyhd8ed1ab_0.conda
+  sha256: 6a2f86ef0965605d742b5b94229bf8b829258d0a9f640e3651901cc72ef9a0a5
+  md5: e3bffa82b874f8b9a2631bddb3869529
   depends:
-  - importlib_resources >=6.5.2,<6.5.3.0a0
-  - python >=3.9
+  - importlib_resources >=7.1.0,<7.1.1.0a0
+  - python >=3.10
   license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 9724
-  timestamp: 1736252443859
-- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
-  sha256: acc1d991837c0afb67c75b77fdc72b4bf022aac71fedd8b9ea45918ac9b08a80
-  md5: c85c76dc67d75619a92f51dfbce06992
+  purls:
+  - pkg:pypi/importlib-resources?source=compressed-mapping
+  size: 10354
+  timestamp: 1776068852701
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-7.1.0-pyhd8ed1ab_0.conda
+  sha256: a563a51aa522998172838e867e6dedcf630bc45796e8612f5a1f6d73e9c8125a
+  md5: 0ba6225c279baf7ea9473a62ea0ec9ae
   depends:
-  - python >=3.9
+  - python >=3.10
   - zipp >=3.1.0
   constrains:
-  - importlib-resources >=6.5.2,<6.5.3.0a0
+  - importlib-resources >=7.1.0,<7.1.1.0a0
   license: Apache-2.0
-  license_family: APACHE
   purls:
-  - pkg:pypi/importlib-resources?source=hash-mapping
-  size: 33781
-  timestamp: 1736252433366
+  - pkg:pypi/importlib-resources?source=compressed-mapping
+  size: 34809
+  timestamp: 1776068839274
 - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
   sha256: e1a9e3b1c8fe62dc3932a616c284b5d8cbe3124bbfbedcf4ce5c828cb166ee19
   md5: 9614359868482abba1bd15ce465e3c42
@@ -5267,7 +5325,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/iniconfig?source=compressed-mapping
+  - pkg:pypi/iniconfig?source=hash-mapping
   size: 13387
   timestamp: 1760831448842
 - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-7.2.0-pyha191276_1.conda
@@ -5339,7 +5397,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/ipython?source=compressed-mapping
+  - pkg:pypi/ipython?source=hash-mapping
   size: 649967
   timestamp: 1774609994657
 - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
@@ -5441,7 +5499,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jinja2?source=hash-mapping
+  - pkg:pypi/jinja2?source=compressed-mapping
   size: 120685
   timestamp: 1764517220861
 - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
@@ -5622,7 +5680,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/kiwisolver?source=compressed-mapping
+  - pkg:pypi/kiwisolver?source=hash-mapping
   size: 77967
   timestamp: 1773067041763
 - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py312h0a2e395_0.conda
@@ -5637,7 +5695,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/kiwisolver?source=compressed-mapping
+  - pkg:pypi/kiwisolver?source=hash-mapping
   size: 77120
   timestamp: 1773067050308
 - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
@@ -5937,19 +5995,19 @@ packages:
   purls: []
   size: 21066639
   timestamp: 1770190428756
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.0-default_h99862b1_0.conda
-  sha256: 914da94dbf829192b2bb360a7684b32e46f047a57de96a2f5ab39a011aeae6ea
-  md5: d966a23335e090a5410cc4f0dec8d00a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.3-default_h99862b1_1.conda
+  sha256: b3576e94643608758ecfc25e1c35a50441b1c729f4c0a9d8c137ac7c0cf58b5c
+  md5: 1cf5d6f2ae346ea959f223401764845c
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libllvm22 >=22.1.0,<22.2.0a0
+  - libllvm22 >=22.1.3,<22.2.0a0
   - libstdcxx >=14
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 21661249
-  timestamp: 1772101075353
+  size: 21627287
+  timestamp: 1776099638135
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-21.1.0-default_h746c552_1.conda
   sha256: e6c0123b888d6abf03c66c52ed89f9de1798dde930c5fd558774f26e994afbc6
   md5: 327c78a8ce710782425a89df851392f7
@@ -5963,19 +6021,19 @@ packages:
   purls: []
   size: 12358102
   timestamp: 1757383373129
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.0-default_h746c552_0.conda
-  sha256: 4a9dd814492a129f2ff40cd4ab0b942232c9e3c6dbc0d0aaf861f1f65e99cc7d
-  md5: 140459a7413d8f6884eb68205ce39a0d
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.3-default_h746c552_1.conda
+  sha256: 7a86861402343f1cc0845b837986d677dd93cfe5006d4f02126aa13581d93b41
+  md5: 80daec8cf93185515ac7b5d359e3f929
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libllvm22 >=22.1.0,<22.2.0a0
+  - libllvm22 >=22.1.3,<22.2.0a0
   - libstdcxx >=14
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 12817500
-  timestamp: 1772101411287
+  size: 12822694
+  timestamp: 1776099888592
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
   sha256: 205c4f19550f3647832ec44e35e6d93c8c206782bdd620c1d7cf66237580ff9c
   md5: 49c553b47ff679a6a1e9fc80b9c5a2d4
@@ -6130,29 +6188,29 @@ packages:
   purls: []
   size: 76624
   timestamp: 1774719175983
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.5.0-ha770c72_1.conda
-  sha256: 8178fcddd8f9419f28b38aa766103de2bd5501d5bb0689efb6d78b753166771a
-  md5: 85f6e5bf235010af3b8a72de8dfafb71
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.5.1-ha770c72_0.conda
+  sha256: 9d098af5bc668dc7ad9b762fdb7c509ec08e601c920efc132218ae37d0abe2f5
+  md5: d85028c6a2e14f54b120a3c937a59ede
   depends:
-  - libfabric1 2.5.0 h8f87c3e_1
+  - libfabric1 2.5.1 hf621623_0
   license: BSD-2-Clause OR GPL-2.0-only
   license_family: BSD
   purls: []
-  size: 14838
-  timestamp: 1774457775916
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.5.0-h8f87c3e_1.conda
-  sha256: afb4a5026907771ded464410d5971a909d1a52e12cdcebd080b2d8e915552c19
-  md5: c29115a9cb2decec04a8942c8e5c347c
+  size: 14945
+  timestamp: 1776131629515
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.5.1-hf621623_0.conda
+  sha256: 5feb4955dccce20dc9b8c94a8d7a58298da196ee5e69cc97fd44115f39dbeefb
+  md5: 042569510660f7580be2f5ce64432e7a
   depends:
-  - __glibc >=2.17,<3.0.a0
+  - __glibc >=2.28,<3.0.a0
   - libgcc >=14
   - libnl >=3.11.0,<4.0a0
   - rdma-core >=61.0
   license: BSD-2-Clause OR GPL-2.0-only
   license_family: BSD
   purls: []
-  size: 709812
-  timestamp: 1774457775193
+  size: 712300
+  timestamp: 1776131628810
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
   sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
   md5: a360c33a5abe61c07959e449fa1453eb
@@ -6436,9 +6494,9 @@ packages:
   purls: []
   size: 139036
   timestamp: 1760385590993
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
-  sha256: cc9aba923eea0af8e30e0f94f2ad7156e2984d80d1e8e7fe6be5a1f257f0eb32
-  md5: 8397539e3a0bbd1695584fb4f927485a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
+  sha256: 10056646c28115b174de81a44e23e3a0a3b95b5347d2e6c45cc6d49d35294256
+  md5: 6178c6f2fb254558238ef4e6c56fb782
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -6446,8 +6504,8 @@ packages:
   - jpeg <0.0.0a
   license: IJG AND BSD-3-Clause AND Zlib
   purls: []
-  size: 633710
-  timestamp: 1762094827865
+  size: 633831
+  timestamp: 1775962768273
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h47877c9_openblas.conda
   build_number: 6
   sha256: 371f517eb7010b21c6cc882c7606daccebb943307cb9a3bf2c70456a5c024f7d
@@ -6521,9 +6579,9 @@ packages:
   purls: []
   size: 44333366
   timestamp: 1765959132513
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.2-hf7376ad_0.conda
-  sha256: eda0013a9979d142f520747e3621749c493f5fbc8f9d13a52ac7a2b699338e7c
-  md5: 7147b0792a803cd5b9929ce5d48f7818
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.3-hf7376ad_0.conda
+  sha256: ad732019e8dd963efb5a54b5ff49168f191246bc418c3033762b6e8cb64b530c
+  md5: aeb186f7165bf287495a267fa8ff4129
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -6535,20 +6593,20 @@ packages:
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 44217146
-  timestamp: 1774480335347
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
-  sha256: 755c55ebab181d678c12e49cced893598f2bab22d582fbbf4d8b83c18be207eb
-  md5: c7c83eecbb72d88b940c249af56c8b17
+  size: 44235531
+  timestamp: 1775641389057
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+  sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
+  md5: b88d90cad08e6bc8ad540cb310a761fb
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   constrains:
-  - xz 5.8.2.*
+  - xz 5.8.3.*
   license: 0BSD
   purls: []
-  size: 113207
-  timestamp: 1768752626120
+  size: 113478
+  timestamp: 1775825492909
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libmamba-1.5.12-h44b872a_2.conda
   sha256: 729da9fa10c48327d529c963284eeb3a113bcc29e8cc37b80eb240981c799c09
   md5: ff5f9c18872c86ca9d85dba533507e65
@@ -6765,17 +6823,17 @@ packages:
   purls: []
   size: 28424
   timestamp: 1749901812541
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.56-h421ea60_0.conda
-  sha256: 4f9fca3bc21e485ec0b3eb88db108b6cf9ab9a481cdf7d2ac6f9d30350b45ead
-  md5: 97169784f0775c85683c3d8badcea2c3
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
+  sha256: 06323fb0a831440f0b72a53013182e1d4bb219e3ea958bb37af98b25dc0cf518
+  md5: 06f225e6d8c549ad6c0201679828a882
   depends:
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libzlib >=1.3.2,<2.0a0
   license: zlib-acknowledgement
   purls: []
-  size: 317540
-  timestamp: 1774513272700
+  size: 317779
+  timestamp: 1775692841709
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.7-h5c52fec_1.conda
   sha256: 06a8ace6cc5ee47b85a5e64fad621e5912a12a0202398f54f302eb4e8b9db1fd
   md5: a4769024afeab4b32ac8167c2f92c7ac
@@ -6838,6 +6896,26 @@ packages:
   purls: []
   size: 18375357
   timestamp: 1772457911476
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-h49af25d_2.conda
+  sha256: 475013475a3209c24a82f9e80c545d56ccca2fa04df85952852f3d73caa38ff9
+  md5: b9846db0abffb09847e2cb0fec4b4db6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.2,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - gdk-pixbuf >=2.42.12,<3.0a0
+  - harfbuzz >=10.1.0
+  - libgcc >=13
+  - libglib >=2.82.2,<3.0a0
+  - libpng >=1.6.44,<1.7.0a0
+  - libxml2 >=2.13.5,<2.14.0a0
+  - pango >=1.54.0,<2.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 6342757
+  timestamp: 1734902068235
 - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.58.4-he92a37e_3.conda
   sha256: a45ef03e6e700cc6ac6c375e27904531cf8ade27eb3857e080537ff283fb0507
   md5: d27665b20bc4d074b86e628b3ba5ab8b
@@ -6918,29 +6996,29 @@ packages:
   purls: []
   size: 519098
   timestamp: 1773328331358
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-h0c1763c_0.conda
-  sha256: 1daeb5187efcdbe3bdf2dc66f1161e09cb8dfd01618015d2106feae13cf3390d
-  md5: a7bda2babcbb004443cb1c0be9a8c353
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-h0c1763c_0.conda
+  sha256: d1688f91c013f9be0ad46492d4ec976ccc1dff5705a0b42be957abb73bf853bf
+  md5: 393c8b31bd128e3d979e7ec17e9507c6
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: blessing
   purls: []
-  size: 949843
-  timestamp: 1772818873928
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
-  sha256: d716847b7deca293d2e49ed1c8ab9e4b9e04b9d780aea49a97c26925b28a7993
-  md5: fd893f6a3002a635b5e50ceb9dd2c0f4
+  size: 954044
+  timestamp: 1775753743691
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
+  sha256: ec37c79f737933bbac965f5dc0f08ef2790247129a84bb3114fad4900adce401
+  md5: 810d83373448da85c3f673fbcb7ad3a3
   depends:
   - __glibc >=2.17,<3.0.a0
-  - icu >=78.2,<79.0a0
+  - icu >=78.3,<79.0a0
   - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: blessing
   purls: []
-  size: 951405
-  timestamp: 1772818874251
+  size: 958864
+  timestamp: 1775753750179
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
   sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
   md5: eecce068c7e4eddeb169591baac20ac4
@@ -7289,23 +7367,23 @@ packages:
   - pkg:pypi/loguru?source=hash-mapping
   size: 59696
   timestamp: 1746634858826
-- conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.0.2-py311h8840267_2.conda
-  sha256: 0ac54d70e352ed29db9114d87c37915f5c81687df13bc9b7e470148a183bbaca
-  md5: 70d29ba2cad4b6b18c0e63d4c9369d83
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.0.4-py311h8840267_0.conda
+  sha256: c8afa74df87afb8f2216e2c456c98c545968cbce37a88c931207c43c8cd40fcd
+  md5: a3a012bff94a3e283ace97069a42c74c
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libxml2
   - libxml2-16 >=2.14.6
   - libxslt >=1.1.43,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause and MIT-CMU
   purls:
   - pkg:pypi/lxml?source=hash-mapping
-  size: 1600828
-  timestamp: 1762506370014
+  size: 1562522
+  timestamp: 1776025070505
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.4.5-py311h1c460e0_1.conda
   sha256: a3c5fc64083cd168a65b0e5f8866e46edaeded85ed75f85a6c4dec9071447d5a
   md5: 987c0686ab1d618850db2fb0f837a88d
@@ -7483,9 +7561,9 @@ packages:
   license: GPL-3.0-or-later
   size: 39393439
   timestamp: 1774620141154
-- conda: https://conda.anaconda.org/mantid/label/nightly/linux-64/mantid-6.15.20260331.2253-np21py312h62f99c1_0.conda
-  sha256: a550059b89d56687742fa0a586fe24fc4a942d060898a82a573a5772c06805ca
-  md5: 31614e9b3f99fc527394c390707b36d7
+- conda: https://conda.anaconda.org/mantid/label/nightly/linux-64/mantid-6.15.20260413.1004-np21py312hf11577e_0.conda
+  sha256: 3889316893d4eb0e08b3aafb3a9cffb363d439955039a51e42ee6cc06f79b37c
+  md5: 97a8bcb3c0eae65afd1d6ba70cf001b9
   depends:
   - gsl >=2.8,<2.9.0a0
   - hdf4 >=4.2.15,<4.3.0a0
@@ -7510,37 +7588,37 @@ packages:
   - libboost-python >=1.88.0,<1.89.0a0
   - libglu >=9.0
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - _openmp_mutex >=4.5
   - libstdcxx >=13
   - libgcc >=13
-  - libopenblas >=0.3.27,<1.0a0
-  - gsl >=2.8,<2.9.0a0
-  - numpy >=1.21,<3
-  - jsoncpp >=1.9.6,<1.9.7.0a0
-  - muparser >=2.3.4,<2.4.0a0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - _openmp_mutex >=4.5
+  - libgcc >=13
   - tbb >=2021.13.0
-  - python_abi 3.12.* *_cp312
-  - libzlib >=1.3.2,<2.0a0
-  - libgl >=1.7.0,<2.0a0
-  - xorg-libx11 >=1.8.13,<2.0a0
-  - gtest >=1.17.0,<1.17.1.0a0
+  - occt >=7.9.3,<7.9.4.0a0
+  - libglu >=9.0.3,<9.1.0a0
   - librdkafka >=2.13.2,<2.14.0a0
   - poco >=1.15.1,<1.15.2.0a0
-  - libboost >=1.88.0,<1.89.0a0
-  - libglu >=9.0.3,<9.1.0a0
-  - xorg-libxxf86vm >=1.1.7,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libboost-python >=1.88.0,<1.89.0a0
-  - occt >=7.9.3,<7.9.4.0a0
+  - libgl >=1.7.0,<2.0a0
+  - gtest >=1.17.0,<1.17.1.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - libopenblas >=0.3.27,<1.0a0
   - hdf4 >=4.2.15,<4.2.16.0a0
+  - numpy >=1.21,<3
+  - xorg-libxxf86vm >=1.1.7,<2.0a0
+  - jsoncpp >=1.9.6,<1.9.7.0a0
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - python_abi 3.12.* *_cp312
+  - gsl >=2.8,<2.9.0a0
+  - muparser >=2.3.4,<2.4.0a0
+  - libboost >=1.88.0,<1.89.0a0
   constrains:
   - matplotlib-base 3.9.*
   - pyparsing <3.3.0
-  - pystog >=0.5.0
+  - pystog >=0.6.3
   license: GPL-3.0-or-later
-  size: 39408032
-  timestamp: 1775002946655
+  size: 39415280
+  timestamp: 1776090474338
 - conda: https://conda.anaconda.org/mantid-ornl/label/main/linux-64/mantidqt-6.15.0.1-py311he66f075_0.conda
   sha256: d6dc71ecfd97adfa50e6a5bd1742b927af76efc1786f6bd109a07f2d27223ddf
   md5: 5b3eba83bcf894f9589293fe09975613
@@ -7605,35 +7683,36 @@ packages:
   license: GPL-3.0-or-later
   size: 10366781
   timestamp: 1774620663514
-- conda: https://conda.anaconda.org/mantid/label/nightly/linux-64/mantidqt-6.15.20260331.2253-py312he48a509_0.conda
-  sha256: 09e5ebcdb2e1659c0dc5890d42e3f40bd0630eb53c800c3f603bed97cebd8a43
-  md5: 4d1a43942f357594722938c1712e4164
+- conda: https://conda.anaconda.org/mantid/label/nightly/linux-64/mantidqt-6.15.20260413.1004-py312he48a509_0.conda
+  sha256: fd92528118b2c2d29ef239de0583f3235f4178c5dbc3f0b2aea52cdc38becbc4
+  md5: fead32b11af2b9e4aa099b7249980937
   depends:
-  - mantid ==6.15.20260331.2253
+  - mantid ==6.15.20260413.1004
   - matplotlib 3.9.*
   - qscintilla2 >=2.14.1,<2.15.0a0
   - qt-main >=5.15.15,<5.16.0a0
   - qtpy >=2.4,!=2.4.2
   - python
   - qt-gtk-platformtheme
-  - _openmp_mutex >=4.5
-  - libstdcxx >=13
   - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - tbb >=2021.13.0
-  - libopenblas >=0.3.27,<1.0a0
-  - qt-main >=5.15.15,<5.16.0a0
+  - libstdcxx >=13
+  - libgcc >=13
+  - _openmp_mutex >=4.5
   - libboost-python >=1.88.0,<1.89.0a0
-  - python_abi 3.12.* *_cp312
-  - mantid ==6.15.20260331.2253 np21py312h62f99c1_0
-  - libboost >=1.88.0,<1.89.0a0
   - libgl >=1.7.0,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - tbb >=2021.13.0
+  - xorg-libxxf86vm >=1.1.7,<2.0a0
+  - qt-main >=5.15.15,<5.16.0a0
   - xorg-libx11 >=1.8.13,<2.0a0
   - pyqt >=5.15.9,<5.16.0a0
-  - xorg-libxxf86vm >=1.1.7,<2.0a0
+  - mantid ==6.15.20260413.1004 np21py312hf11577e_0
+  - libopenblas >=0.3.27,<1.0a0
+  - libboost >=1.88.0,<1.89.0a0
   license: GPL-3.0-or-later
-  size: 10434757
-  timestamp: 1775003408710
+  size: 10457632
+  timestamp: 1776090963394
 - conda: https://conda.anaconda.org/mantid-ornl/label/main/linux-64/mantidworkbench-6.15.0.1-py311h5e3fa56_0.conda
   sha256: 7fb3c96d90ccdd61cb9ebfb2045c5e46658d0d3f8a7c4d6d7e032eba5478ae30
   md5: 08de1debb472a0371ed3bf940ea857ba
@@ -7690,12 +7769,12 @@ packages:
   license: GPL-3.0-or-later
   size: 2802612
   timestamp: 1774626903114
-- conda: https://conda.anaconda.org/mantid/label/nightly/linux-64/mantidworkbench-6.15.20260331.2253-py312hc9b079f_0.conda
-  sha256: 2541ca57bc7071c9d176b196b005cd9bc520de372c29a0127b4b92af25644fb7
-  md5: ed08da3a52cb07570c98273ef54e13c6
+- conda: https://conda.anaconda.org/mantid/label/nightly/linux-64/mantidworkbench-6.15.20260413.1004-py312h595221b_0.conda
+  sha256: bb0c5adba8867db858c9c6b287d5002c442a204334e88ed02a374c9b8cc21dc5
+  md5: 2f84d13712cf7e4411f452316d8fe774
   depends:
   - ipykernel
-  - mantidqt ==6.15.20260331.2253
+  - mantidqt ==6.15.20260413.1004
   - psutil >=5.8.0
   - python >=3.12.13,<3.13.0a0
   - matplotlib 3.9.*
@@ -7706,18 +7785,18 @@ packages:
   - setuptools >=82.0.1,<82.1.0a0
   - pystack
   - lz4
-  - python_abi 3.12.* *_cp312
-  - tbb >=2021.13.0
-  - xorg-libx11 >=1.8.13,<2.0a0
   - libgl >=1.7.0,<2.0a0
-  - mantidqt ==6.15.20260331.2253 py312he48a509_0
+  - tbb >=2021.13.0
+  - mantidqt ==6.15.20260413.1004 py312he48a509_0
+  - xorg-libx11 >=1.8.13,<2.0a0
   - xorg-libxxf86vm >=1.1.7,<2.0a0
+  - python_abi 3.12.* *_cp312
   constrains:
-  - mslice 2.15.*
-  - mantiddocs ==6.15.20260331.2253
+  - mslice >=2.14
+  - mantiddocs ==6.15.20260413.1004
   license: GPL-3.0-or-later
-  size: 2802074
-  timestamp: 1775017974649
+  size: 2802143
+  timestamp: 1776105642408
 - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
   sha256: 7b1da4b5c40385791dbc3cc85ceea9fad5da680a27d5d3cb8bfaa185e304a89e
   md5: 5b5203189eb668f042ac2b0826244964
@@ -7743,7 +7822,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/markupsafe?source=compressed-mapping
+  - pkg:pypi/markupsafe?source=hash-mapping
   size: 26756
   timestamp: 1772445078834
 - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
@@ -7759,7 +7838,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/markupsafe?source=compressed-mapping
+  - pkg:pypi/markupsafe?source=hash-mapping
   size: 26057
   timestamp: 1772445297924
 - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py314h67df5f8_1.conda
@@ -7953,9 +8032,9 @@ packages:
   - pkg:pypi/menuinst?source=hash-mapping
   size: 181675
   timestamp: 1765733217223
-- conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-11.0.1-pyhcf101f3_0.conda
-  sha256: af8f30fb9542f48167fedbe1ab14230bfb82245cd4338b70c30dd55729714472
-  md5: 6fbedd565de86ec83bc96531ee3ab856
+- conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-11.0.2-pyhcf101f3_0.conda
+  sha256: 74f7b461e0f0e0709a0c8abb018de9ad885258b74790ffda1e750ac5ddde0a85
+  md5: b874955758a30a37c78b82ea5cf78fdb
   depends:
   - python >=3.10
   - python
@@ -7963,8 +8042,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/more-itertools?source=compressed-mapping
-  size: 71354
-  timestamp: 1775153285920
+  size: 71254
+  timestamp: 1775762492525
 - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
   sha256: 39c4700fb3fbe403a77d8cc27352fa72ba744db487559d5d44bf8411bb4ea200
   md5: c7f302fd11eeb0987a6a5e1f3aed6a21
@@ -8290,7 +8369,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/numpy?source=compressed-mapping
+  - pkg:pypi/numpy?source=hash-mapping
   size: 8927860
   timestamp: 1773839233468
 - conda: https://conda.anaconda.org/conda-forge/linux-64/occt-7.9.3-novtk_hb176d5c_102.conda
@@ -8361,21 +8440,6 @@ packages:
   purls: []
   size: 279846
   timestamp: 1771349499024
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-hbde042b_1.conda
-  sha256: 2e185a3dc2bdc4525dd68559efa3f24fa9159a76c40473e320732b35115163b2
-  md5: 3c40a106eadf7c14c6236ceddb267893
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cyrus-sasl >=2.1.28,<3.0a0
-  - krb5 >=1.22.2,<1.23.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - openssl >=3.5.5,<4.0a0
-  license: OLDAP-2.8
-  license_family: BSD
-  purls: []
-  size: 785570
-  timestamp: 1771970256722
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
   sha256: cb0b07db15e303e6f0a19646807715d28f1264c6350309a559702f4f34f37892
   md5: 2e5bf4f1da39c0b32778561c3c4e5878
@@ -8391,9 +8455,24 @@ packages:
   purls: []
   size: 780253
   timestamp: 1748010165522
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
-  sha256: 44c877f8af015332a5d12f5ff0fb20ca32f896526a7d0cdb30c769df1144fb5c
-  md5: f61eb8cd60ff9057122a3d338b99c00f
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+  sha256: 21c4f6c7f41dc9bec2ea2f9c80440d9a4d45a6f2ac13243e658f10dcf1044146
+  md5: 680608784722880fbfe1745067570b00
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cyrus-sasl >=2.1.28,<3.0a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - openssl >=3.5.6,<4.0a0
+  license: OLDAP-2.8
+  license_family: BSD
+  purls: []
+  size: 786149
+  timestamp: 1775741359582
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+  sha256: c0ef482280e38c71a08ad6d71448194b719630345b0c9c60744a2010e8a8e0cb
+  md5: da1b85b6a87e141f5140bb9924cecab0
   depends:
   - __glibc >=2.17,<3.0.a0
   - ca-certificates
@@ -8401,8 +8480,8 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 3164551
-  timestamp: 1769555830639
+  size: 3167099
+  timestamp: 1775587756857
 - conda: https://conda.anaconda.org/conda-forge/noarch/orsopy-1.2.1-pyhd8ed1ab_1.conda
   sha256: ab2e2c8cac273488028874c3eb29064907814c06c2154495584d69353fbd73b8
   md5: 7793211c1838805e0e19af038fa132ab
@@ -8428,18 +8507,17 @@ packages:
   purls: []
   size: 3831848
   timestamp: 1770417713801
-- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
-  sha256: c1fc0f953048f743385d31c468b4a678b3ad20caffdeaa94bed85ba63049fd58
-  md5: b76541e68fea4d511b1ac46a28dcd2c6
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.1-pyhc364b38_0.conda
+  sha256: 171d977bc977fd80f2a05de3d4b7d571c4ec3cdea436ed364e5cd50547c50881
+  md5: b8ae38639d323d808da535fb71e31be8
   depends:
   - python >=3.8
   - python
   license: Apache-2.0
-  license_family: APACHE
   purls:
   - pkg:pypi/packaging?source=compressed-mapping
-  size: 72010
-  timestamp: 1769093650580
+  size: 89360
+  timestamp: 1776209387231
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
   sha256: 3613774ad27e48503a3a6a9d72017087ea70f1426f6e5541dbdb59a3b626eaaf
   md5: 79f71230c069a287efe3a8614069ddf1
@@ -8649,7 +8727,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pip?source=compressed-mapping
+  - pkg:pypi/pip?source=hash-mapping
   size: 1181790
   timestamp: 1770270305795
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
@@ -8687,9 +8765,9 @@ packages:
   - pkg:pypi/pkginfo?source=hash-mapping
   size: 30536
   timestamp: 1739984682585
-- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
-  sha256: 0289f0a38337ee201d984f8f31f11f6ef076cfbbfd0ab9181d12d9d1d099bf46
-  md5: 82c1787f2a65c0155ef9652466ee98d6
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
+  sha256: 8f29915c172f1f7f4f7c9391cd5dac3ebf5d13745c8b7c8006032615246345a5
+  md5: 89c0b6d1793601a2a3a3f7d2d3d8b937
   depends:
   - python >=3.10
   - python
@@ -8697,8 +8775,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/platformdirs?source=compressed-mapping
-  size: 25646
-  timestamp: 1773199142345
+  size: 25862
+  timestamp: 1775741140609
 - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
   sha256: e14aafa63efa0528ca99ba568eaf506eb55a0371d12e6250aaaa61718d2eb62e
   md5: d7585b6550ad04c8c5e21097ada2888e
@@ -9098,26 +9176,24 @@ packages:
   - pkg:pypi/pycparser?source=hash-mapping
   size: 110100
   timestamp: 1733195786147
-- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
-  sha256: 868569d9505b7fe246c880c11e2c44924d7613a8cdcc1f6ef85d5375e892f13d
-  md5: c3946ed24acdb28db1b5d63321dbca7d
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.0-pyhcf101f3_0.conda
+  sha256: 237330a57a9d4d742cdf22259daafada9f287b68da9ffccdf138af4647d0910f
+  md5: c176d6075acee8d6847988b7865bd1af
   depends:
   - typing-inspection >=0.4.2
   - typing_extensions >=4.14.1
   - python >=3.10
-  - typing-extensions >=4.6.1
   - annotated-types >=0.6.0
-  - pydantic-core ==2.41.5
+  - pydantic-core ==2.46.0
   - python
   license: MIT
-  license_family: MIT
   purls:
-  - pkg:pypi/pydantic?source=hash-mapping
-  size: 340482
-  timestamp: 1764434463101
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py311h902ca64_1.conda
-  sha256: da6e2060a91de065031214f9ca56e24906785ea412cd274d1f32128992dc0d43
-  md5: 08d407f0331ff8e871db23bec7eef83c
+  - pkg:pypi/pydantic?source=compressed-mapping
+  size: 346673
+  timestamp: 1776083858303
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.0-py311h902ca64_0.conda
+  sha256: 79b7aa29185bb8df60e07446079eaed85e36215565985865f3368add012bd4cd
+  md5: ab0d6303704f5986c0e0594e3eb60e34
   depends:
   - python
   - typing-extensions >=4.6.0,!=4.7.0
@@ -9127,14 +9203,13 @@ packages:
   constrains:
   - __glibc >=2.17
   license: MIT
-  license_family: MIT
   purls:
   - pkg:pypi/pydantic-core?source=hash-mapping
-  size: 1938184
-  timestamp: 1762988992467
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py312h868fb18_1.conda
-  sha256: 07f899d035e06598682d3904d55f1529fac71b15e12b61d44d6a5fbf8521b0fe
-  md5: 56a776330a7d21db63a7c9d6c3711a04
+  size: 1899051
+  timestamp: 1776075322616
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.0-py312h868fb18_0.conda
+  sha256: d1e79e65c1a93a9b1fdc3e507859162d14b34a6431821acdc2b3b1b064e92549
+  md5: ba29f93f3325186934a130553d78b340
   depends:
   - python
   - typing-extensions >=4.6.0,!=4.7.0
@@ -9144,14 +9219,13 @@ packages:
   constrains:
   - __glibc >=2.17
   license: MIT
-  license_family: MIT
   purls:
   - pkg:pypi/pydantic-core?source=hash-mapping
-  size: 1935221
-  timestamp: 1762989004359
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py314h2e6c369_1.conda
-  sha256: 7e0ae379796e28a429f8e48f2fe22a0f232979d65ec455e91f8dac689247d39f
-  md5: 432b0716a1dfac69b86aa38fdd59b7e6
+  size: 1913988
+  timestamp: 1776075325221
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.0-py314h2e6c369_0.conda
+  sha256: 8767d8df39e780f50d38fca986d312ecc61ae29eb5339e08112d1d057f376229
+  md5: 4a31d8fa5ef5829a57240de15cb5d3a9
   depends:
   - python
   - typing-extensions >=4.6.0,!=4.7.0
@@ -9161,11 +9235,10 @@ packages:
   constrains:
   - __glibc >=2.17
   license: MIT
-  license_family: MIT
   purls:
   - pkg:pypi/pydantic-core?source=hash-mapping
-  size: 1943088
-  timestamp: 1762988995556
+  size: 1911038
+  timestamp: 1776075326093
 - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.13.1-pyhd8ed1ab_0.conda
   sha256: 343988d65c08477a87268d4fbeba59d0295514143965d2755ac4519b73155479
   md5: cc0da73801948100ae97383b8da12993
@@ -9713,17 +9786,17 @@ packages:
   - pkg:pypi/pystack?source=hash-mapping
   size: 427150
   timestamp: 1762504109810
-- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
-  sha256: 9e749fb465a8bedf0184d8b8996992a38de351f7c64e967031944978de03a520
-  md5: 2b694bad8a50dc2f712f5368de866480
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+  sha256: 960f59442173eee0731906a9077bd5ccf60f4b4226f05a22d1728ab9a21a879c
+  md5: 6a991452eadf2771952f39d43615bb3e
   depends:
+  - colorama >=0.4
   - pygments >=2.7.2
   - python >=3.10
   - iniconfig >=1.0.1
   - packaging >=22
   - pluggy >=1.5,<2
   - tomli >=1
-  - colorama >=0.4
   - exceptiongroup >=1
   - python
   constrains:
@@ -9731,9 +9804,9 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pytest?source=hash-mapping
-  size: 299581
-  timestamp: 1765062031645
+  - pkg:pypi/pytest?source=compressed-mapping
+  size: 299984
+  timestamp: 1775644472530
 - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
   sha256: 44e42919397bd00bfaa47358a6ca93d4c21493a8c18600176212ec21a8d25ca5
   md5: 67d1790eefa81ed305b89d8e314c7923
@@ -9817,24 +9890,24 @@ packages:
   purls: []
   size: 31608571
   timestamp: 1772730708989
-- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_101_cp314.conda
-  build_number: 101
-  sha256: cb0628c5f1732f889f53a877484da98f5a0e0f47326622671396fb4f2b0cd6bd
-  md5: c014ad06e60441661737121d3eae8a60
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.4-habeac84_100_cp314.conda
+  build_number: 100
+  sha256: dec247c5badc811baa34d6085df9d0465535883cf745e22e8d79092ad54a3a7b
+  md5: a443f87920815d41bfe611296e507995
   depends:
   - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
   - ld_impl_linux-64 >=2.36.1
-  - libexpat >=2.7.3,<3.0a0
+  - libexpat >=2.7.5,<3.0a0
   - libffi >=3.5.2,<3.6.0a0
   - libgcc >=14
   - liblzma >=5.8.2,<6.0a0
   - libmpdec >=4.0.0,<5.0a0
-  - libsqlite >=3.51.2,<4.0a0
-  - libuuid >=2.41.3,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libsqlite >=3.52.0,<4.0a0
+  - libuuid >=2.42,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
   - ncurses >=6.5,<7.0a0
-  - openssl >=3.5.5,<4.0a0
+  - openssl >=3.5.6,<4.0a0
   - python_abi 3.14.* *_cp314
   - readline >=8.3,<9.0a0
   - tk >=8.6.13,<8.7.0a0
@@ -9842,12 +9915,12 @@ packages:
   - zstd >=1.5.7,<1.6.0a0
   license: Python-2.0
   purls: []
-  size: 36702440
-  timestamp: 1770675584356
+  size: 36705460
+  timestamp: 1775614357822
   python_site_packages_path: lib/python3.14/site-packages
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-build-1.4.2-pyhc364b38_1.conda
-  sha256: 3f76a55e524728cd4092d78dd01107c8c3e91a66842317b49c7c8209a332c4f1
-  md5: 09971b38d49f16c47a8769aeb171ef3d
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-build-1.4.3-pyhc364b38_0.conda
+  sha256: f36faffa91fa8492b61ed68deae1a5a6e8e1efee808b5af2a971eeb0ca039719
+  md5: d039729a4537b67fa7b4a9335abd5070
   depends:
   - python >=3.9
   - colorama
@@ -9859,11 +9932,10 @@ packages:
   constrains:
   - build <0
   license: MIT
-  license_family: MIT
   purls:
   - pkg:pypi/build?source=hash-mapping
-  size: 28291
-  timestamp: 1774469084833
+  size: 29272
+  timestamp: 1775863949133
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
   sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
   md5: 5b8d21249ff20967101ffa321cab24e8
@@ -9977,9 +10049,9 @@ packages:
   - pkg:pypi/pytz?source=compressed-mapping
   size: 201725
   timestamp: 1773679724369
-- conda: https://conda.anaconda.org/conda-forge/noarch/pyvista-0.47.1-pyhd8ed1ab_1.conda
-  sha256: 1257ccb38525cdef1f1b10da8e5d3bd7c36992359a96462e2130f9562e6bcee7
-  md5: c2f767478b4deb9f5a381ca7b9ebff3b
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyvista-0.47.3-pyhd8ed1ab_0.conda
+  sha256: 33600f8358157b0168c5fcd58d8a58249cec1922425d3b51b7cce8c90fe209d7
+  md5: dd2843b31ac41a2f8b1595060605967e
   depends:
   - cyclopts >=4.0.0
   - matplotlib-base >=3.0.1
@@ -9994,8 +10066,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyvista?source=hash-mapping
-  size: 2176679
-  timestamp: 1773418651859
+  size: 2181211
+  timestamp: 1775850363567
 - conda: https://conda.anaconda.org/conda-forge/noarch/pyvistaqt-0.11.4-pyhd8ed1ab_0.conda
   sha256: 2735312d6860b567d0d29df0fd14b010b89fe8d6d4b8a46758b7d8ba1c07131f
   md5: 9455f6d735e4a7709e3bb13b2c237837
@@ -10021,7 +10093,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyyaml?source=compressed-mapping
+  - pkg:pypi/pyyaml?source=hash-mapping
   size: 206190
   timestamp: 1770223702917
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
@@ -10036,7 +10108,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyyaml?source=compressed-mapping
+  - pkg:pypi/pyyaml?source=hash-mapping
   size: 198293
   timestamp: 1770223620706
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
@@ -10051,7 +10123,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyyaml?source=compressed-mapping
+  - pkg:pypi/pyyaml?source=hash-mapping
   size: 202391
   timestamp: 1770223462836
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py311h57d2397_2.conda
@@ -10067,7 +10139,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pyzmq?source=compressed-mapping
+  - pkg:pypi/pyzmq?source=hash-mapping
   size: 383627
   timestamp: 1771716979818
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
@@ -10085,7 +10157,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pyzmq?source=hash-mapping
+  - pkg:pypi/pyzmq?source=compressed-mapping
   size: 211567
   timestamp: 1771716961404
 - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
@@ -10295,6 +10367,55 @@ packages:
   purls: []
   size: 52149940
   timestamp: 1756072007197
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qt-webengine-5.15.15-h0071231_2.conda
+  sha256: 480b5412dea614a9a7b33f459f5eb13382c4eaaf90b3c59a7ca307557f49612c
+  md5: bef8cde68b1a2deed9f50ac9449e8cf3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.13,<1.3.0a0
+  - dbus >=1.13.6,<2.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.13.3,<3.0a0
+  - harfbuzz >=10.4.0
+  - libcups >=2.3.3,<2.4.0a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libglib >=2.84.0,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libpng >=1.6.47,<1.7.0a0
+  - libsqlite >=3.49.1,<4.0a0
+  - libstdcxx >=13
+  - libwebp
+  - libwebp-base >=1.5.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libxkbcommon >=1.8.1,<2.0a0
+  - libxml2 >=2.13.7,<2.14.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - nspr >=4.36,<5.0a0
+  - nss >=3.110,<4.0a0
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxi >=1.8.2,<2.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  - xorg-libxtst >=1.2.5,<2.0a0
+  constrains:
+  - qt 5.15.3|5.15.4|5.15.6|5.15.8|5.15.15
+  license: LGPL-3.0-only
+  license_family: LGPL
+  purls: []
+  size: 51203060
+  timestamp: 1743391297154
 - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-webengine-5.15.15-h2da670d_3.conda
   sha256: 23215778e66336f07c54d6831c357ebe57b82779bc9f5f765104febfb82c68d1
   md5: 48c3a9b4427a725a5d83111aca16f818
@@ -10780,9 +10901,9 @@ packages:
   - pkg:pypi/rfc3986?source=hash-mapping
   size: 38028
   timestamp: 1733921806657
-- conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
-  sha256: b06ce84d6a10c266811a7d3adbfa1c11f13393b91cc6f8a5b468277d90be9590
-  md5: 7a6289c50631d620652f5045a63eb573
+- conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+  sha256: 3d6ba2c0fcdac3196ba2f0615b4104e532525ffa1335b50a2878be5ff488814a
+  md5: 0242025a3c804966bf71aa04eee82f66
   depends:
   - markdown-it-py >=2.2.0
   - pygments >=2.13.0,<3.0.0
@@ -10790,11 +10911,10 @@ packages:
   - typing_extensions >=4.0.0,<5.0.0
   - python
   license: MIT
-  license_family: MIT
   purls:
-  - pkg:pypi/rich?source=compressed-mapping
-  size: 208472
-  timestamp: 1771572730357
+  - pkg:pypi/rich?source=hash-mapping
+  size: 208577
+  timestamp: 1775991661559
 - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
   sha256: 202e90d6624abc924e185166f6fcfdd29c6749ec26d60480a0a34c898c0b67fd
   md5: cbd84dbdb3f5a7d762b5fb2b0d49e7cd
@@ -10959,10 +11079,10 @@ packages:
   - pkg:pypi/ruamel-yaml-clib?source=hash-mapping
   size: 150041
   timestamp: 1766159514023
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.9-h7805a7d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.10-h7805a7d_0.conda
   noarch: python
-  sha256: da5b2a8e2a1c25209fb74126da0f271f21e099f2354a46d7fb1e4f927a15a290
-  md5: d820fa7f8798399fc73ef03fb55756be
+  sha256: 9b1da9620cb73a58127651b71ac1bf15836aad49fbe5a4bf734a3a0e3cecf0d2
+  md5: f78d03a6c57a122772ed115c49cd743c
   depends:
   - python
   - libgcc >=14
@@ -10973,8 +11093,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/ruff?source=compressed-mapping
-  size: 9232676
-  timestamp: 1775177456692
+  size: 9224697
+  timestamp: 1775763996127
 - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.1-h1cbb8d7_1.conda
   sha256: dbbe4ab36b90427f12d69fc14a8b601b6bca4185c6c4dd67b8046a8da9daec03
   md5: 9d978822b57bafe72ebd3f8b527bba71
@@ -11053,7 +11173,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/scipy?source=compressed-mapping
+  - pkg:pypi/scipy?source=hash-mapping
   size: 17099824
   timestamp: 1771880736635
 - conda: https://conda.anaconda.org/conda-forge/noarch/scooby-0.11.0-pyhd8ed1ab_0.conda
@@ -11259,7 +11379,7 @@ packages:
   timestamp: 1762948049098
 - pypi: ./
   name: snapred
-  version: 2.3.0
+  version: 2.4.0.dev1
   sha256: 6768250918e1c5259a6c814f35eb4e45c816cfc47c3fb1b8fc9711b55e1912ee
   requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
@@ -11497,20 +11617,20 @@ packages:
   - pkg:pypi/sphinxcontrib-serializinghtml?source=hash-mapping
   size: 28669
   timestamp: 1733750596111
-- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.52.0-hbc0de68_0.conda
-  sha256: 4d18611828bd8370f63a9f6e7437bc5ddfe8d53b37cc589f0591ae35d545e0c7
-  md5: a754c9683cbdc54174414b5831ad5ef1
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.0-hbc0de68_0.conda
+  sha256: 9649537a273a82318d47e1ee3838d301d4f002ed16546b6c6334fd241a913342
+  md5: af291b31a656f7d1b1d9c1f6ee45e9e9
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libsqlite 3.52.0 h0c1763c_0
-  - libzlib >=1.3.1,<2.0a0
+  - libsqlite 3.53.0 h0c1763c_0
+  - libzlib >=1.3.2,<2.0a0
   - ncurses >=6.5,<7.0a0
   - readline >=8.3,<9.0a0
   license: blessing
   purls: []
-  size: 204195
-  timestamp: 1772818887484
+  size: 205073
+  timestamp: 1775753757115
 - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
   sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
   md5: b1b505328da7a6b246787df4b5a49fbc
@@ -11682,7 +11802,7 @@ packages:
   - python
   license: MPL-2.0 and MIT
   purls:
-  - pkg:pypi/tqdm?source=compressed-mapping
+  - pkg:pypi/tqdm?source=hash-mapping
   size: 94132
   timestamp: 1770153424136
 - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
@@ -11768,16 +11888,16 @@ packages:
   - pkg:pypi/typer?source=compressed-mapping
   size: 116134
   timestamp: 1775138098187
-- conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20250915-pyhd8ed1ab_1.conda
-  sha256: ba565f80b5dc5d88f34587b391f21807efd54099516f11beae5cb29a7925fd3d
-  md5: 0fcb42ddc8e8ba6f906274108e6d891d
+- conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20260408-pyhd8ed1ab_0.conda
+  sha256: 38d66db1dd8a1149b1c444371a2ffc647adaeb9ed3c65874d13e067dbf0368c5
+  md5: 7a260267fdb5d0989fd55f8d822a2927
   depends:
   - python >=3.10
   license: Apache-2.0 AND MIT
   purls:
   - pkg:pypi/types-pyyaml?source=hash-mapping
-  size: 22060
-  timestamp: 1762942278334
+  size: 22644
+  timestamp: 1775652241720
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
   sha256: 7c2df5721c742c2a47b2c8f960e718c930031663ac1174da67c1ed5999f7938c
   md5: edd329d7d3a4ab45dcf905899a7a6115
@@ -11959,9 +12079,9 @@ packages:
   purls: []
   size: 14226
   timestamp: 1767012219987
-- conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.3-h0f56927_0.conda
-  sha256: 020737ed7048ac02752a3953b0f375c16ea84f2d49e54e9fac2d1e6e9e9a65c5
-  md5: a041ace41c2356f7a67b69a9516d5e4d
+- conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.6-h0f56927_0.conda
+  sha256: b4e119c6776d5f752f7f10a1e4810dcbcfe0a6b32cc23689b0009f93af76bf6c
+  md5: f78bab5fcaf462a4309c88c18def5574
   depends:
   - libstdcxx >=14
   - libgcc >=14
@@ -11970,8 +12090,8 @@ packages:
   - __glibc >=2.17
   license: Apache-2.0 OR MIT
   purls: []
-  size: 19021408
-  timestamp: 1775089429161
+  size: 19227106
+  timestamp: 1775743419931
 - conda: https://conda.anaconda.org/conda-forge/noarch/versioningit-3.3.0-pyhd8ed1ab_0.conda
   sha256: 4b9a3f6738ab6e241b12b2fe9258f7e051678b911ca0f0ab042becc29096ff51
   md5: 57b96d99ac0f5a548f7001618db6a561
@@ -12556,7 +12676,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/yarl?source=compressed-mapping
+  - pkg:pypi/yarl?source=hash-mapping
   size: 147028
   timestamp: 1772409590700
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h387f397_9.conda
@@ -12574,18 +12694,18 @@ packages:
   purls: []
   size: 310648
   timestamp: 1757370847287
-- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
-  sha256: b4533f7d9efc976511a73ef7d4a2473406d7f4c750884be8e8620b0ce70f4dae
-  md5: 30cd29cb87d819caead4d55184c1d115
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
+  sha256: 523616c0530d305d2216c2b4a8dfd3872628b60083255b89c5e0d8c42e738cca
+  md5: e1c36c6121a7c9c76f2f148f1e83b983
   depends:
   - python >=3.10
   - python
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/zipp?source=hash-mapping
-  size: 24194
-  timestamp: 1764460141901
+  - pkg:pypi/zipp?source=compressed-mapping
+  size: 24461
+  timestamp: 1776131454755
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
   sha256: 245c9ee8d688e23661b95e3c6dd7272ca936fabc03d423cdb3cdee1bbcf9f2f2
   md5: c2a01a08fc991620a74b32420e97868a
@@ -12640,7 +12760,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/zstandard?source=compressed-mapping
+  - pkg:pypi/zstandard?source=hash-mapping
   size: 467133
   timestamp: 1762512686069
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda

--- a/src/snapred/backend/data/GroceryService.py
+++ b/src/snapred/backend/data/GroceryService.py
@@ -17,6 +17,7 @@ from snapred.backend.dao.state import DetectorState
 from snapred.backend.dao.WorkspaceMetadata import UNSET, WorkspaceMetadata
 from snapred.backend.data.LocalDataService import LocalDataService
 from snapred.backend.error.LiveDataState import LiveDataState
+from snapred.backend.error.RunStatus import RunStatus
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.backend.recipe.FetchGroceriesRecipe import FetchGroceriesRecipe
@@ -878,18 +879,64 @@ class GroceryService:
             data = self.grocer.executeRecipe(workspace=workspaceName, loader=loader, loaderArgs=json.dumps(loaderArgs))
             data["fromLiveData"] = True
             if data["result"]:
-                run = self.mantidSnapper.mtd[workspaceName].getRun()
-                liveRunNumber = run.getProperty("run_number").value if run.hasProperty("run_number") else 0
+                if data.get("runStatus"):
+                    try:
+                        runStatus = RunStatus(data["runStatus"])
+                        if runStatus != RunStatus.RUNNING:
+                            # There is some type of issue with the live run.
+                            self.deleteWorkspaceUnconditional(workspaceName)
+                            data = {"result": False}
+                            if liveDataArgs is not None:
+                                match runStatus:
+                                    case RunStatus.PAUSED:
+                                        raise LiveDataState.runStateTransition(runNumber, runNumber)
+                                    case RunStatus.STOPPED:
+                                        raise LiveDataState.runStateTransition("0", runNumber)
+                                    case RunStatus.ERROR:
+                                        raise LiveDataState.runError(runNumber)
+                                    case _:
+                                        raise RuntimeError(
+                                            f"implementation error: unexpected 'RunStatus' value: '{runStatus}'"
+                                        )
+                            raise RuntimeError(
+                                f"Neutron data for run '{runNumber}' is not present on disk, "
+                                "and there is a problem with the live-data run:\n"
+                                f"    live-run status: {runStatus}."
+                            )
+                    except ValueError as e:
+                        logger.debug(
+                            f"Error when parsing 'RunStatus' returned by `FetchGroceriesAlgorithm`:\n"
+                            f"    {data['runStatus']}:\n"
+                            f"    {e}."
+                        )
 
-                if int(runNumber) != int(liveRunNumber):
-                    # Live run number is unexpected => there has been a live-data run-state change.
+                run = self.mantidSnapper.mtd[workspaceName].getRun()
+                # IMPORTANT: due to issues with the `SNSLiveEventData` listener implementation, we cannot assume
+                #   that the 'run_number' property has actually been set.
+                liveRunNumber = run.getProperty("run_number").value if run.hasProperty("run_number") else None
+
+                if liveRunNumber is not None:
+                    if int(runNumber) != int(liveRunNumber):
+                        # Live run number is unexpected => there has been a live-data run-state change.
+                        self.deleteWorkspaceUnconditional(workspaceName)
+                        data = {"result": False}
+                        if liveDataArgs is not None:
+                            raise LiveDataState.runStateTransition(liveRunNumber, runNumber)
+                        raise RuntimeError(
+                            f"Neutron data for run '{runNumber}' is not present on disk, nor is it the live-data run"
+                        )
+                elif liveDataArgs is not None:
+                    # Temporary fix for `SNSLiveEventDataListener` not setting the run-number:
+                    #   just set it here.
+                    self.mantidSnapper.mtd[workspaceName].mutableRun()["run_number"] = str(runNumber)
+                else:
+                    # Do NOT fix the run-number in the fallback case.
                     self.deleteWorkspaceUnconditional(workspaceName)
                     data = {"result": False}
-                    if liveDataArgs is not None:
-                        raise LiveDataState.runStateTransition(liveRunNumber, runNumber)
                     raise RuntimeError(
-                        f"Neutron data for run '{runNumber}' is not present on disk, " + "nor is it the live-data run"
+                        f"Neutron data for run '{runNumber}' is not present on disk, nor is it the live-data run"
                     )
+
                 self._loadedRuns[self._key(runNumber, False)] = 0
                 self._liveDataKeys.append(self._key(runNumber, False))
         else:

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -5,13 +5,13 @@ import os
 import re
 import shutil
 import socket
+import stat
 import tempfile
 from datetime import datetime, timedelta, timezone
 from errno import ENOENT as NOT_FOUND
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
-from urllib.parse import urlparse
 
 import h5py
 import numpy as np
@@ -1487,7 +1487,7 @@ class LocalDataService:
 
     @lru_cache
     def hasLiveDataConnection(self) -> bool:
-        """For 'live data' methods: test if there is a listener connection to the instrument."""
+        """Test if there is a listener connection to the instrument (works with UDS or TCP)."""
 
         # NOTE: adding `lru_cache` to this method bypasses a possible race condition in
         #   `ConfigService.getFacility(...)`.  (And yes, that should be a `const` method.  :( )
@@ -1498,21 +1498,32 @@ class LocalDataService:
 
         status = False
         if Config["liveData.enabled"]:
-            # Normalize to an actual "URL" and then strip off the protocol (not actually "http") and port:
-            #   `liveDataAddress` returns a string similar to "bl3-daq1.sns.gov:31415".
+            # `liveDataAddress()` returns a string similar to "bl3-daq1.sns.gov:31415",
+            #   but during testing, it might also return a Unix domain socket (UDS) path string.
 
             facility, instrument = Config["liveData.facility.name"], Config["liveData.instrument.name"]
-            hostname = urlparse(
-                "http://" + ConfigService.getFacility(facility).instrument(instrument).liveDataAddress()
-            ).hostname
-            status = True
-            try:
-                socket.gethostbyaddr(hostname)
-            except Exception as e:  # noqa: BLE001
-                # specifically:
-                #   we're expecting a `socket.gaierror`, but any exception will indicate that there's no connection
-                logger.debug(f"`hasLiveDataConnection` returns `False`: exception: {e}")
-                status = False
+            address_str = ConfigService.getFacility(facility).instrument(instrument).liveDataAddress()
+            address = self._parseSocketAddress(address_str)
+
+            if isinstance(address, Path):  # UDS path
+                # For UDS, check that the file exists and is a socket
+                try:
+                    status = address.exists() and address.is_socket()
+                except Exception:  # noqa: BLE001
+                    # .is_socket() only in Python 3.12+; otherwise use stat.S_ISSOCK
+                    try:
+                        st_mode = os.stat(address).st_mode
+                        status = stat.S_ISSOCK(st_mode)
+                    except Exception as e2:  # noqa: BLE001
+                        logger.debug(f"`hasLiveDataConnection` (UDS) returned `False`: exception: {e2}")
+            elif isinstance(address, tuple):
+                host, port = address
+                try:
+                    # DNS check: host is reachable from the local network
+                    socket.gethostbyaddr(host)
+                    status = True
+                except Exception as e:  # noqa: BLE001
+                    logger.debug(f"`hasLiveDataConnection` (INET) returns `False`: exception: {e}")
 
         return status
 
@@ -1572,6 +1583,46 @@ class LocalDataService:
     def readLiveData(self, ws: WorkspaceName, duration: int) -> WorkspaceName:
         # A duration of zero => read all of the available data.
         return self._readLiveData(ws, duration)
+
+    @classmethod
+    def _parseSocketAddress(cls, address: str) -> Path | tuple[str, int]:
+        """
+        Parse a socket address string, specified as either a Unix-domain socket path, or an IP/host:port,
+          into a Python-compatible format: `Path | tuple[str, int]`.
+        """
+        # Note: this duplicates code from the `SocketAddress` class in:
+        #   "<mantid codebase>/Framework/LiveData/src/ADARA/utils/packet_playback/adara_parser.py"
+
+        # Match [IPv6]:port, IPv4:port, or hostname:port
+        # Hostname spec (RFC 1123): letter/digit first, can contain '-', '.', letters, digits
+        host_port_re = re.compile(
+            r"""
+            ^
+            (?:\[(?P<ipv6>[0-9a-fA-F:]+)\]|      # [IPv6]
+               (?P<host>[a-zA-Z0-9.\-]+)         # or hostname/domain, or IPv4
+            )
+            :
+            (?P<port>\d{1,5})                    # Port
+            $
+            """,
+            re.VERBOSE,
+        )
+
+        match = host_port_re.match(address)
+        if match:
+            ip = match.group("ipv6") or match.group("host")
+            port = int(match.group("port"))
+
+            if 0 < port <= 65535:
+                return (ip, port)
+            else:
+                raise ValueError(f"Port out of range: {port}")
+
+        # If not host:port, treat as Unix socket path (absolute only)
+        if address.startswith("/"):
+            return Path(address)
+
+        raise ValueError(f"Invalid address format: {address}")
 
     ### GENERALIZED PROGRESS REPORTING:
     def _progressRecordsFilenameStem(self) -> str:

--- a/src/snapred/backend/data/LocalDataService.py
+++ b/src/snapred/backend/data/LocalDataService.py
@@ -5,13 +5,13 @@ import os
 import re
 import shutil
 import socket
+import stat
 import tempfile
 from datetime import datetime, timedelta, timezone
 from errno import ENOENT as NOT_FOUND
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
-from urllib.parse import urlparse
 
 import h5py
 import numpy as np
@@ -1495,7 +1495,7 @@ class LocalDataService:
 
     @lru_cache
     def hasLiveDataConnection(self) -> bool:
-        """For 'live data' methods: test if there is a listener connection to the instrument."""
+        """Test if there is a listener connection to the instrument (works with UDS or TCP)."""
 
         # NOTE: adding `lru_cache` to this method bypasses a possible race condition in
         #   `ConfigService.getFacility(...)`.  (And yes, that should be a `const` method.  :( )
@@ -1506,21 +1506,32 @@ class LocalDataService:
 
         status = False
         if Config["liveData.enabled"]:
-            # Normalize to an actual "URL" and then strip off the protocol (not actually "http") and port:
-            #   `liveDataAddress` returns a string similar to "bl3-daq1.sns.gov:31415".
+            # `liveDataAddress()` returns a string similar to "bl3-daq1.sns.gov:31415",
+            #   but during testing, it might also return a Unix domain socket (UDS) path string.
 
             facility, instrument = Config["liveData.facility.name"], Config["liveData.instrument.name"]
-            hostname = urlparse(
-                "http://" + ConfigService.getFacility(facility).instrument(instrument).liveDataAddress()
-            ).hostname
-            status = True
-            try:
-                socket.gethostbyaddr(hostname)
-            except Exception as e:  # noqa: BLE001
-                # specifically:
-                #   we're expecting a `socket.gaierror`, but any exception will indicate that there's no connection
-                logger.debug(f"`hasLiveDataConnection` returns `False`: exception: {e}")
-                status = False
+            address_str = ConfigService.getFacility(facility).instrument(instrument).liveDataAddress()
+            address = self._parseSocketAddress(address_str)
+
+            if isinstance(address, Path):  # UDS path
+                # For UDS, check that the file exists and is a socket
+                try:
+                    status = address.exists() and address.is_socket()
+                except Exception:  # noqa: BLE001
+                    # .is_socket() only in Python 3.12+; otherwise use stat.S_ISSOCK
+                    try:
+                        st_mode = os.stat(address).st_mode
+                        status = stat.S_ISSOCK(st_mode)
+                    except Exception as e2:  # noqa: BLE001
+                        logger.debug(f"`hasLiveDataConnection` (UDS) returned `False`: exception: {e2}")
+            elif isinstance(address, tuple):
+                host, port = address
+                try:
+                    # DNS check: host is reachable from the local network
+                    socket.gethostbyaddr(host)
+                    status = True
+                except Exception as e:  # noqa: BLE001
+                    logger.debug(f"`hasLiveDataConnection` (INET) returns `False`: exception: {e}")
 
         return status
 
@@ -1580,6 +1591,46 @@ class LocalDataService:
     def readLiveData(self, ws: WorkspaceName, duration: int) -> WorkspaceName:
         # A duration of zero => read all of the available data.
         return self._readLiveData(ws, duration)
+
+    @classmethod
+    def _parseSocketAddress(cls, address: str) -> Path | tuple[str, int]:
+        """
+        Parse a socket address string, specified as either a Unix-domain socket path, or an IP/host:port,
+          into a Python-compatible format: `Path | tuple[str, int]`.
+        """
+        # Note: this duplicates code from the `SocketAddress` class in:
+        #   "<mantid codebase>/Framework/LiveData/src/ADARA/utils/packet_playback/adara_parser.py"
+
+        # Match [IPv6]:port, IPv4:port, or hostname:port
+        # Hostname spec (RFC 1123): letter/digit first, can contain '-', '.', letters, digits
+        host_port_re = re.compile(
+            r"""
+            ^
+            (?:\[(?P<ipv6>[0-9a-fA-F:]+)\]|      # [IPv6]
+               (?P<host>[a-zA-Z0-9.\-]+)         # or hostname/domain, or IPv4
+            )
+            :
+            (?P<port>\d{1,5})                    # Port
+            $
+            """,
+            re.VERBOSE,
+        )
+
+        match = host_port_re.match(address)
+        if match:
+            ip = match.group("ipv6") or match.group("host")
+            port = int(match.group("port"))
+
+            if 0 < port <= 65535:
+                return (ip, port)
+            else:
+                raise ValueError(f"Port out of range: {port}")
+
+        # If not host:port, treat as Unix socket path (absolute only)
+        if address.startswith("/"):
+            return Path(address)
+
+        raise ValueError(f"Invalid address format: {address}")
 
     ### GENERALIZED PROGRESS REPORTING:
     def _progressRecordsFilenameStem(self) -> str:

--- a/src/snapred/backend/error/LiveDataState.py
+++ b/src/snapred/backend/error/LiveDataState.py
@@ -18,6 +18,12 @@ class LiveDataState(Exception):
         # <run number> > 0 <- <run number> == 0
         RUN_START = auto()
 
+        # <run number> > 0: no change in <run number>
+        RUN_PAUSE = auto()
+
+        # <run number> > 0: no change in <run number>
+        RUN_ERROR = auto()
+
         # <run number> == 0 <- <run number> > 0
         RUN_END = auto()
 
@@ -27,17 +33,25 @@ class LiveDataState(Exception):
     class Model(BaseModel):
         message: str
         transition: "LiveDataState.Type"
-
         endRunNumber: str
         startRunNumber: str
 
         @model_validator(mode="after")
         def _validate_LiveDataState(self):
-            if self.endRunNumber == self.startRunNumber or (
-                (int(self.endRunNumber) > 0 and int(self.startRunNumber) > 0)
+            is_same = self.endRunNumber == self.startRunNumber
+            is_decreasing = (
+                int(self.endRunNumber) > 0
+                and int(self.startRunNumber) > 0
                 and int(self.endRunNumber) < int(self.startRunNumber)
-            ):
-                raise ValueError(f"not a run-state transition: {self.endRunNumber} <- {self.startRunNumber}")
+            )
+
+            if (
+                is_same and self.transition not in {LiveDataState.Type.RUN_PAUSE, LiveDataState.Type.RUN_ERROR}
+            ) or is_decreasing:
+                raise ValueError(
+                    f"Not a valid run-state transition: {self.transition}:"
+                    f"    {self.endRunNumber} <- {self.startRunNumber}"
+                )
             return self
 
     def __init__(self, message: str, transition: "Type", endRunNumber: str, startRunNumber: str):
@@ -69,6 +83,15 @@ class LiveDataState(Exception):
         return LiveDataState(**raw.dict())
 
     @staticmethod
+    def runError(runNumber: str | int) -> "LiveDataState":
+        return LiveDataState(
+            message=f"run {runNumber} in error state",
+            transition=LiveDataState.Type.RUN_ERROR,
+            endRunNumber=str(runNumber),
+            startRunNumber=str(runNumber),
+        )
+
+    @staticmethod
     def runStateTransition(endRunNumber: str | int, startRunNumber: str | int) -> "LiveDataState":
         transition = LiveDataState.Type.UNSET
         message = "unknown state transition"
@@ -78,6 +101,9 @@ class LiveDataState(Exception):
         elif int(endRunNumber) == 0 and int(startRunNumber) > 0:
             transition = LiveDataState.Type.RUN_END
             message = f"end of run {startRunNumber}"
+        elif int(endRunNumber) == int(startRunNumber):
+            transition = LiveDataState.Type.RUN_PAUSE
+            message = f"pause of run {startRunNumber}"
         elif int(endRunNumber) > 0 and int(startRunNumber) > 0:
             transition = LiveDataState.Type.RUN_GAP
             message = f"run-number gap: {endRunNumber} <- {startRunNumber}"

--- a/src/snapred/backend/error/RunStatus.py
+++ b/src/snapred/backend/error/RunStatus.py
@@ -1,0 +1,65 @@
+from enum import StrEnum
+
+import mantid.api
+
+
+class RunStatus(StrEnum):
+    STOPPED = "STOPPED"
+    PAUSED = "PAUSED"
+    RUNNING = "RUNNING"
+    ERROR = "ERROR"
+
+    @classmethod
+    def from_run(cls, run: mantid.api.Run) -> "RunStatus":
+        """Factory method to determine the RunStatus from a Mantid Run object."""
+
+        # Be careful here, this is SNAP specific:
+        #   it's important to use logs which are available at SNS (e.g. no `icp_event` logs will be present).
+
+        # Helper function to safely get the last value of a TimeSeriesProperty
+        def get_last_value(log_name):
+            if run.hasProperty(log_name):
+                prop = run.getProperty(log_name)
+                if hasattr(prop, "value") and len(prop.value) > 0:
+                    # Extract either a single string, or the last point in a time-series.
+                    if isinstance(prop.value, str):
+                        return prop.value
+                    return prop.value[-1]
+            return None
+
+        # 1. Check for an ERROR/ABORT state
+        # Look at the scan abort PVs. If they evaluate to True/1, the run was aborted.
+        abort_state = get_last_value("BL3:Exp:ScanAbort")
+        if abort_state is None:
+            abort_state = get_last_value("BL3:Exp:IM:ScanAbort")
+
+        if abort_state:  # Evaluates to True if 1 or True
+            return cls.ERROR
+
+        # 2. Check if the run is officially STOPPED
+        # Mantid still injects 'end_time' when the run finishes and is packaged.
+        if run.hasProperty("end_time"):
+            return cls.STOPPED
+
+        # 3. Check for a PAUSED state using the dedicated 'pause' log
+        pause_state = get_last_value("pause")
+        if pause_state:  # Evaluates to True if 1 or True
+            return cls.PAUSED
+
+        # 4. Check the explicit Run Status PV (which unfortunately, usually does not exist  :(  ):
+        status = get_last_value("BL3:CS:RunControl:StateEnum")
+        if status is not None:
+            status_str = str(status).strip().upper()
+            if "PAUSE" in status_str:
+                return cls.PAUSED
+            elif "STOP" in status_str or "IDLE" in status_str:
+                return cls.STOPPED
+            elif "ACQUIRING" in status_str or "RECORD" in status_str or "RUN" in status_str:
+                return cls.RUNNING
+
+        # 5. Fallback: If no aborts, no pauses, and no end_time, assume RUNNING
+        return cls.RUNNING
+
+
+# Usage:
+# status = RunStatus.from_run(my_workspace.getRun())

--- a/src/snapred/backend/recipe/FetchGroceriesRecipe.py
+++ b/src/snapred/backend/recipe/FetchGroceriesRecipe.py
@@ -61,6 +61,7 @@ class FetchGroceriesRecipe:
             data["result"] = algo.execute()
             data["loader"] = algo.getPropertyValue("LoaderType")
             data["workspace"] = workspace
+            data["runStatus"] = algo.getPropertyValue("RunStatus")
         except (RuntimeError, TypeError) as e:
             # TODO: use `MantidSnapper`!
             name = "FetchGroceriesAlgorithm"

--- a/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
+++ b/src/snapred/backend/recipe/algorithm/FetchGroceriesAlgorithm.py
@@ -49,6 +49,12 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
             doc="Workspace containing the loaded data",
         )
         self.declareProperty(
+            "RunStatus",
+            defaultValue="",
+            direction=Direction.Output,
+            doc="Run status information for live-data runs",
+        )
+        self.declareProperty(
             "LoaderType",
             "",
             StringListValidator(
@@ -152,6 +158,7 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
         filename = self.getPropertyValue("Filename")
         outWS = self.getPropertyValue("OutputWorkspace")
         loaderType = self.getPropertyValue("LoaderType")
+        runStatus = ""
 
         # Allow live-data mode to replace an existing workspace
         addOrReplace = loaderType == "LoadLiveDataInterval"
@@ -184,7 +191,7 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
                         **{instrumentPropertySource: instrumentSource},
                     )
                 case "LoadLiveDataInterval":
-                    self.mantidSnapper.LoadLiveDataInterval(
+                    _, runStatus = self.mantidSnapper.LoadLiveDataInterval(
                         "loading live-data interval",
                         OutputWorkspace=outWS,
                         Instrument=loaderArgs["Instrument"],
@@ -197,6 +204,8 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
                     )
 
             self.mantidSnapper.executeQueue()
+            # collapse the `Callback`: *why* is this necessary?
+            runStatus = str(runStatus)
         else:
             logger.debug(f"A workspace with name {outWS} already exists in the ADS, and so will not be loaded")
             loaderType = ""
@@ -221,6 +230,7 @@ class FetchGroceriesAlgorithm(PythonAlgorithm):
                     self.mantidSnapper.mtd[name].populateInstrumentParameters()
 
         self.setPropertyValue("OutputWorkspace", outWS)
+        self.setPropertyValue("RunStatus", runStatus)
         self.setPropertyValue("LoaderType", str(loaderType))
 
 

--- a/src/snapred/backend/recipe/algorithm/LoadLiveDataInterval.py
+++ b/src/snapred/backend/recipe/algorithm/LoadLiveDataInterval.py
@@ -10,10 +10,20 @@ from mantid.api import (
     PythonAlgorithm,
     mtd,
 )
-from mantid.kernel import ConfigService, DateAndTime, Direction
+from mantid.kernel import (
+    BoolTimeSeriesProperty,
+    ConfigService,
+    DateAndTime,
+    Direction,
+    FloatTimeSeriesProperty,
+    Int32TimeSeriesProperty,
+    Int64TimeSeriesProperty,
+    StringTimeSeriesProperty,
+)
 
 from snapred.backend.dao.RunMetadata import RunMetadata
 from snapred.backend.data.util.PV_logs_util import datetimeFromLogTime
+from snapred.backend.error.RunStatus import RunStatus
 from snapred.backend.log.logger import snapredLogger
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config
@@ -85,6 +95,15 @@ class LoadLiveDataInterval(PythonAlgorithm):
         # TODO: should "PreserveEvents" even be a declared property?
         #  Does this algorithm even work when this is turned off?
         self.declareProperty("PreserveEvents", defaultValue=True, direction=Direction.Input)
+
+        # `RunStatus` returns either 'RUNNING', or the string representation of the `RunStatus`
+        #    of the last non-running chunk.
+        self.declareProperty(
+            "RunStatus",
+            defaultValue="RUNNING",
+            direction=Direction.Output,
+            doc=f"Status of the live data run: {{{', '.join(s.name for s in RunStatus)}}}",
+        )
 
         self.mantidSnapper = MantidSnapper(self, __name__)
 
@@ -273,17 +292,85 @@ class LoadLiveDataInterval(PythonAlgorithm):
     def _createChildAlgorithm(cls, self_, *args, **kwargs):
         return self_.createChildAlgorithm(*args, **kwargs)
 
+    @classmethod
+    def _checkIntervalOverlaps(
+        cls, interval: Tuple[np.datetime64, np.datetime64], chunkIntervals: List[Tuple[np.datetime64, np.datetime64]]
+    ) -> bool:
+        # Returns True if `interval` overlaps with any interval in `chunkIntervals`.
+        # Two intervals A and B overlap when A.start < B.end AND A.end > B.start.
+        a_start, a_end = interval
+        for b_start, b_end in chunkIntervals:
+            if a_start < b_end and a_end > b_start:
+                return True
+        return False
+
+    @classmethod
+    def _fallbackChunkInterval(
+        cls,
+        ws,
+        requiredStartTime: np.datetime64,
+        chunkIntervals: List[Tuple[np.datetime64, np.datetime64]],
+    ):
+        # Scan the workspace's Run logs for TimeSeriesProperty entries that can provide
+        # a fallback time interval when the loaded chunk contains no events.
+        #
+        # Returns the candidate (start_dt, end_dt) with the largest span, or None if none found.
+
+        _TSP_TYPES = (
+            FloatTimeSeriesProperty,
+            BoolTimeSeriesProperty,
+            Int32TimeSeriesProperty,
+            Int64TimeSeriesProperty,
+            StringTimeSeriesProperty,
+        )
+
+        best_interval = None
+        best_span = np.timedelta64(0, "ns")
+        valid_candidates = []
+
+        for prop in ws.getRun().getProperties():
+            if not isinstance(prop, _TSP_TYPES):
+                continue
+            if prop.size() == 0:
+                continue
+
+            start_dt = prop.firstTime().to_datetime64()
+            end_dt = prop.lastTime().to_datetime64()
+
+            if start_dt >= end_dt:
+                continue
+            if start_dt < requiredStartTime:
+                continue
+            if cls._checkIntervalOverlaps((start_dt, end_dt), chunkIntervals):
+                continue
+
+            valid_candidates.append((prop.name, start_dt, end_dt))
+
+            span = end_dt - start_dt
+            if span > best_span:
+                best_span = span
+                best_interval = (start_dt, end_dt)
+
+        if valid_candidates:
+            lines = "\n".join(f"  '{name}': ({start}, {end})" for name, start, end in valid_candidates)
+            logger.warning(f"Fallback chunk-interval candidates from TimeSeriesProperty logs:\n{lines}")
+
+        return best_interval
+
     # --------- end: `LoadLiveDataInterval` call break out to static methods. ------------------------------------------
 
     def PyExec(self):
+        runStatus: RunStatus | None = None
         chunkWs = self.mantidSnapper.mtd.unique_hidden_name()
         self.chunkIntervals = []
         try:
             outputWs = self.getProperty("OutputWorkspace").valueAsStr
             startTime = self.getProperty("StartTime").value
 
-            waitTimeIncrement = 10  # seconds
-            dataLoadTimeout = Config["liveData.dataLoadTimeout"]
+            try:
+                allowDeadTime = Config["liveData.allowDeadTime"]
+            except KeyError:
+                allowDeadTime = False
 
             # Create the "LoadLiveData" child and set its properties.
             loadLiveData = self._createChildAlgorithm(self, "LoadLiveData", 0.0, 0.75, self.isLogging())
@@ -302,21 +389,43 @@ class LoadLiveDataInterval(PythonAlgorithm):
             # Load the first data-chunk: this replaces any contents of the output workspace.
             loadLiveData.execute()
 
-            run = self.mantidSnapper.mtd[chunkWs].getRun()
-            activeRunNumber = self.mantidSnapper.mtd[chunkWs].getRunNumber()
+            runStatus: RunStatus = RunStatus.RUNNING
+            deadTimeDuration = 0
+            if self.mantidSnapper.mtd[chunkWs].getNumberEvents():
+                run = self.mantidSnapper.mtd[chunkWs].getRun()
+                runStatus = RunStatus.from_run(run)
+                if runStatus != RunStatus.RUNNING:
+                    raise RuntimeError("`LoadLiveDataInterval`: cannot extract initial chunk from inactive run.")
 
-            logger.info(f"Run interval: ({run.startTime().to_datetime64()}, {run.endTime().to_datetime64()})")
-            logger.info(
-                f"Loaded-chunk interval: ({self.mantidSnapper.mtd[chunkWs].getPulseTimeMin().to_datetime64()}, "
-                f"{self.mantidSnapper.mtd[chunkWs].getPulseTimeMax().to_datetime64()})"
-            )
+                logger.info(f"Run interval: ({run.startTime().to_datetime64()}, {run.endTime().to_datetime64()})")
 
-            self.chunkIntervals.append(
-                (
-                    self.mantidSnapper.mtd[chunkWs].getPulseTimeMin().to_datetime64(),
-                    self.mantidSnapper.mtd[chunkWs].getPulseTimeMax().to_datetime64(),
+                logger.info(
+                    f"Loaded-chunk interval: ({self.mantidSnapper.mtd[chunkWs].getPulseTimeMin().to_datetime64()}, "
+                    f"{self.mantidSnapper.mtd[chunkWs].getPulseTimeMax().to_datetime64()})"
                 )
-            )
+
+                self.chunkIntervals.append(
+                    (
+                        self.mantidSnapper.mtd[chunkWs].getPulseTimeMin().to_datetime64(),
+                        self.mantidSnapper.mtd[chunkWs].getPulseTimeMax().to_datetime64(),
+                    )
+                )
+            else:
+                requiredStartTime = self._requiredLoadInterval(chunkWs, startTime)[0]
+                fallback = self._fallbackChunkInterval(
+                    self.mantidSnapper.mtd[chunkWs], requiredStartTime, self.chunkIntervals
+                )
+                if fallback is not None:
+                    logger.warning(f"NO EVENTS in initially-loaded chunk: using fallback interval {fallback}.")
+                    self.chunkIntervals.append(fallback)
+                else:
+                    if not allowDeadTime:
+                        logger.error("Initial chunk contained no events and no suitable fallback interval was found.")
+                        raise RuntimeError(
+                            "Initial chunk contained no events and no suitable fallback interval was found."
+                        )
+                    deadTimeDuration = 10  # `SNSLiveEventDataListener` initially accumulates 10 s of data.
+                    logger.warning("NO EVENTS in initially-loaded chunk interval.")
 
             self.mantidSnapper.CloneWorkspace(
                 "replace output workspace", OutputWorkspace=outputWs, InputWorkspace=chunkWs
@@ -327,15 +436,53 @@ class LoadLiveDataInterval(PythonAlgorithm):
             waitTime = 0
             dataLoadTimeout = Config["liveData.dataLoadTimeout"]
             waitTimeIncrement = Config["liveData.chunkLoadWait"]
+            maxDeadTime = Config["liveData.time_comparison_threshold"]  # this is also the maximum data-gap duration
             while (waitTime < dataLoadTimeout) and not self._loadIsComplete(outputWs, startTime, self.chunkIntervals):
                 sleep(waitTimeIncrement)
                 waitTime += waitTimeIncrement
                 # Load another chunk of data.
                 loadLiveData.execute()
 
-                # Check for possible run-state change:
-                if activeRunNumber != self.mantidSnapper.mtd[chunkWs].getRunNumber():
+                # Check for run-state transitions.
+                run = self.mantidSnapper.mtd[chunkWs].getRun()
+                runStatus = RunStatus.from_run(run)
+                if runStatus != RunStatus.RUNNING:
                     break
+
+                # Check for dead time:
+
+                # Implementation note:
+                #   - when there are no events, `getPulseTimeMin()` and `getPulseTimeMax()` return
+                #     `DateAndTime::maximum()` and `DateAndTime::minimum()` respectively.
+                if not self.mantidSnapper.mtd[chunkWs].getNumberEvents():
+                    requiredStartTime = self._requiredLoadInterval(chunkWs, startTime)[0]
+                    fallback = self._fallbackChunkInterval(
+                        self.mantidSnapper.mtd[chunkWs], requiredStartTime, self.chunkIntervals
+                    )
+                    if fallback is not None:
+                        logger.warning(f"NO NEW EVENTS in {waitTimeIncrement} s: using fallback interval {fallback}.")
+                        self.chunkIntervals.append(fallback)
+                        deadTimeDuration = 0
+                    else:
+                        if allowDeadTime:
+                            deadTimeDuration += waitTimeIncrement
+                            logger.warning(f"NO NEW EVENTS in {waitTimeIncrement} s")
+                            if deadTimeDuration >= maxDeadTime:
+                                # No events for longer than the configured comparison threshold: stop waiting.
+                                logger.warning(
+                                    f"NO NEW EVENTS in {deadTimeDuration} s: exiting chunk-accumulation sequence."
+                                )
+                                break
+                        else:
+                            logger.warning(
+                                f"NO NEW EVENTS in {waitTimeIncrement} s: exiting chunk-accumulation sequence."
+                            )
+                            break
+                    # Skip accumulation / logging for empty chunks.
+                    continue
+                else:
+                    # Reset accumulator once we see events again.
+                    deadTimeDuration = 0
 
                 logger.info(
                     f"Loaded-chunk interval: ({self.mantidSnapper.mtd[chunkWs].getPulseTimeMin().to_datetime64()}, "
@@ -379,6 +526,7 @@ class LoadLiveDataInterval(PythonAlgorithm):
             )
             self.mantidSnapper.executeQueue()
 
+        self.setProperty("RunStatus", runStatus)
         self.setProperty("OutputWorkspace", outputWs)
 
 

--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -54,6 +54,7 @@ class MantidSnapper:
     ##
     ## KNOWN NON-REENTRANT ALGORITHMS
     ##
+    _nonReentrantAlgorithms = "LoadLiveData", "LoadLiveDataInterval"
     _liveDataLock = Lock()
     _nonReentrantMutexes = {"LoadLiveData": _liveDataLock, "LoadLiveDataInterval": _liveDataLock}
 
@@ -244,13 +245,15 @@ class MantidSnapper:
             self.cleanup()
             raise AlgorithmException(name, str(e)) from e
         finally:
-            self._cleanupNonConcurrent(name, algorithm)
-            if mutex is not None:
-                mutex.release()
+            try:
+                self._cleanupNonConcurrent(name, algorithm)
+            finally:
+                if mutex is not None:
+                    mutex.release()
 
     @classmethod
     def _cleanupNonConcurrent(cls, name, algorithm):
-        if name in cls._nonConcurrentAlgorithms:
+        if name in cls._nonConcurrentAlgorithms or name in cls._nonReentrantAlgorithms:
             cls._waitForAlgorithmCompletion(name)
             cls._removeAlgorithm(algorithm)
 
@@ -301,12 +304,11 @@ class MantidSnapper:
 
     @classmethod
     def _addWorkspaceInfo(cls, workspaceName: str, algorithmName: str, propertyName: str):
-        cls._infoMutex.acquire()
-        cls._workspacesInfo[workspaceName] = {
-            "propertyName": propertyName,
-            "algorithm": algorithmName,
-        }
-        cls._infoMutex.release()
+        with cls._infoMutex:
+            cls._workspacesInfo[workspaceName] = {
+                "propertyName": propertyName,
+                "algorithm": algorithmName,
+            }
 
     @classmethod
     def getWorkspacesInfo(cls) -> Dict[str, Dict[str, Any]]:

--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -247,9 +247,11 @@ class MantidSnapper:
             self.cleanup()
             raise AlgorithmException(name, str(e)) from e
         finally:
-            self._cleanupNonConcurrent(name, algorithm)
-            if mutex is not None:
-                mutex.release()
+            try:
+                self._cleanupNonConcurrent(name, algorithm)
+            finally:
+                if mutex is not None:
+                    mutex.release()
 
     @classmethod
     def _cleanupNonConcurrent(cls, name, algorithm):
@@ -304,12 +306,11 @@ class MantidSnapper:
 
     @classmethod
     def _addWorkspaceInfo(cls, workspaceName: str, algorithmName: str, propertyName: str):
-        cls._infoMutex.acquire()
-        cls._workspacesInfo[workspaceName] = {
-            "propertyName": propertyName,
-            "algorithm": algorithmName,
-        }
-        cls._infoMutex.release()
+        with cls._infoMutex:
+            cls._workspacesInfo[workspaceName] = {
+                "propertyName": propertyName,
+                "algorithm": algorithmName,
+            }
 
     @classmethod
     def getWorkspacesInfo(cls) -> Dict[str, Dict[str, Any]]:

--- a/src/snapred/backend/service/ReductionService.py
+++ b/src/snapred/backend/service/ReductionService.py
@@ -208,7 +208,8 @@ class ReductionService(Service):
         N_groups = len(self._getGroupingMap(request.runNumber, request.useLiteMode))
         if N_groups >= 1 and not request.liveDataMode:
             inputFilePath = self.groceryService.createNeutronFilePath(request.runNumber, request.useLiteMode)
-            if inputFilePath.exists():
+            # in the live-data case, `inputFilePath` may be `None`
+            if inputFilePath and inputFilePath.exists():
                 # As the workspaces aren't actually loaded yet, this estimate uses the file size in bytes.
                 dataSize = float(inputFilePath.stat().st_size)
                 N_ref = float(N_groups * dataSize)

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -98,6 +98,10 @@ liveData:
   # Comparison threshold for the data pulse-time interval.
   time_comparison_threshold: 10 # seconds
 
+  # When true, allow dead-time handling (increment dead-time counter, break on maxDeadTime).
+  # When false (default), exit gracefully when no events and no fallback interval are found.
+  allowDeadTime: false
+
   # The ONLY supported mode right now is 'REPLACE':
   #   any other mode requires stay-resident `LoadLiveData` treatment.
   accumulationMethod: Replace
@@ -397,4 +401,4 @@ lockfile:
   checkFrequency: 10 # seconds
   timeout: 240 # seconds
   # Shared scratch directory across analysis nodes.
-  root: /SNS/EXAMPLES/scratch/snapred
+  root: ${IPTS.default}/EXAMPLES/scratch/snapred

--- a/src/snapred/resources/application.yml
+++ b/src/snapred/resources/application.yml
@@ -101,6 +101,10 @@ liveData:
   # Comparison threshold for the data pulse-time interval.
   time_comparison_threshold: 10 # seconds
 
+  # When true, allow dead-time handling (increment dead-time counter, break on maxDeadTime).
+  # When false (default), exit gracefully when no events and no fallback interval are found.
+  allowDeadTime: false
+
   # The ONLY supported mode right now is 'REPLACE':
   #   any other mode requires stay-resident `LoadLiveData` treatment.
   accumulationMethod: Replace
@@ -403,4 +407,4 @@ lockfile:
   checkFrequency: 10 # seconds
   timeout: 240 # seconds
   # Shared scratch directory across analysis nodes.
-  root: /SNS/EXAMPLES/scratch/snapred
+  root: ${IPTS.default}/EXAMPLES/scratch/snapred

--- a/src/snapred/ui/presenter/WorkflowPresenter.py
+++ b/src/snapred/ui/presenter/WorkflowPresenter.py
@@ -344,9 +344,13 @@ class WorkflowPresenter(QObject):
     @Slot(object)
     def liveDataStateTransition(self, liveDataInfo: LiveDataState.Model):
         # The associated signal is of type ``Signal(SNAPResponseHandler.liveDataStateTransition) as Signal(object)``
-        QMessageBox.information(self.view, "Live Data:", liveDataInfo.message)
+
         # Any live-data transition resets the workflow:
         #   at which point the live-data part of the request view should display the new live-data status.
+        self.reset()
+
+        # In case it's a modal dialog, display the message box after performing the reset.
+        QMessageBox.information(self.view, "Live Data:", liveDataInfo.message)
 
     @Slot()
     def requestCancellation(self):

--- a/src/snapred/ui/workflow/DiffCalWorkflow.py
+++ b/src/snapred/ui/workflow/DiffCalWorkflow.py
@@ -740,6 +740,8 @@ class DiffCalWorkflow(WorkflowImplementer):
             createRecordRequest=createRecordRequest,
         )
 
-        response = self.request(path="calibration/save", payload=payload.model_dump_json())
-        lock.release()
+        try:
+            response = self.request(path="calibration/save", payload=payload.model_dump_json())
+        finally:
+            lock.release()
         return response

--- a/src/snapred/ui/workflow/NormalizationWorkflow.py
+++ b/src/snapred/ui/workflow/NormalizationWorkflow.py
@@ -371,8 +371,10 @@ class NormalizationWorkflow(WorkflowImplementer):
             createIndexEntryRequest=createIndexEntryRequest,
             createRecordRequest=createRecordRequest,
         )
-        response = self.request(path="normalization/save", payload=payload.model_dump_json())
-        lock.release()
+        try:
+            response = self.request(path="normalization/save", payload=payload.model_dump_json())
+        finally:
+            lock.release()
         return response
 
     @EntryExitLogger(logger=logger)

--- a/tests/cis_tests/listener_check.py
+++ b/tests/cis_tests/listener_check.py
@@ -1,0 +1,12 @@
+#
+# Test if we can successfully connect to SNAP's live-data listener.
+#
+import socket
+
+SNAP_ADARA_SERVER = ("bl3-daq1.sns.gov", 31415)
+#1. Create the socket (AF_INET = IPv4, SOCK_STREAM = TCP)
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+    # 2. Connect to the ADARA server
+    s.connect(SNAP_ADARA_SERVER)
+    
+    print(f"SUCCESSFULLY connected to {SNAP_ADARA_SERVER}")

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -99,6 +99,10 @@ liveData:
   # Comparison threshold for the data pulse-time interval.
   time_comparison_threshold: 10 # seconds
 
+  # When true, allow dead-time handling (increment dead-time counter, break on maxDeadTime).
+  # When false (default), exit gracefully when no events and no fallback interval are found.
+  allowDeadTime: false
+
   # The ONLY supported mode right now is 'REPLACE':
   #   any other mode requires stay-resident `LoadLiveData` treatment.
   accumulationMethod: Replace

--- a/tests/resources/application.yml
+++ b/tests/resources/application.yml
@@ -101,6 +101,10 @@ liveData:
   # Comparison threshold for the data pulse-time interval.
   time_comparison_threshold: 10 # seconds
 
+  # When true, allow dead-time handling (increment dead-time counter, break on maxDeadTime).
+  # When false (default), exit gracefully when no events and no fallback interval are found.
+  allowDeadTime: false
+
   # The ONLY supported mode right now is 'REPLACE':
   #   any other mode requires stay-resident `LoadLiveData` treatment.
   accumulationMethod: Replace

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -54,6 +54,7 @@ from snapred.backend.dao.WorkspaceMetadata import UNSET, DiffcalStateMetadata, W
 from snapred.backend.data.GroceryService import GroceryService
 from snapred.backend.error.AlgorithmException import AlgorithmException
 from snapred.backend.error.LiveDataState import LiveDataState
+from snapred.backend.error.RunStatus import RunStatus
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config, Resource
 from snapred.meta.InternalConstants import ReservedRunNumber
@@ -866,6 +867,7 @@ class TestGroceryService(unittest.TestCase):
             "result": True,
             "loader": "LoadNexusProcessed",
             "workspace": self.fetchedWSname,
+            "runStatus": "",
         }
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
@@ -3970,3 +3972,251 @@ class TestGroceryService(unittest.TestCase):
 
             with pytest.raises(RuntimeError, match="Expected instrument to be snaplite for the lite resolution."):
                 self.instance._validateWorkspaceInstrument(item, "wsName")
+
+    # ----- tests for the runStatus-based routing in _fetchLiveData -----
+
+    def test_fetchLiveData_runStatus_running_continues_normally(self):
+        """_fetchLiveData continues normally when runStatus is RUNNING."""
+        runNumber = self.runNumber
+        workspaceName = self.instance._createNeutronWorkspaceName(runNumber, False)
+        item = GroceryListItem(
+            workspaceType="neutron",
+            runNumber=runNumber,
+            useLiteMode=False,
+            loader="",
+            liveDataArgs=LiveDataArgs(duration=datetime.timedelta(seconds=42)),
+        )
+
+        with (
+            mock.patch.object(self.instance, "grocer") as mockGrocer,
+            mock.patch.object(self.instance.dataService, "hasLiveDataConnection", return_value=True),
+            mock.patch.object(self.instance, "mantidSnapper") as mockSnapper,
+            mock.patch.dict(self.instance._loadedRuns, clear=True),
+        ):
+            mockGrocer.executeRecipe.return_value = {
+                "result": True,
+                "loader": "LoadLiveDataInterval",
+                "workspace": workspaceName,
+                "runStatus": RunStatus.RUNNING,
+            }
+            mockSnapper.mtd.__getitem__.return_value = mock.Mock(getRun=mock.Mock(return_value=self.mockRun(runNumber)))
+
+            data = self.instance._fetchLiveData(item)
+            assert data["result"] is True
+
+    def test_fetchLiveData_runStatus_paused_with_live_data_args_raises_LiveDataState(self):
+        """_fetchLiveData raises LiveDataState (RUN_PAUSE) when runStatus is PAUSED and liveDataArgs is set."""
+        runNumber = self.runNumber
+        workspaceName = self.instance._createNeutronWorkspaceName(runNumber, False)
+        item = GroceryListItem(
+            workspaceType="neutron",
+            runNumber=runNumber,
+            useLiteMode=False,
+            loader="",
+            liveDataArgs=LiveDataArgs(duration=datetime.timedelta(seconds=42)),
+        )
+
+        with (
+            mock.patch.object(self.instance, "grocer") as mockGrocer,
+            mock.patch.object(self.instance.dataService, "hasLiveDataConnection", return_value=True),
+            mock.patch.object(self.instance, "deleteWorkspaceUnconditional"),
+        ):
+            mockGrocer.executeRecipe.return_value = {
+                "result": True,
+                "loader": "LoadLiveDataInterval",
+                "workspace": workspaceName,
+                "runStatus": RunStatus.PAUSED,
+            }
+
+            with pytest.raises(LiveDataState) as exc_info:
+                self.instance._fetchLiveData(item)
+            assert exc_info.value.transition == LiveDataState.Type.RUN_PAUSE
+
+    def test_fetchLiveData_runStatus_stopped_with_live_data_args_raises_LiveDataState(self):
+        """_fetchLiveData raises LiveDataState (RUN_END) when runStatus is STOPPED and liveDataArgs is set."""
+        runNumber = self.runNumber
+        workspaceName = self.instance._createNeutronWorkspaceName(runNumber, False)
+        item = GroceryListItem(
+            workspaceType="neutron",
+            runNumber=runNumber,
+            useLiteMode=False,
+            loader="",
+            liveDataArgs=LiveDataArgs(duration=datetime.timedelta(seconds=42)),
+        )
+
+        with (
+            mock.patch.object(self.instance, "grocer") as mockGrocer,
+            mock.patch.object(self.instance.dataService, "hasLiveDataConnection", return_value=True),
+            mock.patch.object(self.instance, "deleteWorkspaceUnconditional"),
+        ):
+            mockGrocer.executeRecipe.return_value = {
+                "result": True,
+                "loader": "LoadLiveDataInterval",
+                "workspace": workspaceName,
+                "runStatus": RunStatus.STOPPED,
+            }
+
+            with pytest.raises(LiveDataState) as exc_info:
+                self.instance._fetchLiveData(item)
+            assert exc_info.value.transition == LiveDataState.Type.RUN_END
+
+    def test_fetchLiveData_runStatus_error_with_live_data_args_raises_LiveDataState(self):
+        """_fetchLiveData raises LiveDataState (RUN_ERROR) when runStatus is ERROR and liveDataArgs is set."""
+        runNumber = self.runNumber
+        workspaceName = self.instance._createNeutronWorkspaceName(runNumber, False)
+        item = GroceryListItem(
+            workspaceType="neutron",
+            runNumber=runNumber,
+            useLiteMode=False,
+            loader="",
+            liveDataArgs=LiveDataArgs(duration=datetime.timedelta(seconds=42)),
+        )
+
+        with (
+            mock.patch.object(self.instance, "grocer") as mockGrocer,
+            mock.patch.object(self.instance.dataService, "hasLiveDataConnection", return_value=True),
+            mock.patch.object(self.instance, "deleteWorkspaceUnconditional"),
+        ):
+            mockGrocer.executeRecipe.return_value = {
+                "result": True,
+                "loader": "LoadLiveDataInterval",
+                "workspace": workspaceName,
+                "runStatus": RunStatus.ERROR,
+            }
+
+            with pytest.raises(LiveDataState) as exc_info:
+                self.instance._fetchLiveData(item)
+            assert exc_info.value.transition == LiveDataState.Type.RUN_ERROR
+
+    def test_fetchLiveData_runStatus_not_running_without_live_data_args_raises_RuntimeError(self):
+        """_fetchLiveData raises RuntimeError for any non-RUNNING status when liveDataArgs is None."""
+        runNumber = self.runNumber
+        workspaceName = self.instance._createNeutronWorkspaceName(runNumber, False)
+        item = GroceryListItem(
+            workspaceType="neutron",
+            runNumber=runNumber,
+            useLiteMode=False,
+            loader="",
+        )
+
+        with (
+            mock.patch.object(self.instance, "grocer") as mockGrocer,
+            mock.patch.object(self.instance.dataService, "hasLiveDataConnection", return_value=True),
+            mock.patch.object(self.instance, "deleteWorkspaceUnconditional"),
+        ):
+            mockGrocer.executeRecipe.return_value = {
+                "result": True,
+                "loader": "LoadLiveDataInterval",
+                "workspace": workspaceName,
+                "runStatus": RunStatus.STOPPED,
+            }
+
+            with pytest.raises(RuntimeError, match=".*problem with the live-data run.*"):
+                self.instance._fetchLiveData(item)
+
+    def test_fetchLiveData_runStatus_invalid_value_logs_debug_and_continues(self):
+        """_fetchLiveData logs a debug message and continues normally when runStatus is not a valid RunStatus value."""
+        runNumber = self.runNumber
+        workspaceName = self.instance._createNeutronWorkspaceName(runNumber, False)
+        item = GroceryListItem(
+            workspaceType="neutron",
+            runNumber=runNumber,
+            useLiteMode=False,
+            loader="",
+            liveDataArgs=LiveDataArgs(duration=datetime.timedelta(seconds=42)),
+        )
+
+        with (
+            mock.patch.object(self.instance, "grocer") as mockGrocer,
+            mock.patch.object(self.instance.dataService, "hasLiveDataConnection", return_value=True),
+            mock.patch.object(self.instance, "mantidSnapper") as mockSnapper,
+            mock.patch.dict(self.instance._loadedRuns, clear=True),
+            mock.patch(ThisService + "logger") as mockLogger,
+        ):
+            mockGrocer.executeRecipe.return_value = {
+                "result": True,
+                "loader": "LoadLiveDataInterval",
+                "workspace": workspaceName,
+                "runStatus": "NOT_A_VALID_RUN_STATUS_VALUE",
+            }
+            mockSnapper.mtd.__getitem__.return_value = mock.Mock(getRun=mock.Mock(return_value=self.mockRun(runNumber)))
+
+            data = self.instance._fetchLiveData(item)
+            assert data["result"] is True
+            mockLogger.debug.assert_called_once()
+
+    # ----- tests for liveRunNumber=None paths in _fetchLiveData -----
+
+    def _mockRunWithoutRunNumber(self) -> mock.Mock:
+        """Return a mock mantid.api.Run that has NO 'run_number' property."""
+        return mock.Mock(
+            spec=Run,
+            hasProperty=mock.Mock(return_value=False),
+            getProperty=mock.Mock(return_value=None),
+        )
+
+    def test_fetchLiveData_live_run_number_none_with_live_data_args_sets_run_number(self):
+        """When run_number is absent in the live workspace and liveDataArgs is set,
+        _fetchLiveData patches the workspace run-number in-place and succeeds."""
+        runNumber = self.runNumber
+        workspaceName = self.instance._createNeutronWorkspaceName(runNumber, False)
+        item = GroceryListItem(
+            workspaceType="neutron",
+            runNumber=runNumber,
+            useLiteMode=False,
+            loader="",
+            liveDataArgs=LiveDataArgs(duration=datetime.timedelta(seconds=42)),
+        )
+
+        with (
+            mock.patch.object(self.instance, "grocer") as mockGrocer,
+            mock.patch.object(self.instance.dataService, "hasLiveDataConnection", return_value=True),
+            mock.patch.object(self.instance, "mantidSnapper") as mockSnapper,
+            mock.patch.dict(self.instance._loadedRuns, clear=True),
+        ):
+            mockGrocer.executeRecipe.return_value = {
+                "result": True,
+                "loader": "LoadLiveDataInterval",
+                "workspace": workspaceName,
+            }
+            mockWs = mock.MagicMock()
+            mockWs.getRun.return_value = self._mockRunWithoutRunNumber()
+            mockSnapper.mtd.__getitem__.return_value = mockWs
+
+            data = self.instance._fetchLiveData(item)
+
+            assert data["result"] is True
+            # The workspace run-number should have been patched with the item's run number:
+            mockWs.mutableRun.return_value.__setitem__.assert_called_once_with("run_number", runNumber)
+
+    def test_fetchLiveData_live_run_number_none_without_live_data_args_raises_runtime_error(self):
+        """When run_number is absent in the live workspace and liveDataArgs is None (fallback mode),
+        _fetchLiveData deletes the workspace and raises RuntimeError."""
+        runNumber = self.runNumber
+        workspaceName = self.instance._createNeutronWorkspaceName(runNumber, False)
+        item = GroceryListItem(
+            workspaceType="neutron",
+            runNumber=runNumber,
+            useLiteMode=False,
+            loader="",
+            # liveDataArgs is intentionally absent (None) → fallback mode
+        )
+
+        with (
+            mock.patch.object(self.instance, "grocer") as mockGrocer,
+            mock.patch.object(self.instance.dataService, "hasLiveDataConnection", return_value=True),
+            mock.patch.object(self.instance, "mantidSnapper") as mockSnapper,
+            mock.patch.object(self.instance, "deleteWorkspaceUnconditional") as mockDeleteWorkspace,
+        ):
+            mockGrocer.executeRecipe.return_value = {
+                "result": True,
+                "loader": "LoadLiveDataInterval",
+                "workspace": workspaceName,
+            }
+            mockSnapper.mtd.__getitem__.return_value = mock.Mock(
+                getRun=mock.Mock(return_value=self._mockRunWithoutRunNumber())
+            )
+
+            with pytest.raises(RuntimeError, match=".*nor is it the live-data run.*"):
+                self.instance._fetchLiveData(item)
+            mockDeleteWorkspace.assert_called_once_with(workspaceName)

--- a/tests/unit/backend/data/test_GroceryService.py
+++ b/tests/unit/backend/data/test_GroceryService.py
@@ -54,6 +54,7 @@ from snapred.backend.dao.WorkspaceMetadata import UNSET, DiffcalStateMetadata, W
 from snapred.backend.data.GroceryService import GroceryService
 from snapred.backend.error.AlgorithmException import AlgorithmException
 from snapred.backend.error.LiveDataState import LiveDataState
+from snapred.backend.error.RunStatus import RunStatus
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Config import Config, Resource
 from snapred.meta.InternalConstants import ReservedRunNumber
@@ -866,6 +867,7 @@ class TestGroceryService(unittest.TestCase):
             "result": True,
             "loader": "LoadNexusProcessed",
             "workspace": self.fetchedWSname,
+            "runStatus": "",
         }
         assert_wksp_almost_equal(
             Workspace1=self.sampleWS,
@@ -3930,3 +3932,251 @@ class TestGroceryService(unittest.TestCase):
 
             with pytest.raises(RuntimeError, match="Expected instrument to be snaplite for the lite resolution."):
                 self.instance._validateWorkspaceInstrument(item, "wsName")
+
+    # ----- tests for the runStatus-based routing in _fetchLiveData -----
+
+    def test_fetchLiveData_runStatus_running_continues_normally(self):
+        """_fetchLiveData continues normally when runStatus is RUNNING."""
+        runNumber = self.runNumber
+        workspaceName = self.instance._createNeutronWorkspaceName(runNumber, False)
+        item = GroceryListItem(
+            workspaceType="neutron",
+            runNumber=runNumber,
+            useLiteMode=False,
+            loader="",
+            liveDataArgs=LiveDataArgs(duration=datetime.timedelta(seconds=42)),
+        )
+
+        with (
+            mock.patch.object(self.instance, "grocer") as mockGrocer,
+            mock.patch.object(self.instance.dataService, "hasLiveDataConnection", return_value=True),
+            mock.patch.object(self.instance, "mantidSnapper") as mockSnapper,
+            mock.patch.dict(self.instance._loadedRuns, clear=True),
+        ):
+            mockGrocer.executeRecipe.return_value = {
+                "result": True,
+                "loader": "LoadLiveDataInterval",
+                "workspace": workspaceName,
+                "runStatus": RunStatus.RUNNING,
+            }
+            mockSnapper.mtd.__getitem__.return_value = mock.Mock(getRun=mock.Mock(return_value=self.mockRun(runNumber)))
+
+            data = self.instance._fetchLiveData(item)
+            assert data["result"] is True
+
+    def test_fetchLiveData_runStatus_paused_with_live_data_args_raises_LiveDataState(self):
+        """_fetchLiveData raises LiveDataState (RUN_PAUSE) when runStatus is PAUSED and liveDataArgs is set."""
+        runNumber = self.runNumber
+        workspaceName = self.instance._createNeutronWorkspaceName(runNumber, False)
+        item = GroceryListItem(
+            workspaceType="neutron",
+            runNumber=runNumber,
+            useLiteMode=False,
+            loader="",
+            liveDataArgs=LiveDataArgs(duration=datetime.timedelta(seconds=42)),
+        )
+
+        with (
+            mock.patch.object(self.instance, "grocer") as mockGrocer,
+            mock.patch.object(self.instance.dataService, "hasLiveDataConnection", return_value=True),
+            mock.patch.object(self.instance, "deleteWorkspaceUnconditional"),
+        ):
+            mockGrocer.executeRecipe.return_value = {
+                "result": True,
+                "loader": "LoadLiveDataInterval",
+                "workspace": workspaceName,
+                "runStatus": RunStatus.PAUSED,
+            }
+
+            with pytest.raises(LiveDataState) as exc_info:
+                self.instance._fetchLiveData(item)
+            assert exc_info.value.transition == LiveDataState.Type.RUN_PAUSE
+
+    def test_fetchLiveData_runStatus_stopped_with_live_data_args_raises_LiveDataState(self):
+        """_fetchLiveData raises LiveDataState (RUN_END) when runStatus is STOPPED and liveDataArgs is set."""
+        runNumber = self.runNumber
+        workspaceName = self.instance._createNeutronWorkspaceName(runNumber, False)
+        item = GroceryListItem(
+            workspaceType="neutron",
+            runNumber=runNumber,
+            useLiteMode=False,
+            loader="",
+            liveDataArgs=LiveDataArgs(duration=datetime.timedelta(seconds=42)),
+        )
+
+        with (
+            mock.patch.object(self.instance, "grocer") as mockGrocer,
+            mock.patch.object(self.instance.dataService, "hasLiveDataConnection", return_value=True),
+            mock.patch.object(self.instance, "deleteWorkspaceUnconditional"),
+        ):
+            mockGrocer.executeRecipe.return_value = {
+                "result": True,
+                "loader": "LoadLiveDataInterval",
+                "workspace": workspaceName,
+                "runStatus": RunStatus.STOPPED,
+            }
+
+            with pytest.raises(LiveDataState) as exc_info:
+                self.instance._fetchLiveData(item)
+            assert exc_info.value.transition == LiveDataState.Type.RUN_END
+
+    def test_fetchLiveData_runStatus_error_with_live_data_args_raises_LiveDataState(self):
+        """_fetchLiveData raises LiveDataState (RUN_ERROR) when runStatus is ERROR and liveDataArgs is set."""
+        runNumber = self.runNumber
+        workspaceName = self.instance._createNeutronWorkspaceName(runNumber, False)
+        item = GroceryListItem(
+            workspaceType="neutron",
+            runNumber=runNumber,
+            useLiteMode=False,
+            loader="",
+            liveDataArgs=LiveDataArgs(duration=datetime.timedelta(seconds=42)),
+        )
+
+        with (
+            mock.patch.object(self.instance, "grocer") as mockGrocer,
+            mock.patch.object(self.instance.dataService, "hasLiveDataConnection", return_value=True),
+            mock.patch.object(self.instance, "deleteWorkspaceUnconditional"),
+        ):
+            mockGrocer.executeRecipe.return_value = {
+                "result": True,
+                "loader": "LoadLiveDataInterval",
+                "workspace": workspaceName,
+                "runStatus": RunStatus.ERROR,
+            }
+
+            with pytest.raises(LiveDataState) as exc_info:
+                self.instance._fetchLiveData(item)
+            assert exc_info.value.transition == LiveDataState.Type.RUN_ERROR
+
+    def test_fetchLiveData_runStatus_not_running_without_live_data_args_raises_RuntimeError(self):
+        """_fetchLiveData raises RuntimeError for any non-RUNNING status when liveDataArgs is None."""
+        runNumber = self.runNumber
+        workspaceName = self.instance._createNeutronWorkspaceName(runNumber, False)
+        item = GroceryListItem(
+            workspaceType="neutron",
+            runNumber=runNumber,
+            useLiteMode=False,
+            loader="",
+        )
+
+        with (
+            mock.patch.object(self.instance, "grocer") as mockGrocer,
+            mock.patch.object(self.instance.dataService, "hasLiveDataConnection", return_value=True),
+            mock.patch.object(self.instance, "deleteWorkspaceUnconditional"),
+        ):
+            mockGrocer.executeRecipe.return_value = {
+                "result": True,
+                "loader": "LoadLiveDataInterval",
+                "workspace": workspaceName,
+                "runStatus": RunStatus.STOPPED,
+            }
+
+            with pytest.raises(RuntimeError, match=".*problem with the live-data run.*"):
+                self.instance._fetchLiveData(item)
+
+    def test_fetchLiveData_runStatus_invalid_value_logs_debug_and_continues(self):
+        """_fetchLiveData logs a debug message and continues normally when runStatus is not a valid RunStatus value."""
+        runNumber = self.runNumber
+        workspaceName = self.instance._createNeutronWorkspaceName(runNumber, False)
+        item = GroceryListItem(
+            workspaceType="neutron",
+            runNumber=runNumber,
+            useLiteMode=False,
+            loader="",
+            liveDataArgs=LiveDataArgs(duration=datetime.timedelta(seconds=42)),
+        )
+
+        with (
+            mock.patch.object(self.instance, "grocer") as mockGrocer,
+            mock.patch.object(self.instance.dataService, "hasLiveDataConnection", return_value=True),
+            mock.patch.object(self.instance, "mantidSnapper") as mockSnapper,
+            mock.patch.dict(self.instance._loadedRuns, clear=True),
+            mock.patch(ThisService + "logger") as mockLogger,
+        ):
+            mockGrocer.executeRecipe.return_value = {
+                "result": True,
+                "loader": "LoadLiveDataInterval",
+                "workspace": workspaceName,
+                "runStatus": "NOT_A_VALID_RUN_STATUS_VALUE",
+            }
+            mockSnapper.mtd.__getitem__.return_value = mock.Mock(getRun=mock.Mock(return_value=self.mockRun(runNumber)))
+
+            data = self.instance._fetchLiveData(item)
+            assert data["result"] is True
+            mockLogger.debug.assert_called_once()
+
+    # ----- tests for liveRunNumber=None paths in _fetchLiveData -----
+
+    def _mockRunWithoutRunNumber(self) -> mock.Mock:
+        """Return a mock mantid.api.Run that has NO 'run_number' property."""
+        return mock.Mock(
+            spec=Run,
+            hasProperty=mock.Mock(return_value=False),
+            getProperty=mock.Mock(return_value=None),
+        )
+
+    def test_fetchLiveData_live_run_number_none_with_live_data_args_sets_run_number(self):
+        """When run_number is absent in the live workspace and liveDataArgs is set,
+        _fetchLiveData patches the workspace run-number in-place and succeeds."""
+        runNumber = self.runNumber
+        workspaceName = self.instance._createNeutronWorkspaceName(runNumber, False)
+        item = GroceryListItem(
+            workspaceType="neutron",
+            runNumber=runNumber,
+            useLiteMode=False,
+            loader="",
+            liveDataArgs=LiveDataArgs(duration=datetime.timedelta(seconds=42)),
+        )
+
+        with (
+            mock.patch.object(self.instance, "grocer") as mockGrocer,
+            mock.patch.object(self.instance.dataService, "hasLiveDataConnection", return_value=True),
+            mock.patch.object(self.instance, "mantidSnapper") as mockSnapper,
+            mock.patch.dict(self.instance._loadedRuns, clear=True),
+        ):
+            mockGrocer.executeRecipe.return_value = {
+                "result": True,
+                "loader": "LoadLiveDataInterval",
+                "workspace": workspaceName,
+            }
+            mockWs = mock.MagicMock()
+            mockWs.getRun.return_value = self._mockRunWithoutRunNumber()
+            mockSnapper.mtd.__getitem__.return_value = mockWs
+
+            data = self.instance._fetchLiveData(item)
+
+            assert data["result"] is True
+            # The workspace run-number should have been patched with the item's run number:
+            mockWs.mutableRun.return_value.__setitem__.assert_called_once_with("run_number", runNumber)
+
+    def test_fetchLiveData_live_run_number_none_without_live_data_args_raises_runtime_error(self):
+        """When run_number is absent in the live workspace and liveDataArgs is None (fallback mode),
+        _fetchLiveData deletes the workspace and raises RuntimeError."""
+        runNumber = self.runNumber
+        workspaceName = self.instance._createNeutronWorkspaceName(runNumber, False)
+        item = GroceryListItem(
+            workspaceType="neutron",
+            runNumber=runNumber,
+            useLiteMode=False,
+            loader="",
+            # liveDataArgs is intentionally absent (None) → fallback mode
+        )
+
+        with (
+            mock.patch.object(self.instance, "grocer") as mockGrocer,
+            mock.patch.object(self.instance.dataService, "hasLiveDataConnection", return_value=True),
+            mock.patch.object(self.instance, "mantidSnapper") as mockSnapper,
+            mock.patch.object(self.instance, "deleteWorkspaceUnconditional") as mockDeleteWorkspace,
+        ):
+            mockGrocer.executeRecipe.return_value = {
+                "result": True,
+                "loader": "LoadLiveDataInterval",
+                "workspace": workspaceName,
+            }
+            mockSnapper.mtd.__getitem__.return_value = mock.Mock(
+                getRun=mock.Mock(return_value=self._mockRunWithoutRunNumber())
+            )
+
+            with pytest.raises(RuntimeError, match=".*nor is it the live-data run.*"):
+                self.instance._fetchLiveData(item)
+            mockDeleteWorkspace.assert_called_once_with(workspaceName)

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -648,6 +648,227 @@ def test_hasLiveDataConnection_config_disabled(mockGetHostByAddr):
         mockGetHostByAddr.assert_not_called()
 
 
+## ====== Tests for: `LocalDataService.hasLiveDataConnection` (UDS paths) ======
+
+
+@mock.patch(ThisService + "ConfigService")
+def test_hasLiveDataConnection_uds_socket_file_exists(mockConfigService):
+    """UDS path: the configured address is a Unix domain socket that exists → True."""
+    with Config_override("liveData.enabled", True):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            socket_path = os.path.join(tmpdir, "test.sock")
+            # Create a real Unix domain socket file:
+            sock = socket.socket(socket.AF_UNIX)
+            sock.bind(socket_path)
+            try:
+                mockConfigService.getFacility.return_value.instrument.return_value.liveDataAddress.return_value = (
+                    socket_path
+                )
+                instance = LocalDataService()
+                assert instance.hasLiveDataConnection()
+            finally:
+                sock.close()
+
+
+@mock.patch(ThisService + "ConfigService")
+def test_hasLiveDataConnection_uds_path_exists_but_not_socket(mockConfigService):
+    """UDS path: the configured address is a regular file, not a socket → False."""
+    with Config_override("liveData.enabled", True):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            regular_file = os.path.join(tmpdir, "not_a_socket.txt")
+            # Create a plain regular file:
+            with open(regular_file, "w") as f:
+                f.write("not a socket")
+            mockConfigService.getFacility.return_value.instrument.return_value.liveDataAddress.return_value = (
+                regular_file
+            )
+            instance = LocalDataService()
+            assert not instance.hasLiveDataConnection()
+
+
+@mock.patch(ThisService + "ConfigService")
+def test_hasLiveDataConnection_uds_path_does_not_exist(mockConfigService):
+    """UDS path: the configured socket path does not exist at all → False."""
+    with Config_override("liveData.enabled", True):
+        mockConfigService.getFacility.return_value.instrument.return_value.liveDataAddress.return_value = (
+            "/tmp/_snapred_nonexistent_socket_zyxwvuts.sock"
+        )
+        instance = LocalDataService()
+        assert not instance.hasLiveDataConnection()
+
+
+@mock.patch(ThisService + "ConfigService")
+def test_hasLiveDataConnection_uds_is_socket_raises_os_stat_fallback_true(mockConfigService):
+    """UDS path: is_socket() raises (simulating Python < 3.12) → os.stat fallback identifies a socket → True."""
+    with Config_override("liveData.enabled", True):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            socket_path = os.path.join(tmpdir, "test_fallback.sock")
+            # Create a real Unix domain socket file:
+            sock = socket.socket(socket.AF_UNIX)
+            sock.bind(socket_path)
+            try:
+                mockConfigService.getFacility.return_value.instrument.return_value.liveDataAddress.return_value = (
+                    socket_path
+                )
+                # Simulate a Python version where is_socket() is unavailable:
+                with mock.patch("pathlib.Path.is_socket", side_effect=AttributeError("is_socket() not available")):
+                    instance = LocalDataService()
+                    assert instance.hasLiveDataConnection()
+            finally:
+                sock.close()
+
+
+@mock.patch(ThisService + "ConfigService")
+def test_hasLiveDataConnection_uds_is_socket_raises_os_stat_also_raises(mockConfigService):
+    """UDS path: is_socket() raises AND os.stat also raises → returns False."""
+    with Config_override("liveData.enabled", True):
+        mockConfigService.getFacility.return_value.instrument.return_value.liveDataAddress.return_value = (
+            "/tmp/_snapred_nonexistent_socket_zyxwvuts.sock"
+        )
+        # Patch pathlib.Path.exists to raise (so the outer try-block raises, triggering the except branch),
+        # then also make os.stat raise (so the inner fallback try-block also fails).
+        with (
+            mock.patch("pathlib.Path.exists", side_effect=RuntimeError("exists() unexpectedly failed")),
+            mock.patch("os.stat", side_effect=OSError("os.stat failed")),
+        ):
+            instance = LocalDataService()
+            assert not instance.hasLiveDataConnection()
+
+
+## ====== Tests for: `LocalDataService._parseSocketAddress:     ======
+#  (See also: "<mantid codebase>/LiveData/test/Python/test_adara_player_util.py" `Test_SocketAddress`.)
+
+
+def test_parse_hostname():
+    """Checks that hostnames and DNS names parse as (host, port) tuples."""
+
+    # Simple "localhost"
+    result = LocalDataService._parseSocketAddress("localhost:12345")
+    assert result == ("localhost", 12345)
+
+    # Common DNS-style name
+    result = LocalDataService._parseSocketAddress("example.com:80")
+    assert result == ("example.com", 80)
+
+    # Subdomain and hyphen in name
+    result = LocalDataService._parseSocketAddress("my-db-server.local:54321")
+    assert result == ("my-db-server.local", 54321)
+
+    # Fully qualified domain name (FQDN)
+    result = LocalDataService._parseSocketAddress("bl3-daq1.sns.gov:31415")
+    assert result == ("bl3-daq1.sns.gov", 31415)
+
+    # Hostname with digits
+    result = LocalDataService._parseSocketAddress("node123:8081")
+    assert result == ("node123", 8081)
+
+
+def test_parse_invalid_hostname_formats():
+    """Ensures invalid hostname/port addresses throw errors."""
+
+    # Hostname, missing port
+    with pytest.raises(ValueError, match=".*Invalid address format.*"):
+        LocalDataService._parseSocketAddress("example.com")
+
+    # Hostname, port out of range
+    with pytest.raises(ValueError, match=".*Port out of range.*"):
+        LocalDataService._parseSocketAddress("localhost:99999")
+
+    # Port is zero (not allowed)
+    with pytest.raises(ValueError, match=".*Port out of range.*"):
+        LocalDataService._parseSocketAddress("someserv:0")
+
+    # Hostname with invalid character
+    with pytest.raises(ValueError, match=".*Invalid address format.*"):
+        LocalDataService._parseSocketAddress("bad*host:8000")
+
+    # Leading colon, missing host
+    with pytest.raises(ValueError, match=".*Invalid address format.*"):
+        LocalDataService._parseSocketAddress(":8080")
+
+
+def test_parse_ipv4():
+    """Checks that IPv4 address/port strings parse to expected tuples."""
+    # Standard IPv4 address
+    result = LocalDataService._parseSocketAddress("192.168.1.100:8080")
+    assert result == ("192.168.1.100", 8080)
+
+    # Localhost
+    result = LocalDataService._parseSocketAddress("127.0.0.1:9000")
+    assert result == ("127.0.0.1", 9000)
+
+    # High port number
+    result = LocalDataService._parseSocketAddress("10.0.0.1:65535")
+    assert result == ("10.0.0.1", 65535)
+
+    # Low port number
+    result = LocalDataService._parseSocketAddress("172.16.0.1:1")
+    assert result == ("172.16.0.1", 1)
+
+
+def test_parse_ipv6():
+    """Checks that IPv6 address/port strings parse correctly, including bracket handling."""
+    # IPv6 with brackets (required format)
+    result = LocalDataService._parseSocketAddress("[::1]:8080")
+    assert result == ("::1", 8080)
+
+    # Full IPv6 address
+    result = LocalDataService._parseSocketAddress("[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:9000")
+    assert result == ("2001:0db8:85a3:0000:0000:8a2e:0370:7334", 9000)
+
+    # Compressed IPv6 address
+    result = LocalDataService._parseSocketAddress("[2001:db8::1]:443")
+    assert result == ("2001:db8::1", 443)
+
+    # IPv6 loopback
+    result = LocalDataService._parseSocketAddress("[::1]:12345")
+    assert result, ("::1", 12345)
+
+
+def test_parse_unix_socket():
+    """Tests parsing of Unix domain socket paths to Path objects."""
+    # Absolute path starting with /
+    result = LocalDataService._parseSocketAddress("/tmp/my_socket.sock")
+    assert isinstance(result, Path)
+    assert result == Path("/tmp/my_socket.sock")
+
+    # Another Unix socket path
+    result = LocalDataService._parseSocketAddress("/var/run/adara.sock")
+    assert isinstance(result, Path)
+    assert result == Path("/var/run/adara.sock")
+
+    # Path with multiple components
+    result = LocalDataService._parseSocketAddress("/home/user/.local/share/app/socket")
+    assert isinstance(result, Path)
+    assert result == Path("/home/user/.local/share/app/socket")
+
+
+def test_parse_invalid_format():
+    """Ensures invalid address strings throw errors."""
+    # Port out of range (too high)
+    with pytest.raises(ValueError, match=".*Port out of range.*"):
+        LocalDataService._parseSocketAddress("192.168.1.1:65536")
+
+    # Port out of range (negative)
+    with pytest.raises(ValueError, match=".*Invalid address format.*"):
+        LocalDataService._parseSocketAddress("192.168.1.1:-1")
+
+    # Port is zero
+    with pytest.raises(ValueError, match=".*Port out of range.*"):
+        LocalDataService._parseSocketAddress("192.168.1.1:0")
+
+    # Invalid format - no match for IP:port or Unix socket
+    with pytest.raises(ValueError, match=".*Invalid address format.*"):
+        LocalDataService._parseSocketAddress("not-a-valid-address")
+
+    # IPv6 without brackets
+    with pytest.raises(ValueError, match=".*Invalid address format.*"):
+        LocalDataService._parseSocketAddress("::1:8080")
+
+
+## ====== end: Tests for: `LocalDataService._parseSocketAddress ======
+
+
 @mock.patch(ThisService + "RunMetadata")
 def test__liveMetadataFromRun(mockRunMetadata):
     mockMetadata = mock.Mock(spec=RunMetadata)

--- a/tests/unit/backend/data/test_LocalDataService.py
+++ b/tests/unit/backend/data/test_LocalDataService.py
@@ -659,6 +659,227 @@ def test_hasLiveDataConnection_config_disabled(mockGetHostByAddr):
         mockGetHostByAddr.assert_not_called()
 
 
+## ====== Tests for: `LocalDataService.hasLiveDataConnection` (UDS paths) ======
+
+
+@mock.patch(ThisService + "ConfigService")
+def test_hasLiveDataConnection_uds_socket_file_exists(mockConfigService):
+    """UDS path: the configured address is a Unix domain socket that exists → True."""
+    with Config_override("liveData.enabled", True):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            socket_path = os.path.join(tmpdir, "test.sock")
+            # Create a real Unix domain socket file:
+            sock = socket.socket(socket.AF_UNIX)
+            sock.bind(socket_path)
+            try:
+                mockConfigService.getFacility.return_value.instrument.return_value.liveDataAddress.return_value = (
+                    socket_path
+                )
+                instance = LocalDataService()
+                assert instance.hasLiveDataConnection()
+            finally:
+                sock.close()
+
+
+@mock.patch(ThisService + "ConfigService")
+def test_hasLiveDataConnection_uds_path_exists_but_not_socket(mockConfigService):
+    """UDS path: the configured address is a regular file, not a socket → False."""
+    with Config_override("liveData.enabled", True):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            regular_file = os.path.join(tmpdir, "not_a_socket.txt")
+            # Create a plain regular file:
+            with open(regular_file, "w") as f:
+                f.write("not a socket")
+            mockConfigService.getFacility.return_value.instrument.return_value.liveDataAddress.return_value = (
+                regular_file
+            )
+            instance = LocalDataService()
+            assert not instance.hasLiveDataConnection()
+
+
+@mock.patch(ThisService + "ConfigService")
+def test_hasLiveDataConnection_uds_path_does_not_exist(mockConfigService):
+    """UDS path: the configured socket path does not exist at all → False."""
+    with Config_override("liveData.enabled", True):
+        mockConfigService.getFacility.return_value.instrument.return_value.liveDataAddress.return_value = (
+            "/tmp/_snapred_nonexistent_socket_zyxwvuts.sock"
+        )
+        instance = LocalDataService()
+        assert not instance.hasLiveDataConnection()
+
+
+@mock.patch(ThisService + "ConfigService")
+def test_hasLiveDataConnection_uds_is_socket_raises_os_stat_fallback_true(mockConfigService):
+    """UDS path: is_socket() raises (simulating Python < 3.12) → os.stat fallback identifies a socket → True."""
+    with Config_override("liveData.enabled", True):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            socket_path = os.path.join(tmpdir, "test_fallback.sock")
+            # Create a real Unix domain socket file:
+            sock = socket.socket(socket.AF_UNIX)
+            sock.bind(socket_path)
+            try:
+                mockConfigService.getFacility.return_value.instrument.return_value.liveDataAddress.return_value = (
+                    socket_path
+                )
+                # Simulate a Python version where is_socket() is unavailable:
+                with mock.patch("pathlib.Path.is_socket", side_effect=AttributeError("is_socket() not available")):
+                    instance = LocalDataService()
+                    assert instance.hasLiveDataConnection()
+            finally:
+                sock.close()
+
+
+@mock.patch(ThisService + "ConfigService")
+def test_hasLiveDataConnection_uds_is_socket_raises_os_stat_also_raises(mockConfigService):
+    """UDS path: is_socket() raises AND os.stat also raises → returns False."""
+    with Config_override("liveData.enabled", True):
+        mockConfigService.getFacility.return_value.instrument.return_value.liveDataAddress.return_value = (
+            "/tmp/_snapred_nonexistent_socket_zyxwvuts.sock"
+        )
+        # Patch pathlib.Path.exists to raise (so the outer try-block raises, triggering the except branch),
+        # then also make os.stat raise (so the inner fallback try-block also fails).
+        with (
+            mock.patch("pathlib.Path.exists", side_effect=RuntimeError("exists() unexpectedly failed")),
+            mock.patch("os.stat", side_effect=OSError("os.stat failed")),
+        ):
+            instance = LocalDataService()
+            assert not instance.hasLiveDataConnection()
+
+
+## ====== Tests for: `LocalDataService._parseSocketAddress:     ======
+#  (See also: "<mantid codebase>/LiveData/test/Python/test_adara_player_util.py" `Test_SocketAddress`.)
+
+
+def test_parse_hostname():
+    """Checks that hostnames and DNS names parse as (host, port) tuples."""
+
+    # Simple "localhost"
+    result = LocalDataService._parseSocketAddress("localhost:12345")
+    assert result == ("localhost", 12345)
+
+    # Common DNS-style name
+    result = LocalDataService._parseSocketAddress("example.com:80")
+    assert result == ("example.com", 80)
+
+    # Subdomain and hyphen in name
+    result = LocalDataService._parseSocketAddress("my-db-server.local:54321")
+    assert result == ("my-db-server.local", 54321)
+
+    # Fully qualified domain name (FQDN)
+    result = LocalDataService._parseSocketAddress("bl3-daq1.sns.gov:31415")
+    assert result == ("bl3-daq1.sns.gov", 31415)
+
+    # Hostname with digits
+    result = LocalDataService._parseSocketAddress("node123:8081")
+    assert result == ("node123", 8081)
+
+
+def test_parse_invalid_hostname_formats():
+    """Ensures invalid hostname/port addresses throw errors."""
+
+    # Hostname, missing port
+    with pytest.raises(ValueError, match=".*Invalid address format.*"):
+        LocalDataService._parseSocketAddress("example.com")
+
+    # Hostname, port out of range
+    with pytest.raises(ValueError, match=".*Port out of range.*"):
+        LocalDataService._parseSocketAddress("localhost:99999")
+
+    # Port is zero (not allowed)
+    with pytest.raises(ValueError, match=".*Port out of range.*"):
+        LocalDataService._parseSocketAddress("someserv:0")
+
+    # Hostname with invalid character
+    with pytest.raises(ValueError, match=".*Invalid address format.*"):
+        LocalDataService._parseSocketAddress("bad*host:8000")
+
+    # Leading colon, missing host
+    with pytest.raises(ValueError, match=".*Invalid address format.*"):
+        LocalDataService._parseSocketAddress(":8080")
+
+
+def test_parse_ipv4():
+    """Checks that IPv4 address/port strings parse to expected tuples."""
+    # Standard IPv4 address
+    result = LocalDataService._parseSocketAddress("192.168.1.100:8080")
+    assert result == ("192.168.1.100", 8080)
+
+    # Localhost
+    result = LocalDataService._parseSocketAddress("127.0.0.1:9000")
+    assert result == ("127.0.0.1", 9000)
+
+    # High port number
+    result = LocalDataService._parseSocketAddress("10.0.0.1:65535")
+    assert result == ("10.0.0.1", 65535)
+
+    # Low port number
+    result = LocalDataService._parseSocketAddress("172.16.0.1:1")
+    assert result == ("172.16.0.1", 1)
+
+
+def test_parse_ipv6():
+    """Checks that IPv6 address/port strings parse correctly, including bracket handling."""
+    # IPv6 with brackets (required format)
+    result = LocalDataService._parseSocketAddress("[::1]:8080")
+    assert result == ("::1", 8080)
+
+    # Full IPv6 address
+    result = LocalDataService._parseSocketAddress("[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:9000")
+    assert result == ("2001:0db8:85a3:0000:0000:8a2e:0370:7334", 9000)
+
+    # Compressed IPv6 address
+    result = LocalDataService._parseSocketAddress("[2001:db8::1]:443")
+    assert result == ("2001:db8::1", 443)
+
+    # IPv6 loopback
+    result = LocalDataService._parseSocketAddress("[::1]:12345")
+    assert result, ("::1", 12345)
+
+
+def test_parse_unix_socket():
+    """Tests parsing of Unix domain socket paths to Path objects."""
+    # Absolute path starting with /
+    result = LocalDataService._parseSocketAddress("/tmp/my_socket.sock")
+    assert isinstance(result, Path)
+    assert result == Path("/tmp/my_socket.sock")
+
+    # Another Unix socket path
+    result = LocalDataService._parseSocketAddress("/var/run/adara.sock")
+    assert isinstance(result, Path)
+    assert result == Path("/var/run/adara.sock")
+
+    # Path with multiple components
+    result = LocalDataService._parseSocketAddress("/home/user/.local/share/app/socket")
+    assert isinstance(result, Path)
+    assert result == Path("/home/user/.local/share/app/socket")
+
+
+def test_parse_invalid_format():
+    """Ensures invalid address strings throw errors."""
+    # Port out of range (too high)
+    with pytest.raises(ValueError, match=".*Port out of range.*"):
+        LocalDataService._parseSocketAddress("192.168.1.1:65536")
+
+    # Port out of range (negative)
+    with pytest.raises(ValueError, match=".*Invalid address format.*"):
+        LocalDataService._parseSocketAddress("192.168.1.1:-1")
+
+    # Port is zero
+    with pytest.raises(ValueError, match=".*Port out of range.*"):
+        LocalDataService._parseSocketAddress("192.168.1.1:0")
+
+    # Invalid format - no match for IP:port or Unix socket
+    with pytest.raises(ValueError, match=".*Invalid address format.*"):
+        LocalDataService._parseSocketAddress("not-a-valid-address")
+
+    # IPv6 without brackets
+    with pytest.raises(ValueError, match=".*Invalid address format.*"):
+        LocalDataService._parseSocketAddress("::1:8080")
+
+
+## ====== end: Tests for: `LocalDataService._parseSocketAddress ======
+
+
 @mock.patch(ThisService + "RunMetadata")
 def test__liveMetadataFromRun(mockRunMetadata):
     mockMetadata = mock.Mock(spec=RunMetadata)

--- a/tests/unit/backend/error/test_LiveDataState.py
+++ b/tests/unit/backend/error/test_LiveDataState.py
@@ -1,5 +1,6 @@
 # Test-related imports go last:
 import pytest
+from pydantic import ValidationError
 
 from snapred.backend.error.LiveDataState import LiveDataState
 
@@ -11,6 +12,52 @@ def test_LiveDataState():
     assert state.transition == LiveDataState.Type.RUN_START
     assert state.endRunNumber == "12345"
     assert state.startRunNumber == "0"
+
+
+def test_LiveDataState_type_enum_members():
+    # LiveDataState.Type has the correct set of members.
+    expected = {"UNSET", "RUN_START", "RUN_PAUSE", "RUN_ERROR", "RUN_END", "RUN_GAP"}
+    actual = {t.name for t in LiveDataState.Type}
+    assert actual == expected
+
+
+def test_LiveDataState_model_requires_all_fields():
+    # Model raises when required fields are missing.
+    with pytest.raises(ValidationError, match="Field required"):
+        LiveDataState.Model()
+
+
+def test_LiveDataState_validator_same_run_ok_for_pause():
+    # Same endRunNumber and startRunNumber are allowed for RUN_PAUSE.
+    model = LiveDataState.Model(
+        message="pause",
+        transition=LiveDataState.Type.RUN_PAUSE,
+        endRunNumber="12345",
+        startRunNumber="12345",
+    )
+    assert model.endRunNumber == "12345"
+
+
+def test_LiveDataState_validator_same_run_ok_for_error():
+    # Same endRunNumber and startRunNumber are allowed for RUN_ERROR.
+    model = LiveDataState.Model(
+        message="error",
+        transition=LiveDataState.Type.RUN_ERROR,
+        endRunNumber="12345",
+        startRunNumber="12345",
+    )
+    assert model.endRunNumber == "12345"
+
+
+def test_LiveDataState_validator_decreasing_raises():
+    # Decreasing non-zero run numbers raise ValueError.
+    with pytest.raises((ValueError, Exception), match=r"Not a valid run-state transition:.*"):
+        LiveDataState.Model(
+            message="bad",
+            transition=LiveDataState.Type.RUN_GAP,
+            endRunNumber="12344",
+            startRunNumber="12345",
+        )
 
 
 def test_LiveDataState_runStateTransition_start():
@@ -29,6 +76,13 @@ def test_LiveDataState_runStateTransition_end():
     assert "0" not in state.message
 
 
+def test_LiveDataState_runStateTransition_pause():
+    # equal run numbers create a RUN_PAUSE state (not a raise)
+    state = LiveDataState.runStateTransition("12345", "12345")
+    assert state.transition == LiveDataState.Type.RUN_PAUSE
+    assert "12345" in state.message
+
+
 def test_LiveDataState_runStateTransition_gap():
     # a gap in run-number values, without an intervening "no run" state, is recognized
     state = LiveDataState.runStateTransition("12346", "12345")
@@ -43,13 +97,34 @@ def test_LiveDataState_runStateTransition_unexpected():
         LiveDataState.runStateTransition("-1", "-2")
 
 
-def test_LiveDataState_runStateTransition_no_transition():
-    # start and end run numbers cannot be the same
-    with pytest.raises(ValueError, match=r"not a run-state transition:.*"):
-        LiveDataState.runStateTransition("12345", "12345")
-
-
 def test_LiveDataState_runStateTransition_invalid_transition():
     # run numbers cannot decrease, except to zero
-    with pytest.raises(ValueError, match=r"not a run-state transition:.*"):
+    with pytest.raises((ValueError, Exception), match=r"Not a valid run-state transition:.*"):
         LiveDataState.runStateTransition("12344", "12345")
+
+
+def test_LiveDataState_runError():
+    # runError() creates a RUN_ERROR state with the given run number.
+    state = LiveDataState.runError("12345")
+    assert state.transition == LiveDataState.Type.RUN_ERROR
+    assert "12345" in state.message
+    assert state.endRunNumber == "12345"
+    assert state.startRunNumber == "12345"
+
+
+def test_LiveDataState_runError_accepts_int():
+    # runError() converts an integer run number to string.
+    state = LiveDataState.runError(12345)
+    assert state.endRunNumber == "12345"
+    assert state.startRunNumber == "12345"
+
+
+def test_LiveDataState_parse_raw():
+    # parse_raw() reconstructs a LiveDataState from its JSON model representation.
+    original = LiveDataState.runError("12345")
+    json_str = original.model.model_dump_json()
+    parsed = LiveDataState.parse_raw(json_str)
+    assert parsed.transition == original.transition
+    assert parsed.endRunNumber == original.endRunNumber
+    assert parsed.startRunNumber == original.startRunNumber
+    assert parsed.message == original.message

--- a/tests/unit/backend/error/test_RunStatus.py
+++ b/tests/unit/backend/error/test_RunStatus.py
@@ -1,0 +1,322 @@
+# Test-related imports go last:
+from unittest import mock
+
+import pytest
+
+from snapred.backend.error.RunStatus import RunStatus
+
+# ---- SNS-specific PV names used by RunStatus.from_run ----
+_PV_SCAN_ABORT = "BL3:Exp:ScanAbort"
+_PV_SCAN_ABORT_ALT = "BL3:Exp:IM:ScanAbort"
+_PV_PAUSE = "pause"
+_PV_RUN_CONTROL = "BL3:CS:RunControl:StateEnum"
+
+
+def _make_run(
+    scan_abort=None,
+    scan_abort_alt=None,
+    has_end_time=False,
+    pause=None,
+    run_control=None,
+):
+    """Helper: build a mock mantid.api.Run with configurable SNS log properties.
+
+    Parameters
+    ----------
+    scan_abort : last value for 'BL3:Exp:ScanAbort', or None if not present.
+    scan_abort_alt : last value for 'BL3:Exp:IM:ScanAbort', or None if not present.
+    has_end_time : whether the 'end_time' property is present.
+    pause : last value for 'pause' log, or None if not present.
+    run_control : last string value for 'BL3:CS:RunControl:StateEnum', or None if not present.
+    """
+    run = mock.Mock()
+
+    prop_values = {}
+    if scan_abort is not None:
+        prop_values[_PV_SCAN_ABORT] = [scan_abort]
+    if scan_abort_alt is not None:
+        prop_values[_PV_SCAN_ABORT_ALT] = [scan_abort_alt]
+    if has_end_time:
+        prop_values["end_time"] = ["2026-04-09T00:00:00"]
+    if pause is not None:
+        prop_values[_PV_PAUSE] = [pause]
+    if run_control is not None:
+        prop_values[_PV_RUN_CONTROL] = [run_control]
+
+    def _has_property(name):
+        return name in prop_values
+
+    def _get_property(name):
+        prop = mock.Mock()
+        prop.value = prop_values.get(name, [])
+        return prop
+
+    run.hasProperty.side_effect = _has_property
+    run.getProperty.side_effect = _get_property
+    return run
+
+
+# --- StrEnum basics ---
+
+
+def test_RunStatus_enum_members():
+    expected = {"STOPPED", "PAUSED", "RUNNING", "ERROR"}
+    actual = {s.name for s in RunStatus}
+    assert actual == expected
+
+
+def test_RunStatus_string_values():
+    assert str(RunStatus.RUNNING) == "RUNNING"
+    assert str(RunStatus.STOPPED) == "STOPPED"
+    assert str(RunStatus.PAUSED) == "PAUSED"
+    assert str(RunStatus.ERROR) == "ERROR"
+
+
+def test_RunStatus_from_string():
+    assert RunStatus("RUNNING") == RunStatus.RUNNING
+    assert RunStatus("STOPPED") == RunStatus.STOPPED
+    assert RunStatus("PAUSED") == RunStatus.PAUSED
+    assert RunStatus("ERROR") == RunStatus.ERROR
+
+
+def test_RunStatus_invalid_string_raises():
+    with pytest.raises(ValueError, match="is not a valid RunStatus"):
+        RunStatus("UNKNOWN_STATUS")
+
+
+# --- from_run: step 1 — abort/error detection ---
+
+
+def test_from_run_error_when_scan_abort_pv_true():
+    """BL3:Exp:ScanAbort=True → ERROR."""
+    run = _make_run(scan_abort=True)
+    assert RunStatus.from_run(run) == RunStatus.ERROR
+
+
+def test_from_run_error_when_scan_abort_pv_one():
+    """BL3:Exp:ScanAbort=1 (truthy integer) → ERROR."""
+    run = _make_run(scan_abort=1)
+    assert RunStatus.from_run(run) == RunStatus.ERROR
+
+
+def test_from_run_error_when_alt_scan_abort_pv_true():
+    """BL3:Exp:IM:ScanAbort=True → ERROR (when primary ScanAbort not present)."""
+    run = _make_run(scan_abort_alt=True)
+    assert RunStatus.from_run(run) == RunStatus.ERROR
+
+
+def test_from_run_no_error_when_scan_abort_pv_false():
+    """BL3:Exp:ScanAbort=False → does NOT trigger ERROR; falls through to RUNNING fallback."""
+    run = _make_run(scan_abort=False)
+    assert RunStatus.from_run(run) == RunStatus.RUNNING
+
+
+def test_from_run_error_takes_priority_over_end_time():
+    """ScanAbort=True overrides end_time; ERROR wins over STOPPED."""
+    run = _make_run(scan_abort=True, has_end_time=True)
+    assert RunStatus.from_run(run) == RunStatus.ERROR
+
+
+# --- from_run: step 2 — stopped detection via end_time ---
+
+
+def test_from_run_stopped_when_end_time_present():
+    """'end_time' present and no abort → STOPPED."""
+    run = _make_run(has_end_time=True)
+    assert RunStatus.from_run(run) == RunStatus.STOPPED
+
+
+def test_from_run_end_time_does_not_override_abort():
+    """end_time + ScanAbort=True → still ERROR (abort checked first)."""
+    run = _make_run(scan_abort=True, has_end_time=True)
+    assert RunStatus.from_run(run) == RunStatus.ERROR
+
+
+# --- from_run: step 3 — paused detection via 'pause' log ---
+
+
+def test_from_run_paused_when_pause_log_true():
+    """'pause' log last value = True → PAUSED."""
+    run = _make_run(pause=True)
+    assert RunStatus.from_run(run) == RunStatus.PAUSED
+
+
+def test_from_run_paused_when_pause_log_one():
+    """'pause' log last value = 1 (truthy) → PAUSED."""
+    run = _make_run(pause=1)
+    assert RunStatus.from_run(run) == RunStatus.PAUSED
+
+
+def test_from_run_not_paused_when_pause_log_false():
+    """'pause' log last value = False → falls through (RUNNING fallback)."""
+    run = _make_run(pause=False)
+    assert RunStatus.from_run(run) == RunStatus.RUNNING
+
+
+def test_from_run_pause_takes_priority_over_run_control_running():
+    """'pause'=True wins over a Det:Status of ACQUIRING."""
+    run = _make_run(pause=True, run_control="ACQUIRING")
+    assert RunStatus.from_run(run) == RunStatus.PAUSED
+
+
+# --- from_run: step 4 — `BL3:CS:RunControl:StateEnum` PV ---
+
+
+def test_from_run_run_control_pause_returns_paused():
+    """RunControl containing 'PAUSE' → PAUSED."""
+    run = _make_run(run_control="PAUSE")
+    assert RunStatus.from_run(run) == RunStatus.PAUSED
+
+
+def test_from_run_run_control_paused_case_insensitive():
+    """RunControl 'paused' (lowercase) → PAUSED."""
+    run = _make_run(run_control="paused")
+    assert RunStatus.from_run(run) == RunStatus.PAUSED
+
+
+def test_from_run_run_control_stop_returns_stopped():
+    """RunControl containing 'STOP' → STOPPED."""
+    run = _make_run(run_control="STOP")
+    assert RunStatus.from_run(run) == RunStatus.STOPPED
+
+
+def test_from_run_run_control_idle_returns_stopped():
+    """RunControl containing 'IDLE' → STOPPED."""
+    run = _make_run(run_control="IDLE")
+    assert RunStatus.from_run(run) == RunStatus.STOPPED
+
+
+def test_from_run_run_control_acquiring_returns_running():
+    """RunControl containing 'ACQUIRING' → RUNNING."""
+    run = _make_run(run_control="ACQUIRING")
+    assert RunStatus.from_run(run) == RunStatus.RUNNING
+
+
+def test_from_run_run_control_recording_returns_running():
+    """RunControl containing 'RECORD' → RUNNING."""
+    run = _make_run(run_control="RECORDING")
+    assert RunStatus.from_run(run) == RunStatus.RUNNING
+
+
+def test_from_run_run_control_run_returns_running():
+    """RunControl containing 'RUN' → RUNNING."""
+    run = _make_run(run_control="RUN")
+    assert RunStatus.from_run(run) == RunStatus.RUNNING
+
+
+def test_from_run_run_control_unknown_falls_through_to_running():
+    """RunControl with an unrecognized value falls through to RUNNING fallback."""
+    run = _make_run(run_control="UNKNOWN_STATE")
+    assert RunStatus.from_run(run) == RunStatus.RUNNING
+
+
+# --- from_run: step 5 — fallback ---
+
+
+def test_from_run_fallback_running_when_no_relevant_logs():
+    """No abort PVs, no end_time, no pause log, no Det:Status → fallback RUNNING."""
+    run = _make_run()
+    assert RunStatus.from_run(run) == RunStatus.RUNNING
+
+
+# --- priority ordering ---
+
+
+def test_from_run_abort_takes_priority_over_pause():
+    """ScanAbort=True beats pause=True; ERROR wins."""
+    run = _make_run(scan_abort=True, pause=True)
+    assert RunStatus.from_run(run) == RunStatus.ERROR
+
+
+def test_from_run_abort_takes_priority_over_run_control_paused():
+    """ScanAbort=True beats Det:Status='PAUSE'; ERROR wins."""
+    run = _make_run(scan_abort=True, run_control="PAUSE")
+    assert RunStatus.from_run(run) == RunStatus.ERROR
+
+
+def test_from_run_end_time_takes_priority_over_pause_log():
+    """end_time present beats pause=True; STOPPED wins (abort checked first)."""
+    run = _make_run(has_end_time=True, pause=True)
+    assert RunStatus.from_run(run) == RunStatus.STOPPED
+
+
+def test_from_run_end_time_takes_priority_over_run_control():
+    """end_time present beats any Det:Status value."""
+    run = _make_run(has_end_time=True, run_control="ACQUIRING")
+    assert RunStatus.from_run(run) == RunStatus.STOPPED
+
+
+def test_from_run_primary_scan_abort_takes_priority_over_alt():
+    """If primary ScanAbort is present and False, alt abort is not checked even if True."""
+    # Primary is False → skip alt; no other signals → RUNNING fallback
+    run = _make_run(scan_abort=False, scan_abort_alt=True)
+    # Primary ScanAbort is False so abort condition is False; alt is not checked.
+    assert RunStatus.from_run(run) == RunStatus.RUNNING
+
+
+# --- get_last_value: edge cases for property introspection ---
+
+
+def test_get_last_value_property_without_value_attribute_returns_none():
+    """get_last_value returns None when the property object exposes no 'value' attribute.
+
+    This covers the 'hasattr(prop, "value")' guard inside get_last_value.
+    """
+    # Build a run where the abort PVs are present but their property objects
+    # have no 'value' attribute; all other PVs are absent.
+    prop_without_value = mock.Mock(spec=[])  # spec=[] → no attributes, so hasattr(..., "value") is False
+
+    run = mock.Mock()
+    present = {_PV_SCAN_ABORT, _PV_SCAN_ABORT_ALT}
+    run.hasProperty.side_effect = lambda name: name in present
+    run.getProperty.side_effect = lambda name: prop_without_value if name in present else None
+
+    # Both abort PVs return None from get_last_value; no end_time/pause/run_control → RUNNING.
+    assert RunStatus.from_run(run) == RunStatus.RUNNING
+
+
+def test_get_last_value_empty_value_list_returns_none():
+    """get_last_value returns None when the property value list is empty.
+
+    This covers the 'len(prop.value) > 0' guard inside get_last_value.
+    """
+    # Build a run where abort/pause PVs are present but their value lists are empty.
+    run = mock.Mock()
+
+    def _has_property(name):
+        return name in (_PV_SCAN_ABORT, _PV_SCAN_ABORT_ALT, _PV_PAUSE)
+
+    def _get_property(_name):
+        prop = mock.Mock()
+        prop.value = []  # empty list → len == 0 → get_last_value returns None
+        return prop
+
+    run.hasProperty.side_effect = _has_property
+    run.getProperty.side_effect = _get_property
+
+    # All get_last_value calls return None; no end_time/run_control → RUNNING fallback.
+    assert RunStatus.from_run(run) == RunStatus.RUNNING
+
+
+def test_get_last_value_string_prop_value_returns_string_directly():
+    """get_last_value returns the string directly when prop.value is a plain string.
+
+    This covers the 'isinstance(prop.value, str)' branch inside get_last_value.
+    Mantid may return a bare string for certain log types rather than a time-series array.
+    """
+    # Use 'BL3:CS:RunControl:StateEnum' as the test PV; all others absent.
+    run = mock.Mock()
+
+    def _has_property(name):
+        return name == _PV_RUN_CONTROL
+
+    def _get_property(_name):
+        prop = mock.Mock()
+        prop.value = "ACQUIRING"  # bare string, not a list
+        return prop
+
+    run.hasProperty.side_effect = _has_property
+    run.getProperty.side_effect = _get_property
+
+    # get_last_value("BL3:CS:RunControl:StateEnum") returns "ACQUIRING" via the string branch.
+    assert RunStatus.from_run(run) == RunStatus.RUNNING

--- a/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
+++ b/tests/unit/backend/recipe/algorithm/test_FetchGroceriesAlgorithm.py
@@ -150,6 +150,9 @@ class TestFetchGroceriesAlgorithm(unittest.TestCase):
         algo.setPropertyValue("LoaderType", "LoadNexus")
         assert "LoadNexus" == algo.getPropertyValue("LoaderType")
 
+        # RunStatus output property must exist (used to pass live-data run status back to recipe)
+        assert algo.getPropertyValue("RunStatus") == ""
+
         # set instrument name
         algo.setPropertyValue("InstrumentName", "SNAP")
         assert "SNAP" == algo.getPropertyValue("InstrumentName")

--- a/tests/unit/backend/recipe/algorithm/test_LoadLiveDataInterval.py
+++ b/tests/unit/backend/recipe/algorithm/test_LoadLiveDataInterval.py
@@ -20,6 +20,7 @@ from util.Config_helpers import Config_override
 
 from snapred.backend.dao.RunMetadata import RunMetadata
 from snapred.backend.data.util.PV_logs_util import datetimeFromLogTime
+from snapred.backend.error.RunStatus import RunStatus
 from snapred.backend.recipe.algorithm.LoadLiveDataInterval import LoadLiveDataInterval
 from snapred.meta.Config import Config
 
@@ -35,9 +36,15 @@ class TestLoadLiveDataInterval(unittest.TestCase):
         self.instrument = Config["instrument.name"]
         self.preserveEvents = True
 
+        # Default: treat all chunks as from a RUNNING run.
+        # Tests for RunStatus-based detection can override via self._from_run_patcher.side_effect.
+        self._from_run_patch = mock.patch.object(RunStatus, "from_run", return_value=RunStatus.RUNNING)
+        self._from_run_patcher = self._from_run_patch.start()
+
     def tearDown(self):
         if mtd.doesExist(self.outputWs):
             DeleteWorkspace(self.outputWs)
+        self._from_run_patch.stop()
 
     @classmethod
     def setUpClass(cls):
@@ -74,6 +81,14 @@ class TestLoadLiveDataInterval(unittest.TestCase):
                 AbsoluteStartTime=str(DateAndTime(cls.chunkEdges[n])),
                 AbsoluteStopTime=str(DateAndTime(cls.chunkEdges[n + 1])),
             )
+
+        # `CreateSampleWorkspace` creates workspaces with run number 0.
+        # Set a non-zero run number on all workspaces so that
+        # `LoadLiveDataInterval`'s inactive-run guard does not fire.
+        _runNumber = "12345"
+        mtd[cls.fullWs].mutableRun()["run_number"] = _runNumber
+        for ws in cls.chunkWss:
+            mtd[ws].mutableRun()["run_number"] = _runNumber
 
     @classmethod
     def tearDownClass(cls):
@@ -152,7 +167,7 @@ class TestLoadLiveDataInterval(unittest.TestCase):
         self.instance.initialize()
 
         assert set([p.name for p in self.instance.getProperties()]) == set(
-            ("OutputWorkspace", "StartTime", "EndTime", "Instrument", "PreserveEvents")
+            ("OutputWorkspace", "StartTime", "EndTime", "Instrument", "PreserveEvents", "RunStatus")
         )
 
         # verify default values
@@ -702,6 +717,9 @@ class TestLoadLiveDataInterval(unittest.TestCase):
             assert "A timeout occurred during data loading" in msg
 
     def test_exec_load_run_state_change(self):
+        # Force a run-state change during the chunk-assembly loop via RunStatus.from_run:
+        # * The initial chunk is RUNNING, one loop chunk is RUNNING, then the next is STOPPED.
+        # * This causes the loop to break, resulting in an incomplete load.
         mock_LoadLiveData = mock.Mock()
 
         self.instance.initialize()
@@ -732,15 +750,6 @@ class TestLoadLiveDataInterval(unittest.TestCase):
                 (datetime.datetime.fromisoformat(self.startTime) + timedelta(minutes=15)).isoformat()
             )
 
-            # Force a run-state change during the chunk-assembly loop:
-            # * Note that there's no separate log message for this case,
-            #   which is not an error.  When required, the state-change will be logged elsewhere.
-            # * In the case of the present test however, the assembled data-interval will be incomplete.
-            mock_chunkWs.getRunNumber.side_effect = ("12345", "12345", 0)
-
-            mock_chunkIntervals = [  # noqa: F841
-                (mock_chunkWs.getPulseTimeMin.return_value, mock_chunkWs.getPulseTimeMax.return_value)
-            ]
             mock_mtd = mock.MagicMock()
             mock_mtd.__getitem__.return_value = mock_chunkWs
             mock_mtd.doesExist.side_effect = lambda ws: ws == mock.sentinel.chunkWs
@@ -752,9 +761,18 @@ class TestLoadLiveDataInterval(unittest.TestCase):
             mock_loadIsComplete.return_value = False
             mock_sleep.side_effect = lambda _: None
 
+            # Simulate a run-state change on the 3rd call to RunStatus.from_run:
+            #   - Call 1 (initial chunk): RUNNING
+            #   - Call 2 (loop iter 1): RUNNING
+            #   - Call 3 (loop iter 2): STOPPED → break
+            self._from_run_patcher.side_effect = [RunStatus.RUNNING, RunStatus.RUNNING, RunStatus.STOPPED]
+
             self.instance.execute()
             msg = mock_logger.warning.mock_calls[0].args[0]
             assert "The complete data interval could not be loaded" in msg
+
+            # Three execute calls: 1 initial + 2 loop iterations.
+            assert mock_LoadLiveData.execute.call_count == 3
 
     def test_exec_filter_init(self):
         mock_LoadLiveData = mock.Mock()
@@ -1136,3 +1154,595 @@ class TestLoadLiveDataInterval(unittest.TestCase):
 
             # Verify that no filtering was required:
             mock_FilterByTime.execute.assert_not_called()
+
+    # ---------------------------------------------------------------------------
+    # Tests for _checkIntervalOverlaps
+    # ---------------------------------------------------------------------------
+
+    def test__checkIntervalOverlaps_empty_list(self):
+        t0 = np.datetime64("2010-01-01T00:00:00", "ns")
+        t1 = np.datetime64("2010-01-01T01:00:00", "ns")
+        assert not LoadLiveDataInterval._checkIntervalOverlaps((t0, t1), [])
+
+    def test__checkIntervalOverlaps_no_overlap(self):
+        # [t0, t1] and [t2, t3] are non-overlapping (t1 <= t2).
+        t0 = np.datetime64("2010-01-01T00:00:00", "ns")
+        t1 = np.datetime64("2010-01-01T01:00:00", "ns")
+        t2 = np.datetime64("2010-01-01T01:00:00", "ns")
+        t3 = np.datetime64("2010-01-01T02:00:00", "ns")
+        assert not LoadLiveDataInterval._checkIntervalOverlaps((t0, t1), [(t2, t3)])
+
+    def test__checkIntervalOverlaps_overlap(self):
+        t0 = np.datetime64("2010-01-01T00:00:00", "ns")
+        t1 = np.datetime64("2010-01-01T01:30:00", "ns")
+        t2 = np.datetime64("2010-01-01T01:00:00", "ns")
+        t3 = np.datetime64("2010-01-01T02:00:00", "ns")
+        assert LoadLiveDataInterval._checkIntervalOverlaps((t0, t1), [(t2, t3)])
+
+    def test__checkIntervalOverlaps_contained(self):
+        # candidate is fully contained within an existing interval.
+        t0 = np.datetime64("2010-01-01T00:30:00", "ns")
+        t1 = np.datetime64("2010-01-01T00:45:00", "ns")
+        t2 = np.datetime64("2010-01-01T00:00:00", "ns")
+        t3 = np.datetime64("2010-01-01T01:00:00", "ns")
+        assert LoadLiveDataInterval._checkIntervalOverlaps((t0, t1), [(t2, t3)])
+
+    def test__checkIntervalOverlaps_multiple_no_overlap(self):
+        t0 = np.datetime64("2010-01-01T02:00:00", "ns")
+        t1 = np.datetime64("2010-01-01T03:00:00", "ns")
+        existing = [
+            (np.datetime64("2010-01-01T00:00:00", "ns"), np.datetime64("2010-01-01T01:00:00", "ns")),
+            (np.datetime64("2010-01-01T01:00:00", "ns"), np.datetime64("2010-01-01T02:00:00", "ns")),
+        ]
+        assert not LoadLiveDataInterval._checkIntervalOverlaps((t0, t1), existing)
+
+    def test__checkIntervalOverlaps_multiple_one_overlaps(self):
+        t0 = np.datetime64("2010-01-01T01:30:00", "ns")
+        t1 = np.datetime64("2010-01-01T02:30:00", "ns")
+        existing = [
+            (np.datetime64("2010-01-01T00:00:00", "ns"), np.datetime64("2010-01-01T01:00:00", "ns")),
+            (np.datetime64("2010-01-01T02:00:00", "ns"), np.datetime64("2010-01-01T03:00:00", "ns")),
+        ]
+        assert LoadLiveDataInterval._checkIntervalOverlaps((t0, t1), existing)
+
+    # ---------------------------------------------------------------------------
+    # Tests for _fallbackChunkInterval
+    # ---------------------------------------------------------------------------
+
+    def _make_tsp_mock(self, name, start_iso, end_iso, size=1):
+        """Helper: create a mock TimeSeriesProperty-like object."""
+        from mantid.kernel import FloatTimeSeriesProperty
+
+        prop = mock.MagicMock(spec=FloatTimeSeriesProperty)
+        prop.name = name
+        prop.size.return_value = size
+        prop.firstTime.return_value.to_datetime64.return_value = np.datetime64(start_iso, "ns") if start_iso else None
+        prop.lastTime.return_value.to_datetime64.return_value = np.datetime64(end_iso, "ns") if end_iso else None
+        return prop
+
+    def test__fallbackChunkInterval_no_properties(self):
+        ws = mock.Mock()
+        ws.getRun.return_value.getProperties.return_value = []
+        requiredStart = np.datetime64("2010-01-01T00:00:00", "ns")
+        result = LoadLiveDataInterval._fallbackChunkInterval(ws, requiredStart, [])
+        assert result is None
+
+    def test__fallbackChunkInterval_empty_tsp_ignored(self):
+        # A TSP with size() == 0 should be ignored (not called for firstTime/lastTime).
+        from mantid.kernel import FloatTimeSeriesProperty
+
+        prop = mock.MagicMock(spec=FloatTimeSeriesProperty)
+        prop.size.return_value = 0
+
+        ws = mock.Mock()
+        ws.getRun.return_value.getProperties.return_value = [prop]
+        requiredStart = np.datetime64("2010-01-01T00:00:00", "ns")
+        result = LoadLiveDataInterval._fallbackChunkInterval(ws, requiredStart, [])
+        assert result is None
+        prop.firstTime.assert_not_called()
+
+    def test__fallbackChunkInterval_non_tsp_ignored(self):
+        # A non-TSP property (e.g., a plain mock without FloatTimeSeriesProperty spec) should be ignored.
+        prop = mock.Mock()  # not spec'd to any TSP type
+        prop.size.return_value = 5
+        ws = mock.Mock()
+        ws.getRun.return_value.getProperties.return_value = [prop]
+        requiredStart = np.datetime64("2010-01-01T00:00:00", "ns")
+        result = LoadLiveDataInterval._fallbackChunkInterval(ws, requiredStart, [])
+        assert result is None
+
+    def test__fallbackChunkInterval_before_required_start_ignored(self):
+        # A TSP whose start_dt is before requiredStartTime should be ignored.
+        prop = self._make_tsp_mock("log1", "2010-01-01T00:00:00", "2010-01-01T01:00:00")
+        ws = mock.Mock()
+        ws.getRun.return_value.getProperties.return_value = [prop]
+        # requiredStart is after the TSP interval start.
+        requiredStart = np.datetime64("2010-01-01T00:30:00", "ns")
+        result = LoadLiveDataInterval._fallbackChunkInterval(ws, requiredStart, [])
+        assert result is None
+
+    def test__fallbackChunkInterval_overlapping_ignored(self):
+        # A TSP that overlaps with an existing chunkInterval should be ignored.
+        prop = self._make_tsp_mock("log1", "2010-01-01T00:00:00", "2010-01-01T01:00:00")
+        ws = mock.Mock()
+        ws.getRun.return_value.getProperties.return_value = [prop]
+        requiredStart = np.datetime64("2010-01-01T00:00:00", "ns")
+        existing = [(np.datetime64("2010-01-01T00:30:00", "ns"), np.datetime64("2010-01-01T01:30:00", "ns"))]
+        result = LoadLiveDataInterval._fallbackChunkInterval(ws, requiredStart, existing)
+        assert result is None
+
+    def test__fallbackChunkInterval_returns_largest_span(self):
+        # Given two valid TSP candidates, the one with the larger span should be returned.
+        prop_small = self._make_tsp_mock("small", "2010-01-01T00:00:00", "2010-01-01T00:30:00")
+        prop_large = self._make_tsp_mock("large", "2010-01-01T00:00:00", "2010-01-01T01:00:00")
+        ws = mock.Mock()
+        ws.getRun.return_value.getProperties.return_value = [prop_small, prop_large]
+        requiredStart = np.datetime64("2010-01-01T00:00:00", "ns")
+
+        result = LoadLiveDataInterval._fallbackChunkInterval(ws, requiredStart, [])
+
+        assert result == (
+            np.datetime64("2010-01-01T00:00:00", "ns"),
+            np.datetime64("2010-01-01T01:00:00", "ns"),
+        )
+
+    def test__fallbackChunkInterval_logs_warning_for_all_candidates(self):
+        # Verify that a WARNING is logged listing all valid candidates.
+        prop_a = self._make_tsp_mock("prop_a", "2010-01-01T00:00:00", "2010-01-01T00:30:00")
+        prop_b = self._make_tsp_mock("prop_b", "2010-01-01T00:00:00", "2010-01-01T01:00:00")
+        ws = mock.Mock()
+        ws.getRun.return_value.getProperties.return_value = [prop_a, prop_b]
+        requiredStart = np.datetime64("2010-01-01T00:00:00", "ns")
+
+        with mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "logger") as mock_logger:
+            LoadLiveDataInterval._fallbackChunkInterval(ws, requiredStart, [])
+            # At least one WARNING call should have been made listing both candidate names.
+            warning_calls = mock_logger.warning.call_args_list
+            assert len(warning_calls) >= 1
+            combined = " ".join(str(c) for c in warning_calls)
+            assert "prop_a" in combined
+            assert "prop_b" in combined
+
+    def test__fallbackChunkInterval_all_tsp_types_accepted(self):
+        # Verify that all five TSP types are accepted.
+        from mantid.kernel import (
+            BoolTimeSeriesProperty,
+            FloatTimeSeriesProperty,
+            Int32TimeSeriesProperty,
+            Int64TimeSeriesProperty,
+            StringTimeSeriesProperty,
+        )
+
+        start = "2010-01-01T00:00:00"
+        end = "2010-01-01T01:00:00"
+        props = [
+            mock.MagicMock(spec=FloatTimeSeriesProperty),
+            mock.MagicMock(spec=BoolTimeSeriesProperty),
+            mock.MagicMock(spec=Int32TimeSeriesProperty),
+            mock.MagicMock(spec=Int64TimeSeriesProperty),
+            mock.MagicMock(spec=StringTimeSeriesProperty),
+        ]
+        for i, p in enumerate(props):
+            p.name = f"prop_{i}"
+            p.size.return_value = 1
+            p.firstTime.return_value.to_datetime64.return_value = np.datetime64(start, "ns")
+            p.lastTime.return_value.to_datetime64.return_value = np.datetime64(end, "ns")
+
+        ws = mock.Mock()
+        ws.getRun.return_value.getProperties.return_value = props
+        requiredStart = np.datetime64(start, "ns")
+
+        result = LoadLiveDataInterval._fallbackChunkInterval(ws, requiredStart, [])
+        # All five should be valid candidates; result should not be None.
+        assert result is not None
+
+    # ---------------------------------------------------------------------------
+    # Tests for new PyExec behaviors
+    # ---------------------------------------------------------------------------
+
+    def test_exec_initial_chunk_no_events_fallback_found(self):
+        # When the initial chunk has no events but a fallback interval is found,
+        # the fallback interval should be appended to chunkIntervals.
+        mock_LoadLiveData = mock.Mock()
+
+        self.instance.initialize()
+        self._setProperties(
+            self.instance,
+            OutputWorkspace=self.outputWs,
+            StartTime=self.startTime,
+            Instrument=Config["instrument.name"],
+            PreserveEvents=self.preserveEvents,
+        )
+
+        fallback_interval = (
+            np.datetime64("2010-01-01T00:00:00", "ns"),
+            np.datetime64("2010-01-01T01:00:00", "ns"),
+        )
+
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "logger") as mock_logger,
+            mock.patch.object(self.instance, "createChildAlgorithm") as mock_createChildAlgorithm,
+            mock.patch.object(self.instance, "mantidSnapper") as mock_snapper,
+            mock.patch.object(self.instance, "isLogging"),
+            mock.patch.object(LoadLiveDataInterval, "_loadIsComplete") as mock_loadIsComplete,
+            mock.patch.object(LoadLiveDataInterval, "_requiredLoadInterval") as mock_requiredLoadInterval,
+            mock.patch.object(LoadLiveDataInterval, "_fallbackChunkInterval") as mock_fallback,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_createChildAlgorithm.return_value = mock_LoadLiveData
+
+            mock_chunkWs = mock.Mock()
+            mock_chunkWs.getNumberEvents.return_value = 0
+            mock_mtd = mock.MagicMock()
+            mock_mtd.__getitem__.return_value = mock_chunkWs
+            mock_mtd.doesExist.side_effect = lambda ws: ws == mock.sentinel.chunkWs
+            mock_mtd.unique_hidden_name.return_value = mock.sentinel.chunkWs
+            mock_snapper.mtd = mock_mtd
+
+            mock_requiredLoadInterval.return_value = (fallback_interval[0], fallback_interval[1])
+            mock_fallback.return_value = fallback_interval
+            mock_loadIsComplete.return_value = True
+
+            self.instance.execute()
+
+            mock_fallback.assert_called_once()
+            # A warning about using the fallback should be logged.
+            warning_msgs = " ".join(c.args[0] for c in mock_logger.warning.call_args_list)
+            assert "fallback" in warning_msgs.lower() or "NO EVENTS" in warning_msgs
+
+    def test_exec_initial_chunk_no_events_no_fallback_no_allow_dead_time_raises(self):
+        # When the initial chunk has no events, no fallback is found, and
+        # liveData.allowDeadTime is False (or missing), a RuntimeError should be raised.
+        mock_LoadLiveData = mock.Mock()
+
+        self.instance.initialize()
+        self._setProperties(
+            self.instance,
+            OutputWorkspace=self.outputWs,
+            StartTime=self.startTime,
+            Instrument=Config["instrument.name"],
+            PreserveEvents=self.preserveEvents,
+        )
+
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(self.instance, "createChildAlgorithm") as mock_createChildAlgorithm,
+            mock.patch.object(self.instance, "mantidSnapper") as mock_snapper,
+            mock.patch.object(self.instance, "isLogging"),
+            mock.patch.object(LoadLiveDataInterval, "_requiredLoadInterval") as mock_requiredLoadInterval,
+            mock.patch.object(LoadLiveDataInterval, "_fallbackChunkInterval") as mock_fallback,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_createChildAlgorithm.return_value = mock_LoadLiveData
+
+            mock_chunkWs = mock.Mock()
+            mock_chunkWs.getNumberEvents.return_value = 0
+            mock_mtd = mock.MagicMock()
+            mock_mtd.__getitem__.return_value = mock_chunkWs
+            mock_mtd.doesExist.side_effect = lambda ws: ws == mock.sentinel.chunkWs
+            mock_mtd.unique_hidden_name.return_value = mock.sentinel.chunkWs
+            mock_snapper.mtd = mock_mtd
+
+            mock_requiredLoadInterval.return_value = (
+                np.datetime64("2010-01-01T00:00:00", "ns"),
+                np.datetime64("2010-01-01T01:00:00", "ns"),
+            )
+            mock_fallback.return_value = None
+
+            # allowDeadTime is False (default in test config) => should raise.
+            with pytest.raises(RuntimeError, match="Initial chunk contained no events"):
+                self.instance.PyExec()
+
+    def test_exec_initial_chunk_no_events_no_fallback_allow_dead_time_continues(self):
+        # When the initial chunk has no events, no fallback is found, but
+        # liveData.allowDeadTime is True, the existing dead-time behavior should proceed.
+        mock_LoadLiveData = mock.Mock()
+
+        self.instance.initialize()
+        self._setProperties(
+            self.instance,
+            OutputWorkspace=self.outputWs,
+            StartTime=self.startTime,
+            Instrument=Config["instrument.name"],
+            PreserveEvents=self.preserveEvents,
+        )
+
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "sleep") as mock_sleep,
+            mock.patch.object(self.instance, "createChildAlgorithm") as mock_createChildAlgorithm,
+            mock.patch.object(self.instance, "mantidSnapper") as mock_snapper,
+            mock.patch.object(self.instance, "isLogging"),
+            mock.patch.object(LoadLiveDataInterval, "_loadIsComplete") as mock_loadIsComplete,
+            mock.patch.object(LoadLiveDataInterval, "_requiredLoadInterval") as mock_requiredLoadInterval,
+            mock.patch.object(LoadLiveDataInterval, "_fallbackChunkInterval") as mock_fallback,
+            Config_override("liveData.allowDeadTime", True),
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_createChildAlgorithm.return_value = mock_LoadLiveData
+            mock_sleep.side_effect = lambda _: None
+
+            mock_chunkWs = mock.Mock()
+            mock_chunkWs.getNumberEvents.return_value = 0
+            mock_mtd = mock.MagicMock()
+            mock_mtd.__getitem__.return_value = mock_chunkWs
+            mock_mtd.doesExist.side_effect = lambda ws: ws == mock.sentinel.chunkWs
+            mock_mtd.unique_hidden_name.return_value = mock.sentinel.chunkWs
+            mock_snapper.mtd = mock_mtd
+
+            mock_requiredLoadInterval.return_value = (
+                np.datetime64("2010-01-01T00:00:00", "ns"),
+                np.datetime64("2010-01-01T01:00:00", "ns"),
+            )
+            mock_fallback.return_value = None
+            mock_loadIsComplete.return_value = True
+
+            # Should NOT raise; should complete (dead-time mode).
+            self.instance.execute()
+
+    def test_exec_loop_chunk_no_events_fallback_found(self):
+        # In the loop, when a chunk has no events but a fallback is found,
+        # the fallback should be appended and deadTimeDuration reset to 0.
+        mock_LoadLiveData = mock.Mock()
+
+        self.instance.initialize()
+        self._setProperties(
+            self.instance,
+            OutputWorkspace=self.outputWs,
+            StartTime=self.startTime,
+            Instrument=Config["instrument.name"],
+            PreserveEvents=self.preserveEvents,
+        )
+
+        fallback_interval = (
+            np.datetime64("2010-01-01T00:00:00", "ns"),
+            np.datetime64("2010-01-01T01:00:00", "ns"),
+        )
+
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "logger") as mock_logger,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "sleep") as mock_sleep,
+            mock.patch.object(self.instance, "createChildAlgorithm") as mock_createChildAlgorithm,
+            mock.patch.object(self.instance, "mantidSnapper") as mock_snapper,
+            mock.patch.object(self.instance, "isLogging"),
+            mock.patch.object(LoadLiveDataInterval, "_loadIsComplete") as mock_loadIsComplete,
+            mock.patch.object(LoadLiveDataInterval, "_requiredLoadInterval") as mock_requiredLoadInterval,
+            mock.patch.object(LoadLiveDataInterval, "_fallbackChunkInterval") as mock_fallback,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_createChildAlgorithm.return_value = mock_LoadLiveData
+            mock_sleep.side_effect = lambda _: None
+
+            # First call (initial chunk) has events; second call (loop chunk) has none.
+            mock_chunkWs = mock.Mock()
+            mock_chunkWs.getNumberEvents.side_effect = [1, 0]
+            mock_chunkWs.getPulseTimeMin.return_value = DateAndTime(self.startTime)
+            mock_chunkWs.getPulseTimeMax.return_value = DateAndTime(
+                (datetime.datetime.fromisoformat(self.startTime) + timedelta(minutes=15)).isoformat()
+            )
+            mock_mtd = mock.MagicMock()
+            mock_mtd.__getitem__.return_value = mock_chunkWs
+            mock_mtd.doesExist.side_effect = lambda ws: ws == mock.sentinel.chunkWs
+            mock_mtd.unique_hidden_name.return_value = mock.sentinel.chunkWs
+            mock_snapper.mtd = mock_mtd
+
+            mock_requiredLoadInterval.return_value = (fallback_interval[0], fallback_interval[1])
+            mock_fallback.return_value = fallback_interval
+            # First call: don't complete. Second call: complete.
+            mock_loadIsComplete.side_effect = [False, True]
+
+            self.instance.execute()
+
+            # The fallback should have been called (for the loop empty-chunk case).
+            mock_fallback.assert_called()
+            # A warning about using the fallback should be logged.
+            warning_msgs = " ".join(c.args[0] for c in mock_logger.warning.call_args_list)
+            assert "fallback" in warning_msgs.lower() or "NO NEW EVENTS" in warning_msgs
+
+    def test_exec_loop_chunk_no_events_no_fallback_no_allow_dead_time_breaks(self):
+        # In the loop, when a chunk has no events, no fallback is found, and
+        # liveData.allowDeadTime is False, the loop should break gracefully.
+        mock_LoadLiveData = mock.Mock()
+
+        self.instance.initialize()
+        self._setProperties(
+            self.instance,
+            OutputWorkspace=self.outputWs,
+            StartTime=self.startTime,
+            Instrument=Config["instrument.name"],
+            PreserveEvents=self.preserveEvents,
+        )
+
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "logger") as mock_logger,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "sleep") as mock_sleep,
+            mock.patch.object(self.instance, "createChildAlgorithm") as mock_createChildAlgorithm,
+            mock.patch.object(self.instance, "mantidSnapper") as mock_snapper,
+            mock.patch.object(self.instance, "isLogging"),
+            mock.patch.object(LoadLiveDataInterval, "_loadIsComplete") as mock_loadIsComplete,
+            mock.patch.object(LoadLiveDataInterval, "_requiredLoadInterval") as mock_requiredLoadInterval,
+            mock.patch.object(LoadLiveDataInterval, "_fallbackChunkInterval") as mock_fallback,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_createChildAlgorithm.return_value = mock_LoadLiveData
+            mock_sleep.side_effect = lambda _: None
+
+            # Initial chunk has events; loop chunk has none.
+            mock_chunkWs = mock.Mock()
+            mock_chunkWs.getNumberEvents.side_effect = [1, 0]
+            mock_chunkWs.getPulseTimeMin.return_value = DateAndTime(self.startTime)
+            mock_chunkWs.getPulseTimeMax.return_value = DateAndTime(
+                (datetime.datetime.fromisoformat(self.startTime) + timedelta(minutes=15)).isoformat()
+            )
+            mock_mtd = mock.MagicMock()
+            mock_mtd.__getitem__.return_value = mock_chunkWs
+            mock_mtd.doesExist.side_effect = lambda ws: ws == mock.sentinel.chunkWs
+            mock_mtd.unique_hidden_name.return_value = mock.sentinel.chunkWs
+            mock_snapper.mtd = mock_mtd
+
+            mock_requiredLoadInterval.return_value = (
+                np.datetime64("2010-01-01T00:00:00", "ns"),
+                np.datetime64("2010-01-01T01:00:00", "ns"),
+            )
+            mock_fallback.return_value = None
+            # Never complete so we rely on the break.
+            mock_loadIsComplete.return_value = False
+
+            self.instance.execute()
+
+            # LoadLiveData.execute should have been called exactly twice:
+            #   once for the initial chunk, once in the loop before the break.
+            assert mock_LoadLiveData.execute.call_count == 2
+
+            # A graceful-exit warning should be logged.
+            warning_msgs = " ".join(c.args[0] for c in mock_logger.warning.call_args_list)
+            assert "gracefully" in warning_msgs.lower() or "NO NEW EVENTS" in warning_msgs
+
+    def test_exec_loop_chunk_no_events_no_fallback_allow_dead_time_continues(self):
+        # In the loop, when a chunk has no events, no fallback, and allowDeadTime is True,
+        # the existing dead-time behavior should apply (increment and eventually break on maxDeadTime).
+        mock_LoadLiveData = mock.Mock()
+
+        self.instance.initialize()
+        self._setProperties(
+            self.instance,
+            OutputWorkspace=self.outputWs,
+            StartTime=self.startTime,
+            Instrument=Config["instrument.name"],
+            PreserveEvents=self.preserveEvents,
+        )
+
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "logger") as mock_logger,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "sleep") as mock_sleep,
+            mock.patch.object(self.instance, "createChildAlgorithm") as mock_createChildAlgorithm,
+            mock.patch.object(self.instance, "mantidSnapper") as mock_snapper,
+            mock.patch.object(self.instance, "isLogging"),
+            mock.patch.object(LoadLiveDataInterval, "_loadIsComplete") as mock_loadIsComplete,
+            mock.patch.object(LoadLiveDataInterval, "_requiredLoadInterval") as mock_requiredLoadInterval,
+            mock.patch.object(LoadLiveDataInterval, "_fallbackChunkInterval") as mock_fallback,
+            Config_override("liveData.allowDeadTime", True),
+            Config_override("liveData.chunkLoadWait", 3),
+            Config_override("liveData.time_comparison_threshold", 6),  # => 2 empty chunks before break
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_createChildAlgorithm.return_value = mock_LoadLiveData
+            mock_sleep.side_effect = lambda _: None
+
+            # Initial chunk has events; all loop chunks have none.
+            mock_chunkWs = mock.Mock()
+            mock_chunkWs.getNumberEvents.side_effect = [1, 0, 0, 0, 0, 0]
+            mock_chunkWs.getPulseTimeMin.return_value = DateAndTime(self.startTime)
+            mock_chunkWs.getPulseTimeMax.return_value = DateAndTime(
+                (datetime.datetime.fromisoformat(self.startTime) + timedelta(minutes=15)).isoformat()
+            )
+            mock_mtd = mock.MagicMock()
+            mock_mtd.__getitem__.return_value = mock_chunkWs
+            mock_mtd.doesExist.side_effect = lambda ws: ws == mock.sentinel.chunkWs
+            mock_mtd.unique_hidden_name.return_value = mock.sentinel.chunkWs
+            mock_snapper.mtd = mock_mtd
+
+            mock_requiredLoadInterval.return_value = (
+                np.datetime64("2010-01-01T00:00:00", "ns"),
+                np.datetime64("2010-01-01T01:00:00", "ns"),
+            )
+            mock_fallback.return_value = None
+            mock_loadIsComplete.return_value = False
+
+            self.instance.execute()
+
+            # With chunkLoadWait=3 and maxDeadTime=6: after 2 empty loop chunks (6s) it should break.
+            # So total execute calls = 1 (initial) + 2 (loop) = 3.
+            assert mock_LoadLiveData.execute.call_count == 3
+
+            # NO NEW EVENTS warnings should be logged.
+            warning_msgs = " ".join(c.args[0] for c in mock_logger.warning.call_args_list)
+            assert "NO NEW EVENTS" in warning_msgs
+
+    def test_exec_initial_chunk_inactive_run_raises(self):
+        # When the initial chunk has events but RunStatus.from_run returns non-RUNNING,
+        # a RuntimeError should be raised.
+        mock_LoadLiveData = mock.Mock()
+
+        self.instance.initialize()
+        self._setProperties(
+            self.instance,
+            OutputWorkspace=self.outputWs,
+            StartTime=self.startTime,
+            Instrument=Config["instrument.name"],
+            PreserveEvents=self.preserveEvents,
+        )
+
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(self.instance, "createChildAlgorithm") as mock_createChildAlgorithm,
+            mock.patch.object(self.instance, "mantidSnapper") as mock_snapper,
+            mock.patch.object(self.instance, "isLogging"),
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_createChildAlgorithm.return_value = mock_LoadLiveData
+
+            mock_chunkWs = mock.Mock()
+            mock_chunkWs.getNumberEvents.return_value = 1  # has events → triggers from_run check
+            mock_mtd = mock.MagicMock()
+            mock_mtd.__getitem__.return_value = mock_chunkWs
+            mock_mtd.doesExist.side_effect = lambda ws: ws == mock.sentinel.chunkWs
+            mock_mtd.unique_hidden_name.return_value = mock.sentinel.chunkWs
+            mock_snapper.mtd = mock_mtd
+
+            # Simulate an inactive run.
+            self._from_run_patcher.return_value = RunStatus.STOPPED
+
+            with pytest.raises(RuntimeError, match="cannot extract initial chunk from inactive run"):
+                self.instance.PyExec()
+
+    def test_exec_loop_chunk_inactive_run_breaks(self):
+        # When a loop chunk's RunStatus.from_run returns non-RUNNING, the loop should break.
+        mock_LoadLiveData = mock.Mock()
+
+        self.instance.initialize()
+        self._setProperties(
+            self.instance,
+            OutputWorkspace=self.outputWs,
+            StartTime=self.startTime,
+            Instrument=Config["instrument.name"],
+            PreserveEvents=self.preserveEvents,
+        )
+
+        with (
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "ConfigService") as mock_ConfigService,
+            mock.patch.object(inspect.getmodule(LoadLiveDataInterval), "sleep") as mock_sleep,
+            mock.patch.object(self.instance, "createChildAlgorithm") as mock_createChildAlgorithm,
+            mock.patch.object(self.instance, "mantidSnapper") as mock_snapper,
+            mock.patch.object(self.instance, "isLogging"),
+            mock.patch.object(LoadLiveDataInterval, "_loadIsComplete") as mock_loadIsComplete,
+        ):
+            mock_ConfigService.getFacility.return_value.instrument.return_value = mock.sentinel.InstrumentInfo
+            mock_createChildAlgorithm.return_value = mock_LoadLiveData
+            mock_sleep.side_effect = lambda _: None
+
+            mock_chunkWs = mock.Mock()
+            mock_chunkWs.getNumberEvents.return_value = 1  # always has events
+            mock_chunkWs.getPulseTimeMin.return_value = DateAndTime(self.startTime)
+            mock_chunkWs.getPulseTimeMax.return_value = DateAndTime(
+                (datetime.datetime.fromisoformat(self.startTime) + timedelta(minutes=15)).isoformat()
+            )
+            mock_mtd = mock.MagicMock()
+            mock_mtd.__getitem__.return_value = mock_chunkWs
+            mock_mtd.doesExist.side_effect = lambda ws: ws == mock.sentinel.chunkWs
+            mock_mtd.unique_hidden_name.return_value = mock.sentinel.chunkWs
+            mock_snapper.mtd = mock_mtd
+
+            mock_loadIsComplete.return_value = False
+
+            # Initial chunk: RUNNING; first loop chunk: STOPPED → break.
+            self._from_run_patcher.side_effect = [RunStatus.RUNNING, RunStatus.STOPPED]
+
+            self.instance.execute()
+
+            # Only 2 execute calls: 1 initial + 1 loop (then break on STOPPED).
+            assert mock_LoadLiveData.execute.call_count == 2

--- a/tests/unit/backend/recipe/algorithm/test_MantidSnapper.py
+++ b/tests/unit/backend/recipe/algorithm/test_MantidSnapper.py
@@ -53,6 +53,31 @@ class TestMantidSnapper(unittest.TestCase):
             with pytest.raises(TimeoutError, match="Timeout occurred while waiting for instance of"):
                 mantidSnapper.executeQueue()
 
+            # Mutex must still be released even when TimeoutError is raised
+            assert MantidSnapper._nonConcurrentAlgorithmMutex.release.called
+
+    @mock.patch(PatchRoot.format("AlgorithmManager"))
+    def test_timeout_nonReentrant_mutex_released(self, mockAlgorithmManager):
+        """Verify non-reentrant mutex is released even when _waitForAlgorithmCompletion raises TimeoutError."""
+        mockAlgorithmManager.runningInstancesOf = mock.Mock(return_value=["theAlgoThatNeverEnds"])
+        mockAlgorithmManager.create.return_value = self.fakeFunction
+
+        fakeMutex = mock.Mock()
+        with (
+            mock.patch.object(MantidSnapper, "_timeout", 0.2),
+            mock.patch.object(MantidSnapper, "_nonReentrantAlgorithms", ("fakeFunction",)),
+            mock.patch.object(MantidSnapper, "_nonReentrantMutexes", {"fakeFunction": fakeMutex}),
+        ):
+            mantidSnapper = MantidSnapper(parentAlgorithm=None, name="")
+            mantidSnapper.fakeFunction("test", fakeOutput="output")
+
+            with pytest.raises(TimeoutError, match="Timeout occurred while waiting for instance of"):
+                mantidSnapper.executeQueue()
+
+            # The mutex MUST be released even though TimeoutError was raised
+            assert fakeMutex.acquire.called
+            assert fakeMutex.release.called
+
     @mock.patch(PatchRoot.format("AlgorithmManager"))
     def test_timeout_concurrent(self, mockAlgorithmManager):
         mockAlgorithmManager.runningInstancesOf = mock.Mock(return_value=["theAlgoThatNeverEnds"])

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -163,7 +163,9 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         """Test fetch method with LoadLiveDataInterval loader"""
         mock_instance = mockAlgo.return_value
         mock_instance.execute.return_value = "data"
-        mock_instance.getPropertyValue.return_value = "LoadLiveDataInterval"
+        mock_instance.getPropertyValue.side_effect = lambda name: (
+            "LoadLiveDataInterval" if name == "LoaderType" else ""
+        )
 
         self.clearoutWorkspaces()
         res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadLiveDataInterval")
@@ -171,6 +173,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         assert res["result"]
         assert res["loader"] == "LoadLiveDataInterval"
         assert res["workspace"] == self.fetchedWSname
+        assert "runStatus" in res
 
     def test_fetch_failed(self):
         # this is some file that it can't load

--- a/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
+++ b/tests/unit/backend/recipe/test_FetchGroceriesRecipe.py
@@ -163,9 +163,7 @@ class TestFetchGroceriesRecipe(unittest.TestCase):
         """Test fetch method with LoadLiveDataInterval loader"""
         mock_instance = mockAlgo.return_value
         mock_instance.execute.return_value = "data"
-        mock_instance.getPropertyValue.side_effect = lambda name: (
-            "LoadLiveDataInterval" if name == "LoaderType" else ""
-        )
+        mock_instance.getPropertyValue.side_effect = lambda name: "LoadLiveDataInterval" if name == "LoaderType" else ""
 
         self.clearoutWorkspaces()
         res = self.rx.executeRecipe(self.filePath, self.fetchedWSname, "LoadLiveDataInterval")


### PR DESCRIPTION
 ## Description of work

These changes fix several defects in SNAPRed's live-data system.  Primarily the changes have to do with how dead-time intervals (i.e. intervals with a _zero_ event count, and no timing information) are treated.  In addition, several changes have been made in order to address open issues with the back-end (e.g. `GroceryService`, during live-data fallback)  and front-end (e.g. live-data pane `reset` at run-number change) implementation.  At present, some of these changes are implemented as _temporary_ _workarounds_, as the root-cause of the associated issue requires a change in the `SNSLiveEventDataListener` implementation (upcoming).

## Explanation of work

This commit includes the following changes:

  * 'LocalDataService.hasLiveDataConnection': allow both INET and UDS (Unix domain socket) addresses;
    these are follow-on changes from the ADARA-packet replay work.
  
  * 'MantidSnapper': cleanup live-data algorithms immediately following execution;
    this change is necessary to quickly release the 'SNSLiveEventDataListener' instances.

  * 'LoadLiveDataInterval': identify and respond to dead-time gaps:
    A dead-time gap is a period of time where the detected events count is zero; this is associated with the listener
    returning a chunk-workspace that usually has no time-interval information -- this is obviously a defect,
    but it is not fixed as part of this PR!  When no time-interval information is present,
    `getPulseTimeMin()` and `getPulseTimeMax()` return \<max DataAndTime\> and \<min DateAndTime\> respectively.
    Previously, if these values were actually used as the chunk-interval, it resulted in a set of chunk-intervals that
    could never be completed, because a fully-overlapping sequence would never be obtained.
    
  * 'LoadLiveDataInterval': add fallback mechanism for empty chunks: search for alternate time-series PVs.
  
  * 'LoadLiveDataInterval': 'RunStatus' output property.  'RunStatus' is now derived from the PV logs, rather than
    strictly from the run-number.  WIP: which logs are most reliable for this is still an open issue!  It is possible
    that the best log to use for this is not actually being streamed (by ADARA) 'BL3:CS:RunControl:StateEnum'.
  
  * 'WorkflowPresenter': in response to a 'LiveDataState' exception, 'reset' *first*.
    This fixes the issue that previously, the warning `QMessageBox` blocked the live-data pane from resetting,
    resulting in defects such as continuing the reduce cycle even when the run-number had changed (but using the previous
    run-number's workspace).
    
  * 'GroceryService': Temporary work-arounds prior to `SNSLiveEventDataListener` fixes.
    Sometimes the `run_number` log is not actually attached:
    
      - use the new `RunStatus` if it is available (the live-data case); 
        use the run-number to determine a state change *only* if it is non-zero.
    
      - in the live-data case: if the run-number is not set, *set* the run number on the workspace
        using the value from the metadata;
      
      - in the fallback case: if the run-number is not set, raise an exception
        (same as current behavior: we must have a run-number in this case to determine if the fallback applies).
      
  
## To test

Unit test coverage should be fairly complete.  Several of these changes can be best assessed by simply examining the code, and verifying that there's unit-test coverage.  (You _could_ run the Adara-packet player examples -- but that's almost certainly "above and beyond" the requirements of testing this PR!)

### Dev testing

The way I've been testing this system is to simultaneously open SNAPRed's live-data pane on "next", and on _this_ branch.  (Remember to _enable_ live-data in your `dev.yml`; and make sure your calibration directory is _writable_ in case you need to create the state.)  Once the _metadata_ for an active run is displayed, set the time-interval to _5 minutes_ (this ensures that the per-reduction  chunk-assembly sequence will not be overly long) -- then hit the "continue" key in both panes.  Once it gets to that point, allow the reduction to continue without normalization.  If the work of this PR has been successful, you'll see several defects occur in the "next" pane, that are bypassed in the new branch.  Particularly, at run-state-change, the panel should _reset_, and go back to the "ready" state (, but "next" will either _crash_, or will continue to reduce, but with a mis-named workspace).  If you do see dead-time intervals, next will perform the weird time-interval thing, timeout at chunk-assembly (, and possibly crash); this branch should simply ignore the dead-time (except for the warning) and continue without much issue.

### CIS testing
Same as for dev testing.

## Links to EWM items


[EWM#13905](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=13905)

[EWM#13769](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=13769)

### Verification

- [ ] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] acceptance criterion 1
- [ ] acceptance criterion 2
