### PR TITLE
Fix live reduction when Mantid default facility is not SNS

### DIFF
--- a/docs/source/developer/implementation_notes/index.rst
+++ b/docs/source/developer/implementation_notes/index.rst
@@ -13,4 +13,5 @@ provide additional information that will be useful during SNAPRed development.
    :caption: Index
 
    grouping_workspaces.rst
+   mantid_config_ownership.rst
    profiling_and_progress_recording.rst

--- a/docs/source/developer/implementation_notes/mantid_config_ownership.rst
+++ b/docs/source/developer/implementation_notes/mantid_config_ownership.rst
@@ -1,0 +1,125 @@
+Mantid ``ConfigService`` ownership
+----------------------------------
+
+Mantid's ``ConfigService`` is a process-wide singleton.  When SNAPRed runs inside ``mantid_workbench``
+it therefore shares that configuration with the workbench itself and with anything else the user is
+doing in that session.  Any SNAPRed change to it is visible everywhere, immediately.
+
+For this reason SNAPRed treats the Mantid configuration as *borrowed*, never *owned*: every entry
+that SNAPRed modifies is saved, overridden, and then restored.
+
+Default facility and instrument
+===============================
+
+The awkward case is ``default.facility`` / ``default.instrument``.
+
+Mantid's live-data algorithms (``LoadLiveData``, ``StartLiveData``, ``MonitorLiveData``) build the
+allowed-values list for their ``Instrument`` property from the *default facility* -- that is, from
+``ConfigService.getFacility()`` with no argument -- restricted to those instruments which have a
+live-data listener.  If the default facility is not ``SNS``, that list comes back *empty*, and so
+``Instrument="SNAP"`` is rejected:
+
+.. code-block:: text
+
+   Invalid value for property Instrument (string) from string "SNAP": When setting value of
+   property "Instrument": The value "SNAP" is not in the list of allowed values
+
+SNAPRed consequently cannot reduce SNAP data at all when the user's Mantid default instrument or
+facility is set to anything else.
+
+Two properties of this validator constrain any workaround:
+
+1. **The allowed-values list is fixed at algorithm initialization** and never re-evaluated.
+   ``AlgorithmManager.create`` initializes the algorithm, so the default facility must *already* be
+   correct at the point of creation -- setting it afterwards has no effect.  This is also why simply
+   adding a ``Facility`` *property* to these algorithms would not help: property values are only set
+   after initialization, by which time the validator is frozen.  An upstream fix would instead have
+   to relax the ``StringListValidator`` on ``Instrument`` and perform the check in
+   ``validateInputs``, where both properties are available.
+
+2. **Naming the listener explicitly does not avoid the lookup.**  Setting ``Listener`` and
+   ``Address`` while leaving ``Instrument`` empty still resolves the listener from the default
+   instrument, and fails with "Attempted to access live listener for <instrument> instrument, which
+   has no listeners."
+
+Why the change is scoped
+========================
+
+Two placements were rejected:
+
+* **At SNAPRed module load.**  This would change the default facility for the entire workbench
+  session, and Python offers no dependable module unload, so there would be no correct point at
+  which to restore it.  Independently of that, doing resource-affecting work as an import side
+  effect is an antipattern.
+* **Only at GUI startup.**  This is what SNAPRed did historically (see
+  ``SNAPRedGUI._addLiveDataMantidConfigEntries``).  It leaves every non-GUI entry point broken:
+  consumers which import ``snapred.backend`` directly -- ``SNAPWrap``, scripts, tests -- never
+  construct the GUI, and so inherit the user's own facility setting.
+
+Instead, the default facility and instrument are overridden only for as long as it takes to create
+and run a live-data algorithm.  This is implemented by ``snapred.meta.mantid.LiveDataFacility`` and
+applied centrally in ``MantidSnapper.executeAlgorithm``, which is the single point through which all
+SNAPRed live-data algorithm calls pass.
+
+Because the override *is* still process-wide while it is in effect, it is deliberately entered
+*inside* ``MantidSnapper._liveDataLock`` -- the mutex which already serializes ``LoadLiveData`` and
+``LoadLiveDataInterval``.  This keeps the interval during which another thread could observe the
+modified configuration as short as the live-data call itself.
+
+The scope covers ``execute``, not merely initialization: ``LoadLiveData`` resolves its listener and
+address from the facility configuration at execution time, as can be observed from the resulting
+connection attempt to the SNAP listener address.
+
+No startup hook is required
+===========================
+
+Because the scope is applied at the point of use, there is deliberately *no* SNAPRed startup or
+shutdown call for a consumer to remember.  This holds only as long as nothing outside a
+``MantidSnapper`` algorithm call depends on the Mantid *default* facility or instrument.  At the time
+of writing, the only such dependency is ``LoadLiveDataInterval.validateInputs``, which runs during
+``execute`` and is therefore already inside the scope.  Everything else resolves the facility or
+instrument *by name* (see "Practical notes" below).
+
+If a future code path needs the default facility outside a live-data algorithm call, that assumption
+breaks, and an explicit start/shutdown pair -- which every consumer, including ``SNAPWrap``, would
+then have to call -- becomes the fallback.
+
+Non-reentrance
+==============
+
+While the scope is active the default facility is not what the user set, so nesting it would mean an
+outer live-data call silently running under an inner call's facility.  Re-entry is therefore treated
+as a defect: ``liveDataFacility`` raises ``LiveDataFacilityReentranceError`` rather than
+accommodating it.  Mantid runs algorithms one at a time, so there is no legitimate reason for these
+scopes to nest.
+
+Two details matter here:
+
+* **The check must happen before the live-data mutex is acquired.**  Nesting live-data calls through
+  ``MantidSnapper`` already deadlocks on ``_liveDataLock``, silently and with no diagnostic -- both
+  ``LoadLiveData`` and ``LoadLiveDataInterval`` map to the same non-reentrant lock.  A check placed
+  inside the scope would never be reached.
+* **The check must be conditional on the algorithm needing the facility.**  A live-data algorithm
+  legitimately calls *ordinary* algorithms through ``MantidSnapper`` from within its own ``PyExec``,
+  and hence from inside the scope: ``LoadLiveDataInterval`` calls ``CloneWorkspace``, ``Plus``,
+  ``FilterByTime`` and ``DeleteWorkspace``.  Rejecting those would break working code.
+
+Note also that algorithm *creation* now happens inside the mutex rather than before it.  This is
+deliberate: creating a second ``LoadLiveData`` instance while one is running risks creating a second
+listener, and the previous ordering left a window in which two threads could each construct one
+before either acquired the lock.
+
+Practical notes
+===============
+
+* Both keys must always be set together.  Setting the facility alone never yields the right
+  instrument: ``ConfigService.setString("default.facility", ...)`` leaves the *previous* instrument in
+  place, while ``ConfigService.setFacility(...)`` resets it to the facility's *first* instrument
+  (``DAS``, for SNS -- which is not a real instrument).
+* Look up instruments *by name* wherever possible.  ``ConfigService.getInstrument(<name>)`` and
+  ``ConfigService.getFacility(<name>)`` search all facilities and are unaffected by the default, as
+  used by ``LocalDataService.hasLiveDataConnection`` and ``CheckIPTS.getValidInstruments``.  Only the
+  property *validator* is facility-bound.
+* The ``liveData.facility.name`` and ``liveData.instrument.name`` :ref:`Config <applicationyml>`
+  entries -- not hard-coded ``"SNS"`` / ``"SNAP"`` -- are what get applied, so that the
+  ``TEST_LIVE`` / ``ADARA_FileReader`` mock-listener configuration continues to work for testing.

--- a/src/snapred/backend/recipe/algorithm/CheckIPTS.py
+++ b/src/snapred/backend/recipe/algorithm/CheckIPTS.py
@@ -27,7 +27,10 @@ class CheckIPTS(PythonAlgorithm):
 
         for name in ["SNS", "HFIR"]:
             facility = ConfigService.getFacility(name)
-            facilityInstruments = sorted([item.shortName() for item in facility.instruments() if item != "DAS"])
+            # Note: `item` is an `InstrumentInfo`, so the "DAS" exclusion must compare against its short name.
+            facilityInstruments = sorted(
+                [item.shortName() for item in facility.instruments() if item.shortName() != "DAS"]
+            )
             instruments.extend(facilityInstruments)
 
         return instruments

--- a/src/snapred/backend/recipe/algorithm/MantidSnapper.py
+++ b/src/snapred/backend/recipe/algorithm/MantidSnapper.py
@@ -13,6 +13,11 @@ from snapred.backend.log.logger import snapredLogger
 # must import to register with AlgorithmManager
 from snapred.meta.Callback import Callback, callback
 from snapred.meta.Config import Config, Resource
+from snapred.meta.mantid.LiveDataFacility import (
+    assertNoLiveDataFacility,
+    liveDataFacilityFor,
+    needsLiveDataFacility,
+)
 from snapred.meta.pointer import access_pointer, create_pointer
 
 logger = snapredLogger.getLogger(__name__)
@@ -199,31 +204,48 @@ class MantidSnapper:
         return mutex
 
     def executeAlgorithm(self, name, outputs, **kwargs):
-        algorithm = self._createAlgorithm(name)
+        algorithm = None
         mutex = None
         try:
+            # Nested *live-data* calls would deadlock on the live-data mutex below, silently and with
+            #   no diagnostic.  Report the re-entry here, *before* the mutex is acquired.
+            #   Note that this must be conditional: a live-data algorithm legitimately calls other,
+            #   ordinary algorithms through `MantidSnapper` from inside its own `PyExec` -- and hence
+            #   from inside the facility scope -- e.g. `LoadLiveDataInterval` calls `CloneWorkspace`,
+            #   `Plus`, `FilterByTime` and `DeleteWorkspace`.
+            if needsLiveDataFacility(name):
+                assertNoLiveDataFacility(name)
+
             # Protect non-reentrant algorithms.
 
             mutex = self._obtainMutex(name)
             if mutex is not None:
                 mutex.acquire()
 
-            for prop, val in kwargs.items():
-                # Unwrap any deferred-output Callback so that boost::python sees
-                # the underlying str / workspace name / value, not the wrapper.
-                if isinstance(val, Callback):
-                    val = val.get()
-                if val is None:
-                    continue
+            # For live-data algorithms, SNAPRed's facility and instrument must be the Mantid defaults:
+            #   these algorithms validate their `Instrument` property against the *default facility*,
+            #   and they do so when the algorithm is initialized -- which `_createAlgorithm` does.
+            #   `ConfigService` is a process-wide singleton, so this scope is deliberately entered
+            #   *inside* the live-data mutex above, and exited as soon as the algorithm has run.
+            with liveDataFacilityFor(name):
+                algorithm = self._createAlgorithm(name)
 
-                # for pointer property, set via its pointer
-                # allows for "pass-by-reference"-like behavior
-                # this is safe even if the memory address is directly passed
-                if isinstance(algorithm.getProperty(prop), PointerProperty) and type(val) is not int:
-                    val = create_pointer(val)
-                algorithm.setProperty(prop, val)
-            if not algorithm.execute():
-                raise RuntimeError(f"{name} failed to execute")
+                for prop, val in kwargs.items():
+                    # Unwrap any deferred-output Callback so that boost::python sees
+                    # the underlying str / workspace name / value, not the wrapper.
+                    if isinstance(val, Callback):
+                        val = val.get()
+                    if val is None:
+                        continue
+
+                    # for pointer property, set via its pointer
+                    # allows for "pass-by-reference"-like behavior
+                    # this is safe even if the memory address is directly passed
+                    if isinstance(algorithm.getProperty(prop), PointerProperty) and type(val) is not int:
+                        val = create_pointer(val)
+                    algorithm.setProperty(prop, val)
+                if not algorithm.execute():
+                    raise RuntimeError(f"{name} failed to execute")
             for prop, val in outputs.items():
                 # TODO: Special cases are bad
                 if name == "LoadDiffCal":
@@ -248,7 +270,9 @@ class MantidSnapper:
             raise AlgorithmException(name, str(e)) from e
         finally:
             try:
-                self._cleanupNonConcurrent(name, algorithm)
+                # `algorithm` is `None` if creation itself failed.
+                if algorithm is not None:
+                    self._cleanupNonConcurrent(name, algorithm)
             finally:
                 if mutex is not None:
                     mutex.release()

--- a/src/snapred/meta/mantid/LiveDataFacility.py
+++ b/src/snapred/meta/mantid/LiveDataFacility.py
@@ -73,20 +73,51 @@ def liveDataFacilityActive() -> bool:
         return _active
 
 
+def _reentranceError(context: str) -> LiveDataFacilityReentranceError:
+    return LiveDataFacilityReentranceError(
+        f"A live-data facility scope is already active, and cannot be nested (entering: {context}).\n"
+        "  While such a scope is active the Mantid default facility is overridden process-wide,"
+        " so nesting would run the outer call under the wrong facility.\n"
+        "  This indicates a defect in the calling code: live-data algorithms are expected to run"
+        " one at a time."
+    )
+
+
 def assertNoLiveDataFacility(context: str):
     """Fail loudly if a live-data facility scope is already active.
 
     Call this *before* acquiring any live-data mutex, so that re-entry reports itself instead of
       deadlocking.
+
+    Note that this is an *advisory* check only -- it cannot be atomic with respect to a subsequent
+      entry.  `liveDataFacility` performs the authoritative check-and-claim itself; this exists so
+      that the common single-threaded nesting mistake is reported before a mutex can swallow it.
     """
     if liveDataFacilityActive():
-        raise LiveDataFacilityReentranceError(
-            f"A live-data facility scope is already active, and cannot be nested (entering: {context}).\n"
-            "  While such a scope is active the Mantid default facility is overridden process-wide,"
-            " so nesting would run the outer call under the wrong facility.\n"
-            "  This indicates a defect in the calling code: live-data algorithms are expected to run"
-            " one at a time."
-        )
+        raise _reentranceError(context)
+
+
+def _claimLiveDataFacility(context: str):
+    """Atomically claim the live-data facility scope, or raise if it is already claimed.
+
+    The check and the claim *must* occur in a single critical section.  Performing them separately
+      allows two threads to both pass the check before either claims, so both then override the
+      process-wide Mantid configuration -- and the one which exits last restores the *overridden*
+      values rather than the user's, permanently changing the user's default facility.
+    """
+    global _active
+
+    with _activeLock:
+        if _active:
+            raise _reentranceError(context)
+        _active = True
+
+
+def _releaseLiveDataFacility():
+    global _active
+
+    with _activeLock:
+        _active = False
 
 
 @contextmanager
@@ -96,20 +127,14 @@ def liveDataFacility(context: str = "live-data algorithm"):
     Restores the previous `default.facility` and `default.instrument` on exit, including on error.
       Raises `LiveDataFacilityReentranceError` if such a scope is already active.
     """
-    global _active
-
-    assertNoLiveDataFacility(context)
-
-    facility, instrument = Config["liveData.facility.name"], Config["liveData.instrument.name"]
-    with _activeLock:
-        _active = True
+    _claimLiveDataFacility(context)
     try:
+        facility, instrument = Config["liveData.facility.name"], Config["liveData.instrument.name"]
         logger.debug(f"applying live-data facility '{facility}' / instrument '{instrument}' for {context}")
         with amend_config(facility=facility, instrument=instrument):
             yield
     finally:
-        with _activeLock:
-            _active = False
+        _releaseLiveDataFacility()
 
 
 def liveDataFacilityFor(algorithmName: str) -> AbstractContextManager:

--- a/src/snapred/meta/mantid/LiveDataFacility.py
+++ b/src/snapred/meta/mantid/LiveDataFacility.py
@@ -1,0 +1,128 @@
+import threading
+from contextlib import AbstractContextManager, contextmanager, nullcontext
+
+from mantid.kernel import amend_config
+
+from snapred.backend.log.logger import snapredLogger
+from snapred.meta.Config import Config
+
+logger = snapredLogger.getLogger(__name__)
+
+##
+## Mantid's live-data algorithms (`LoadLiveData`, `StartLiveData`, `MonitorLiveData`) build the
+##   allowed-values list for their `Instrument` property from the *default facility* -- that is, from
+##   `ConfigService.getFacility()` with no argument -- restricted to those instruments which have a
+##   live-data listener.  When the default facility is not "SNS", that list comes back *empty*, and so
+##   `Instrument="SNAP"` is rejected outright:
+##
+##     Invalid value for property Instrument (string) from string "SNAP": When setting value of
+##     property "Instrument": The value "SNAP" is not in the list of allowed values
+##
+##   This means SNAPRed cannot reduce SNAP data when the user's Mantid default instrument/facility is
+##   set to anything else.
+##
+## Two properties of this validator determine how it must be worked around:
+##
+##   1. The allowed-values list is fixed when the algorithm is *initialized*, and is never
+##      re-evaluated afterwards.  `AlgorithmManager.create` initializes the algorithm, so the default
+##      facility must already be correct at the point of creation -- setting it later has no effect.
+##      (This is also why an additional `Facility` *property* on these algorithms would not help:
+##      property values are only set after initialization.)
+##
+##   2. Specifying `Listener` and `Address` explicitly does not avoid the lookup: the algorithm still
+##      resolves the listener from the default instrument, and fails with
+##      "Attempted to access live listener for <instrument> instrument, which has no listeners."
+##
+## `ConfigService` is a process-wide singleton, so SNAPRed must not simply set the default facility
+##   permanently: doing so at module load would change the facility for the entire Mantid workbench
+##   session, and Python offers no dependable module unload.  Instead, the change is made only for as
+##   long as it takes to create and run a live-data algorithm, and is then reverted.  Callers are
+##   expected to hold this scope under `MantidSnapper._liveDataLock`, so that the interval during
+##   which the process-wide default facility is modified stays as short as possible.
+##
+
+
+# Mantid algorithms whose `Instrument` property is validated against the default facility.
+LIVE_DATA_ALGORITHMS = frozenset({"LoadLiveData", "StartLiveData", "MonitorLiveData"})
+
+
+##
+## NON-REENTRANCE
+##
+## While this scope is active, the process-wide default facility is *not* what the user set.  Nesting
+##   it would therefore mean an outer live-data call silently running under an inner call's facility,
+##   so re-entry is treated as a defect and raised rather than accommodated.  Mantid executes
+##   algorithms one at a time, so there is no legitimate reason for these scopes to nest.
+##
+## Note that nesting live-data calls through `MantidSnapper` already *deadlocks* on
+##   `MantidSnapper._liveDataLock`, silently and with no diagnostic.  For the check below to be
+##   reached at all, it must therefore be performed *before* that mutex is acquired -- see
+##   `MantidSnapper.executeAlgorithm`.
+##
+_active = False
+_activeLock = threading.Lock()
+
+
+class LiveDataFacilityReentranceError(RuntimeError):
+    """Raised when a live-data facility scope is entered while another is already active."""
+
+
+def liveDataFacilityActive() -> bool:
+    """Whether a live-data facility scope is currently in effect anywhere in this process."""
+    with _activeLock:
+        return _active
+
+
+def assertNoLiveDataFacility(context: str):
+    """Fail loudly if a live-data facility scope is already active.
+
+    Call this *before* acquiring any live-data mutex, so that re-entry reports itself instead of
+      deadlocking.
+    """
+    if liveDataFacilityActive():
+        raise LiveDataFacilityReentranceError(
+            f"A live-data facility scope is already active, and cannot be nested (entering: {context}).\n"
+            "  While such a scope is active the Mantid default facility is overridden process-wide,"
+            " so nesting would run the outer call under the wrong facility.\n"
+            "  This indicates a defect in the calling code: live-data algorithms are expected to run"
+            " one at a time."
+        )
+
+
+@contextmanager
+def liveDataFacility(context: str = "live-data algorithm"):
+    """Temporarily make SNAPRed's live-data facility and instrument the Mantid defaults.
+
+    Restores the previous `default.facility` and `default.instrument` on exit, including on error.
+      Raises `LiveDataFacilityReentranceError` if such a scope is already active.
+    """
+    global _active
+
+    assertNoLiveDataFacility(context)
+
+    facility, instrument = Config["liveData.facility.name"], Config["liveData.instrument.name"]
+    with _activeLock:
+        _active = True
+    try:
+        logger.debug(f"applying live-data facility '{facility}' / instrument '{instrument}' for {context}")
+        with amend_config(facility=facility, instrument=instrument):
+            yield
+    finally:
+        with _activeLock:
+            _active = False
+
+
+def liveDataFacilityFor(algorithmName: str) -> AbstractContextManager:
+    """As `liveDataFacility`, but a no-op for algorithms which do not consult the default facility.
+
+    `algorithmName` may name a SNAPRed algorithm which *wraps* a Mantid live-data algorithm (e.g.
+      `LoadLiveDataInterval`), in which case the scope must also cover the wrapped child algorithm.
+    """
+    return liveDataFacility(algorithmName) if needsLiveDataFacility(algorithmName) else nullcontext()
+
+
+def needsLiveDataFacility(algorithmName: str) -> bool:
+    """Whether running `algorithmName` requires SNAPRed's live-data facility to be the Mantid default."""
+    # `LoadLiveDataInterval` is a SNAPRed algorithm which creates a `LoadLiveData` child, and whose
+    #   `validateInputs` also resolves the instrument via the default facility.
+    return algorithmName in LIVE_DATA_ALGORITHMS or algorithmName == "LoadLiveDataInterval"

--- a/src/snapred/ui/main.py
+++ b/src/snapred/ui/main.py
@@ -39,6 +39,7 @@ LOGGERCLASSKEY = "logging.channels.consoleChannel.class"
 LOGGERLEVELKEY = "logging.loggers.root.level"
 DATASEARCH_DIR_KEY = "datasearch.directories"
 DEFAULT_FACILITY_KEY = "default.facility"
+DEFAULT_INSTRUMENT_KEY = "default.instrument"
 FILEEVENTDATALISTENER_FILENAME_KEY = "fileeventdatalistener.filename"
 FILEEVENTDATALISTENER_CHUNKS_KEY = "fileeventdatalistener.chunks"
 
@@ -197,11 +198,19 @@ class SNAPRedGUI(QMainWindow):
         self._mantidConfig.setString(DATASEARCH_DIR_KEY, self._savedMantidConfigEntries[DATASEARCH_DIR_KEY])
 
     def _addLiveDataMantidConfigEntries(self):
-        # Save any current default-facility setting:
+        # Save any current default-facility and default-instrument settings:
         self._savedMantidConfigEntries[DEFAULT_FACILITY_KEY] = self._mantidConfig[DEFAULT_FACILITY_KEY]
+        self._savedMantidConfigEntries[DEFAULT_INSTRUMENT_KEY] = self._mantidConfig[DEFAULT_INSTRUMENT_KEY]
 
-        # Add the required default-facility value:
+        # Add the required default-facility and default-instrument values.
+        #   Both are required: Mantid's live-data algorithms build the allowed values for their
+        #   `Instrument` property from the *default facility*, so a non-SNS default facility makes
+        #   `Instrument="SNAP"` unusable.  Setting the facility via `setString` leaves the previous
+        #   instrument in place (whereas `ConfigService.setFacility` would reset it to the facility's
+        #   first instrument) -- neither yields the instrument we need, so it is set explicitly here.
+        #   The instrument is set _after_ the facility, so that it wins in either case.
         self._mantidConfig.setString(DEFAULT_FACILITY_KEY, Config["liveData.facility.name"])
+        self._mantidConfig.setString(DEFAULT_INSTRUMENT_KEY, Config["liveData.instrument.name"])
 
         if Config["liveData.facility.name"] == "TEST_LIVE":
             # Save any current values from the file-listener keys:
@@ -217,8 +226,10 @@ class SNAPRedGUI(QMainWindow):
             self._mantidConfig.setString(FILEEVENTDATALISTENER_CHUNKS_KEY, str(Config["liveData.testInput.chunks"]))
 
     def _restoreLiveDataMantidConfigEntries(self):
-        # Restore any previous default-facility setting:
+        # Restore any previous default-facility and default-instrument settings.
+        #   As in `_addLiveDataMantidConfigEntries`, the instrument is restored _after_ the facility.
         self._mantidConfig.setString(DEFAULT_FACILITY_KEY, self._savedMantidConfigEntries[DEFAULT_FACILITY_KEY])
+        self._mantidConfig.setString(DEFAULT_INSTRUMENT_KEY, self._savedMantidConfigEntries[DEFAULT_INSTRUMENT_KEY])
 
         if Config["liveData.facility.name"] == "TEST_LIVE":
             # Restore any previous values to the file-listener keys:

--- a/tests/unit/backend/data/test_liveDataFacilityConfig.py
+++ b/tests/unit/backend/data/test_liveDataFacilityConfig.py
@@ -1,0 +1,178 @@
+##
+## Regression tests for: "snapred live reduction fails if mantid default instrument is not SNAP".
+##
+## Root cause: Mantid's `LiveDataAlgorithm::init()` builds the allowed-values list for its
+##   `Instrument` property from the *default facility* (`ConfigService.getFacility()`, no argument),
+##   restricted to those instruments which have a live-data listener.  When the default facility is
+##   not "SNS", that list comes back *empty*, and so `Instrument="SNAP"` is rejected outright with:
+##
+##     Invalid value for property Instrument (string) from string "SNAP": When setting value of
+##     property "Instrument": The value "SNAP" is not in the list of allowed values
+##
+##   SNAPRed sets `default.facility` only from `SNAPRedGUI.__init__` (see `snapred.ui.main`), so any
+##   non-GUI entry point (e.g. `snapwrap`, which imports `snapred.backend` directly) inherits the
+##   user's own facility setting and then fails inside `LocalDataService._readLiveData`.
+##
+## These tests characterize the Mantid-side behavior that the fix depends upon.  They deliberately do
+##   *not* assert anything about where SNAPRed performs the facility/instrument setup: that decision
+##   is still open, and these tests should hold for any of the candidate implementations.
+##
+
+import mantid.simpleapi  # noqa: F401  (import registers `LoadLiveData` with the `AlgorithmFactory`)
+import pytest
+from mantid.api import AlgorithmManager
+from mantid.kernel import ConfigService, amend_config
+
+from snapred.meta.Config import Config
+
+DEFAULT_FACILITY_KEY = "default.facility"
+DEFAULT_INSTRUMENT_KEY = "default.instrument"
+
+# A facility which is definitely neither SNS nor HFIR, and which has no live-data listeners at all.
+#   Any such facility reproduces the defect: "ILL" is used here only because it is always present
+#   in Mantid's `facilities.xml`.
+OTHER_FACILITY = "ILL"
+OTHER_INSTRUMENT = "IN5"
+
+LIVE_DATA_ALGORITHMS = ("LoadLiveData", "StartLiveData")
+
+
+@pytest.fixture
+def mantidFacilityConfig():
+    """Yield the Mantid `ConfigService`, restoring the default facility and instrument afterwards.
+
+    `ConfigService` is a process-wide singleton, so any test which modifies it *must* put it back.
+    """
+    mantidConfig = ConfigService.Instance()
+    saved = {key: mantidConfig[key] for key in (DEFAULT_FACILITY_KEY, DEFAULT_INSTRUMENT_KEY)}
+
+    yield mantidConfig
+
+    # The facility must be restored *before* the instrument: setting the facility resets the
+    #   instrument to that facility's default.
+    mantidConfig.setString(DEFAULT_FACILITY_KEY, saved[DEFAULT_FACILITY_KEY])
+    mantidConfig.setString(DEFAULT_INSTRUMENT_KEY, saved[DEFAULT_INSTRUMENT_KEY])
+
+
+def _initializedLiveDataAlgorithm(name: str):
+    algorithm = AlgorithmManager.create(name)
+    algorithm.initialize()
+    return algorithm
+
+
+def _allowedInstruments(name: str):
+    return list(_initializedLiveDataAlgorithm(name).getProperty("Instrument").allowedValues)
+
+
+@pytest.mark.parametrize("algorithmName", LIVE_DATA_ALGORITHMS)
+def test_liveDataInstrumentRejectedWhenDefaultFacilityIsNotSNS(mantidFacilityConfig, algorithmName):
+    """The defect itself: a non-SNS default facility makes the SNAP live-data instrument unusable."""
+    mantidFacilityConfig.setString(DEFAULT_FACILITY_KEY, OTHER_FACILITY)
+    mantidFacilityConfig.setString(DEFAULT_INSTRUMENT_KEY, OTHER_INSTRUMENT)
+
+    liveDataInstrument = Config["liveData.instrument.name"]
+    assert liveDataInstrument not in _allowedInstruments(algorithmName)
+
+    algorithm = _initializedLiveDataAlgorithm(algorithmName)
+    with pytest.raises(ValueError, match="not in the list of allowed values"):
+        algorithm.setProperty("Instrument", liveDataInstrument)
+
+
+@pytest.mark.parametrize("algorithmName", LIVE_DATA_ALGORITHMS)
+def test_liveDataInstrumentAcceptedWhenFacilityAndInstrumentAreSet(mantidFacilityConfig, algorithmName):
+    """Setting *both* the facility and the instrument makes the live-data instrument usable again."""
+    mantidFacilityConfig.setString(DEFAULT_FACILITY_KEY, OTHER_FACILITY)
+    mantidFacilityConfig.setString(DEFAULT_INSTRUMENT_KEY, OTHER_INSTRUMENT)
+
+    facility, instrument = Config["liveData.facility.name"], Config["liveData.instrument.name"]
+    with amend_config(facility=facility, instrument=instrument):
+        assert mantidFacilityConfig[DEFAULT_FACILITY_KEY] == facility
+        assert mantidFacilityConfig[DEFAULT_INSTRUMENT_KEY] == instrument
+        assert instrument in _allowedInstruments(algorithmName)
+
+        # No exception: this is the call which fails in the defect report.
+        _initializedLiveDataAlgorithm(algorithmName).setProperty("Instrument", instrument)
+
+
+def test_amendConfigRestoresPreviousFacilityAndInstrument(mantidFacilityConfig):
+    """`amend_config` must not leak SNAPRed's facility/instrument into the enclosing session.
+
+    This is the property which makes a scoped change viable despite `ConfigService` being a singleton.
+    """
+    mantidFacilityConfig.setString(DEFAULT_FACILITY_KEY, OTHER_FACILITY)
+    mantidFacilityConfig.setString(DEFAULT_INSTRUMENT_KEY, OTHER_INSTRUMENT)
+
+    with amend_config(facility=Config["liveData.facility.name"], instrument=Config["liveData.instrument.name"]):
+        pass
+
+    assert mantidFacilityConfig[DEFAULT_FACILITY_KEY] == OTHER_FACILITY
+    assert mantidFacilityConfig[DEFAULT_INSTRUMENT_KEY] == OTHER_INSTRUMENT
+
+
+def test_settingFacilityAloneDoesNotSetTheInstrument(mantidFacilityConfig):
+    """Setting the facility alone never yields the correct default instrument, by either route.
+
+    This is the bug fixed in `SNAPRedGUI._addLiveDataMantidConfigEntries`, which previously set
+      `default.facility` and left `default.instrument` wrong.  The two routes differ:
+
+        - `setString(DEFAULT_FACILITY_KEY, ...)` leaves the *previous* instrument in place;
+        - `ConfigService.setFacility(...)` resets it to the facility's *first* instrument.
+
+      Neither produces the live-data instrument, so both must be set explicitly.
+    """
+    facility, instrument = Config["liveData.facility.name"], Config["liveData.instrument.name"]
+
+    # Route 1: `setString` leaves the stale instrument behind.
+    mantidFacilityConfig.setString(DEFAULT_FACILITY_KEY, OTHER_FACILITY)
+    mantidFacilityConfig.setString(DEFAULT_INSTRUMENT_KEY, OTHER_INSTRUMENT)
+    mantidFacilityConfig.setString(DEFAULT_FACILITY_KEY, facility)
+    assert mantidFacilityConfig[DEFAULT_INSTRUMENT_KEY] == OTHER_INSTRUMENT
+    assert mantidFacilityConfig[DEFAULT_INSTRUMENT_KEY] != instrument
+
+    # Route 2: `setFacility` resets the instrument, but not to the one we need.
+    mantidFacilityConfig.setString(DEFAULT_FACILITY_KEY, OTHER_FACILITY)
+    mantidFacilityConfig.setString(DEFAULT_INSTRUMENT_KEY, OTHER_INSTRUMENT)
+    ConfigService.setFacility(facility)
+    assert mantidFacilityConfig[DEFAULT_INSTRUMENT_KEY] != OTHER_INSTRUMENT
+    assert mantidFacilityConfig[DEFAULT_INSTRUMENT_KEY] != instrument
+
+
+@pytest.mark.parametrize("algorithmName", LIVE_DATA_ALGORITHMS)
+def test_allowedInstrumentsAreSnapshottedAtInitialize(mantidFacilityConfig, algorithmName):
+    """The allowed-values list is fixed at `initialize()` and not re-evaluated afterwards.
+
+    This bounds how long SNAPRed must hold a modified `ConfigService`: the scope needs to cover
+      algorithm creation, `initialize()` and `setProperty`, but not the data load itself.
+
+    Note: whether the *execute* path of `LoadLiveData` also requires the default facility has not
+      been verified here -- doing so needs a live listener.  See the story notes.
+    """
+    instrument = Config["liveData.instrument.name"]
+
+    with amend_config(facility=Config["liveData.facility.name"], instrument=instrument):
+        algorithm = _initializedLiveDataAlgorithm(algorithmName)
+        algorithm.setProperty("Instrument", instrument)
+
+    mantidFacilityConfig.setString(DEFAULT_FACILITY_KEY, OTHER_FACILITY)
+    mantidFacilityConfig.setString(DEFAULT_INSTRUMENT_KEY, OTHER_INSTRUMENT)
+
+    # The already-initialized algorithm retains both its value and its allowed-values list.
+    assert algorithm.getProperty("Instrument").value == instrument
+    assert instrument in list(algorithm.getProperty("Instrument").allowedValues)
+    algorithm.setProperty("Instrument", instrument)
+
+
+def test_getInstrumentSearchesAllFacilities(mantidFacilityConfig):
+    """`ConfigService.getInstrument(<name>)` is not restricted to the default facility.
+
+    Lookups which name the instrument explicitly -- as `LocalDataService.hasLiveDataConnection` does
+      -- therefore keep working under a non-SNS default.  Only the *property validator* is
+      facility-bound.
+    """
+    mantidFacilityConfig.setString(DEFAULT_FACILITY_KEY, OTHER_FACILITY)
+    mantidFacilityConfig.setString(DEFAULT_INSTRUMENT_KEY, OTHER_INSTRUMENT)
+
+    instrumentInfo = ConfigService.getInstrument(Config["liveData.instrument.name"])
+
+    assert instrumentInfo.name() == Config["liveData.instrument.name"]
+    assert instrumentInfo.facility().name() == Config["liveData.facility.name"]

--- a/tests/unit/backend/recipe/algorithm/test_CheckIPTS.py
+++ b/tests/unit/backend/recipe/algorithm/test_CheckIPTS.py
@@ -1,0 +1,55 @@
+import mantid.simpleapi  # noqa: F401  (import registers algorithms with the `AlgorithmFactory`)
+import pytest
+from mantid.kernel import ConfigService
+
+from snapred.backend.recipe.algorithm.CheckIPTS import CheckIPTS
+from snapred.meta.Config import Config
+
+
+@pytest.fixture
+def algorithm():
+    algo = CheckIPTS()
+    algo.initialize()
+    return algo
+
+
+def test_getValidInstrumentsIncludesTheSNAPRedInstrument(algorithm):
+    """The instrument SNAPRed actually uses must be an allowed value.
+
+    Note that `getValidInstruments` queries "SNS" and "HFIR" *by name*, so unlike Mantid's live-data
+      algorithms this list does not depend on the user's default facility.
+    """
+    assert Config["instrument.name"] in algorithm.getValidInstruments()
+
+
+def test_getValidInstrumentsExcludesDAS(algorithm):
+    """ "DAS" is not a real instrument and must be filtered out.
+
+    Regression test: the exclusion previously compared an `InstrumentInfo` against the string "DAS",
+      which is never equal, so the filter silently did nothing.  "DAS" matters here because it is the
+      first instrument in the SNS facility, and so is what `ConfigService.setFacility("SNS")` selects
+      as the default instrument.
+    """
+    assert "DAS" not in algorithm.getValidInstruments()
+
+
+def test_getValidInstrumentsAllowsEmptyString(algorithm):
+    """An empty `Instrument` is documented as "uses default instrument", so it must stay allowed."""
+    assert "" in algorithm.getValidInstruments()
+
+
+def test_getValidInstrumentsCoversBothFacilities(algorithm):
+    """Both SNS and HFIR instruments are included, independent of the default facility."""
+    instruments = algorithm.getValidInstruments()
+
+    for facilityName in ("SNS", "HFIR"):
+        facility = ConfigService.getFacility(facilityName)
+        expected = {item.shortName() for item in facility.instruments() if item.shortName() != "DAS"}
+        assert expected <= set(instruments)
+
+
+def test_instrumentPropertyAcceptsTheSNAPRedInstrument(algorithm):
+    """End-to-end on the property itself: `Instrument=SNAP` must be settable."""
+    algorithm.setProperty("Instrument", Config["instrument.name"])
+
+    assert algorithm.getProperty("Instrument").value == Config["instrument.name"]

--- a/tests/unit/backend/recipe/algorithm/test_MantidSnapper.py
+++ b/tests/unit/backend/recipe/algorithm/test_MantidSnapper.py
@@ -2,12 +2,20 @@ import unittest
 from unittest import mock
 
 import pytest
-from mantid.kernel import Direction
+from mantid.kernel import ConfigService, Direction
 
 from snapred.backend.recipe.algorithm.MantidSnapper import MantidSnapper
 from snapred.meta.Callback import callback
+from snapred.meta.Config import Config
 
 PatchRoot: str = "snapred.backend.recipe.algorithm.MantidSnapper.{0}"
+
+DEFAULT_FACILITY_KEY = "default.facility"
+DEFAULT_INSTRUMENT_KEY = "default.instrument"
+
+# A facility which is neither SNS nor HFIR, and which has no live-data listeners.
+OTHER_FACILITY = "ILL"
+OTHER_INSTRUMENT = "IN5"
 
 
 class TestMantidSnapper(unittest.TestCase):
@@ -118,3 +126,89 @@ class TestMantidSnapper(unittest.TestCase):
             mantidSnapper.executeQueue()
             assert MantidSnapper._nonReentrantMutexes["fakeFunction"].acquire.called
             assert MantidSnapper._nonReentrantMutexes["fakeFunction"].release.called
+
+
+class TestMantidSnapperLiveDataFacility(unittest.TestCase):
+    """`MantidSnapper` must make SNAPRed's facility the Mantid default while running live-data algorithms.
+
+    Mantid's live-data algorithms validate their `Instrument` property against the *default facility*,
+      and do so at algorithm *initialization* -- which `AlgorithmManager.create` performs.  So the
+      facility must already be correct at the point of creation, not merely before `execute`.
+
+    See `snapred.meta.mantid.LiveDataFacility` for the full explanation.
+    """
+
+    def setUp(self):
+        self.fakeOutput = mock.Mock()
+        self.fakeOutput.name = "fakeOutput"
+        self.fakeOutput.direction = Direction.Output
+
+        self.fakeAlgorithm = mock.Mock()
+        self.fakeAlgorithm.getProperties.return_value = [self.fakeOutput]
+        self.fakeAlgorithm.getProperty.return_value = self.fakeOutput
+
+        self.mantidConfig = ConfigService.Instance()
+        self._saved = {key: self.mantidConfig[key] for key in (DEFAULT_FACILITY_KEY, DEFAULT_INSTRUMENT_KEY)}
+        self.mantidConfig.setString(DEFAULT_FACILITY_KEY, OTHER_FACILITY)
+        self.mantidConfig.setString(DEFAULT_INSTRUMENT_KEY, OTHER_INSTRUMENT)
+
+        # Record the default facility and instrument as seen at each algorithm creation.
+        self.observedAtCreate = []
+
+    def tearDown(self):
+        self.mantidConfig.setString(DEFAULT_FACILITY_KEY, self._saved[DEFAULT_FACILITY_KEY])
+        self.mantidConfig.setString(DEFAULT_INSTRUMENT_KEY, self._saved[DEFAULT_INSTRUMENT_KEY])
+
+    def _recordingCreate(self, *_args, **_kwargs):
+        self.observedAtCreate.append(
+            (self.mantidConfig[DEFAULT_FACILITY_KEY], self.mantidConfig[DEFAULT_INSTRUMENT_KEY])
+        )
+        return self.fakeAlgorithm
+
+    def _runAlgorithm(self, mockAlgorithmManager, name):
+        mockAlgorithmManager.create.side_effect = self._recordingCreate
+        mantidSnapper = MantidSnapper(parentAlgorithm=None, name="")
+        getattr(mantidSnapper, name)("test", fakeOutput="output")
+        mantidSnapper.executeQueue()
+
+    @mock.patch(PatchRoot.format("AlgorithmManager"))
+    def test_liveDataAlgorithmIsCreatedUnderTheSNAPRedFacility(self, mockAlgorithmManager):
+        self._runAlgorithm(mockAlgorithmManager, "LoadLiveData")
+
+        expected = (Config["liveData.facility.name"], Config["liveData.instrument.name"])
+        # The final creation is the one inside `executeAlgorithm`: it must see SNAPRed's facility.
+        assert self.observedAtCreate[-1] == expected
+
+    @mock.patch(PatchRoot.format("AlgorithmManager"))
+    def test_liveDataIntervalIsCreatedUnderTheSNAPRedFacility(self, mockAlgorithmManager):
+        # `LoadLiveDataInterval` is a SNAPRed algorithm which creates a `LoadLiveData` child.
+        self._runAlgorithm(mockAlgorithmManager, "LoadLiveDataInterval")
+
+        expected = (Config["liveData.facility.name"], Config["liveData.instrument.name"])
+        assert self.observedAtCreate[-1] == expected
+
+    @mock.patch(PatchRoot.format("AlgorithmManager"))
+    def test_facilityIsRestoredAfterALiveDataAlgorithm(self, mockAlgorithmManager):
+        self._runAlgorithm(mockAlgorithmManager, "LoadLiveData")
+
+        assert self.mantidConfig[DEFAULT_FACILITY_KEY] == OTHER_FACILITY
+        assert self.mantidConfig[DEFAULT_INSTRUMENT_KEY] == OTHER_INSTRUMENT
+
+    @mock.patch(PatchRoot.format("AlgorithmManager"))
+    def test_facilityIsRestoredWhenALiveDataAlgorithmFails(self, mockAlgorithmManager):
+        self.fakeAlgorithm.execute.return_value = False
+
+        with pytest.raises(Exception, match="LoadLiveData"):
+            self._runAlgorithm(mockAlgorithmManager, "LoadLiveData")
+
+        assert self.mantidConfig[DEFAULT_FACILITY_KEY] == OTHER_FACILITY
+        assert self.mantidConfig[DEFAULT_INSTRUMENT_KEY] == OTHER_INSTRUMENT
+
+    @mock.patch(PatchRoot.format("AlgorithmManager"))
+    def test_nonLiveDataAlgorithmDoesNotChangeTheFacility(self, mockAlgorithmManager):
+        self._runAlgorithm(mockAlgorithmManager, "LoadEventNexus")
+
+        # The user's configuration must be untouched throughout.
+        assert self.observedAtCreate[-1] == (OTHER_FACILITY, OTHER_INSTRUMENT)
+        assert self.mantidConfig[DEFAULT_FACILITY_KEY] == OTHER_FACILITY
+        assert self.mantidConfig[DEFAULT_INSTRUMENT_KEY] == OTHER_INSTRUMENT

--- a/tests/unit/meta/mantid/test_LiveDataFacility.py
+++ b/tests/unit/meta/mantid/test_LiveDataFacility.py
@@ -1,9 +1,12 @@
+import threading
+import time
 from contextlib import nullcontext
 
 import pytest
 from mantid.kernel import ConfigService
 
 from snapred.meta.Config import Config
+from snapred.meta.mantid import LiveDataFacility
 from snapred.meta.mantid.LiveDataFacility import (
     LiveDataFacilityReentranceError,
     assertNoLiveDataFacility,
@@ -167,3 +170,65 @@ def test_ordinaryAlgorithmScopeNestsInsideALiveDataScope(otherDefaultFacility):
         with liveDataFacilityFor("CloneWorkspace"):
             # Still the live-data facility, courtesy of the enclosing scope -- and no error.
             assert otherDefaultFacility[DEFAULT_FACILITY_KEY] == Config["liveData.facility.name"]
+
+
+##
+## ATOMICITY OF THE RE-ENTRANCE CLAIM
+##
+
+
+def test_nestingIsRejectedEvenIfTheAdvisoryCheckIsBypassed(otherDefaultFacility, monkeypatch):
+    """`liveDataFacility` must perform its own authoritative check-and-claim.
+
+    Regression test: the check and the claim were once two separate critical sections, with only
+      `assertNoLiveDataFacility` guarding entry.  Two threads could then both pass the check before
+      either claimed, both override the process-wide configuration, and the one exiting last would
+      restore the *overridden* values -- permanently changing the user's default facility.
+
+    Bypassing the advisory check here stands in for losing that race deterministically.
+    """
+    monkeypatch.setattr(LiveDataFacility, "assertNoLiveDataFacility", lambda _context: None)
+
+    with liveDataFacility("outer"):
+        with pytest.raises(LiveDataFacilityReentranceError, match="cannot be nested"):
+            with liveDataFacility("inner"):
+                pass
+
+    assert otherDefaultFacility[DEFAULT_FACILITY_KEY] == OTHER_FACILITY
+    assert otherDefaultFacility[DEFAULT_INSTRUMENT_KEY] == OTHER_INSTRUMENT
+
+
+def test_concurrentEntryAdmitsOnlyOneHolderAndDoesNotLeakConfig(otherDefaultFacility):
+    """Under contention the scope must admit one holder at a time and always restore the user's config."""
+    occupancy = {"current": 0, "max": 0}
+    occupancyLock = threading.Lock()
+    admitted, rejected = [], []
+
+    def contend(index):
+        try:
+            with liveDataFacility(f"thread-{index}"):
+                with occupancyLock:
+                    occupancy["current"] += 1
+                    occupancy["max"] = max(occupancy["max"], occupancy["current"])
+                time.sleep(0.02)
+                with occupancyLock:
+                    occupancy["current"] -= 1
+            admitted.append(index)
+        except LiveDataFacilityReentranceError:
+            rejected.append(index)
+
+    threads = [threading.Thread(target=contend, args=(i,)) for i in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert not any(thread.is_alive() for thread in threads), "a contending thread failed to finish"
+    # Contenders are rejected rather than queued, so some will not be admitted -- but never two at once.
+    assert occupancy["max"] == 1
+    assert len(admitted) + len(rejected) == 8
+    assert admitted, "at least one thread should have been admitted"
+
+    # Whatever the interleaving, the user's configuration must be intact.
+    assert otherDefaultFacility[DEFAULT_FACILITY_KEY] == OTHER_FACILITY
+    assert otherDefaultFacility[DEFAULT_INSTRUMENT_KEY] == OTHER_INSTRUMENT

--- a/tests/unit/meta/mantid/test_LiveDataFacility.py
+++ b/tests/unit/meta/mantid/test_LiveDataFacility.py
@@ -1,0 +1,169 @@
+from contextlib import nullcontext
+
+import pytest
+from mantid.kernel import ConfigService
+
+from snapred.meta.Config import Config
+from snapred.meta.mantid.LiveDataFacility import (
+    LiveDataFacilityReentranceError,
+    assertNoLiveDataFacility,
+    liveDataFacility,
+    liveDataFacilityActive,
+    liveDataFacilityFor,
+    needsLiveDataFacility,
+)
+
+DEFAULT_FACILITY_KEY = "default.facility"
+DEFAULT_INSTRUMENT_KEY = "default.instrument"
+
+# A facility which is neither SNS nor HFIR, and which has no live-data listeners.
+OTHER_FACILITY = "ILL"
+OTHER_INSTRUMENT = "IN5"
+
+
+@pytest.fixture
+def otherDefaultFacility():
+    """Set a non-SNS default facility and instrument, restoring the originals afterwards."""
+    mantidConfig = ConfigService.Instance()
+    saved = {key: mantidConfig[key] for key in (DEFAULT_FACILITY_KEY, DEFAULT_INSTRUMENT_KEY)}
+
+    mantidConfig.setString(DEFAULT_FACILITY_KEY, OTHER_FACILITY)
+    mantidConfig.setString(DEFAULT_INSTRUMENT_KEY, OTHER_INSTRUMENT)
+
+    yield mantidConfig
+
+    mantidConfig.setString(DEFAULT_FACILITY_KEY, saved[DEFAULT_FACILITY_KEY])
+    mantidConfig.setString(DEFAULT_INSTRUMENT_KEY, saved[DEFAULT_INSTRUMENT_KEY])
+
+
+def test_liveDataFacilitySetsFacilityAndInstrument(otherDefaultFacility):
+    with liveDataFacility():
+        assert otherDefaultFacility[DEFAULT_FACILITY_KEY] == Config["liveData.facility.name"]
+        assert otherDefaultFacility[DEFAULT_INSTRUMENT_KEY] == Config["liveData.instrument.name"]
+
+
+def test_liveDataFacilityRestoresPreviousSettings(otherDefaultFacility):
+    with liveDataFacility():
+        pass
+
+    assert otherDefaultFacility[DEFAULT_FACILITY_KEY] == OTHER_FACILITY
+    assert otherDefaultFacility[DEFAULT_INSTRUMENT_KEY] == OTHER_INSTRUMENT
+
+
+def test_liveDataFacilityRestoresPreviousSettingsAfterAnException(otherDefaultFacility):
+    """`ConfigService` is process-wide, so the restore must survive a failing live-data load."""
+    with pytest.raises(RuntimeError, match="live-data load failed"):
+        with liveDataFacility():
+            raise RuntimeError("live-data load failed")
+
+    assert otherDefaultFacility[DEFAULT_FACILITY_KEY] == OTHER_FACILITY
+    assert otherDefaultFacility[DEFAULT_INSTRUMENT_KEY] == OTHER_INSTRUMENT
+
+
+@pytest.mark.parametrize(
+    "algorithmName",
+    ["LoadLiveData", "StartLiveData", "MonitorLiveData", "LoadLiveDataInterval"],
+)
+def test_needsLiveDataFacilityForLiveDataAlgorithms(algorithmName):
+    assert needsLiveDataFacility(algorithmName)
+
+
+@pytest.mark.parametrize("algorithmName", ["LoadEventNexus", "LoadGroupingDefinition", "Rebin", ""])
+def test_doesNotNeedLiveDataFacilityForOtherAlgorithms(algorithmName):
+    assert not needsLiveDataFacility(algorithmName)
+
+
+def test_liveDataFacilityForIsANoOpForOtherAlgorithms(otherDefaultFacility):
+    scope = liveDataFacilityFor("LoadEventNexus")
+
+    assert isinstance(scope, nullcontext)
+    with scope:
+        # A non-live-data algorithm must not disturb the user's Mantid configuration at all.
+        assert otherDefaultFacility[DEFAULT_FACILITY_KEY] == OTHER_FACILITY
+        assert otherDefaultFacility[DEFAULT_INSTRUMENT_KEY] == OTHER_INSTRUMENT
+
+
+def test_liveDataFacilityForAppliesToLiveDataAlgorithms(otherDefaultFacility):
+    with liveDataFacilityFor("LoadLiveData"):
+        assert otherDefaultFacility[DEFAULT_FACILITY_KEY] == Config["liveData.facility.name"]
+        assert otherDefaultFacility[DEFAULT_INSTRUMENT_KEY] == Config["liveData.instrument.name"]
+
+
+##
+## NON-REENTRANCE
+##
+
+
+@pytest.mark.usefixtures("otherDefaultFacility")
+def test_liveDataFacilityIsNotReentrant():
+    with liveDataFacility("outer"):
+        with pytest.raises(LiveDataFacilityReentranceError, match="cannot be nested"):
+            with liveDataFacility("inner"):
+                pass
+
+
+@pytest.mark.usefixtures("otherDefaultFacility")
+def test_reentranceErrorNamesTheEnteringContext():
+    with liveDataFacility("outer"):
+        with pytest.raises(LiveDataFacilityReentranceError, match="entering: LoadLiveData"):
+            with liveDataFacility("LoadLiveData"):
+                pass
+
+
+def test_facilityIsStillRestoredAfterAReentranceError(otherDefaultFacility):
+    """A rejected inner scope must not disturb the outer scope, nor the eventual restore."""
+    with liveDataFacility("outer"):
+        with pytest.raises(LiveDataFacilityReentranceError):
+            with liveDataFacility("inner"):
+                pass
+        # The outer scope is still intact.
+        assert otherDefaultFacility[DEFAULT_FACILITY_KEY] == Config["liveData.facility.name"]
+
+    assert otherDefaultFacility[DEFAULT_FACILITY_KEY] == OTHER_FACILITY
+    assert otherDefaultFacility[DEFAULT_INSTRUMENT_KEY] == OTHER_INSTRUMENT
+
+
+def test_scopeIsReusableAfterAnException(otherDefaultFacility):
+    """The active flag must be cleared on the way out, or the first failure poisons every later call."""
+    with pytest.raises(RuntimeError, match="load failed"):
+        with liveDataFacility("first"):
+            raise RuntimeError("load failed")
+
+    assert not liveDataFacilityActive()
+
+    # A subsequent scope must still work.
+    with liveDataFacility("second"):
+        assert otherDefaultFacility[DEFAULT_FACILITY_KEY] == Config["liveData.facility.name"]
+
+
+@pytest.mark.usefixtures("otherDefaultFacility")
+def test_liveDataFacilityActiveReportsState():
+    assert not liveDataFacilityActive()
+    with liveDataFacility("scope"):
+        assert liveDataFacilityActive()
+    assert not liveDataFacilityActive()
+
+
+def test_assertNoLiveDataFacilityPassesWhenInactive():
+    # Must not raise.
+    assertNoLiveDataFacility("LoadLiveData")
+
+
+@pytest.mark.usefixtures("otherDefaultFacility")
+def test_liveDataFacilityForIsAlsoNonReentrant():
+    with liveDataFacilityFor("LoadLiveData"):
+        with pytest.raises(LiveDataFacilityReentranceError):
+            with liveDataFacilityFor("LoadLiveDataInterval"):
+                pass
+
+
+def test_ordinaryAlgorithmScopeNestsInsideALiveDataScope(otherDefaultFacility):
+    """A live-data algorithm calls ordinary algorithms from inside its own scope; that must be allowed.
+
+    `LoadLiveDataInterval`, for example, calls `CloneWorkspace`, `Plus`, `FilterByTime` and
+      `DeleteWorkspace` through `MantidSnapper` from within `PyExec`.
+    """
+    with liveDataFacilityFor("LoadLiveData"):
+        with liveDataFacilityFor("CloneWorkspace"):
+            # Still the live-data facility, courtesy of the enclosing scope -- and no error.
+            assert otherDefaultFacility[DEFAULT_FACILITY_KEY] == Config["liveData.facility.name"]

--- a/tests/unit/ui/test_mainLiveDataConfig.py
+++ b/tests/unit/ui/test_mainLiveDataConfig.py
@@ -1,0 +1,81 @@
+##
+## Coverage for `SNAPRedGUI`'s save/override/restore of the Mantid default facility and instrument.
+##
+## These tests exercise `_addLiveDataMantidConfigEntries` / `_restoreLiveDataMantidConfigEntries`
+##   directly against a stub, rather than constructing the GUI: the methods only touch
+##   `self._mantidConfig` and `self._savedMantidConfigEntries`, so no Qt widgets are required.
+##
+
+import pytest
+from mantid.kernel import ConfigService
+
+from snapred.meta.Config import Config
+
+# `snapred.ui.main` pulls in the full view layer, which requires a Mantid version matching the
+#   `pyproject.toml` pin.  Skip rather than error when the environment is behind.
+main = pytest.importorskip(
+    "snapred.ui.main",
+    reason="'snapred.ui.main' requires the pinned mantid version (see 'pyproject.toml')",
+    exc_type=ImportError,
+)
+
+DEFAULT_FACILITY_KEY = "default.facility"
+DEFAULT_INSTRUMENT_KEY = "default.instrument"
+
+OTHER_FACILITY = "ILL"
+OTHER_INSTRUMENT = "IN5"
+
+
+class _ConfigHolder:
+    """Minimal stand-in for `SNAPRedGUI`, exposing only what these two methods use."""
+
+    def __init__(self, mantidConfig):
+        self._mantidConfig = mantidConfig
+        self._savedMantidConfigEntries = {}
+
+
+@pytest.fixture
+def holder():
+    mantidConfig = ConfigService.Instance()
+    saved = {key: mantidConfig[key] for key in (DEFAULT_FACILITY_KEY, DEFAULT_INSTRUMENT_KEY)}
+
+    mantidConfig.setString(DEFAULT_FACILITY_KEY, OTHER_FACILITY)
+    mantidConfig.setString(DEFAULT_INSTRUMENT_KEY, OTHER_INSTRUMENT)
+
+    yield _ConfigHolder(mantidConfig)
+
+    mantidConfig.setString(DEFAULT_FACILITY_KEY, saved[DEFAULT_FACILITY_KEY])
+    mantidConfig.setString(DEFAULT_INSTRUMENT_KEY, saved[DEFAULT_INSTRUMENT_KEY])
+
+
+def test_bothFacilityAndInstrumentAreApplied(holder):
+    """Setting the facility alone is not enough -- see `snapred.meta.mantid.LiveDataFacility`."""
+    main.SNAPRedGUI._addLiveDataMantidConfigEntries(holder)
+
+    assert holder._mantidConfig[DEFAULT_FACILITY_KEY] == Config["liveData.facility.name"]
+    assert holder._mantidConfig[DEFAULT_INSTRUMENT_KEY] == Config["liveData.instrument.name"]
+
+
+def test_bothFacilityAndInstrumentAreSaved(holder):
+    main.SNAPRedGUI._addLiveDataMantidConfigEntries(holder)
+
+    assert holder._savedMantidConfigEntries[DEFAULT_FACILITY_KEY] == OTHER_FACILITY
+    assert holder._savedMantidConfigEntries[DEFAULT_INSTRUMENT_KEY] == OTHER_INSTRUMENT
+
+
+def test_bothFacilityAndInstrumentAreRestored(holder):
+    """The user's Mantid configuration must survive a SNAPRed session unchanged."""
+    main.SNAPRedGUI._addLiveDataMantidConfigEntries(holder)
+    main.SNAPRedGUI._restoreLiveDataMantidConfigEntries(holder)
+
+    assert holder._mantidConfig[DEFAULT_FACILITY_KEY] == OTHER_FACILITY
+    assert holder._mantidConfig[DEFAULT_INSTRUMENT_KEY] == OTHER_INSTRUMENT
+
+
+def test_addThenRestoreIsIdempotentAcrossRepeatedSessions(holder):
+    for _ in range(3):
+        main.SNAPRedGUI._addLiveDataMantidConfigEntries(holder)
+        main.SNAPRedGUI._restoreLiveDataMantidConfigEntries(holder)
+
+    assert holder._mantidConfig[DEFAULT_FACILITY_KEY] == OTHER_FACILITY
+    assert holder._mantidConfig[DEFAULT_INSTRUMENT_KEY] == OTHER_INSTRUMENT


### PR DESCRIPTION
## Description of work

Live reduction failed outright for any user whose Mantid default instrument/facility was not
SNAP/SNS. The reported failure came through SNAPWrap on an analysis node:

```
Invalid value for property Instrument (string) from string "SNAP": When setting value of
property "Instrument": The value "SNAP" is not in the list of allowed values
snapred.backend.error.StateValidationException: Instrument State for given Run Number is invalid!
```

Mantid's live-data algorithms (`LoadLiveData`, `StartLiveData`, `MonitorLiveData`) build the
allowed-values list for their `Instrument` property from the **default facility**, restricted to
instruments that have a live-data listener. Under a non-SNS default that list comes back *empty*, so
`Instrument="SNAP"` is rejected before anything else happens.

SNAPRed already set the default facility — but only in `SNAPRedGUI.__init__`. Any consumer that
imports `snapred.backend` directly and never constructs the GUI (SNAPWrap, scripts, tests) inherited
the user's own facility setting. SNAPWrap never touches Mantid's `ConfigService` at all, and reaches
this through `DataFactoryService.constructStateId`, which is exactly the reported traceback.

This makes SNAPRed reduce SNAP data regardless of the user's Mantid configuration, without SNAPRed
permanently changing that configuration out from under them.

## Explanation of work

The fix has to work around two properties of Mantid's validator, both verified against 6.16:

1. **The allowed-values list is frozen when the algorithm is initialized** and is never re-evaluated.
   `AlgorithmManager.create` initializes, and a second `initialize()` is a no-op — so the facility
   must already be correct *at the point of creation*. Setting it later has no effect, and there is
   no Python-exposed way to replace the validator.
2. **Naming the listener explicitly doesn't help.** Setting `Listener`/`Address` with `Instrument`
   empty still resolves from the default instrument, failing with "Attempted to access live listener
   for `<instrument>` instrument, which has no listeners."

Two placements were considered and rejected. Setting the facility at **module load** would change it
for the whole workbench session, and Python has no dependable module unload, so there'd be no correct
point to restore it — quite apart from doing that work as an import side effect. Setting it **only at
GUI startup** is the status quo, and is what leaves every non-GUI entry point broken.

So the override is **scoped**: applied only for as long as it takes to create and run a live-data
algorithm, then reverted. New helper `snapred/meta/mantid/LiveDataFacility.py` wraps
`mantid.kernel.amend_config`, driven by `Config["liveData.facility.name"]` /
`Config["liveData.instrument.name"]` rather than hard-coded `"SNS"`/`"SNAP"`, so the
`TEST_LIVE`/`ADARA_FileReader` mock-listener setup keeps working.

It is applied centrally in `MantidSnapper.executeAlgorithm` rather than at the individual call sites.
That was the more obvious option, but it doesn't work: `MantidSnapper` defers execution to
`executeQueue()`, so wrapping `LocalDataService._readLiveData` and friends would cover enqueue and
miss the actual failure point. Centralizing also means one place instead of three, and it
automatically covers every live-data path.

`ConfigService` is a process-wide singleton, so while the scope is active the default facility is not
what the user set. Two consequences:

- The scope is entered **inside** the existing `MantidSnapper._liveDataLock`, which already serializes
  `LoadLiveData` and `LoadLiveDataInterval`. That keeps the interval in which another thread could
  observe the modified configuration as short as the live-data call itself.
- The scope is **non-reentrant** — nesting would run an outer call under an inner call's facility, so
  it raises `LiveDataFacilityReentranceError` instead.

Two details about that guard are worth calling out, since both are easy to get wrong:

``` python
# The check runs BEFORE the mutex is acquired.  Nesting live-data calls through MantidSnapper
# already deadlocks on _liveDataLock -- silently, with no diagnostic -- so a check placed inside
# the scope would never be reached.  Confirmed with a debugger stack dump.
if needsLiveDataFacility(name):
    assertNoLiveDataFacility(name)
```

It is also **conditional** on the algorithm needing the facility. An unconditional check breaks
working code: a live-data algorithm legitimately calls ordinary algorithms through `MantidSnapper`
from inside its own `PyExec` — `LoadLiveDataInterval` calls `CloneWorkspace`, `Plus`, `FilterByTime`
and `DeleteWorkspace`, all from inside the scope.

One side effect worth noting for review: algorithm creation moved from *before* the mutex to *inside*
it. That closes a window in which two threads could each construct a `LoadLiveData` — and so risk a
second listener — before either acquired the lock. The aggressive `_removeAlgorithm` cleanup is
preserved; it is skipped only when creation itself threw, i.e. when there is nothing to remove.

**No startup hook or consumer change is needed.** Because the scope is applied at the point of use,
there is nothing for SNAPWrap or any other consumer to call. This holds only as long as nothing
outside a `MantidSnapper` call depends on the Mantid *default* facility; the one such dependency,
`LoadLiveDataInterval.validateInputs`, runs during `execute` and is therefore already inside the
scope. Everything else resolves the facility or instrument *by name*. This assumption is written down
in the new implementation note, along with the fallback if it ever breaks.

Two smaller fixes ride along:

- `SNAPRedGUI` now saves and restores `default.instrument` alongside `default.facility`. Setting the
  facility alone never yields the right instrument: `setString` leaves the previous one in place,
  while `ConfigService.setFacility` resets it to the facility's *first* instrument.
- `CheckIPTS.getValidInstruments` compared an `InstrumentInfo` against the string `"DAS"`, which is
  never equal, so the exclusion silently did nothing. `"DAS"` matters precisely because it is what
  `ConfigService.setFacility("SNS")` selects as the default instrument.

New implementation note at `docs/source/developer/implementation_notes/mantid_config_ownership.rst`
documents who owns Mantid's `ConfigService`, why the change is scoped, and the validator behaviour
above — so the next person doesn't have to rediscover it.

## To test

### Dev testing

45 tests added across four files, plus 5 added to an existing one.

- **`tests/unit/backend/data/test_liveDataFacilityConfig.py`** (9) — characterizes the Mantid
  behaviour the fix depends on: the rejection itself under a non-SNS default; facility+instrument
  together making `Instrument="SNAP"` work; `amend_config` restoring the caller's settings;
  allowed-values being frozen at `initialize()`; and `getInstrument(name)` searching all facilities.
  Deliberately written to hold under any of the candidate fixes, so it doesn't encode this particular
  implementation.
- **`tests/unit/meta/mantid/test_LiveDataFacility.py`** (21) — the helper: applies both keys, restores
  them (including after an exception), is a no-op for non-live-data algorithms, is non-reentrant, is
  reusable after a failure, and permits ordinary algorithms to nest inside a live-data scope.
- **`tests/unit/backend/recipe/algorithm/test_MantidSnapper.py`** (+5) — that a live-data algorithm is
  *created* under SNAPRed's facility (the timing that matters), that the facility is restored
  afterwards and on failure, and that non-live-data algorithms don't touch the configuration at all.
- **`tests/unit/backend/recipe/algorithm/test_CheckIPTS.py`** (5) — `DAS` excluded, SNAP present,
  empty string still allowed.
- **`tests/unit/ui/test_mainLiveDataConfig.py`** (4) — the GUI save/override/restore, exercised
  against a stub so no Qt widgets are constructed.

I verified the two most important tests genuinely fail without their fix, rather than trusting that
they pass: the `MantidSnapper` creation-timing tests and the `CheckIPTS` `DAS` test.

**Things reviewers should look at closely:**

- `tests/unit/ui/test_mainLiveDataConfig.py` is `importorskip`-guarded, because `snapred.ui.main`
  needs the pinned Mantid version and my local env is behind (see below). It will **skip** locally and
  run in CI. I verified the underlying logic separately by shimming the one missing symbol, so I
  expect it to pass rather than merely skip — but CI is the first place it actually executes.
- My local `.pixi/envs/dev` is on Mantid 6.15 against the `>=6.16` pin, because `pixi` can't read
  lockfile v7 without an upgrade. Consequence: all of `tests/unit/ui` fails to collect locally, so
  the full suite was run as `pytest tests/unit --ignore=tests/unit/ui`:
  **1518 passed, 31 skipped, 1 failed**. The one failure
  (`test_RunMetadata::test_defaults_log_warning_fromNeXusLogs`) is pre-existing — confirmed by
  stashing on a clean tree.
- The re-entrance guard is a tripwire, not a fix for a live path. Searching the repo, there are only
  two live-data invocation paths and neither can reach the other through `MantidSnapper`
  (`LoadLiveDataInterval` creates its `LoadLiveData` child via `_createChildAlgorithm`). If that
  changes, the guard fires instead of deadlocking.

### CIS testing

The interesting case needs a real listener, so this is best run on an analysis node. It sets a
deliberately wrong default facility, exercises the path from the original traceback, and checks both
that the validator no longer rejects SNAP and that your own Mantid configuration is left untouched.

``` python
#
# EWM 15513: SNAPRed must reduce SNAP data even when the Mantid default instrument is not SNAP.
#
# Run from workbench.  Substitute a run number that exists for you.
#
from mantid.simpleapi import *
from mantid.kernel import ConfigService

from snapred.backend.data.LocalDataService import LocalDataService
from snapred.meta.Config import Config

RUN_NUMBER = "58810"   # <-- substitute a run number available to you

FACILITY_KEY, INSTRUMENT_KEY = "default.facility", "default.instrument"
config = ConfigService.Instance()
saved = (config[FACILITY_KEY], config[INSTRUMENT_KEY])
print(f"your Mantid defaults: {saved[0]} / {saved[1]}")

try:
    # 1. Deliberately set a default facility that is NOT SNS.  Before this fix, this alone was
    #    enough to make live reduction fail.
    config.setString(FACILITY_KEY, "ILL")
    config.setString(INSTRUMENT_KEY, "IN5")
    print(f"forced defaults to: {config[FACILITY_KEY]} / {config[INSTRUMENT_KEY]}")

    # 2. Confirm the underlying Mantid validator really would reject SNAP right now.
    alg = AlgorithmFactory.create("LoadLiveData", -1)
    alg.initialize()
    print(f"LoadLiveData allowed instruments under ILL: {list(alg.getProperty('Instrument').allowedValues)}")

    # 3. Exercise the path from the reported traceback.
    #    EXPECTED: no "not in the list of allowed values" error.
    localDataService = LocalDataService()
    stateId, detectorState = localDataService.generateStateId(RUN_NUMBER)
    print(f"PASS: generateStateId('{RUN_NUMBER}') -> {stateId}")

    # 4. And the live-data metadata read itself, if a live run is active.
    if localDataService.hasLiveDataConnection():
        metadata = localDataService.readLiveMetadata()
        print(f"PASS: live run number = {metadata.runNumber}, active = {metadata.hasActiveRun()}")
    else:
        print("SKIP: no live-data connection from this node")

    # 5. SNAPRed must not have left its own facility behind.
    assert config[FACILITY_KEY] == "ILL", f"facility leaked: {config[FACILITY_KEY]}"
    assert config[INSTRUMENT_KEY] == "IN5", f"instrument leaked: {config[INSTRUMENT_KEY]}"
    print("PASS: SNAPRed restored the default facility and instrument")

finally:
    config.setString(FACILITY_KEY, saved[0])
    config.setString(INSTRUMENT_KEY, saved[1])
    print(f"restored your Mantid defaults: {config[FACILITY_KEY]} / {config[INSTRUMENT_KEY]}")
```

**Failure looks like:** step 3 raises `StateValidationException`, with
`The value "SNAP" is not in the list of allowed values` logged immediately above it.

**Success looks like:** `PASS:` on steps 3 and 5, and step 2 printing an empty allowed-instruments
list — which is the point: the list is empty, and SNAPRed works anyway.

**GUI check (optional).** Set a non-SNAP default instrument in *File → Settings → General* in
workbench, restart, then run a live reduction from the SNAPRed reduction panel. It should proceed
normally. Afterwards, confirm your default instrument in workbench settings is still what you set —
SNAPRed should not have changed it.

## Link to EWM item

[EWM#15513](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=15513)

### Verification

- [ ] the author has read the EWM story and acceptance critera
- [ ] the reviewer has read the EWM story and acceptance criteria
- [ ] the reviewer certifies the acceptance criteria below reflect the criteria in EWM

### Acceptance Criteria

This list is for ease of reference, and does not replace reading the EWM story as part of the review.
Verify this list matches the EWM story before reviewing.

- [ ] SNAPRed reduces SNAP data irrespective of the user's Mantid default instrument setting
- [ ] SNAPRed does not permanently alter the user's Mantid default facility or instrument

### Not covered by this PR

- **Why run 69405's PV file was missing** (EWM#17188). That absence is what routed the code into the
  live-data fallback in the first place, and it still wants an answer from the reporter/IS. This PR
  fixes the failure that resulted, not the missing file.
- **Upstream Mantid change.** The cleaner fix is a `Facility` argument on the live-data algorithms,
  with the check moved from a `StringListValidator` into `validateInputs` — that needs no
  configuration mutation at all and gives far better error messages. Kort and I prototyped and agreed
  on this; it is a separate PR against Mantid on a different timeline, and it deliberately does not
  touch `LoadLiveData` itself. Once it lands, the scoped override here can be retired.