### PR TITLE
refactor Callback implementation

### DIFF
--- a/src/snapred/backend/profiling/ProgressRecorder.py
+++ b/src/snapred/backend/profiling/ProgressRecorder.py
@@ -802,7 +802,7 @@ class _ProgressRecorder(BaseModel):
     @field_serializer("steps")
     def _serialize_steps(self, steps: Dict[Tuple[str, ...], ProgressStep], _info) -> List[ProgressStep]:
         # By default `Tuple[str, ...]` keys don't serialize correctly to JSON.
-        return list(steps.values())  # *** DEBUG *** vs. `self.steps.values()` ? Which is correct?!
+        return list(steps.values())  # TODO: ambiguous: we also have`self.steps.values()`: which is correct here?!
 
 
 # The `ProgressRecorder` singleton.

--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -11,7 +11,7 @@ from snapred.backend.error.AlgorithmException import AlgorithmException
 from snapred.backend.log.logger import snapredLogger
 
 # must import to register with AlgorithmManager
-from snapred.meta.Callback import callback
+from snapred.meta.Callback import Callback, callback
 from snapred.meta.Config import Config, Resource
 from snapred.meta.pointer import access_pointer, create_pointer
 
@@ -20,14 +20,14 @@ logger = snapredLogger.getLogger(__name__)
 
 class _CustomMtd:
     def __getitem__(self, key):
-        if str(key.__class__) == str(callback(int).__class__):
+        if isinstance(key, Callback):
             key = key.get()
         if self.doesExist(key):
             return mtd[key]
         raise KeyError(f"Workspace {key} not found in mtd: {self.getObjectNames()}")
 
     def doesExist(self, key):
-        if str(key.__class__) == str(callback(int).__class__):
+        if isinstance(key, Callback):
             key = key.get()
         return key is not None and mtd.doesExist(key)
 
@@ -54,6 +54,7 @@ class MantidSnapper:
     ##
     ## KNOWN NON-REENTRANT ALGORITHMS
     ##
+    _nonReentrantAlgorithms = "LoadLiveData", "LoadLiveDataInterval"
     _liveDataLock = Lock()
     _nonReentrantMutexes = {"LoadLiveData": _liveDataLock, "LoadLiveDataInterval": _liveDataLock}
 
@@ -208,11 +209,13 @@ class MantidSnapper:
                 mutex.acquire()
 
             for prop, val in kwargs.items():
-                # this line is to appease mantid properties, idk where its pulling empty string from
-                if str(val.__class__) == str(callback(int).__class__):
+                # Unwrap any deferred-output Callback so that boost::python sees
+                # the underlying str / workspace name / value, not the wrapper.
+                if isinstance(val, Callback):
                     val = val.get()
                 if val is None:
                     continue
+
                 # for pointer property, set via its pointer
                 # allows for "pass-by-reference"-like behavior
                 # this is safe even if the memory address is directly passed
@@ -250,7 +253,7 @@ class MantidSnapper:
 
     @classmethod
     def _cleanupNonConcurrent(cls, name, algorithm):
-        if name in cls._nonConcurrentAlgorithms:
+        if name in cls._nonConcurrentAlgorithms or name in cls._nonReentrantAlgorithms:
             cls._waitForAlgorithmCompletion(name)
             cls._removeAlgorithm(algorithm)
 

--- a/src/snapred/meta/Callback.py
+++ b/src/snapred/meta/Callback.py
@@ -1,68 +1,329 @@
-def delegate(cls, attr_name, method_name):
-    def delegated(self, *vargs, **kwargs):
-        a = getattr(self, attr_name)
-        _set = getattr(self, "_set")
-        if not _set:
-            raise AttributeError("Callback not Populated")
-        m = getattr(a, method_name)
-        return m(*vargs, **kwargs)
-
-    setattr(cls, method_name, delegated)
+from functools import lru_cache
+from typing import Any, Type
 
 
-def callback(clazz):
-    ignore = [
+class CallbackMeta(type):
+    """
+    Metaclass that automatically generates forwarding magic methods for Callback classes.
+
+    This metaclass intercepts class creation and automatically adds magic methods
+    that forward operations to the wrapped value. This eliminates the need for
+    manually defining each magic method or dynamically adding them after class creation.
+    """
+
+    # Magic methods that should be forwarded to the wrapped value
+    # This comprehensive list includes arithmetic, comparison, container, and conversion operations
+    _FORWARDED_MAGIC_METHODS = {
+        # Arithmetic operations
+        "__add__",
+        "__sub__",
+        "__mul__",
+        "__truediv__",
+        "__floordiv__",
+        "__mod__",
+        "__pow__",
+        "__lshift__",
+        "__rshift__",
+        "__and__",
+        "__xor__",
+        "__or__",
+        "__radd__",
+        "__rsub__",
+        "__rmul__",
+        "__rtruediv__",
+        "__rfloordiv__",
+        "__rmod__",
+        "__rpow__",
+        "__rlshift__",
+        "__rrshift__",
+        "__rand__",
+        "__rxor__",
+        "__ror__",
+        "__iadd__",
+        "__isub__",
+        "__imul__",
+        "__itruediv__",
+        "__ifloordiv__",
+        "__imod__",
+        "__ipow__",
+        "__ilshift__",
+        "__irshift__",
+        "__iand__",
+        "__ixor__",
+        "__ior__",
+        "__neg__",
+        "__pos__",
+        "__abs__",
+        "__invert__",
+        "__round__",
+        "__floor__",
+        "__ceil__",
+        # Comparison operations
+        "__lt__",
+        "__le__",
+        "__eq__",
+        "__ne__",
+        "__gt__",
+        "__ge__",
+        # Container operations (for lists, dicts, etc.)
+        "__len__",
+        "__getitem__",
+        "__setitem__",
+        "__delitem__",
+        "__iter__",
+        "__next__",
+        "__contains__",
+        "__reversed__",
+        "__missing__",
+        # Conversion operations (note: `__str__` and `__repr__` must NOT be forwarded here)
+        "__int__",
+        "__float__",
+        "__bool__",
+        "__hash__",
+        "__index__",
+        "__complex__",
+        "__bytes__",
+        "__format__",
+        # Context managers
+        "__enter__",
+        "__exit__",
+        # Callable
+        "__call__",
+        # Pickling/copying
+        "__reduce__",
+        "__reduce_ex__",
+        "__copy__",
+        "__deepcopy__",
+        # Async operations
+        "__await__",
+        "__aiter__",
+        "__anext__",
+        "__aenter__",
+        "__aexit__",
+    }
+
+    def __new__(mcs, name: str, bases: tuple, namespace: dict, **_kwargs) -> type:
+        """
+        Create a new Callback class with auto-generated magic methods.
+
+        Args:
+            name: The class name
+            bases: Base classes
+            namespace: Class namespace (attributes and methods)
+            **kwargs: Additional keyword arguments (including _wrapped_type)
+
+        Returns:
+            The newly created class
+        """
+        # Generate forwarding magic methods
+        for method_name in mcs._FORWARDED_MAGIC_METHODS:
+            if method_name not in namespace:  # Don't override explicitly defined methods
+                namespace[method_name] = mcs._make_forwarder(method_name)
+
+        return super().__new__(mcs, name, bases, namespace)
+
+    @staticmethod
+    def _make_forwarder(method_name: str):
+        """
+        Create a magic method that forwards to the wrapped value.
+
+        Args:
+            method_name: The name of the magic method to forward
+
+        Returns:
+            A function that forwards the method call to _value
+        """
+
+        def forwarder(self, *args, **kwargs):
+            if not self._set:
+                raise AttributeError(f"Callback method '{method_name}' called before value is set")
+            # Use object.__getattribute__ to avoid recursion through __getattr__
+            value = object.__getattribute__(self, "_value")
+            method_impl = getattr(value, method_name)
+            return method_impl(*args, **kwargs)
+
+        forwarder.__name__ = method_name
+        forwarder.__doc__ = f"Forward {method_name} to the wrapped value"
+        return forwarder
+
+
+class Callback(metaclass=CallbackMeta):
+    """
+    Callback wrapper that defers access to a value until it's populated.
+
+    This class uses a metaclass to automatically forward magic methods to the
+    wrapped value, enabling transparent operations on primitive types and objects.
+
+    Attributes:
+        _wrapped_type: The type being wrapped (set by the factory function)
+        _set: Whether the callback has been populated with a value
+        _value: The wrapped value (None if not populated)
+        _ignore: Set of attribute names that should not be forwarded
+    """
+
+    # These attributes are handled directly by the Callback class
+    # and should not be forwarded to _value
+    _ignore = {
         "_ignore",
         "update",
         "_set",
         "get",
         "__class__",
         "_value",
-        "__getitem__",
         "__new__",
         "__init__",
         "__getattr__",
-        "getattr",
         "__getattribute__",
         "__setattr__",
         "__subclasscheck__",
-    ]
+        "__instancecheck__",
+        "__repr__",
+        "__str__",
+    }
 
-    class Callback(object):
-        _ignore = ignore
-        _set = False
-        _value: clazz = None
+    def __init__(self):
+        """Initialize an unpopulated callback."""
+        self._set = False
+        self._value = None
 
-        def __init__(self):
-            pass
+    def update(self, value: Any) -> None:
+        """
+        Populate the callback with a value.
 
-        def update(self, value):
-            self._set = True
-            self._value = value
+        Args:
+            value: The value to wrap
+        """
+        self._set = True
+        self._value = value
 
-        def get(self):
-            if not self._set:
-                raise AttributeError("Callback not Populated")
-            return self._value
+    def get(self) -> Any:
+        """
+        Get the wrapped value, raising an error if not populated.
 
-        def __getattr__(self, name):
-            if name in self._ignore:
-                return __getattr__(name)  # noqa: F821
-            if not self._set:
-                raise AttributeError("Callback not Populated")
-            return getattr(self._value, name)
+        Returns:
+            The wrapped value
 
-        def __getitem__(self, items):
-            if not self._set:
-                return self
-            return self._value.__getitem__(items)
+        Raises:
+            AttributeError: If the callback has not been populated
+        """
+        if not self._set:
+            raise AttributeError("Callback not Populated")
+        return self._value
 
-        def __subclasscheck__(cls, subclass):
-            return clazz.__subclasscheck__(subclass)
+    def __getattr__(self, name: str) -> Any:
+        """
+        Forward attribute access to the wrapped value.
+        This is called for non-magic methods and attributes.
 
-    # Forward all methods to the _value, throw if not populated
-    for name in dir(clazz):
-        if name not in ignore:
-            delegate(Callback, "_value", name)
+        Args:
+            name: The attribute name
 
-    return Callback()
+        Returns:
+            The attribute value from the wrapped object
+
+        Raises:
+            AttributeError: If the callback is not populated
+        """
+        if name in self._ignore:
+            # Use object's implementation for ignored attributes
+            return object.__getattribute__(self, name)
+
+        if not self._set:
+            raise AttributeError("Callback not Populated")
+
+        # Forward to the wrapped value
+        return getattr(self._value, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """
+        Control attribute setting to protect internal attributes.
+
+        Args:
+            name: The attribute name
+            value: The attribute value
+        """
+        # Allow setting internal attributes during initialization
+        if name in {"_ignore", "_set", "_value"} or name.startswith("_"):
+            object.__setattr__(self, name, value)
+        elif hasattr(self, "_set") and self._set and hasattr(self, "_value"):
+            # Forward to wrapped value if populated
+            setattr(self._value, name, value)
+        else:
+            # If not populated, set on self
+            object.__setattr__(self, name, value)
+
+    def __repr__(self) -> str:
+        """String representation of the callback."""
+        wrapped_type = getattr(self, "_wrapped_type", None)
+        type_name = wrapped_type.__name__ if wrapped_type else "Unknown"
+
+        if self._set:
+            return f"Callback({type_name}, value={self._value!r})"
+        else:
+            return f"Callback({type_name}, not populated)"
+
+    def __str__(self) -> str:
+        """String conversion - forward to value if populated."""
+        if self._set:
+            return str(self._value)
+        wrapped_type = getattr(self, "_wrapped_type", None)
+        type_name = wrapped_type.__name__ if wrapped_type else "Unknown"
+        return f"<Callback({type_name})>"
+
+
+@lru_cache(maxsize=None)
+def _get_callback_class(clazz: Type) -> Type[Callback]:
+    """
+    Internal cached function that creates or retrieves a cached Callback class for the given type.
+
+    This function uses LRU caching to ensure that only one Callback class is created
+    per wrapped type, improving memory efficiency and enabling proper type checking.
+
+    Args:
+        clazz: The type to wrap (e.g., int, str, Workspace)
+
+    Returns:
+        A Callback class (not an instance) that wraps the given type
+    """
+    # Create a new Callback subclass with the wrapped type set
+    # We use type() to dynamically create a subclass with _wrapped_type set
+    return type(
+        f"Callback[{clazz.__name__}]",
+        (Callback,),
+        {
+            "_wrapped_type": clazz,
+            "__module__": Callback.__module__,
+        },
+    )
+
+
+def callback(clazz: Type) -> Callback:
+    """
+    Factory function that creates a new Callback instance for the given type.
+
+    This function uses a cached class creation mechanism to ensure that only one
+    Callback class is created per wrapped type, but returns a new instance each time.
+
+    Args:
+        clazz: The type to wrap (e.g., int, str, Workspace)
+
+    Returns:
+        A new instance of a Callback class that wraps the given type
+
+    Example:
+        >>> count = callback(int)
+        >>> count.update(5)
+        >>> result = count + 10  # Works! Returns 15
+        >>> ws = callback(Workspace)
+        >>> ws.update(some_workspace)
+        >>> name = ws.name()  # Forwarded to underlying workspace
+        >>>
+        >>> # Each call returns a new instance, but same class
+        >>> cb1 = callback(int)
+        >>> cb2 = callback(int)
+        >>> cb1 is not cb2  # Different instances
+        >>> cb1.__class__ is cb2.__class__  # Same class
+    """
+    # Get the cached class and instantiate it
+    CallbackSubclass = _get_callback_class(clazz)
+    return CallbackSubclass()

--- a/tests/cis_tests/live_data_memory_leak.py
+++ b/tests/cis_tests/live_data_memory_leak.py
@@ -1,0 +1,135 @@
+# Use this script to test Diffraction Calibration
+from typing import List
+from pathlib import Path
+from datetime import datetime
+import json
+import pydantic
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+import time
+import tracemalloc
+
+from mantid.simpleapi import *
+from mantid.kernel import ConfigService
+
+import snapred
+SNAPRed_module_root = Path(snapred.__file__).parent.parent
+
+from snapred.backend.data.LocalDataService import LocalDataService
+from snapred.backend.dao.ingredients.GroceryListItem import GroceryListItem
+from snapred.backend.dao.RunMetadata import RunMetadata
+from snapred.backend.data.GroceryService import GroceryService
+from snapred.meta.Config import Config, datasearch_directories
+
+# Test helper utility routines:
+# -----------------------------
+import sys
+sys.path.insert(0, str(Path(SNAPRed_module_root).parent / 'tests'))
+from util.script_as_test import not_a_test, pause
+from util.IPTS_override import IPTS_override
+
+def get_pid_rss_kb(pid: int):
+    """
+    Retrieves the Resident Set Size (RSS) in KB for a given PID 
+    using the Linux /proc/[pid]/smaps_rollup file.
+    """
+    path = f"/proc/{pid}/smaps_rollup"
+    try:
+        with open(path, "r") as f:
+            for line in f:
+                if line.startswith("Rss:"):
+                    # Format is usually: "Rss:                1234 kB"
+                    parts = line.split()
+                    return int(parts[1])
+    except FileNotFoundError:
+        return f"Error: {path} not found. (Requires Linux kernel 4.14+)"
+    except PermissionError:
+        return f"Error: Permission denied accessing {path}."
+    except Exception as e:
+        return f"Error: {str(e)}"
+
+# -----------------------------
+
+############################
+# FAKE live-data listener: 
+
+# FILEEVENTDATALISTENER_FILENAME_KEY = "fileeventdatalistener.filename"
+# FILEEVENTDATALISTENER_CHUNKS_KEY = "fileeventdatalistener.chunks"
+# ConfigService.setString(FILEEVENTDATALISTENER_FILENAME_KEY, Config["liveData.testInput.inputFilename"])
+# ConfigService.setString(FILEEVENTDATALISTENER_CHUNKS_KEY, str(Config["liveData.testInput.chunks"]))
+
+# end: FAKE live-data listener
+#############################
+
+# Always set the facility:
+ConfigService.setFacility(Config["liveData.facility.name"])
+
+### OVERRIDE IPTS location (optional), re-initialize STATE ###         
+with (
+    # Allow input data directories to possibly be at a different location from "/SNS":
+    #   defaults to `Config["IPTS.root"]`.
+    IPTS_override(),
+    ):
+
+    ##################################################################
+    ## Get the current live-data run number:                        ##
+    ## -- this needs to happen _after_ the override settings above! ##
+    ##################################################################
+    dataService = LocalDataService()
+
+    N_tests = 250
+    tracemalloc.start()    
+    start_perf = time.perf_counter()
+    for n_test in range(N_tests):
+        metadata = dataService.readLiveMetadata()
+        runNumber = metadata.runNumber
+        
+        ## if runNumber == RunMetadata.INACTIVE_RUN:
+        ##    raise RuntimeError("No run is currently active.  Please wait a while and try again.")
+
+        if not dataService.hasLiveDataConnection():
+            raise RuntimeError("There doesn't seem to be a live-data connection. Please check your 'application.yml' and try again.")
+        
+        end_perf = time.perf_counter()
+        elapsed = end_perf - start_perf
+        pid = os.getpid()
+        rss = get_pid_rss_kb(pid)
+        print(f"{elapsed:.4f} seconds: RSS {rss} kB")
+        
+        time.sleep(30.0)
+    
+    snapshot = tracemalloc.take_snapshot()
+    top_stats = snapshot.statistics('lineno')
+
+    print("-----------------------------------------------------------")
+    print("--------------- Memory-allocation traces ------------------")
+    print("-----------------------------------------------------------")
+
+    print("[ Top 10 ]")
+    for stat in top_stats[:10]:
+        print(stat)    
+
+    print("-----------------------------------------------------------")
+        
+    """    
+    ## Load the input data, and convert to lite mode: ##   
+    clerk = GroceryListItem.builder()
+    clerk.name("inputData").neutron(runNumber).useLiteMode(isLite).add()
+    groceries = GroceryService().fetchGroceryDict(clerk.buildDict())
+    logs = mtd[groceries['inputData']].getRun()
+    startTime = logs.startTime().to_datetime64()
+    endTime = logs.endTime().to_datetime64()
+    
+    # `getPulseTimeMin()` and `getPulseTimeMax()` return "stripped" results, for some reason,
+    #   but the 'proton_charge' time-series log still has the pulse times.
+    pulseTimes = mtd[groceries['inputData']].getRun()['proton_charge'].times
+    minPulseTime =  pulseTimes[0]   
+    maxPulseTime =  pulseTimes[-1]
+    
+    print("-------------------------")
+    print(f"Time interval (from PV logs):\n    [{startTime}, {endTime}]")    
+    print(f"    (from proton-charge times):\n    [{minPulseTime}, {maxPulseTime}]")
+    print("-------------------------")
+    """
+    

--- a/tests/cis_tests/live_data_memory_leak_v2.py
+++ b/tests/cis_tests/live_data_memory_leak_v2.py
@@ -1,0 +1,192 @@
+# Use this script to test Diffraction Calibration
+from typing import List
+from pathlib import Path
+from datetime import datetime
+import json
+import logging
+import pydantic
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+import socket
+import time
+from urllib.parse import urlparse
+import tracemalloc
+
+from mantid.api import Run
+from mantid.simpleapi import *
+from mantid.kernel import ConfigService
+
+import snapred
+SNAPRed_module_root = Path(snapred.__file__).parent.parent
+
+from snapred.backend.dao.RunMetadata import RunMetadata
+from snapred.backend.dao.state.DetectorState import DetectorState
+from snapred.meta.Config import Config, datasearch_directories
+from snapred.meta.mantid.WorkspaceNameGenerator import WorkspaceName
+
+# Test helper utility routines:
+# -----------------------------
+import sys
+sys.path.insert(0, str(Path(SNAPRed_module_root).parent / 'tests'))
+from util.script_as_test import not_a_test, pause
+from util.IPTS_override import IPTS_override
+
+
+# Basic configuration to output DEBUG level and above
+logging.basicConfig(level=logging.DEBUG)
+
+logger = logging.getLogger("live_data_memory_leak_v2")
+
+
+def get_pid_rss_kb(pid: int):
+    """
+    Retrieves the Resident Set Size (RSS) in KB for a given PID 
+    using the Linux /proc/[pid]/smaps_rollup file.
+    """
+    path = f"/proc/{pid}/smaps_rollup"
+    try:
+        with open(path, "r") as f:
+            for line in f:
+                if line.startswith("Rss:"):
+                    # Format is usually: "Rss:                1234 kB"
+                    parts = line.split()
+                    return int(parts[1])
+    except FileNotFoundError:
+        return f"Error: {path} not found. (Requires Linux kernel 4.14+)"
+    except PermissionError:
+        return f"Error: Permission denied accessing {path}."
+    except Exception as e:
+        return f"Error: {str(e)}"
+
+def hasLiveDataConnection() -> bool:
+    """For 'live data' methods: test if there is a listener connection to the instrument."""
+
+    # NOTE: adding `lru_cache` to this method bypasses a possible race condition in
+    #   `ConfigService.getFacility(...)`.  (And yes, that should be a `const` method.  :( )
+
+    # In addition to 'analysis.sns.gov', other nodes on the subnet should be OK as well.
+    #   So this check should also return True on those nodes.
+    # If this method returns True, then the `SNSLiveEventDataListener` should be able to function.
+
+    status = False
+    if Config["liveData.enabled"]:
+        # Normalize to an actual "URL" and then strip off the protocol (not actually "http") and port:
+        #   `liveDataAddress` returns a string similar to "bl3-daq1.sns.gov:31415".
+
+        facility, instrument = Config["liveData.facility.name"], Config["liveData.instrument.name"]
+        hostname = urlparse(
+            "http://" + ConfigService.getFacility(facility).instrument(instrument).liveDataAddress()
+        ).hostname
+        status = True
+        try:
+            socket.gethostbyaddr(hostname)
+        except Exception as e:  # noqa: BLE001
+            # specifically:
+            #   we're expecting a `socket.gaierror`, but any exception will indicate that there's no connection
+            logger.debug(f"`hasLiveDataConnection` returns `False`: exception: {e}")
+            status = False
+
+    return status
+
+def _liveMetadataFromRun(run: Run) -> RunMetadata:
+    """Construct a 'RunMetadata' instance from a 'mantid.api.Run' instance."""
+
+    metadata = None
+    runNumber = run.getProperty("run_number").value if run.hasProperty("run_number") else None
+    try:
+        # WORK-AROUND for this script specifically:
+        stateIdSchema = DetectorState.LEGACY_SCHEMA
+        """
+        stateIdSchema = (
+            # A run number of `None` or 0 indicates either an inactive, or an incompletely initialized run:
+            #   in that case, the rest of the metadata may still be valid,
+            #   so we fallback to using the LEGACY_SCHEMA.
+            self.readInstrumentConfig(runNumber).stateIdSchema if bool(runNumber) else DetectorState.LEGACY_SCHEMA
+        )
+        """
+        metadata = RunMetadata.fromRun(run, stateIdSchema, liveData=True)
+    except (KeyError, RuntimeError, ValueError) as e:
+        raise RuntimeError(f"Unable to extract RunMetadata from Run:\n  {e}") from e
+    return metadata
+
+def _readLiveData(ws: WorkspaceName, duration: int, *, accumulationMethod="Replace", preserveEvents=False):
+    # Initialize `startTime` to indicate that we want `duration` seconds of data prior to the current time.
+    startTime = (
+        RunMetadata.FROM_NOW_ISO8601
+        if duration == 0
+        else (datetime.utcnow() + timedelta(seconds=-duration)).isoformat()
+    )
+
+    # TODO: this call is partially duplicated at `FetchGroceriesAlgorithm`.
+    #   However, this separate method is required in order to specify a "fast load" for metadata purposes.
+    LoadLiveData(
+        OutputWorkspace=ws,
+        Instrument=Config["liveData.instrument.name"],
+        AccumulationMethod=accumulationMethod,
+        StartTime=startTime,
+        PreserveEvents=preserveEvents,
+    )
+
+    return ws
+
+def readLiveMetadata() -> RunMetadata:
+    # This method serves both as the direct `RunMetadata` access point for the non-fallback live-data case,
+    #   and also for the fallback case.
+
+    ws = mtd.unique_hidden_name()
+
+    # Retrieve the smallest possible data increment, in order to read the logs:
+    ws = _readLiveData(ws, duration=0)
+    metadata = _liveMetadataFromRun(mtd[ws].getRun())
+
+    DeleteWorkspace(Workspace=ws)
+    return metadata
+
+# -----------------------------
+
+# Always set the facility:
+ConfigService.setFacility(Config["liveData.facility.name"])
+
+### OVERRIDE IPTS location (optional), re-initialize STATE ###         
+with (
+    # Allow input data directories to possibly be at a different location from "/SNS":
+    #   defaults to `Config["IPTS.root"]`.
+    IPTS_override(),
+    ):
+
+    ##################################################################
+    ## Get the current live-data run number:                        ##
+    ## -- this needs to happen _after_ the override settings above! ##
+    ##################################################################
+
+    N_tests = 4320
+    tracemalloc.start()    
+    start_perf = time.perf_counter()
+    for n_test in range(N_tests):
+        if not hasLiveDataConnection():
+            raise RuntimeError("There doesn't seem to be a live-data connection. Please check your 'application.yml' and try again.")
+
+        metadata = readLiveMetadata()
+        runNumber = metadata.runNumber
+                
+        end_perf = time.perf_counter()
+        elapsed = end_perf - start_perf
+        pid = os.getpid()
+        rss = get_pid_rss_kb(pid)
+        print(f"{elapsed:.4f} seconds: RSS {rss} kB")
+        
+        time.sleep(5.0)
+    
+    snapshot = tracemalloc.take_snapshot()
+    top_stats = snapshot.statistics('lineno')
+
+    print("-----------------------------------------------------------")
+    print("--------------- Memory-allocation traces ------------------")
+    print("-----------------------------------------------------------")
+
+    print("[ Top 10 ]")
+    for stat in top_stats[:10]:
+        print(stat)    
+
+    print("-----------------------------------------------------------")

--- a/tests/unit/meta/test_Callback.py
+++ b/tests/unit/meta/test_Callback.py
@@ -2,7 +2,7 @@ import unittest
 
 import pytest
 
-from snapred.meta.Callback import callback
+from snapred.meta.Callback import Callback, callback
 
 
 class TestCallback(unittest.TestCase):
@@ -50,3 +50,117 @@ class TestCallback(unittest.TestCase):
         assert testCallback.__float__() == 123.456
         assert testCallback == 123.456
         assert testCallback + 1 == 124.456
+
+    def test_getattr_nameInIgnore(self):
+        # When `__getattr__` is invoked with a name that is in `self._ignore`,
+        # the implementation falls through to the Callback object.
+        testCallback = callback(str)
+        assert testCallback.__getattr__("_ignore") == Callback._ignore
+
+    def test_setattr_notPopulated(self):
+        # Setting an attribute when the callback is not populated should
+        # succeed (the class does not override `__setattr__`) and must not
+        # mark the callback as populated.
+        testCallback = callback(str)
+        assert testCallback._set is False
+        testCallback.someNewAttribute = "hello"
+        assert testCallback.someNewAttribute == "hello"
+        # Setting an arbitrary attribute must not flip the populated flag.
+        assert testCallback._set is False
+        # `get` should still raise because the callback was never updated.
+        with pytest.raises(AttributeError):
+            testCallback.get()
+
+    def test_repr_notPopulated(self):
+        testCallback = callback(str)
+        repr_ = repr(testCallback)
+        assert "Callback(str" in repr_
+        assert "not populated" in repr_
+
+    def test_repr_populated(self):
+        testCallback = callback(str)
+        testCallback.update("test")
+        repr_ = repr(testCallback)
+        assert "Callback(str" in repr_
+        assert f"value={'test'!r}" in repr_
+
+    def test_str_notPopulated(self):
+        testCallback = callback(str)
+        str_ = str(testCallback)
+        assert "<Callback(str)>" == str_
+
+    def test_str_populated(self):
+        testCallback = callback(str)
+        testCallback.update("test")
+        str_ = str(testCallback)
+        assert str_ == "test"
+
+    def test_callbackInstances(self):
+        # `callback()` returns distinct instances, but the underlying class is
+        # cached per wrapped type.
+        cb1 = callback(int)
+        cb2 = callback(int)
+        cb3 = callback(str)
+
+        # Distinct instances ...
+        assert cb1 is not cb2
+        # ... but a single cached class per wrapped type ...
+        assert cb1.__class__ is cb2.__class__
+        # ... and a distinct class for each distinct wrapped type.
+        assert cb1.__class__ is not cb3.__class__
+
+        # Generated class names encode the wrapped type.
+        assert cb1.__class__.__name__ == "Callback[int]"
+        assert cb3.__class__.__name__ == "Callback[str]"
+
+        # Independent state: updating one instance does not affect the other.
+        cb1.update(10)
+        cb2.update(20)
+        assert cb1.get() == 10
+        assert cb2.get() == 20
+
+        # Forwarded magic methods continue to work for each instance.
+        assert cb1 + 5 == 15
+        assert cb2 + 5 == 25
+
+    def test_strSet(self):
+        # Once populated, `str()` is forwarded to the wrapped value.
+        testCallback = callback(str)
+        testCallback.update("test")
+        assert str(testCallback) == "test"
+
+    def test_listCallback(self):
+        testCallback = callback(list)
+        testCallback.update([1, 2, 3])
+        assert testCallback.get() == [1, 2, 3]
+        assert len(testCallback) == 3
+        assert testCallback[1] == 2
+        assert 2 in testCallback
+        assert list(iter(testCallback)) == [1, 2, 3]
+
+    def test_setItemForwarded(self):
+        testCallback = callback(list)
+        testCallback.update([1, 2, 3])
+        testCallback[0] = 99
+        assert testCallback.get() == [99, 2, 3]
+
+    def test_setAttrForwardedWhenSet(self):
+        # When populated, setting a non-internal attribute is forwarded to the
+        # wrapped value.
+        class _Bag:
+            pass
+
+        bag = _Bag()
+        testCallback = callback(_Bag)
+        testCallback.update(bag)
+        testCallback.name = "forwarded"
+        assert bag.name == "forwarded"
+
+    def test_unsetMagicMethodThrows(self):
+        # A representative forwarded magic method should raise when the
+        # callback is not populated.
+        testCallback = callback(int)
+        with pytest.raises(AttributeError):
+            testCallback + 1
+        with pytest.raises(AttributeError):
+            len(callback(list))


### PR DESCRIPTION
## Description of work
This PR deals with a major memory-allocation issue in SNAPRed caused by the previous implementation and usage of the `Callback` class by `MantidSnapper`.

The old implementation was creating a new `Callback` class every time `callback(clazz)` was called, then dynamically attaching delegated methods to that class before returning an instance. This meant we were repeatedly allocating distinct callback class objects, each with its own type-object overhead and its own set of generated forwarding methods. The memory issue appears to have come from both the volume of those class allocations and the fact that the generated class objects persisted longer than expected. This refactor fixes that by moving to a stable top-level `Callback`, generating forwarding behavior via `CallbackMeta`, and caching one subclass per wrapped type instead of recreating classes on every call.

## Explanation of work

This commit includes the following changes:
  - Replace the define-class-in-closure pattern with a cached per-type `Callback` subclass.
  - Use `CallbackMeta` to generate forwarding magic methods at class creation time instead of patching them on afterward.
  - Expand magic-method pass-through so wrapped primitive types and other built-ins behave more transparently.
  - Centralize forwarding behavior in `_FORWARDED_MAGIC_METHODS` and `_make_forwarder()` to simplify maintenance.
  - Tighten attribute access/assignment handling to better separate internal state from forwarded behavior.
  - Preserve the existing “not populated” safeguards while improving debugging via `_wrapped_type`, `__repr__`, and `__str__`.

Note (this next change was not strictly necessary, but it makes testing on a laptop, a bit easier):
  - `LoadLiveData` algorithm deletion: match 'MantidSnapper' changes from EWM13905


## To test
New unit tests were added to cover the new changes.

### Dev testing

Two new test scripts are provided at `tests/cis_tests/live_data_memory_leak.py` and `tests/cis_tests/live_data_memory_leak_v2.py`.  The former is a minimal reproducer of the metadata-only loop from the live-data pane; the latter is a mantid-only version of the same thing.

These scripts will run the metadata-only part of SNAPRed's live-data loop, and display a memory-usage summary after each execution.  Before these changes, the former script would only run for 20 cycles or so before triggering an OOM-kill on a laptop with 32 GB of memory.  After these changes, I've successfully run the script for over 12 hours of cycling.

For convenience, I've attached my version of `dev.yml`.  I generally use a mirror of the relevent `/SNS` tree.  Note that in the following you must use the `LD_PRELOAD`: otherwise Mantid's extensive memory fragmentation will confuse the test results.  (I actually used `jemalloc` for my tests, but `tbbmalloc` should work as well.)

The commands to run the test script should be:
``` bash
export LD_PRELOAD=${HOME}/mambaforge/envs/mantid-developer/lib/libtbbmalloc.so
env=dev tests/scripts/live_data_memory_leak.py
```


## Link to EWM item
<!-- LINK TO THE EWM HERE -->

[EWM#16074](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=16074)

### Verification

- [ ] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

<!--
Inside the EWM, paste a link to this PR in a comment there
Link to any other relevant context, such as related mantid PRs, related SNAPRed PRs, related issues, etc.
-->

### Acceptance Criteria

<!-- COPY/PASTE here the acceptance criteria from the EWM story item.
These should come from the TAB and not the description, unless they are given in a specific section of the description.
If none were given, ask the owner what they are.
Make sure they format as a checklist in your PR description.
-->

This list is for ease of reference, and does not replace reading the EWM story as part of the review.  Verify this list matches the EWM story before reviewing.

- [ ] acceptance criterion 1
- [ ] acceptance criterion 2
